### PR TITLE
add clang-format for code style

### DIFF
--- a/csrc/.clang-format
+++ b/csrc/.clang-format
@@ -1,0 +1,37 @@
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 120
+AllowShortFunctionsOnASingleLine: Empty
+DerivePointerAlignment: false
+PointerAlignment: Right
+NamespaceIndentation: None
+SortIncludes: true
+AllowShortLoopsOnASingleLine: false
+BinPackParameters: false              # Prevents packing parameters in declarations
+BinPackArguments: false               # Prevents packing arguments in function calls
+AlignAfterOpenBracket: AlwaysBreak    # Forces a break after the opening parenthesis
+AlignOperands: Align                  # Aligns arguments vertically
+PenaltyBreakBeforeFirstCallParameter: 1  # Encourages breaking before the first argument
+PenaltyReturnTypeOnItsOwnLine: 100    # Keeps return type with function name
+AccessModifierOffset: -4
+
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Never
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+
+BreakBeforeBraces: Custom

--- a/csrc/helloworld/op_host/helloworld.cpp
+++ b/csrc/helloworld/op_host/helloworld.cpp
@@ -8,10 +8,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "aclrtlaunch_helloworld.h"
 #include "defines.h"
 #include "torch_helper.h"
-
-#include "aclrtlaunch_helloworld.h"
 
 namespace sglang {
 namespace npu_kernel {
@@ -45,5 +44,5 @@ HOST_API void printVersion()
     printf("%s\n", LIB_VERSION_FULL);
 }
 
-}
-}
+}  // namespace npu_kernel
+}  // namespace sglang


### PR DESCRIPTION
- added clang-format for code style
- reformatted helloworld.cpp with it

Quick way to use this in clion:
step1: checked box as showing in following picture
<img width="870" height="470" alt="image" src="https://github.com/user-attachments/assets/540c69f6-7d1f-4221-9f46-f4742a660495" />
 
step2: ctrl+alt+L to format