### PR TITLE
add mla_preprocess test script

### DIFF
--- a/tests/python/sgl_kernel_npu/test_mla_preprocess.py
+++ b/tests/python/sgl_kernel_npu/test_mla_preprocess.py
@@ -741,7 +741,7 @@ class TestMLAPO(TestCase):
             )
 
     def test_mla_preprocess_ops_bf16_cachemode1_golden1(self):
-         self.run_tests_and_compare(
+        self.run_tests_and_compare(
             cacheMode=1,
             golden=self.GoldenType.NPU_SMALL_OPS,
             dtype=torch.bfloat16,
@@ -802,7 +802,7 @@ class TestMLAPO(TestCase):
             golden=self.GoldenType.PYTORCH_NATIVE,
             dtype=torch.float16,
             seed=SEED,
-         )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- golden test for mla_preprocess
- include bf16 and fp16 dtype, with cachemode krope_ctkv, int8_nzcache and nzcache
- support two types of golden: unfused NPU small ops and Pytorch native