### PR TITLE
support cache loc update op

### DIFF
--- a/csrc/cache_location_assign/op_kernel/cache_loc_assign_kernel.cpp
+++ b/csrc/cache_location_assign/op_kernel/cache_loc_assign_kernel.cpp
@@ -17,15 +17,18 @@
 
 /* tensor num for each queue */
 constexpr int32_t BUFFER_NUM = 2;
+constexpr uint32_t MAX_STEP = 5;
+
+constexpr uint32_t ASSIGN_TO_POOL = 0;
+constexpr uint32_t RETRIEVE_FROM_POOL = 1;
 
 template <typename T>
 class CacheLocAssignKernel {
 public:
-    __aicore__ inline CacheLocAssignKernel()
-    {}
+    __aicore__ inline CacheLocAssignKernel() {}
 
     __aicore__ inline void Init(GM_ADDR reqPoolIndices, GM_ADDR tokenPool, GM_ADDR startOffset, GM_ADDR endOffset,
-        GM_ADDR outCacheLoc, __gm__ AssignCacheTillingData *tempTilingGM)
+                                GM_ADDR outCacheLoc, __gm__ AssignCacheTillingData *tempTilingGM)
     {
         this->coreId = AscendC::GetBlockIdx();
         this->batchSize = tempTilingGM->batchSize;
@@ -44,13 +47,14 @@ public:
         this->tokenCountAlignInt32 = tempTilingGM->tokenCountAlignInt32;
         this->offsetCountAlignInt64 = tempTilingGM->offsetCountAlignInt64;
         this->cacheLocCountAlignInt32 = tempTilingGM->cacheLocCountAlignInt32;
+        this->cacheLocSize = tempTilingGM->cacheLocSize;
 
         this->rowOffset = this->rowNumNoTail * this->coreId + this->tailOffset;
         this->reqPoolIndicesGM.SetGlobalBuffer((__gm__ T *)reqPoolIndices, this->batchSize);
         this->tokenPoolGM.SetGlobalBuffer((__gm__ int32_t *)tokenPool, tempTilingGM->poolSize * this->rowSize);
         this->startOffsetGm.SetGlobalBuffer((__gm__ int64_t *)startOffset, this->batchSize);
         this->endOffsetGM.SetGlobalBuffer((__gm__ int64_t *)endOffset, this->batchSize);
-        this->cacheLocGM.SetGlobalBuffer((__gm__ int32_t *)outCacheLoc, tempTilingGM->cacheLocSize);
+        this->cacheLocGM.SetGlobalBuffer((__gm__ int32_t *)outCacheLoc, this->cacheLocSize);
 
         AscendC::TBuf<AscendC::TPosition::VECCALC> tmpBuff1, tmpBuff2, tmpBuff3, tmpBuff4, tmpBuff5, tmpBuff6, tmpBuff7;
         this->pipe.InitBuffer(tmpBuff1, tempTilingGM->reqInxBufferSize);
@@ -68,42 +72,65 @@ public:
         this->ubStartOffsetInt32 = tmpBuff4.Get<int32_t>();
         this->ubEndOffsetInt32 = tmpBuff5.Get<int32_t>();
 
-        this->cacheLength = tmpBuff6.Get<int32_t>();
+        this->ubCacheLength = tmpBuff6.Get<int32_t>();
         this->ubCacheLoc = tmpBuff7.Get<int32_t>();
 
         this->pipe.InitBuffer(this->inQueue1, BUFFER_NUM, tempTilingGM->tokenColAlignInt32);
     }
 
-    __aicore__ inline void Process()
+    __aicore__ inline void ProcessForTokenPoolAssign()
     {
         if (this->rowNum > 0) {
-            AscendC::DataCopy(this->ubReqPoolIndices, this->reqPoolIndicesGM, this->reqInxBufferCount);
-            AscendC::DataCopy(this->ubStartOffset, this->startOffsetGm, this->offsetCountAlignInt64);
-            AscendC::DataCopy(this->ubEndOffset, this->endOffsetGM, this->offsetCountAlignInt64);
-            AscendC::DataCopy(this->ubCacheLoc, this->cacheLocGM, this->cacheLocCountAlignInt32);
-
-            int32_t eventIDMTE2TOV = static_cast<int32_t>(GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_V));
-            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(eventIDMTE2TOV);
-            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventIDMTE2TOV);
-
-            AscendC::Cast(this->ubStartOffsetInt32,
-                this->ubStartOffset,
-                AscendC::RoundMode::CAST_NONE,
-                this->offsetCountAlignInt64);
-            AscendC::Cast(
-                this->ubEndOffsetInt32, this->ubEndOffset, AscendC::RoundMode::CAST_NONE, this->offsetCountAlignInt64);
-            this->cacheLength = this->ubEndOffsetInt32 - this->ubStartOffsetInt32;
-
+            PreProcess();
             for (int32_t i = 0; i < this->rowNum; i++) {
                 uint64_t rowIdx = this->rowOffset + i;
                 uint64_t reqIdx = this->ubReqPoolIndices.GetValue(rowIdx);
                 CopyIn(rowIdx, reqIdx);
-                Compute(rowIdx, reqIdx);
+                ComputeForTokenPoolAssign(rowIdx, reqIdx);
             }
         }
     }
 
+    __aicore__ inline void ProcessForCacheUpdate()
+    {
+        if (this->rowNum > 0) {
+            PreProcess();
+            for (int32_t i = 0; i < this->rowNum; i++) {
+                uint64_t rowIdx = this->rowOffset + i;
+                uint64_t reqIdx = this->ubReqPoolIndices.GetValue(rowIdx);
+                CopyIn(rowIdx, reqIdx);
+                ComputeForCacheUpdate(rowIdx);
+            }
+
+            int32_t eventIDVTOMTE3 = static_cast<int32_t>(GetTPipePtr()->FetchEventID(AscendC::HardEvent::V_MTE3));
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(eventIDVTOMTE3);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(eventIDVTOMTE3);
+
+            uint32_t cacheBytes = static_cast<uint32_t>(this->cacheLocSize * sizeof(int32_t));
+            AscendC::DataCopyExtParams copyParams{1, cacheBytes, 0, 0, 0};
+            AscendC::DataCopyPad(this->cacheLocGM, this->ubCacheLoc, copyParams);
+        }
+    }
+
 private:
+    __aicore__ inline void PreProcess()
+    {
+        AscendC::DataCopy(this->ubReqPoolIndices, this->reqPoolIndicesGM, this->reqInxBufferCount);
+        AscendC::DataCopy(this->ubStartOffset, this->startOffsetGm, this->offsetCountAlignInt64);
+        AscendC::DataCopy(this->ubEndOffset, this->endOffsetGM, this->offsetCountAlignInt64);
+        AscendC::DataCopy(this->ubCacheLoc, this->cacheLocGM, this->cacheLocCountAlignInt32);
+
+        int32_t eventIDMTE2TOV = static_cast<int32_t>(GetTPipePtr()->FetchEventID(AscendC::HardEvent::MTE2_V));
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(eventIDMTE2TOV);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventIDMTE2TOV);
+
+        AscendC::Cast(this->ubStartOffsetInt32, this->ubStartOffset, AscendC::RoundMode::CAST_NONE,
+                      this->offsetCountAlignInt64);
+        AscendC::Cast(this->ubEndOffsetInt32, this->ubEndOffset, AscendC::RoundMode::CAST_NONE,
+                      this->offsetCountAlignInt64);
+        this->ubCacheLength = this->ubEndOffsetInt32 - this->ubStartOffsetInt32;
+    }
+
     __aicore__ inline void CopyIn(uint64_t rowIdx, uint64_t reqIdx)
     {
         AscendC::LocalTensor<int32_t> tokenPoolLocal = this->inQueue1.template AllocTensor<int32_t>();
@@ -112,29 +139,46 @@ private:
         this->inQueue1.EnQue(tokenPoolLocal);
     }
 
-    __aicore__ inline void Compute(uint64_t rowIdx, uint64_t reqIdx)
+    __aicore__ inline void ComputeForTokenPoolAssign(uint64_t rowIdx, uint64_t reqIdx)
     {
         AscendC::LocalTensor<int32_t> tokenPoolLocal = this->inQueue1.template DeQue<int32_t>();
         int64_t start = this->ubStartOffset.GetValue(rowIdx);
         int64_t step = this->ubEndOffset.GetValue(rowIdx) - start;
 
-        int64_t idxStart = 0;
-        GetCacheIdx(rowIdx, idxStart);
+        GetCacheIdx(rowIdx, this->lastRowIdx, this->cacheIdxStart);
         for (int64_t j = 0; j < step; j++) {
-            int32_t cache = this->ubCacheLoc.GetValue(idxStart);
+            int32_t cache = this->ubCacheLoc.GetValue(this->cacheIdxStart + j);
             tokenPoolLocal.SetValue(j, cache);
-            idxStart += 1;
         }
 
-        AscendC::DataCopy(tokenPoolGM[reqIdx * this->rowSize + start], tokenPoolLocal, this->tokenCountAlignInt32);
+        uint32_t tokenBytes = static_cast<uint32_t>(MAX_STEP * sizeof(int32_t));
+        AscendC::DataCopyExtParams copyParams{1, tokenBytes, 0, 0, 0};
+        AscendC::DataCopyPad(tokenPoolGM[reqIdx * this->rowSize + start], tokenPoolLocal, copyParams);
+
         this->inQueue1.FreeTensor(tokenPoolLocal);
     }
 
-    __aicore__ inline void GetCacheIdx(uint64_t rowIdx, int64_t &result)
+    __aicore__ inline void ComputeForCacheUpdate(uint64_t rowIdx)
     {
-        for (int64_t i = 0; i < rowIdx; i++) {
-            result += this->cacheLength.GetValue(i);
+        AscendC::LocalTensor<int32_t> tokenPoolLocal = this->inQueue1.template DeQue<int32_t>();
+        int64_t start = this->ubStartOffset.GetValue(rowIdx);
+        int64_t step = this->ubEndOffset.GetValue(rowIdx) - start;
+
+        GetCacheIdx(rowIdx, this->lastRowIdx, this->cacheIdxStart);
+        for (int64_t j = 0; j < step; j++) {
+            int32_t tokenPosition = tokenPoolLocal.GetValue(j);
+            this->ubCacheLoc.SetValue(this->cacheIdxStart + j, tokenPosition);
         }
+
+        this->inQueue1.FreeTensor(tokenPoolLocal);
+    }
+
+    __aicore__ inline void GetCacheIdx(uint64_t rowIdx, uint64_t &lastRowIdx, int64_t &cacheIdxStart)
+    {
+        for (int64_t i = lastRowIdx; i < rowIdx; i++) {
+            cacheIdxStart += this->ubCacheLength.GetValue(i);
+        }
+        lastRowIdx = rowIdx;
     }
 
 private:
@@ -145,7 +189,7 @@ private:
     AscendC::LocalTensor<int32_t> ubStartOffsetInt32;
     AscendC::LocalTensor<int32_t> ubEndOffsetInt32;
 
-    AscendC::LocalTensor<int32_t> cacheLength;
+    AscendC::LocalTensor<int32_t> ubCacheLength;
     AscendC::LocalTensor<int32_t> ubCacheLoc;
 
     AscendC::TQue<AscendC::TPosition::VECIN, BUFFER_NUM> inQueue1;
@@ -164,6 +208,10 @@ private:
     uint64_t tailOffset;
     uint64_t rowOffset;
     uint64_t rowSize;
+    uint64_t cacheLocSize;
+
+    int64_t cacheIdxStart{0};
+    uint64_t lastRowIdx{0};
 
     uint64_t reqInxBufferCount;
     uint64_t tokenCountAlignInt32;
@@ -172,7 +220,8 @@ private:
 };
 
 extern "C" __global__ __aicore__ void cache_loc_assign(GM_ADDR reqPoolIndices, GM_ADDR tokenPool, GM_ADDR startOffset,
-    GM_ADDR endOffset, GM_ADDR outCacheLoc, GM_ADDR tilingGM)
+                                                       GM_ADDR endOffset, GM_ADDR outCacheLoc, GM_ADDR tilingGM,
+                                                       uint32_t assignMode)
 {
     REGISTER_TILING_DEFAULT(AssignCacheTillingData);
     __gm__ AssignCacheTillingData *tempTilingGM = reinterpret_cast<__gm__ AssignCacheTillingData *>(tilingGM);
@@ -180,13 +229,27 @@ extern "C" __global__ __aicore__ void cache_loc_assign(GM_ADDR reqPoolIndices, G
         CacheLocAssignKernel<int32_t> op;
         op.Init(reqPoolIndices, tokenPool, startOffset, endOffset, outCacheLoc, tempTilingGM);
         if ASCEND_IS_AIV {
-            op.Process();
+            switch (assignMode) {
+                case ASSIGN_TO_POOL:
+                    op.ProcessForTokenPoolAssign();
+                    break;
+                case RETRIEVE_FROM_POOL:
+                    op.ProcessForCacheUpdate();
+                    break;
+            }
         }
     } else if (tempTilingGM->key == 2) {
         CacheLocAssignKernel<int64_t> op;
         op.Init(reqPoolIndices, tokenPool, startOffset, endOffset, outCacheLoc, tempTilingGM);
         if ASCEND_IS_AIV {
-            op.Process();
+            switch (assignMode) {
+                case ASSIGN_TO_POOL:
+                    op.ProcessForTokenPoolAssign();
+                    break;
+                case RETRIEVE_FROM_POOL:
+                    op.ProcessForCacheUpdate();
+                    break;
+            }
         }
     }
 }

--- a/csrc/pytorch_extensions.cpp
+++ b/csrc/pytorch_extensions.cpp
@@ -23,26 +23,29 @@ TORCH_LIBRARY_FRAGMENT(npu, m)
     m.def("sgl_kernel_npu_version() -> str", []() { return std::string("") + LIB_VERSION; });
 
     m.def("helloworld(Tensor x, Tensor y) -> Tensor");
-    
-    m.def("alloc_extend(Tensor pre_lens, Tensor seq_lens, Tensor last_loc, Tensor free_pages, int page_size, Tensor(a!) out_indices, Tensor(b!) values) -> ()");
+
+    m.def("alloc_extend(Tensor pre_lens, Tensor seq_lens, Tensor last_loc, Tensor free_pages, int page_size, "
+          "Tensor(a!) out_indices, Tensor(b!) values) -> ()");
 
     m.def("cache_loc_assign(Tensor req_indices, Tensor token_pool, Tensor start_offset, Tensor end_offset, Tensor "
           "out_cache_loc) -> Tensor");
 
-    m.def("assign_cache_op(Tensor! dst_tensor, Tensor src_tensor, Tensor dst_start_idx, Tensor dst_end_idx, Tensor src_start_idx, "
-            "Tensor src_end_idx) -> bool");
+    m.def("cache_loc_update(Tensor req_indices, Tensor token_pool, Tensor start_offset, Tensor end_offset, Tensor "
+          "out_cache_loc) -> Tensor");
+
+    m.def("assign_cache_op(Tensor! out, Tensor src, Tensor dst_start_idx, Tensor dst_end_idx, Tensor src_start_idx, "
+          "Tensor src_end_idx) -> bool");
 
     m.def("mla_preprocess(Tensor hiddenState, Tensor gamma0, Tensor beta0, Tensor wdqkv, "
-                          "Tensor descale0, Tensor gamma1, Tensor beta1, Tensor wuq, "
-                          "Tensor descale1, Tensor gamma2, Tensor cos, Tensor sin, Tensor wuk,"
-                          "Tensor kv_cache, Tensor kv_cache_rope, Tensor slotmapping, "
-                          "Tensor quant_scale0, Tensor quant_offset0, Tensor bias0, "
-                          "Tensor quant_scale1, Tensor quant_offset1, Tensor bias1, *, "
-                          "Tensor? ctkv_scale=None, Tensor? q_nope_scale=None, "
-                          "str? cache_mode=None, str? quant_mode=None, "
-                          "Tensor(a!) q_out0, Tensor(b!) kv_cache_out0, Tensor(c!) q_out1, Tensor(d!) kv_cache_out1) "
-                          "-> (Tensor(a!), Tensor(b!), Tensor(c!), Tensor(d!))");
-
+          "Tensor descale0, Tensor gamma1, Tensor beta1, Tensor wuq, "
+          "Tensor descale1, Tensor gamma2, Tensor cos, Tensor sin, Tensor wuk,"
+          "Tensor kv_cache, Tensor kv_cache_rope, Tensor slotmapping, "
+          "Tensor quant_scale0, Tensor quant_offset0, Tensor bias0, "
+          "Tensor quant_scale1, Tensor quant_offset1, Tensor bias1, *, "
+          "Tensor? ctkv_scale=None, Tensor? q_nope_scale=None, "
+          "str? cache_mode=None, str? quant_mode=None, "
+          "Tensor(a!) q_out0, Tensor(b!) kv_cache_out0, Tensor(c!) q_out1, Tensor(d!) kv_cache_out1) "
+          "-> (Tensor(a!), Tensor(b!), Tensor(c!), Tensor(d!))");
 }
 }  // namespace
 
@@ -53,8 +56,12 @@ TORCH_LIBRARY_IMPL(npu, PrivateUse1, m)
 
     m.impl("cache_loc_assign", TORCH_FN(sglang::npu_kernel::cache_loc_assign));
 
-    m.impl("alloc_extend", TORCH_FN(sglang::npu_kernel::alloc_extend));
+    m.impl("cache_loc_update", TORCH_FN(sglang::npu_kernel::cache_loc_update));
+
     m.impl("assign_cache_op", TORCH_FN(sglang::npu_kernel::assign_cache_op));
+
+    m.impl("alloc_extend", TORCH_FN(sglang::npu_kernel::alloc_extend));
+
     m.impl("mla_preprocess", TORCH_FN(sglang::npu_kernel::mla_preprocess));
 }
 }  // namespace

--- a/csrc/utils/common.h
+++ b/csrc/utils/common.h
@@ -1,0 +1,29 @@
+
+// Licensed under the BSD 3-Clause License  (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UTILS_COMMON_H
+#define UTILS_COMMON_H
+
+
+constexpr uint32_t BLK_SIZE_ALIN_FOR_INT64 = 4;
+constexpr uint32_t BLK_SIZE_ALIN_FOR_INT32 = 8;
+
+inline uint64_t alinInt64Count(uint64_t count)
+{
+    return (count + BLK_SIZE_ALIN_FOR_INT64 - 1) / BLK_SIZE_ALIN_FOR_INT64 * BLK_SIZE_ALIN_FOR_INT64;
+}
+
+inline uint64_t alinInt32Count(uint64_t count)
+{
+    return (count + BLK_SIZE_ALIN_FOR_INT32 - 1) / BLK_SIZE_ALIN_FOR_INT32 * BLK_SIZE_ALIN_FOR_INT32;
+}
+
+#endif  // UTILS_COMMON_H

--- a/include/sgl_kenel_npu_ops.h
+++ b/include/sgl_kenel_npu_ops.h
@@ -15,30 +15,28 @@ namespace sglang {
 namespace npu_kernel {
 at::Tensor helloworld(const at::Tensor &x, const at::Tensor &y);
 
-at::Tensor cache_loc_assign(const at::Tensor &req_indices, const at::Tensor &token_pool,
-    const at::Tensor &start_offset, const at::Tensor &end_offset, const at::Tensor &out_cache_loc);
+at::Tensor cache_loc_assign(const at::Tensor &req_indices, const at::Tensor &token_pool, const at::Tensor &start_offset,
+                            const at::Tensor &end_offset, const at::Tensor &out_cache_loc);
+
+at::Tensor cache_loc_update(const at::Tensor &req_indices, const at::Tensor &token_pool, const at::Tensor &start_offset,
+                            const at::Tensor &end_offset, const at::Tensor &out_cache_loc);
 
 bool assign_cache_op(at::Tensor &dst_tensor, const at::Tensor &src_tensor, const at::Tensor &dst_start_idx,
-    const at::Tensor &dst_end_idx, const at::Tensor &src_start_idx, const at::Tensor &src_end_idx);
+                     const at::Tensor &dst_end_idx, const at::Tensor &src_start_idx, const at::Tensor &src_end_idx);
 
-void alloc_extend(const at::Tensor &pre_lens, const at::Tensor &seq_lens,
-    const at::Tensor &last_loc, const at::Tensor &free_pages, int64_t pages_size, at::Tensor &out_indices, at::Tensor &values);
+void alloc_extend(const at::Tensor &pre_lens, const at::Tensor &seq_lens, const at::Tensor &last_loc,
+                  const at::Tensor &free_pages, int64_t pages_size, at::Tensor &out_indices, at::Tensor &values);
 
-std::tuple<at::Tensor&, at::Tensor&, at::Tensor&, at::Tensor&> mla_preprocess(
+std::tuple<at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &> mla_preprocess(
     const at::Tensor &hiddenState, const at::Tensor &gamma0, const at::Tensor &beta0, const at::Tensor &wdqkv,
-    const at::Tensor &descale0, const at::Tensor &gamma1, const at::Tensor &beta1,
-    const at::Tensor &wuq, const at::Tensor &descale1, const at::Tensor &gamma2,
-    const at::Tensor &cos, const at::Tensor &sin, const at::Tensor &wuk,
-    const at::Tensor &kv_cache, const at::Tensor &kv_cache_rope, const at::Tensor &slotmapping,
+    const at::Tensor &descale0, const at::Tensor &gamma1, const at::Tensor &beta1, const at::Tensor &wuq,
+    const at::Tensor &descale1, const at::Tensor &gamma2, const at::Tensor &cos, const at::Tensor &sin,
+    const at::Tensor &wuk, const at::Tensor &kv_cache, const at::Tensor &kv_cache_rope, const at::Tensor &slotmapping,
     const at::Tensor &quant_scale0, const at::Tensor &quant_offset0, const at::Tensor &bias0,
     const at::Tensor &quant_scale1, const at::Tensor &quant_offset1, const at::Tensor &bias1,
     const c10::optional<at::Tensor> &ctkv_scale, const c10::optional<at::Tensor> &q_nope_scale,
-    c10::optional<c10::string_view> cache_mode, c10::optional<c10::string_view> quant_mode,
-    at::Tensor &q_out0,
-    at::Tensor &kv_cache_out0,
-    at::Tensor &q_out1,
-    at::Tensor &kv_cache_out1);
-
+    c10::optional<c10::string_view> cache_mode, c10::optional<c10::string_view> quant_mode, at::Tensor &q_out0,
+    at::Tensor &kv_cache_out0, at::Tensor &q_out1, at::Tensor &kv_cache_out1);
 }  // namespace npu_kernel
 
 }  // namespace sglang

--- a/tests/python/sgl_kernel_npu/test_cache_assign.py
+++ b/tests/python/sgl_kernel_npu/test_cache_assign.py
@@ -63,9 +63,9 @@ def test_op(req_indx_type):
     ascendC_spend_time = 0
     start = 0
     iter = 20
-
+    
     for i in range(iter):
-        if i > 0:
+        if i == 1:
             start = time.time()
         assign_req_to_token_pool_golden(
             req_pool_indices, token_pool_copy, start_offset, end_offset, out_cache_loc, bs)
@@ -73,32 +73,33 @@ def test_op(req_indx_type):
     golden_spend_time += (time.time() - start) * 1000
 
     for j in range(iter):
-        if j > 0:
+        if j == 1:
             start = time.time()
         assign_req_to_token_pool_native(req_pool_indices, token_pool_copy2, start_offset, end_offset, out_cache_loc, bs)
     torch.npu.synchronize()
     torch_spend_time += (time.time() - start) * 1000
 
+
     for k in range(iter):
-        if k > 0:
+        if k == 1:
             start = time.time()
         torch.ops.npu.cache_loc_assign(req_pool_indices, token_pool, start_offset, end_offset, out_cache_loc)
     torch.npu.synchronize()
-    ascendC_spend_time += (time.time() - start) * 1000
+    ascendC_spend_time += (time.time() - start) * 1000 
 
     accuracy = (token_pool == token_pool_copy).all() and (token_pool == token_pool_copy2).all()
     diff_num = ((token_pool != token_pool_copy).sum()).cpu()
-    assert accuracy == True
-    assert diff_num == torch.tensor([0])
     print(f"{req_indx_type} accuracy: {accuracy}")
     print(f"{req_indx_type} diff_num: {diff_num}")
     print(f"{req_indx_type} golden spend time:  {golden_spend_time / iter} ms")
     print(f"{req_indx_type} torch native spend time:  {torch_spend_time / iter} ms")
     print(f"{req_indx_type} ascend C spend time:  {ascendC_spend_time / iter} ms")
+    assert accuracy == True
+    assert diff_num == torch.tensor([0])
 
 
 if __name__ == '__main__':
-    bs = 50
+    bs = 300
     max_seq_len = 16384
     max_cache_loc = 10000
 

--- a/tests/python/sgl_kernel_npu/test_cache_update.py
+++ b/tests/python/sgl_kernel_npu/test_cache_update.py
@@ -1,0 +1,89 @@
+import torch
+import torch_npu
+import time
+
+import sgl_kernel_npu
+
+def assign_extend_cache_locs_native(
+    req_pool_indices: torch.Tensor,
+    req_to_token: torch.Tensor,
+    start_offset: torch.Tensor,
+    end_offset: torch.Tensor,
+    out_cache_loc: torch.Tensor,
+    bs,
+):
+    out_cache_loc_length = end_offset - start_offset
+    token_pool = req_to_token[req_pool_indices]
+    out_cache_loc_cumsum_length = torch.cumsum(out_cache_loc_length, dim=0)
+    out_cache_loc_cumsum_length = torch.cat(
+        (
+            torch.tensor([0], device=out_cache_loc_length.device),
+            out_cache_loc_cumsum_length,
+        )
+    )
+    for i in range(bs):
+        out_cache_loc[
+            out_cache_loc_cumsum_length[i] : out_cache_loc_cumsum_length[i]
+            + out_cache_loc_length[i]
+        ] = token_pool[i][start_offset[i] : end_offset[i]]
+    return out_cache_loc
+
+
+def test_op(req_indx_type):
+    torch.npu.synchronize()
+
+    golden_spend_time = 0
+    ascendC_spend_time = 0
+    start = 0
+    iter = 20
+    for i in range(iter):
+        if i == 1:
+            start = time.time()
+        assign_extend_cache_locs_native(req_pool_indices, req_to_token, start_offset, end_offset, out_cache_loc, bs)
+    torch.npu.synchronize()
+    golden_spend_time += (time.time() - start) * 1000 
+    print(f"golden_spend_time: {golden_spend_time / iter} ms")
+
+    for j in range(iter):
+        if j == 1:
+            start = time.time()
+        torch.ops.npu.cache_loc_update(req_pool_indices, req_to_token, start_offset, end_offset, out_cache_loc_copy)
+
+    torch.npu.synchronize()
+    ascendC_spend_time += (time.time() - start) * 1000 
+    accuracy = (out_cache_loc == out_cache_loc_copy).all()
+    diff_num = (out_cache_loc != out_cache_loc_copy).sum().cpu()
+    print(f"{req_indx_type} ascendC_spend_time: {ascendC_spend_time / iter} ms")
+    print(f"{req_indx_type} accuracy: {accuracy}")
+    print(f"{req_indx_type} diff_num: {diff_num}")
+    assert accuracy == True
+    assert diff_num == torch.tensor([0])
+
+
+if __name__ == "__main__":
+    bs = 300
+    max_seq_len = 8192
+    max_cache_loc = 10000
+
+    req_to_token = torch.arange(0, max_seq_len, device='npu', dtype=torch.int32)
+    req_to_token = req_to_token.repeat(2000, 1)
+    start_offset = torch.randint(2, max_seq_len, (bs,), device='npu', dtype=torch.int64) - 2
+    end_offset = start_offset + torch.randint(1, 3, (bs,), device='npu', dtype=torch.int64)
+
+    out_cache_loc_length = end_offset - start_offset
+    out_cache_loc_cumsum_length = torch.cumsum(out_cache_loc_length, dim=0, dtype=torch.int32)
+    out_cache_loc = torch.randint(0, max_cache_loc, 
+            (out_cache_loc_cumsum_length[-1],), device='npu', dtype=torch.int64)
+    out_cache_loc_copy = out_cache_loc.clone()
+    out_cache_loc_idx = torch.cat(
+        (torch.tensor([0], device=req_to_token.device, dtype=torch.int32), out_cache_loc_cumsum_length))
+
+    out_cache_loc_copy = out_cache_loc_copy.to(torch.int32)
+    # combo1: int64, int32, int64, int64, int32
+    req_pool_indices = torch.arange(0, bs, device='npu', dtype=torch.int64)
+    test_op("int64")
+
+    # combo1: int32, int32, int64, int64, int32
+    req_pool_indices = torch.arange(0, bs, device='npu', dtype=torch.int32)
+    test_op("int32")
+


### PR DESCRIPTION
Support the cache location update op which uses the same input as the cache location assign op but is used to retrieve the cache location from the token pool rather than assign the cache location to the pool.