### PR TITLE
refactor: make hiddenStateDim a class member in MlaTilingData, Follow up closed PR#82

### DIFF
--- a/csrc/mla_preprocess/op_kernel/mla_preprocess_kernel.cpp
+++ b/csrc/mla_preprocess/op_kernel/mla_preprocess_kernel.cpp
@@ -38,6 +38,7 @@ extern "C" __global__ __aicore__ void mla_preprocess(
 
     mlaTilingData.tilingKey = tilingData->tilingKey;
     mlaTilingData.n = tilingData->n;
+    mlaTilingData.hiddenStateDim = tilingData->hiddenStateDim;
 
     mlaTilingData.mm1.numBatch = tilingData->mm1.numBatch;
     mlaTilingData.mm1.m = tilingData->mm1.m;


### PR DESCRIPTION
This PR refactors the mla_preprocess host code by making hiddenStateDim a class member variable instead of passing it through function arguments.
- Follows up on the previously closed PR #82
- Reduces parameter clutter and improves code readability