### PR TITLE
feat:add env var to switch quant

### DIFF
--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -289,7 +289,7 @@ class Buffer:
         if isinstance(x, tuple):
             raise NotImplementedError("Not support fp8")
         x_scales = None
-        use_quant = os.getenv('DEEP_NORMAL_MODE_USE_INT8_QUANT') == '1'
+        use_quant = os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT") == "1"
 
         if handle is not None:
             raise NotImplementedError(

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -289,9 +289,7 @@ class Buffer:
         if isinstance(x, tuple):
             raise NotImplementedError("Not support fp8")
         x_scales = None
-        use_quant = False
-        if os.getenv('DEEP_NORMAL_MODE_USE_INT8_QUANT') == '1':
-            use_quant = True
+        use_quant = os.getenv('DEEP_NORMAL_MODE_USE_INT8_QUANT') == '1'
 
         if handle is not None:
             raise NotImplementedError(

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -289,7 +289,9 @@ class Buffer:
         if isinstance(x, tuple):
             raise NotImplementedError("Not support fp8")
         x_scales = None
-        use_quant = True
+        use_quant = False
+        if os.getenv('DEEP_NORMAL_MODE_USE_INT8_QUANT') == '1':
+            use_quant = True
 
         if handle is not None:
             raise NotImplementedError(


### PR DESCRIPTION
normal mode use bf16 by default， use `export DEEP_NORMAL_MODE_USE_INT8_QUANT=1` to enable the INT8 quant