### PR TITLE
Supports running the Longcat model with topk=-1 on A2 CANN 8.3

### DIFF
--- a/csrc/deepep/deep_ep.cpp
+++ b/csrc/deepep/deep_ep.cpp
@@ -65,7 +65,7 @@ Buffer::get_dispatch_layout(const torch::Tensor &topk_idx, int num_experts, std:
         }
         int topk = static_cast<int>(topk_idx.size(1));
         for (int i = 0; i < this->padding_cnt; i++) {
-            at::Tensor tmp_topk = torch::randperm(num_experts, topk_idx.options()).slice(0, 0, topk).reshape({1, topk});
+            at::Tensor tmp_topk = torch::arange(0, topk, topk_idx.options()).reshape({1, topk});
             topk_blocks.emplace_back(tmp_topk);
         }
         this->new_topk_idx = torch::cat(topk_blocks, 0);
@@ -347,9 +347,7 @@ Buffer::intranode_combine(const torch::Tensor &x, const torch::Tensor &topk_idx,
             }
             for (int i = 0; i < this->padding_cnt; i++) {
                 if (topk_weights.has_value()) {
-                    at::Tensor tmp_weight = torch::randperm(send_head.size(0), topk_weights->options())
-                                                .slice(0, 0, num_topk)
-                                                .reshape({1, num_topk});
+                    at::Tensor tmp_weight = torch::arange(0, num_topk, topk_weights->options()).reshape({1, num_topk});
                     weight_blocks.emplace_back(tmp_weight);
                 }
             }
@@ -428,7 +426,7 @@ Buffer::low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
         int topk = static_cast<int>(new_topk_idx.size(1));
         for (int i = 0; i < this->padding_cnt; i++) {
             at::Tensor tmp_x = torch::ones({1, x.size(1)}, x.options());
-            at::Tensor tmp_topk = torch::randperm(num_experts, topk_idx.options()).slice(0, 0, topk).reshape({1, topk});
+            at::Tensor tmp_topk = torch::arange(0, topk, topk_idx.options()).reshape({1, topk});
             x_blocks.emplace_back(tmp_x);
             topk_blocks.emplace_back(tmp_topk);
         }
@@ -461,18 +459,13 @@ Buffer::low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
     auto packed_recv_count = at::empty({num_local_experts}, at::dtype(at::kLong).device(device));
     auto expandScales = at::empty({1}, at::dtype(at::kFloat).device(device));
     at::Tensor scales;
-    at::Tensor activateMask;
+    at::Tensor activate_mask = (new_topk_idx >= 0).to(torch::kBool);
     auto expert_scales = at::empty({1}, at::dtype(at::kFloat).device(device));
     int64_t quant_mode = use_fp8 ? 2 : 0;
     int64_t tp_size = 1;
     int64_t tp_rank = 0;
     int64_t expert_shard_type = 0;
     int64_t expert_token_nums_type = 1;
-
-    std::string comm_log = "0";
-    std::vector<char> comm_log_buf(comm_log.begin(), comm_log.end());
-    comm_log_buf.push_back('\0');
-    char *comm_log_ptr = comm_log_buf.data();
 
     // get ep & tp name
     char hcom_ep_name[HCOMM_NAME_LEN];
@@ -482,10 +475,11 @@ Buffer::low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
         HCCL_CHECK(HcclGetCommName(ep_comm, hcom_ep_name));
     }
     char hcom_tp_name[HCOMM_NAME_LEN] = {0};
+    char comm_alg[] = "fullmesh";
 
     EXEC_NPU_CMD(aclnnMoeDistributeDispatchV2, new_x, new_topk_idx,
                  scales,         // smooth scales,
-                 activateMask,   // activateMask
+                 activate_mask,  // activate_mask
                  expert_scales,  // expert_scales
                  hcom_ep_name,   // ep
                  num_ranks,      // rankSize
@@ -500,7 +494,7 @@ Buffer::low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
                  quant_mode,
                  global_bs,               // global_bs
                  expert_token_nums_type,  // expert_token_nums_type
-                 comm_log_ptr, packed_recv_x,
+                 comm_alg, packed_recv_x,
                  packed_recv_x_scales,  // dynamicScalesOut
                  expandIdx,
                  packed_recv_count,  // expertTokenNumsOut
@@ -560,7 +554,8 @@ std::tuple<at::Tensor, std::optional<EventHandle>, std::optional<std::function<v
     at::Tensor ep_send_counts = layout_range;
     at::Tensor expert_scales = new_scales;
     at::Tensor tp_send_counts = at::empty({1}, at::dtype(at::kInt).device(device));
-    at::Tensor x_active_mask, activation_scale, weight_scale, group_list, expand_scales;
+    at::Tensor activation_scale, weight_scale, group_list, expand_scales;
+    at::Tensor x_active_mask = (new_idx >= 0).to(at::kBool);
 
     int64_t tp_world_size = 1;
     int64_t tp_rankId = 0;
@@ -575,16 +570,14 @@ std::tuple<at::Tensor, std::optional<EventHandle>, std::optional<std::function<v
     at::Tensor shared_expert_x{nullptr};
     at::Tensor combined_x = at::empty({num_combined_tokens, hidden}, x.options());
     std::optional<EventHandle> event;
-    std::string comm_log = "0";
-    std::vector<char> comm_log_buf(comm_log.begin(), comm_log.end());
-    comm_log_buf.push_back('\0');
-    char *comm_log_ptr = comm_log_buf.data();
+    char comm_alg[] = "fullmesh";
 
     EXEC_NPU_CMD(aclnnMoeDistributeCombineV2, expand_x, expert_ids, expand_idx, ep_send_counts, expert_scales,
                  tp_send_counts, x_active_mask, activation_scale, weight_scale, group_list, expand_scales,
                  shared_expert_x, hcom_ep_name, num_ranks, rank, num_experts, hcom_tp_name, tp_world_size, tp_rankId,
                  expert_shared_type, shared_expert_num, shared_expert_rank_num, global_bs, out_dtype, comm_quant_mode,
-                 group_list_type, comm_log_ptr, combined_x);
+                 group_list_type, comm_alg, combined_x);
+
     if (this->is_padding) {
         if (this->padding_cnt == PADDING_SIZE) {
             combined_x = this->ori_x;
@@ -629,8 +622,7 @@ std::vector<at::Tensor> Buffer::fused_deep_moe(const at::Tensor &x, const at::Te
         int topk = static_cast<int>(expert_ids.size(1));
         for (int i = 0; i < this->padding_cnt; i++) {
             at::Tensor tmp_x = torch::ones({1, x.size(1)}, x.options());
-            at::Tensor tmp_idx =
-                torch::randperm(num_experts, expert_ids.options()).slice(0, 0, topk).reshape({1, topk});
+            at::Tensor tmp_idx = torch::arange(0, topk, expert_ids.options()).reshape({1, topk});
             x_blocks.emplace_back(tmp_x);
             idx_blocks.emplace_back(tmp_idx);
         }


### PR DESCRIPTION
1. Change the padding generation from randperm back to arange
2. Use "fullmesh" as value of commAlg parameter for the dispatch/combine operator.