### PR TITLE
fix SOC_VERSION not found in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-SOC_VERSION ="${1:-Ascend910_9382}"
+SOC_VERSION="${1:-Ascend910_9382}"
 
 if [ -n "$ASCEND_HOME_PATH" ]; then
     _ASCEND_INSTALL_PATH=$ASCEND_HOME_PATH


### PR DESCRIPTION
fix SOC_VERSION not found in build.sh