### PR TITLE
[Bugfix] Remove unused code that causes split failure in Qwen3-Next

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d.py
@@ -107,9 +107,6 @@ def causal_conv1d_fn_npu(
 
     out_ref = []
     out_ref_b = []
-    seqlens = query_start_loc[1:] - query_start_loc[:-1]
-    seqlens = seqlens.tolist()
-    splits = [torch.split(var, seqlens, dim=-1) for var in (x)]
     out_ref_b.append(
         causal_conv1d_fn_native(
             x,


### PR DESCRIPTION
Fix an issue that causes split failure in Qwen3-Next
<img width="1175" height="579" alt="image" src="https://github.com/user-attachments/assets/04463573-0957-419f-a150-03c74eb9b6de" />
