### PR TITLE
add rmsnorm_without_weight kernel

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/norm/rmsnorm_without_weight.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/norm/rmsnorm_without_weight.py
@@ -38,7 +38,7 @@ def fused_rmsnorm_without_weight_kernel(
     kernel_num: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    total_tasks = tl.cdif(num_tokens, block_l)
+    total_tasks = tl.cdiv(num_tokens, block_l)
 
     for task_id in range(pid, total_tasks, kernel_num):
         token_offsets = task_id * block_l + tl.arange(0, block_l)

--- a/python/sgl_kernel_npu/sgl_kernel_npu/norm/rmsnorm_without_weight.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/norm/rmsnorm_without_weight.py
@@ -42,7 +42,7 @@ def fused_rmsnorm_without_weight_kernel(
 
     for task_id in range(pid, total_tasks, kernel_num):
         token_offsets = task_id * block_l + tl.arange(0, block_l)
-        dim_offsets = tl.arrange(0, hidden_size)
+        dim_offsets = tl.arange(0, hidden_size)
 
         offsets = token_offsets[:, None] * hidden_size + dim_offsets[None, :]
         mask = (token_offsets[:, None] < num_tokens) & (dim_offsets[None, :] < hidden_size)

--- a/python/sgl_kernel_npu/sgl_kernel_npu/norm/rmsnorm_without_weight.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/norm/rmsnorm_without_weight.py
@@ -70,3 +70,5 @@ def fused_rmsnorm_without_weight(x, eps):
         C,
         kernel_num=num_vectorcore,
     )
+
+    return output

--- a/python/sgl_kernel_npu/sgl_kernel_npu/norm/rmsnorm_without_weight.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/norm/rmsnorm_without_weight.py
@@ -45,7 +45,9 @@ def fused_rmsnorm_without_weight_kernel(
         dim_offsets = tl.arange(0, hidden_size)
 
         offsets = token_offsets[:, None] * hidden_size + dim_offsets[None, :]
-        mask = (token_offsets[:, None] < num_tokens) & (dim_offsets[None, :] < hidden_size)
+        mask_token = token_offsets[:, None] < num_tokens
+        mask_dim = dim_offsets[None, :] < hidden_size
+        mask = mask_token & mask_dim
 
         x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
         x_sq = x * x

--- a/python/sgl_kernel_npu/sgl_kernel_npu/norm/rmsnorm_without_weight.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/norm/rmsnorm_without_weight.py
@@ -1,0 +1,72 @@
+import torch
+import triton
+import triton.language as tl
+from sgl_kernel_npu.utils.triton_utils import get_device_properties
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {"block_l": 64},
+        ),
+        triton.Config(
+            {"block_l": 32},
+        ),
+        triton.Config(
+            {"block_l": 16},
+        ),
+        triton.Config(
+            {"block_l": 8},
+        ),
+        triton.Config(
+            {"block_l": 4},
+        ),
+        triton.Config(
+            {"block_l": 2},
+        ),
+    ],
+    key=["num_tokens"],
+)
+@triton.jit
+def fused_rmsnorm_without_weight_kernel(
+    x_ptr,
+    eps,
+    output_ptr,
+    num_tokens,
+    hidden_size: tl.constexpr,
+    block_l: tl.constexpr,
+    kernel_num: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    total_tasks = tl.cdif(num_tokens, block_l)
+
+    for task_id in range(pid, total_tasks, kernel_num):
+        token_offsets = task_id * block_l + tl.arange(0, block_l)
+        dim_offsets = tl.arrange(0, hidden_size)
+
+        offsets = token_offsets[:, None] * hidden_size + dim_offsets[None, :]
+        mask = (token_offsets[:, None] < num_tokens) & (dim_offsets[None, :] < hidden_size)
+
+        x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+        x_sq = x * x
+        var = tl.sum(x_sq, axis=1) * (1 / hidden_size)
+        rstd = tl.math.rsqrt(var + eps)
+
+        y = x * rstd[:, None]
+        tl.store(output_ptr + offsets, y, mask=mask)
+
+
+def fused_rmsnorm_without_weight(x, eps):
+    _, num_vectorcore = get_device_properties()
+    B, L, C = x.shape[0], x.shape[1], x.shape[2]
+    grid = (num_vectorcore,)
+    output = torch.empty_like(x)
+
+    fused_rmsnorm_without_weight_kernel[grid](
+        x,
+        eps,
+        output,
+        B * L,
+        C,
+        kernel_num=num_vectorcore,
+    )

--- a/tests/python/sgl_kernel_npu/test_rmsnorm_without_weight.py
+++ b/tests/python/sgl_kernel_npu/test_rmsnorm_without_weight.py
@@ -11,7 +11,7 @@ def fused_rmsnorm_without_weight_golden(
     return F.rms_norm(x, normalized_shape=(x.shape[-1],), eps=eps)
 
 
-def test_fused_scale():
+def test_fused_rmsnorm():
     B, H, C = 1, 130, 2048
     dtype = torch.float32
 
@@ -32,4 +32,4 @@ def test_fused_scale():
 
 
 if __name__ == "__main__":
-    test_fused_scale()
+    test_fused_rmsnorm()

--- a/tests/python/sgl_kernel_npu/test_rmsnorm_without_weight.py
+++ b/tests/python/sgl_kernel_npu/test_rmsnorm_without_weight.py
@@ -1,0 +1,35 @@
+import numpy as np
+import torch
+import torch.nn.functional as F
+from sgl_kernel_npu.norm.rmsnorm_without_weight import fused_rmsnorm_without_weight
+
+
+def fused_rmsnorm_without_weight_golden(
+    x: torch.Tensor,
+    eps: float,
+):
+    return F.rms_norm(x, normalized_shape=(x.shape[-1],), eps=eps)
+
+
+def test_fused_scale():
+    B, H, C = 1, 130, 2048
+    dtype = torch.float32
+
+    x = torch.randn(B, H, C, dtype=dtype, device="npu")
+    eps = 1e-6
+
+    res = fused_rmsnorm_without_weight_golden(x, eps)
+    ans = fused_rmsnorm_without_weight(x, eps)
+
+    np.testing.assert_allclose(
+        res.cpu().numpy(),
+        ans.cpu().numpy(),
+        rtol=1e-3,
+        err_msg=f"Failed!",
+    )
+
+    print(f"Passed!")
+
+
+if __name__ == "__main__":
+    test_fused_scale()


### PR DESCRIPTION
This PR introduces a fused RMSNorm kernel implemented in Triton, specifically optimized for cases where learnable weights (gamma) are not required.

Model Integration: Successfully integrated into the LTX-2 model pipeline.
E2E Gains: Observed a ~3% improvement in E2E latency compared to the previous normalization implementation.