### PR TITLE
[Feature] Add diagnostic modules to dispatch and combine

### DIFF
--- a/csrc/deepep/deep_ep.hpp
+++ b/csrc/deepep/deep_ep.hpp
@@ -58,15 +58,17 @@ public:
                        const std::optional<at::Tensor> &num_tokens_per_rank, const at::Tensor &is_token_in_rank,
                        const std::optional<at::Tensor> &num_tokens_per_expert, int cached_num_recv_tokens,
                        const std::optional<at::Tensor> &cached_rank_prefix_matrix,
-                       const std::optional<at::Tensor> &cached_channel_prefix_matrix, int expert_alignment,
+                       const std::optional<at::Tensor> &cached_channel_prefix_matrix,
+                       const std::optional<at::Tensor> &dispatch_wait_recv_cost_stats, int expert_alignment,
                        int num_worst_tokens, const Config &config, std::optional<EventHandle> &previous_event,
                        bool async, bool allocate_on_comm_stream, bool use_quant);
 
     void clean_low_latency_buffer(int num_max_dispatch_tokens_per_rank, int hidden, int num_experts);
 
-    std::tuple<torch::Tensor, std::optional<torch::Tensor>, std::optional<EventHandle>> intranode_combine(
-        const torch::Tensor &x, const torch::Tensor &topk_idx, const std::optional<torch::Tensor> &topk_weights,
-        const torch::Tensor &src_idx, const torch::Tensor &send_head);
+    std::tuple<torch::Tensor, std::optional<torch::Tensor>, std::optional<EventHandle>>
+    intranode_combine(const torch::Tensor &x, const torch::Tensor &topk_idx,
+                      const std::optional<torch::Tensor> &topk_weights, const torch::Tensor &src_idx,
+                      const torch::Tensor &send_head, const std::optional<at::Tensor> &combine_send_cost_stats);
 
     std::tuple<at::Tensor, std::optional<at::Tensor>, at::Tensor, at::Tensor, at::Tensor, std::optional<EventHandle>,
                std::optional<std::function<void()>>>

--- a/csrc/deepep/ops/op_host/cam_moe_combine_normal.cpp
+++ b/csrc/deepep/ops/op_host/cam_moe_combine_normal.cpp
@@ -43,6 +43,12 @@ public:
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
 
+        this->Output("combine_send_cost_stats")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_INT32, ge::DT_INT32, ge::DT_INT32, ge::DT_INT32})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+
         this->Attr("ep_group_name").AttrType(REQUIRED).String();
         this->Attr("ep_world_size").AttrType(REQUIRED).Int();
         this->Attr("ep_rank_id").AttrType(REQUIRED).Int();

--- a/csrc/deepep/ops/op_host/cam_moe_combine_normal_tiling.cc
+++ b/csrc/deepep/ops/op_host/cam_moe_combine_normal_tiling.cc
@@ -54,6 +54,7 @@ constexpr uint32_t EP_RECV_COUNTS_INDEX = 2;
 constexpr uint32_t TOPK_WEIGHTS_INDEX = 3;
 constexpr uint32_t TP_RECV_COUNTS_INDEX = 4;
 constexpr uint32_t OUTPUT_X_INDEX = 0;
+constexpr uint32_t OUTPUT_SEND_COST_INDEX = 1;
 
 constexpr uint32_t ATTR_GROUP_EP_INDEX = 0;
 constexpr uint32_t ATTR_EP_WORLD_SIZE_INDEX = 1;
@@ -238,7 +239,7 @@ static bool CheckOptionalInputTensorDim(gert::TilingContext *context, const char
     return true;
 }
 
-static bool CheckOutputTensorDim(gert::TilingContext *context, const char *nodeName)
+static bool CheckOutputTensorDim(gert::TilingContext *context, const char *nodeName, const bool isEnableDiagnose)
 {
     const gert::StorageShape *xStorageShape = context->GetOutputShape(OUTPUT_X_INDEX);
     OP_TILING_CHECK(xStorageShape == nullptr, OP_LOGE(nodeName, "x is null."), return false);
@@ -249,10 +250,19 @@ static bool CheckOutputTensorDim(gert::TilingContext *context, const char *nodeN
     OP_LOGD(nodeName, "x dim0 = %ld", xStorageShape->GetStorageShape().GetDim(0));
     OP_LOGD(nodeName, "x dim1 = %ld", xStorageShape->GetStorageShape().GetDim(1));
 
+    if (isEnableDiagnose) {
+        const gert::StorageShape *sendCostStatsStorageShape = context->GetOutputShape(OUTPUT_SEND_COST_INDEX);
+        OP_TILING_CHECK(sendCostStatsStorageShape == nullptr, OP_LOGE(nodeName, "combine sendCostStatsShape is null."),
+                        return false);
+        OP_TILING_CHECK(sendCostStatsStorageShape->GetStorageShape().GetDimNum() != ONE_DIM,
+                        OP_LOGE(nodeName, "combine sendCostStatsShape must be 1-dimension, but got %lu dim",
+                                sendCostStatsStorageShape->GetStorageShape().GetDimNum()),
+                        return false);
+    }
     return true;
 }
 
-static bool CheckTensorDim(gert::TilingContext *context, const char *nodeName)
+static bool CheckTensorDim(gert::TilingContext *context, const char *nodeName, const bool isEnableDiagnose)
 {
     OP_TILING_CHECK(!CheckInputTensorDim(context, nodeName),
                     OP_LOGE(nodeName, "param shape of input tensor is invalid"), return false);
@@ -260,14 +270,14 @@ static bool CheckTensorDim(gert::TilingContext *context, const char *nodeName)
     OP_TILING_CHECK(!CheckOptionalInputTensorDim(context, nodeName),
                     OP_LOGE(nodeName, "param shape of optional input tensor is invalid"), return false);
 
-    OP_TILING_CHECK(!CheckOutputTensorDim(context, nodeName),
+    OP_TILING_CHECK(!CheckOutputTensorDim(context, nodeName, isEnableDiagnose),
                     OP_LOGE(nodeName, "param shape of output tensor is invalid"), return false);
 
     return true;
 }
 
 // 校验数据类型
-static bool CheckTensorDataType(gert::TilingContext *context, const char *nodeName)
+static bool CheckTensorDataType(gert::TilingContext *context, const char *nodeName, const bool isEnableDiagnose)
 {
     auto recvXDesc = context->GetInputDesc(RECV_X_INDEX);
     OP_TILING_CHECK(recvXDesc == nullptr, OP_LOGE(nodeName, "recvXDesc is null."), return false);
@@ -296,10 +306,20 @@ static bool CheckTensorDataType(gert::TilingContext *context, const char *nodeNa
     OP_TILING_CHECK((xDesc->GetDataType() != recvXDesc->GetDataType()),
                     OP_LOGE(nodeName, "x dataType is invalid, dataType should be equal to recvX dataType , but is "),
                     return false);
+
+    if (isEnableDiagnose) {
+        auto sendCostStatsDesc = context->GetOutputDesc(OUTPUT_SEND_COST_INDEX);
+        OP_TILING_CHECK(sendCostStatsDesc == nullptr, OP_LOGE(nodeName, "combine sendCostStatsDesc is null."),
+                        return false);
+        OP_TILING_CHECK(
+            sendCostStatsDesc->GetDataType() != ge::DT_INT32,
+            OP_LOGE(nodeName, "combine sendCostStatsDesc dataType is invalid, dataType should be int32, but is ."),
+            return false);
+    }
     return true;
 }
 
-static bool CheckTensorFormat(gert::TilingContext *context, const char *nodeName)
+static bool CheckTensorFormat(gert::TilingContext *context, const char *nodeName, const bool isEnableDiagnose)
 {
     auto recvXDesc = context->GetInputDesc(RECV_X_INDEX);
     OP_TILING_CHECK(recvXDesc == nullptr, OP_LOGE(nodeName, "recvXDesc is null."), return false);
@@ -330,6 +350,14 @@ static bool CheckTensorFormat(gert::TilingContext *context, const char *nodeName
     OP_TILING_CHECK(static_cast<ge::Format>(ge::GetPrimaryFormat(xDesc->GetStorageFormat())) == ge::FORMAT_FRACTAL_NZ,
                     OP_LOGE(nodeName, "xFormat is invalid"), return false);
 
+    if (isEnableDiagnose) {
+        auto sendCostStatsDesc = context->GetOutputDesc(OUTPUT_SEND_COST_INDEX);
+        OP_TILING_CHECK(sendCostStatsDesc == nullptr, OP_LOGE(nodeName, "combine sendCostStatsDesc is null."),
+                        return false);
+        OP_TILING_CHECK(static_cast<ge::Format>(ge::GetPrimaryFormat(sendCostStatsDesc->GetStorageFormat())) ==
+                            ge::FORMAT_FRACTAL_NZ,
+                        OP_LOGE(nodeName, "combine sendCostStatsDesc format is invalid"), return false);
+    }
     return true;
 }
 
@@ -435,17 +463,18 @@ static bool CheckAttrs(gert::TilingContext *context, CamMoeCombineNormalTilingDa
     return true;
 }
 
-static ge::graphStatus TilingCheckCamMoeCombineNormal(gert::TilingContext *context, const char *nodeName)
+static ge::graphStatus TilingCheckCamMoeCombineNormal(gert::TilingContext *context, const char *nodeName,
+                                                      const bool isEnableDiagnose)
 {
     // 检查参数shape信息
-    OP_TILING_CHECK(!CheckTensorDim(context, nodeName), OP_LOGE(nodeName, "param shape is invalid"),
+    OP_TILING_CHECK(!CheckTensorDim(context, nodeName, isEnableDiagnose), OP_LOGE(nodeName, "param shape is invalid"),
                     return ge::GRAPH_FAILED);
     // 检查参数dataType信息
-    OP_TILING_CHECK(!CheckTensorDataType(context, nodeName), OP_LOGE(nodeName, "param dataType is invalid"),
-                    return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(!CheckTensorDataType(context, nodeName, isEnableDiagnose),
+                    OP_LOGE(nodeName, "param dataType is invalid"), return ge::GRAPH_FAILED);
     // 检查参数format信息
-    OP_TILING_CHECK(!CheckTensorFormat(context, nodeName), OP_LOGE(nodeName, "param Format is invalid"),
-                    return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(!CheckTensorFormat(context, nodeName, isEnableDiagnose),
+                    OP_LOGE(nodeName, "param Format is invalid"), return ge::GRAPH_FAILED);
     return ge::GRAPH_SUCCESS;
 }
 
@@ -493,8 +522,11 @@ static ge::graphStatus CamMoeCombineNormalA3TilingFuncImpl(gert::TilingContext *
     OP_TILING_CHECK(GetAttrAndSetTilingData(context, *tilingData, nodeName, groupEp, groupTp) == ge::GRAPH_FAILED,
                     OP_LOGE(nodeName, "Getting attr failed."), return ge::GRAPH_FAILED);
 
+    auto sendCostStatsStorageShape = context->GetOutputShape(OUTPUT_SEND_COST_INDEX);
+    bool isEnableDiagnose = (sendCostStatsStorageShape != nullptr);
+    tilingData->camMoeCombineNormalInfo.isEnableDiagnose = isEnableDiagnose;
     // 检查输入输出的dim、format、dataType
-    OP_TILING_CHECK(TilingCheckCamMoeCombineNormal(context, nodeName) != ge::GRAPH_SUCCESS,
+    OP_TILING_CHECK(TilingCheckCamMoeCombineNormal(context, nodeName, isEnableDiagnose) != ge::GRAPH_SUCCESS,
                     OP_LOGE(nodeName, "Tiling check params failed"), return ge::GRAPH_FAILED);
 
     // 检查属性的取值是否合法

--- a/csrc/deepep/ops/op_host/cam_moe_dispatch_normal.cpp
+++ b/csrc/deepep/ops/op_host/cam_moe_dispatch_normal.cpp
@@ -62,6 +62,12 @@ public:
             .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
 
+        this->Output("dispatch_wait_recv_cost_stats")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_INT32, ge::DT_INT32, ge::DT_INT32, ge::DT_INT32})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+
         this->Attr("group_ep").AttrType(REQUIRED).String();
         this->Attr("ep_world_size").AttrType(REQUIRED).Int();
         this->Attr("ep_rank_id").AttrType(REQUIRED).Int();

--- a/csrc/deepep/ops/op_host/cam_moe_dispatch_normal_tiling.cc
+++ b/csrc/deepep/ops/op_host/cam_moe_dispatch_normal_tiling.cc
@@ -59,6 +59,7 @@ constexpr uint32_t RECV_COUNT_INDEX = 5U;
 constexpr uint32_t OUTPUT_EXPAND_X_INDEX = 0U;
 constexpr uint32_t OUTPUT_DYNAMIC_SCALES_INDEX = 1U;
 constexpr uint32_t OUTPUT_ASSIST_INFO_INDEX = 2U;
+constexpr uint32_t OUTPUT_WAIT_RECV_COST_INDEX = 3U;
 
 constexpr uint32_t ATTR_GROUP_EP_INDEX = 0;
 constexpr uint32_t ATTR_EP_WORLD_SIZE_INDEX = 1;
@@ -122,7 +123,8 @@ static void PrintTilingDataInfo(const char *nodeName, CamMoeDispatchNormalTiling
     OP_LOGD(nodeName, "totalWinSize is %lu.", tilingData.camMoeDispatchNormalInfo.totalWinSize);
 }
 
-static bool CheckTensorDim(gert::TilingContext *context, const char *nodeName, const uint32_t quantMode)
+static bool CheckTensorDim(gert::TilingContext *context, const char *nodeName, const uint32_t quantMode,
+                           const bool isEnableDiagnose)
 {
     const gert::StorageShape *xStorageShape = context->GetInputShape(X_INDEX);
     OP_TILING_CHECK(xStorageShape == nullptr, OP_LOGE(nodeName, "xShape is null."), return false);
@@ -172,10 +174,21 @@ static bool CheckTensorDim(gert::TilingContext *context, const char *nodeName, c
                     return false);
     OP_LOGD(nodeName, "assistInfoForCombine dim0 = %ld", assistInfoStorageShape->GetStorageShape().GetDim(0));
 
+    if (isEnableDiagnose) {
+        const gert::StorageShape *waitRecvcostStatsStorageShape = context->GetOutputShape(OUTPUT_WAIT_RECV_COST_INDEX);
+        OP_TILING_CHECK(waitRecvcostStatsStorageShape == nullptr,
+                        OP_LOGE(nodeName, "dispatch waitRecvCostStatsShape is null."), return false);
+        OP_TILING_CHECK(waitRecvcostStatsStorageShape->GetStorageShape().GetDimNum() != ONE_DIM,
+                        OP_LOGE(nodeName, "dispatch waitRecvCostStatsShape dim must be 1, but current dim num is %lu.",
+                                waitRecvcostStatsStorageShape->GetStorageShape().GetDimNum()),
+                        return false);
+    }
+
     return true;
 }
 
-static bool CheckTensorDataType(gert::TilingContext *context, const char *nodeName, const uint32_t quantMode)
+static bool CheckTensorDataType(gert::TilingContext *context, const char *nodeName, const uint32_t quantMode,
+                                const bool isEnableDiagnose)
 {
     auto xDesc = context->GetInputDesc(X_INDEX);
     OP_TILING_CHECK(xDesc == nullptr, OP_LOGE(nodeName, "xDesc is null."), return false);
@@ -216,10 +229,21 @@ static bool CheckTensorDataType(gert::TilingContext *context, const char *nodeNa
                     OP_LOGE(nodeName, "assistInfoForCombine dataType is invalid, dataType should be int32, but is ."),
                     return false);
 
+    if (isEnableDiagnose) {
+        auto waitRecvCostStatsDesc = context->GetOutputDesc(OUTPUT_WAIT_RECV_COST_INDEX);
+        OP_TILING_CHECK(waitRecvCostStatsDesc == nullptr, OP_LOGE(nodeName, "dispatch waitRecvCostStatsDesc is null."),
+                        return false);
+        OP_TILING_CHECK(
+            waitRecvCostStatsDesc->GetDataType() != ge::DT_INT32,
+            OP_LOGE(nodeName, "dispatch waitRecvCostStatsDesc dataType is invalid, dataType should be int32, but is ."),
+            return false);
+    }
+
     return true;
 }
 
-static bool CheckTensorFormat(gert::TilingContext *context, const char *nodeName, const uint32_t quantMode)
+static bool CheckTensorFormat(gert::TilingContext *context, const char *nodeName, const uint32_t quantMode,
+                              const bool isEnableDiagnose)
 {
     auto xDesc = context->GetInputDesc(X_INDEX);
     OP_TILING_CHECK(xDesc == nullptr, OP_LOGE(nodeName, "xDesc is null."), return false);
@@ -251,6 +275,15 @@ static bool CheckTensorFormat(gert::TilingContext *context, const char *nodeName
     OP_TILING_CHECK(
         static_cast<ge::Format>(ge::GetPrimaryFormat(assistInfoDesc->GetStorageFormat())) == ge::FORMAT_FRACTAL_NZ,
         OP_LOGE(nodeName, "assistInfoForCombine format is invalid."), return false);
+
+    if (isEnableDiagnose) {
+        auto waitRecvCostStatsDesc = context->GetOutputDesc(OUTPUT_WAIT_RECV_COST_INDEX);
+        OP_TILING_CHECK(waitRecvCostStatsDesc == nullptr, OP_LOGE(nodeName, "dispatch waitRecvCostStatsDesc is null."),
+                        return false);
+        OP_TILING_CHECK(static_cast<ge::Format>(ge::GetPrimaryFormat(waitRecvCostStatsDesc->GetStorageFormat())) ==
+                            ge::FORMAT_FRACTAL_NZ,
+                        OP_LOGE(nodeName, "dispatch waitRecvCostStatsDesc format is invalid"), return false);
+    }
 
     return true;
 }
@@ -448,14 +481,14 @@ static ge::graphStatus CheckTensorShape(gert::TilingContext *context, const char
 }
 
 static ge::graphStatus TilingCheckCamMoeDispatchNormal(gert::TilingContext *context, const char *nodeName,
-                                                       const uint32_t quantMode)
+                                                       const uint32_t quantMode, const bool isEnableDiagnose)
 {
-    OP_TILING_CHECK(!CheckTensorDim(context, nodeName, quantMode), OP_LOGE(nodeName, "params shape is invalid."),
-                    return ge::GRAPH_FAILED);
-    OP_TILING_CHECK(!CheckTensorDataType(context, nodeName, quantMode),
+    OP_TILING_CHECK(!CheckTensorDim(context, nodeName, quantMode, isEnableDiagnose),
+                    OP_LOGE(nodeName, "params shape is invalid."), return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(!CheckTensorDataType(context, nodeName, quantMode, isEnableDiagnose),
                     OP_LOGE(nodeName, "params dataType is invalid."), return ge::GRAPH_FAILED);
-    OP_TILING_CHECK(!CheckTensorFormat(context, nodeName, quantMode), OP_LOGE(nodeName, "params format is invalid."),
-                    return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(!CheckTensorFormat(context, nodeName, quantMode, isEnableDiagnose),
+                    OP_LOGE(nodeName, "params format is invalid."), return ge::GRAPH_FAILED);
 
     return ge::GRAPH_SUCCESS;
 }
@@ -517,9 +550,14 @@ static ge::graphStatus CamMoeDispatchNormalA3TilingFuncImpl(gert::TilingContext 
 
     quantMode = tilingData->camMoeDispatchNormalInfo.quantMode;
 
+    auto waitRecvcostStatsStorageShape = context->GetOutputShape(OUTPUT_WAIT_RECV_COST_INDEX);
+    bool isEnableDiagnose = (waitRecvcostStatsStorageShape != nullptr);
+    tilingData->camMoeDispatchNormalInfo.isEnableDiagnose = isEnableDiagnose;
+
     // 检查输入输出的dim、format、dataType
-    OP_TILING_CHECK(TilingCheckCamMoeDispatchNormal(context, nodeName, quantMode) != ge::GRAPH_SUCCESS,
-                    OP_LOGE(nodeName, "Tiling check param failed."), return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(
+        TilingCheckCamMoeDispatchNormal(context, nodeName, quantMode, isEnableDiagnose) != ge::GRAPH_SUCCESS,
+        OP_LOGE(nodeName, "Tiling check param failed."), return ge::GRAPH_FAILED);
 
     // 检查属性的取值是否合法
     OP_TILING_CHECK(CheckAttrs(context, nodeName, *tilingData, localMoeExpertNum) != ge::GRAPH_SUCCESS,

--- a/csrc/deepep/ops/op_host/op_api/aclnn_cam_moe_combine_normal.cpp
+++ b/csrc/deepep/ops/op_host/op_api/aclnn_cam_moe_combine_normal.cpp
@@ -19,12 +19,14 @@ aclnnStatus aclnnCamMoeCombineNormalGetWorkspaceSize(const aclTensor *recvX, con
                                                      const aclTensor *tpRecvCountsOptional, char *epGroupName,
                                                      int64_t epWorldSize, int64_t epRankId, char *tpGroupNameOptional,
                                                      int64_t tpWorldSize, int64_t tpRankId, int64_t moeExpertNum,
-                                                     int64_t globalBs, const aclTensor *out, uint64_t *workspaceSize,
+                                                     int64_t globalBs, const aclTensor *out,
+                                                     const aclTensor *sendCostStats, uint64_t *workspaceSize,
                                                      aclOpExecutor **executor)
 {
-    return aclnnInnerCamMoeCombineNormalGetWorkspaceSize(
-        recvX, tokenSrcInfo, epRecvCounts, recvTopkWeights, tpRecvCountsOptional, epGroupName, epWorldSize, epRankId,
-        tpGroupNameOptional, tpWorldSize, tpRankId, moeExpertNum, globalBs, out, workspaceSize, executor);
+    return aclnnInnerCamMoeCombineNormalGetWorkspaceSize(recvX, tokenSrcInfo, epRecvCounts, recvTopkWeights,
+                                                         tpRecvCountsOptional, epGroupName, epWorldSize, epRankId,
+                                                         tpGroupNameOptional, tpWorldSize, tpRankId, moeExpertNum,
+                                                         globalBs, out, sendCostStats, workspaceSize, executor);
 }
 
 aclnnStatus aclnnCamMoeCombineNormal(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,

--- a/csrc/deepep/ops/op_host/op_api/aclnn_cam_moe_combine_normal.h
+++ b/csrc/deepep/ops/op_host/op_api/aclnn_cam_moe_combine_normal.h
@@ -29,7 +29,8 @@ __attribute__((visibility("default"))) aclnnStatus aclnnCamMoeCombineNormalGetWo
     const aclTensor *recvX, const aclTensor *tokenSrcInfo, const aclTensor *epRecvCounts,
     const aclTensor *recvTopkWeights, const aclTensor *tpRecvCountsOptional, char *epGroupName, int64_t epWorldSize,
     int64_t epRankId, char *tpGroupNameOptional, int64_t tpWorldSize, int64_t tpRankId, int64_t moeExpertNum,
-    int64_t globalBs, const aclTensor *out, uint64_t *workspaceSize, aclOpExecutor **executor);
+    int64_t globalBs, const aclTensor *out, const aclTensor *sendCostStats, uint64_t *workspaceSize,
+    aclOpExecutor **executor);
 
 /* function: aclnnMoeCombine
  * workspace : workspace memory addr(input).

--- a/csrc/deepep/ops/op_host/op_api/aclnn_cam_moe_dispatch_normal.cpp
+++ b/csrc/deepep/ops/op_host/op_api/aclnn_cam_moe_dispatch_normal.cpp
@@ -19,12 +19,12 @@ aclnnStatus aclnnCamMoeDispatchNormalGetWorkspaceSize(
     const aclTensor *recvOffset, const aclTensor *recvCount, char *groupEp, int64_t epWorldSize, int64_t epRankId,
     char *groupTpOptional, int64_t tpWorldSize, int64_t tpRankId, int64_t moeExpertNum, int64_t quantMode,
     int64_t globalBs, const aclTensor *recvX, const aclTensor *recvXScales, const aclTensor *assistInfoForCombine,
-    uint64_t *workspaceSize, aclOpExecutor **executor)
+    const aclTensor *waitRecvCostStats, uint64_t *workspaceSize, aclOpExecutor **executor)
 {
-    return aclnnInnerCamMoeDispatchNormalGetWorkspaceSize(x, topkIdx, sendOffset, sendTokenIdx, recvOffset, recvCount,
-                                                          groupEp, epWorldSize, epRankId, groupTpOptional, tpWorldSize,
-                                                          tpRankId, moeExpertNum, quantMode, globalBs, recvX,
-                                                          recvXScales, assistInfoForCombine, workspaceSize, executor);
+    return aclnnInnerCamMoeDispatchNormalGetWorkspaceSize(
+        x, topkIdx, sendOffset, sendTokenIdx, recvOffset, recvCount, groupEp, epWorldSize, epRankId, groupTpOptional,
+        tpWorldSize, tpRankId, moeExpertNum, quantMode, globalBs, recvX, recvXScales, assistInfoForCombine,
+        waitRecvCostStats, workspaceSize, executor);
 }
 
 aclnnStatus aclnnCamMoeDispatchNormal(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,

--- a/csrc/deepep/ops/op_host/op_api/aclnn_cam_moe_dispatch_normal.h
+++ b/csrc/deepep/ops/op_host/op_api/aclnn_cam_moe_dispatch_normal.h
@@ -12,7 +12,7 @@ __attribute__((visibility("default"))) aclnnStatus aclnnCamMoeDispatchNormalGetW
     const aclTensor *recvOffset, const aclTensor *recvCount, char *groupEp, int64_t epWorldSize, int64_t epRankId,
     char *groupTpOptional, int64_t tpWorldSize, int64_t tpRankId, int64_t moeExpertNum, int64_t quantMode,
     int64_t globalBs, const aclTensor *recvX, const aclTensor *recvXScales, const aclTensor *assistInfoForCombine,
-    uint64_t *workspaceSize, aclOpExecutor **executor);
+    const aclTensor *waitRecvCostStats, uint64_t *workspaceSize, aclOpExecutor **executor);
 
 __attribute__((visibility("default"))) aclnnStatus aclnnCamMoeDispatchNormal(void *workspace, uint64_t workspaceSize,
                                                                              aclOpExecutor *executor,

--- a/csrc/deepep/ops/op_kernel/cam_moe_combine_normal.cpp
+++ b/csrc/deepep/ops/op_kernel/cam_moe_combine_normal.cpp
@@ -7,7 +7,8 @@ using namespace CamMoeCombineNormalImpl;
 
 extern "C" __global__ __aicore__ void cam_moe_combine_normal(GM_ADDR recvX, GM_ADDR tokenSrcInfo, GM_ADDR epRecvCount,
                                                              GM_ADDR topkWeights, GM_ADDR tpRecvCount, GM_ADDR XOut,
-                                                             GM_ADDR workspaceGM, GM_ADDR tilingGM)
+                                                             GM_ADDR sendCostStatsOut, GM_ADDR workspaceGM,
+                                                             GM_ADDR tilingGM)
 
 {
     REGISTER_TILING_DEFAULT(CamMoeCombineNormalTilingData);
@@ -16,7 +17,8 @@ extern "C" __global__ __aicore__ void cam_moe_combine_normal(GM_ADDR recvX, GM_A
 #if (ORIG_DTYPE_RECV_X == DT_BF16 || ORIG_DTYPE_RECV_X == DT_FLOAT16)
     GET_TILING_DATA_WITH_STRUCT(CamMoeCombineNormalTilingData, tilingData, tilingGM);
     CamMoeCombineNormal<DTYPE_RECV_X, DTYPE_X, int32_t> op;
-    op.Init(recvX, tokenSrcInfo, epRecvCount, topkWeights, tpRecvCount, XOut, workspaceGM, &pipe, &tilingData);
+    op.Init(recvX, tokenSrcInfo, epRecvCount, topkWeights, tpRecvCount, XOut, sendCostStatsOut, workspaceGM, &pipe,
+            &tilingData);
     op.Process();
 #endif
 }

--- a/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_tiling.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_tiling.h
@@ -22,6 +22,7 @@ struct CamMoeCombineNormalInfo {
     uint64_t totalWinSize;
     float armAvgFactor;
     float epsilon;
+    bool isEnableDiagnose;
 };
 struct CamMoeCombineNormalTilingData {
     Mc2InitTiling mc2InitTiling;

--- a/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal.cpp
+++ b/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal.cpp
@@ -12,7 +12,8 @@ extern "C" __global__ __aicore__ void cam_moe_dispatch_normal(GM_ADDR x, GM_ADDR
                                                               GM_ADDR send_token_idx, GM_ADDR recv_offset,
                                                               GM_ADDR recv_count, GM_ADDR expandXOut,
                                                               GM_ADDR dynamicScalesOut, GM_ADDR assist_info_for_combine,
-                                                              GM_ADDR workspaceGM, GM_ADDR tilingGM)
+                                                              GM_ADDR waitRecvCostStatsOut, GM_ADDR workspaceGM,
+                                                              GM_ADDR tilingGM)
 {
     REGISTER_TILING_DEFAULT(CamMoeDispatchNormalTilingData);
     TPipe pipe;
@@ -21,7 +22,7 @@ extern "C" __global__ __aicore__ void cam_moe_dispatch_normal(GM_ADDR x, GM_ADDR
         GET_TILING_DATA_WITH_STRUCT(CamMoeDispatchNormalTilingData, tilingData, tilingGM);
         CamMoeDispatchNormal<DTYPE_X, DTYPE_RECV_X, false, false, false> op;
         op.Init(x, expertIds, send_offset, send_token_idx, recv_offset, recv_count, expandXOut, dynamicScalesOut,
-                assist_info_for_combine, workspaceGM, &pipe, &tilingData);
+                assist_info_for_combine, waitRecvCostStatsOut, workspaceGM, &pipe, &tilingData);
         op.Process();
         return;
     }
@@ -30,7 +31,7 @@ extern "C" __global__ __aicore__ void cam_moe_dispatch_normal(GM_ADDR x, GM_ADDR
         GET_TILING_DATA_WITH_STRUCT(CamMoeDispatchNormalTilingData, tilingData, tilingGM);
         CamMoeDispatchNormal<DTYPE_X, DTYPE_RECV_X, true, false, false> op;
         op.Init(x, expertIds, send_offset, send_token_idx, recv_offset, recv_count, expandXOut, dynamicScalesOut,
-                assist_info_for_combine, workspaceGM, &pipe, &tilingData);
+                assist_info_for_combine, waitRecvCostStatsOut, workspaceGM, &pipe, &tilingData);
         op.Process();
         return;
     }

--- a/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal_tiling.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal_tiling.h
@@ -14,6 +14,7 @@ struct CamMoeDispatchNormalInfo {
     uint32_t h;             // h
     uint32_t aivNum;        // aivNum
     bool isQuant;           // whether quant or not
+    bool isEnableDiagnose;  // whether enable diagnose or not
     bool reserved2;         // reserved
     bool reserved3;         // reserved
     uint64_t totalUbSize;   // epWorldSize


### PR DESCRIPTION
### Introduce
This feature is primarily used to detect slow anomalies in the dispatch and combine communications within super nodes.(Reference [#311](https://github.com/deepseek-ai/DeepEP/pull/311))
It maintains a statistical matrix of average receive/send wait times: `Matrix[src_rank, dst_rank]`, where each row represents a source rank and each column represents a destination rank.
Specifically:
- The **dispatch** phase records the cumulative time each rank waits to **receive** tokens from other ranks.
- The **combine** phase records the cumulative time each rank spends **sending** tokens to other ranks.

### Usage
- When invoking the `dispatch` operator, pass a tensor named `dispatch_wait_recv_cost_stats` with a size of `num_ranks`.
- When invoking the `combine` operator, pass a tensor named `combine_send_cost_stats` with a size of `num_ranks`.
The waiting time for receiving/sending will be stored in `dispatch_wait_recv_cost_stats` and `combine_send_cost_stats`.

Then use the `diagnose_matrix` interface in `utils.py` to calculate the rank of the anomaly.
```py
def diagnose_matrix(
    mat,
    thres_col=3.0,
    thres_row=3.0,
    thres_point=5.0,
    suppress_points_in_strong_rowscols=True,
):
    ......
    return {
        "abnormal_cols": abnormal_cols,
        "abnormal_rows": abnormal_rows,
        "abnormal_points": abnormal_points,
    }
```

### Test
``` sh
python3 tests/python/deepep/test_intranode.py --enable-diagnose
```
Exapmle, set `thres_col=1.5, thres_row=1.5, thres_point=1.5,`
#### dispatch phase:
```sh
Dispatch wait recv cost stats:
tensor([[148845, 148189, 148516, 148917, 149175, 148609, 149042, 148811, 148254,
         148008, 146934, 146877, 147090, 147280, 148317, 148802],
        [240242, 241228, 241062, 241474, 241554, 240883, 241086, 241024, 240456,
         239860, 239368, 239191, 239388, 239835, 240636, 241514],
        [ 45442,  45366,  44954,  45977,  45931,  45695,  46021,  45750,  45697,
          45162,  44936,  44789,  44868,  45008,  45422,  45949],
        [ 11140,  11426,  11561,  11026,  11676,  11420,  11483,  11832,  12081,
          11950,  11967,  11922,  11587,  11169,  11304,  11705],
        [ 83886,  84607,  84710,  84953,  83828,  84524,  84867,  84652,  84224,
          83438,  82855,  82966,  82970,  83433,  83871,  84772],
        [185506, 185759, 186452, 186777, 186820, 186829, 186591, 186585, 185800,
         185113, 184907, 184779, 185300, 185426, 186420, 186875],
        [  7645,   7618,   7595,   8124,   7528,   7554,   7579,   7601,   7886,
           7863,   7955,   7904,   7878,   7605,   7524,   7527],
        [ 21623,  21667,  21708,  22076,  21894,  21682,  21439,  21199,  22296,
          22129,  22211,  22162,  21832,  21554,  21535,  21750],
        [ 96494,  96721,  97053,  97367,  97448,  97107,  97435,  97041,  97332,
          96661,  96218,  96125,  96277,  96447,  97058,  97533],
        [119295, 119816, 120021, 120098, 120300, 119958, 120291, 120264, 120291,
         120341, 119125, 118995, 119060, 119290, 119858, 120357],
        [ 30058,  30362,  30790,  31232,  31321,  30845,  31011,  31000,  30801,
          30036,  30816,  29784,  29867,  30126,  30843,  31290],
        [ 71937,  72230,  72502,  72596,  72577,  72504,  72557,  72633,  72734,
          72443,  72361,  72867,  72308,  72199,  72428,  72626],
        [ 27953,  28087,  28163,  28825,  28389,  28169,  28187,  28117,  28279,
          27957,  27800,  27879,  28065,  27840,  28082,  28213],
        [235805, 236157, 236579, 237217, 237379, 236157, 236902, 237044, 236624,
         235669, 235336, 234708, 234761, 236550, 235884, 237156],
        [ 19989,  20316,  20501,  20995,  20905,  20428,  20690,  20461,  20383,
          19853,  19794,  19750,  19749,  20279,  20317,  20787],
        [ 36047,  35886,  36091,  36106,  36167,  36144,  36098,  36205,  36308,
          36053,  36103,  36243,  36171,  35978,  36202,  36319]],
       device='npu:0', dtype=torch.int32)
```
Calculated abnormal ranks:
```sh
[Diagnose Dispatch wait recv cost] 
abnormal_rows [[0, 148229.125, 1.7111639000711096], [1, 240550.0625, 2.7769210882803845], [5, 185996.1875, 2.14714862278825], [13, 236245.5, 2.7272290189546036]], 
abnormal_cols [], 
abnormal_points []
```
#### combine phase:
```sh
Combine send cost stats:
tensor([[ 17535,  67014, 501899, 394013, 380369, 421478, 683155, 592656, 425904,
         403497, 414773, 514238, 724636, 708598, 437623, 394191],
        [ 60848,  15988, 502524, 474103, 513227, 420470, 539840, 485127, 464411,
         415381, 365740, 450094, 651227, 522109, 400606, 363934],
        [491042, 483476,   9967,  56094, 442099, 495325, 497743, 463416, 457214,
         412039, 388844, 479295, 469587, 457530, 428783, 352615],
        [510904, 510450,  62957,  13052, 429710, 480017, 512519, 392768, 393602,
         374604, 375297, 538673, 549245, 416121, 360176, 321353],
        [399463, 617925, 543199, 454542,  12542,  65434, 614647, 424236, 398032,
         388118, 329475, 481818, 758660, 564984, 382908, 330476],
        [478183, 578249, 585834, 523876,  66545,  15937, 784692, 577432, 436999,
         393947, 363914, 445326, 726018, 710072, 436198, 403622],
        [464003, 609982, 501194, 402355, 306554, 321554,  15766,  64817, 459165,
         437715, 432248, 571087, 713795, 506062, 342844, 288210],
        [479972, 512734, 474235, 423101, 391073, 437962,  60894,  11336, 448688,
         469527, 456334, 475064, 512557, 463246, 395979, 348762],
        [527042, 592813, 461439, 375299, 362390, 466999, 593294, 442352,  13326,
          62114, 460688, 587821, 678208, 437098, 320981, 355646],
        [558229, 662661, 570484, 479456, 336138, 440521, 743352, 534235,  61249,
          13436, 430387, 579100, 821487, 718146, 411456, 386770],
        [435739, 613712, 583898, 478798, 315877, 361587, 721543, 519360, 429456,
         389244,  12301,  68793, 876324, 615263, 376605, 358820],
        [517460, 597047, 592513, 486437, 323178, 395890, 762980, 579128, 420911,
         393029,  67082,  26066, 868488, 581504, 382181, 332309],
        [553443, 484408, 526832, 489950, 411433, 440452, 500062, 495189, 511627,
         430218, 403097, 516341,  10905,  58856, 482921, 509737],
        [545272, 500621, 481087, 422905, 387628, 459312, 499742, 466025, 458888,
         391166, 419738, 543670,  60611,  12215, 436960, 484767],
        [560601, 660786, 570498, 412770, 318250, 437199, 721577, 472127, 372920,
         354698, 422344, 537366, 826942, 683831,  10575,  66856],
        [521747, 593666, 606340, 518684, 361110, 425254, 726548, 621850, 482865,
         432528, 374748, 476399, 739924, 756717,  71028,  17964]],
       device='npu:0', dtype=torch.int32)
```
Calculated abnormal ranks:
```sh
[Diagnose Combine send cost] 
abnormal_rows [], 
abnormal_cols [], 
abnormal_points [[0, 6, 683155, 1.5760364591299412], [0, 12, 724636, 1.671732997047645], [0, 13, 708598, 1.6347333809553586], [1, 12, 651227, 1.5023786624848157], [4, 12, 758660, 1.750226259170351], [5, 6, 784692, 1.810282002162894], [5, 12, 726018, 1.6749212667470803], [5, 13, 710072, 1.6381338943685044], [6, 12, 713795, 1.6467228437831185], [8, 12, 678208, 1.564623745524221], [9, 1, 662661, 1.5287568649040202], [9, 6, 743352, 1.7149107508064203], [9, 12, 821487, 1.895167952662687], [9, 13, 718146, 1.6567605872434963], [10, 6, 721543, 1.664597455672571], [10, 12, 876324, 2.0216767410186365], [11, 6, 762980, 1.760192485727196], [11, 12, 868488, 2.003599113403026], [14, 1, 660786, 1.524431245738723], [14, 6, 721577, 1.6646758935667683], [14, 12, 826942, 1.9077526206875919], [14, 13, 683831, 1.5775959890263362], [15, 6, 726548, 1.6761439750978042], [15, 12, 739924, 1.707002365473813], [15, 13, 756717, 1.745743764216659]]
```

### Performance
1. Disable diagnosis:
```sh
[tuning] Dispatch (BF16) 114.91 GB/s (HCCS), avg_t: 4067.52 us
[tuning] Combine 100.52 GB/s (HCCS), avg_t: 4649.90 us
```
2. Enable diagnosis
```sh
[tuning] Dispatch (BF16) 114.22 GB/s (HCCS), avg_t: 4091.92 us
[tuning] Combine 99.57 GB/s (HCCS), avg_t: 4693.97 us
```
After multiple tests, the performance loss during the dispatch and combine stages is less than 1%.

