### PR TITLE
feat: route PyTorch deps through internal cache service in CI

### DIFF
--- a/.github/workflows/daily-build-test.yml
+++ b/.github/workflows/daily-build-test.yml
@@ -21,6 +21,10 @@ jobs:
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.3.rc1-a3-ubuntu22.04-py3.11
     timeout-minutes: 350  # 5小时50分钟，留出缓冲时间
+    env:
+      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
 
     steps:
       - name: Clean git config
@@ -74,6 +78,10 @@ jobs:
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.3.rc1-a3-ubuntu22.04-py3.11
     timeout-minutes: 330  # 5.5小时
+    env:
+      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
 
     steps:
       - name: Clean workspace and checkout

--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -758,6 +758,10 @@ jobs:
     runs-on: linux-aarch64-a2-8
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.3.rc1-910b-ubuntu22.04-py3.11
+    env:
+      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
     steps:
       - name: Clean git config
         run: |

--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -62,6 +62,10 @@ jobs:
     runs-on: linux-aarch64-a3-16
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.3.rc1-a3-ubuntu22.04-py3.11
+    env:
+      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
     steps:
       - name: Clean git config
         run: |
@@ -406,6 +410,10 @@ jobs:
     runs-on: linux-aarch64-a3-16
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.3.rc1-a3-ubuntu22.04-py3.11
+    env:
+      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
     steps:
       - name: Clean git config
         run: |

--- a/scripts/npu_ci_install_dependency.sh
+++ b/scripts/npu_ci_install_dependency.sh
@@ -84,6 +84,7 @@ ${PIP_INSTALL} \
     torch==${TORCH_VERSION} \
     torchvision==${TORCHVISION_VERSION} \
     torchaudio==${TORCH_VERSION} \
-    --index-url https://download.pytorch.org/whl/cpu
+    --index-url ${TORCH_CACHE_URL:="https://download.pytorch.org/whl/cpu"} \
+    --extra-index-url ${PYPI_CACHE_URL:="https://pypi.org/simple/"}
 ## torch_npu
 ${PIP_INSTALL} ${TORCH_NPU_URL}


### PR DESCRIPTION
Add TORCH_CACHE_URL, PYPI_CACHE_URL, GITHUB_PROXY_URL env vars to both PR test jobs, and update npu_ci_install_dependency.sh to use them with fallback defaults so local runs still work without the cache service.