### PR TITLE
Fix the severe performance degradation issue of the top9 dispatch in normal mode compared to top8.

### DIFF
--- a/tests/python/deepep/test_intranode.py
+++ b/tests/python/deepep/test_intranode.py
@@ -245,7 +245,7 @@ def test_main(
     for current_x in filter(lambda elem: elem is not None, (x_pure_rand, x)):
         if local_rank == 0:
             print(
-                f'[testing] Running with {"FP8" if isinstance(current_x, tuple) else "BF16"}, with top-k ...',
+                f'[testing] Running with {"FP8" if isinstance(current_x, tuple) else "BF16"}, with top-k {num_topk} ...',
                 flush=True,
             )
         dispatch_args = {


### PR DESCRIPTION
Fix the severe performance degradation issue of the top9 dispatch in normal mode compared to top8.

- Before
[tuning] Dispatch (BF16) 24.28 GB/s (HCCS), avg_t: 21694.41 us
- Now:
[tuning] Dispatch (BF16) 87.82 GB/s (HCCS), avg_t: 5997.77 us