### PR TITLE
support shared expert

### DIFF
--- a/csrc/deepep/config.cpp
+++ b/csrc/deepep/config.cpp
@@ -4,4 +4,21 @@ namespace deep_ep {
 size_t get_low_latency_rdma_size_hint(int num_max_dispatch_tokens_per_rank, int hidden, int num_ranks, int num_experts) {
     return num_max_dispatch_tokens_per_rank;
 }
+
+int get_value_from_env(const std::string &name, int defaultValue)
+{
+    int retValue = defaultValue;
+    if (const char* rank_str = std::getenv(name.c_str())) {
+        char* end;
+        errno = 0;
+        long val = std::strtol(rank_str, &end, 10);
+        if (errno == ERANGE || *end != '\0' || !std::isdigit(*rank_str)) {
+            return retValue;
+        }
+        retValue = static_cast<int>(val);
+        return retValue;
+    } else {
+        return retValue;
+    }
+}
 }

--- a/csrc/deepep/config.hpp
+++ b/csrc/deepep/config.hpp
@@ -1,6 +1,9 @@
 #pragma once
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
+#include <cstdlib>
+#include <cctype>
+#include <string>
 
 namespace deep_ep {
 
@@ -32,4 +35,5 @@ struct Config {
 
 size_t get_low_latency_rdma_size_hint(int num_max_dispatch_tokens_per_rank, int hidden, int num_ranks, int num_experts);
 
+int get_value_from_env(const std::string &name, int defaultValue);
 } // namespace deep_ep

--- a/csrc/deepep/deep_ep.cpp
+++ b/csrc/deepep/deep_ep.cpp
@@ -31,6 +31,8 @@ Buffer::Buffer(int64_t rank, int64_t num_ranks, int64_t num_nvl_bytes, int64_t n
     } else {
         EP_HOST_ASSERT(moe_all_to_all_group_name.size() < 128);
     }
+
+    this->shared_expert_rank_num = get_value_from_env("MOE_SHARED_EXPERT_RANK_NUM", 0);
 }
 
 Buffer::~Buffer() noexcept(false) {
@@ -59,14 +61,19 @@ std::tuple<at::Tensor, std::optional<at::Tensor>, at::Tensor, at::Tensor, at::Te
 
     auto num_tokens = static_cast<int>(new_x.size(0)), hidden = static_cast<int>(new_x.size(1));
     auto num_scales = hidden / 128, num_topk = static_cast<int>(new_topk_idx.size(1));
-    auto num_local_experts = num_experts / num_ranks;
+    auto num_local_experts = num_experts / (num_ranks - shared_expert_rank_num);
+    auto num_max_tokens = 0;
+    if (rank < shared_expert_rank_num) {
+        num_max_tokens = num_max_dispatch_tokens_per_rank * num_ranks / shared_expert_rank_num;
+        num_local_experts = 1;
+    } else { // moe expert
+        num_max_tokens = num_max_dispatch_tokens_per_rank * num_ranks * num_local_experts;
+    }
 
     // Allocate packed tensors
     auto device = new_x.device();
-    auto packed_recv_x = at::empty({num_local_experts * num_ranks * num_max_dispatch_tokens_per_rank, hidden},
-        new_x.options().dtype(use_fp8 ? at::kChar : at::kBFloat16));
-    auto packed_recv_x_scales = at::empty(
-        {num_local_experts * num_ranks * num_max_dispatch_tokens_per_rank}, at::dtype(at::kFloat).device(device));
+    auto packed_recv_x = at::empty({num_max_tokens, hidden}, new_x.options().dtype(use_fp8 ? at::kChar : at::kBFloat16));
+    auto packed_recv_x_scales = at::empty({num_max_tokens}, at::dtype(at::kFloat).device(device));
     auto expandIdx = at::empty({num_tokens * num_topk}, at::dtype(at::kInt).device(device));
     auto packed_recv_count = at::empty({num_local_experts * num_ranks}, at::dtype(at::kInt).device(device));
     auto tp_recv_count = at::empty({1}, at::dtype(at::kInt).device(device));
@@ -79,10 +86,8 @@ std::tuple<at::Tensor, std::optional<at::Tensor>, at::Tensor, at::Tensor, at::Te
     int64_t tp_size = 1;
     int64_t tp_rank = 0;
     int64_t expert_shard_type = 0;
-    int64_t shared_expert_num = 1;
     int64_t expert_token_nums_type = 1;
     int64_t global_bs = num_max_dispatch_tokens_per_rank * num_ranks;
-    int64_t shared_expert_rank_num = 0;
 
     // get ep & tp name
     char hcom_ep_name[128];
@@ -167,9 +172,7 @@ std::tuple<at::Tensor, std::optional<EventHandle>, std::optional<std::function<v
     int64_t tp_world_size = 1;
     int64_t tp_rankId = 0;
     int64_t expert_shared_type = 0;
-    int64_t shared_expert_num = 1;
     int64_t global_bs = num_max_dispatch_tokens_per_rank * num_ranks;
-    int64_t shared_expert_rank_num = 0;
     int64_t out_dtype = 0;
     int64_t comm_quant_mode = 0;
     int64_t group_list_type = 0;

--- a/csrc/deepep/deep_ep.hpp
+++ b/csrc/deepep/deep_ep.hpp
@@ -28,6 +28,9 @@ struct Buffer {
     at::Tensor new_topk_idx;
     at::Tensor new_scales;
 
+    int64_t shared_expert_rank_num;
+    int64_t shared_expert_num = 1;
+
 private:
     std::string moe_all_to_all_group_name;
 


### PR DESCRIPTION
Support setting the number of shared expert ranks through environment variables, default is 0.
```
export MOE_SHARED_EXPERT_RANK_NUM=0
```