### PR TITLE
Support different token hidden sizes and gmm hidden sizes [FusedDeepMoe Operator]

### DIFF
--- a/csrc/deepep/ops/op_kernel/fused_deep_moe_tiling.h
+++ b/csrc/deepep/ops/op_kernel/fused_deep_moe_tiling.h
@@ -28,6 +28,7 @@ struct FusedDeepMoeInfo {
     uint32_t aivNum;               // aivNum
     uint64_t totalUbSize;
     uint64_t totalWinSize;
+    uint64_t gmm1HLen;
 };
 
 struct FusedDeepMoeTilingData {

--- a/csrc/deepep/ops/utils/op_kernel/operator/cam_moe_distribute_combine/op_kernel/a3/cam_moe_distribute_combine.h
+++ b/csrc/deepep/ops/utils/op_kernel/operator/cam_moe_distribute_combine/op_kernel/a3/cam_moe_distribute_combine.h
@@ -607,6 +607,7 @@ __aicore__ inline void CamMoeDistributeCombine<TemplateMC2TypeFunc>::WaitDispatc
         LocalTensor<float> gatherMaskOutTensor = gatherMaskOutBuf_.Get<float>();
         LocalTensor<uint32_t> gatherTmpTensor = gatherTmpBuf_.Get<uint32_t>();
         LocalTensor<float> statusSumOutTensor = statusSumOutBuf_.Get<float>();
+        PipeBarrier<PIPE_ALL>();
 
         gatherTmpTensor.SetValue(0, 1);
         uint32_t mask = 1;  // gatherMask + sum


### PR DESCRIPTION
Support different token hidden sizes and gmm hidden sizes [FusedDeepMoe Operator]
Change 1: supported x token length, from 7168 only -> [512, 7168]
Change 2: supported Gmm1 output dim, from 4096 only -> [1024, 6144] (Gmm2 input dim, from 2048 only -> [512, 3072])