### PR TITLE
Support build option deepep/kernels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project(sgl-kernel-npu LANGUAGES CXX)
 option(BUILD_PYTHON "build python SDK" ON)
 option(BUILD_TESTS  "build test or not" OFF)
 
+option(BUILD_DEEPEP_MODULE "build deepep" ON)
+option(BUILD_KERNELS_MODULE  "build kernels" OFF)
+
 set(CMAKE_CXX_STANDARD 17)
 #set(CMAKE_VERBOSE_MAKEFILE ON)
 
@@ -32,13 +35,10 @@ include(cmake/config_git_last_commit.cmake)
 include(cmake/config_envs.cmake)
 include(cmake/config_ascend.cmake)
 
-if (NOT DEFINED BUILD_TYPE)
-    set(BUILD_TYPE "")
-endif ()
-
-message(STATUS "Build type: ${BUILD_TYPE}")
-
-if (BUILD_TYPE STREQUAL "")
+if (BUILD_KERNELS_MODULE STREQUAL "ON")
     add_subdirectory(csrc)
 endif ()
-add_subdirectory(csrc/deepep)
+
+if (BUILD_DEEPEP_MODULE STREQUAL "ON")
+    add_subdirectory(csrc/deepep)
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ option(BUILD_PYTHON "build python SDK" ON)
 option(BUILD_TESTS  "build test or not" OFF)
 
 option(BUILD_DEEPEP_MODULE "build deepep" ON)
-option(BUILD_KERNELS_MODULE  "build kernels" OFF)
+option(BUILD_KERNELS_MODULE  "build kernels" ON)
 
 set(CMAKE_CXX_STANDARD 17)
 #set(CMAKE_VERBOSE_MAKEFILE ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,10 +35,10 @@ include(cmake/config_git_last_commit.cmake)
 include(cmake/config_envs.cmake)
 include(cmake/config_ascend.cmake)
 
-if (BUILD_KERNELS_MODULE STREQUAL "ON")
+if (BUILD_KERNELS_MODULE)
     add_subdirectory(csrc)
 endif ()
 
-if (BUILD_DEEPEP_MODULE STREQUAL "ON")
+if (BUILD_DEEPEP_MODULE)
     add_subdirectory(csrc/deepep)
 endif ()

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,6 @@ while getopts ":a:" opt; do
         a )
             BUILD_DEEPEP_MODULE="OFF"
             BUILD_KERNELS_MODULE="OFF"
-            BUILD_TYPE=$OPTARG
             case "$OPTARG" in
                 deepep )
                     BUILD_DEEPEP_MODULE="ON"

--- a/build.sh
+++ b/build.sh
@@ -123,15 +123,21 @@ function make_sgl_kernel_npu_package()
 function main()
 {
     build_kernels
-    build_deepep_kernels
 
+    if [[ "$BUILD_DEEPEP_MODULE" == "ON" ]]; then
+        build_deepep_kernels
+    fi
     if pip3 show wheel;then
         echo "wheel has been installed"
     else
         pip3 install wheel
     fi
-    make_deepep_package
-    make_sgl_kernel_npu_package
+    if [[ "$BUILD_DEEPEP_MODULE" == "ON" ]]; then
+        make_deepep_package
+    fi
+    if [[ "$BUILD_KERNELS_MODULE" == "ON" ]]; then
+        make_sgl_kernel_npu_package
+    fi
 }
 
 main

--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,28 @@
 #!/bin/bash
 set -e
 
-BUILD_TYPE=""
+BUILD_DEEPEP_MODULE="ON"
+BUILD_KERNELS_MODULE="ON"
 
 while getopts ":a:" opt; do
     case ${opt} in
         a )
+            BUILD_DEEPEP_MODULE="OFF"
+            BUILD_KERNELS_MODULE="OFF"
             BUILD_TYPE=$OPTARG
-            if [[ "$BUILD_TYPE" != "deepep" ]]; then
-                echo "Error: Invalid value, only 'deepep' is allowed"
-                exit 1
-            fi
+            case "$OPTARG" in
+                deepep )
+                    BUILD_DEEPEP_MODULE="ON"
+                    ;;
+                kernels )
+                    BUILD_KERNELS_MODULE="ON"
+                    ;;
+                * )
+                    echo "Error: Invalid Value"
+                    echo "Allowed value: deepep, kernels"
+                    exit 1
+                    ;;
+            esac
             ;;
         \? )
             echo "Error: unknown flag: -$OPTARG" 1>&2
@@ -56,7 +68,7 @@ function build_kernels()
     rm -rf $BUILD_DIR
     mkdir -p $BUILD_DIR
 
-    cmake $COMPILE_OPTIONS -DCMAKE_INSTALL_PREFIX="$OUTPUT_DIR" -DASCEND_HOME_PATH=$ASCEND_HOME_PATH -DSOC_VERSION=$SOC_VERSION -DBUILD_TYPE=$BUILD_TYPE -B "$BUILD_DIR" -S .
+    cmake $COMPILE_OPTIONS -DCMAKE_INSTALL_PREFIX="$OUTPUT_DIR" -DASCEND_HOME_PATH=$ASCEND_HOME_PATH -DSOC_VERSION=$SOC_VERSION -DBUILD_DEEPEP_MODULE=$BUILD_DEEPEP_MODULE -DBUILD_KERNELS_MODULE=$BUILD_KERNELS_MODULE -B "$BUILD_DIR" -S .
     cmake --build "$BUILD_DIR" -j8 && cmake --build "$BUILD_DIR" --target install
     cd -
 }


### PR DESCRIPTION
## Description
This PR adds new build options to support partial build of the project.

## Changes
*   **Change 1**: Added two new options in `CMakeLists.txt` to enable independent building of the 'deepep' module and other operators.
*   **Change 2**: Updated the `build.sh` to be compatible with the new CMake options. Users can now perform a partial build by passing the `-a deepep/kernels` argument.
*   **Change 3**: Standardized the print messages.

## Testing
*   Conducted basic tests to verify that the build process correctly executes the logic for the specified partial build branches (`deepep` and `kernels`).
