### PR TITLE
The A3 normal operator is modified to support a maximum of 128K long sequences.

### DIFF
--- a/csrc/deepep/ops/op_host/cam_moe_combine_normal_tiling.cc
+++ b/csrc/deepep/ops/op_host/cam_moe_combine_normal_tiling.cc
@@ -56,7 +56,7 @@ constexpr size_t MAX_GROUP_NAME_LENGTH = 128UL;
 constexpr int64_t MAX_EP_WORLD_SIZE = 384;
 constexpr int64_t MIN_EP_WORLD_SIZE = 2;
 constexpr int64_t MAX_TP_WORLD_SIZE = 2;
-constexpr int64_t BS_UPPER_BOUND = 65536;
+constexpr int64_t BS_UPPER_BOUND = 131072;
 
 constexpr uint32_t SYSTEM_NEED_WORKSPACE = 16 * 1024 * 1024;
 constexpr int32_t HCCL_BUFFER_SIZE_DEFAULT = 200 * 1024 * 1024;  // Bytes

--- a/csrc/deepep/ops/op_host/cam_moe_dispatch_normal_tiling.cc
+++ b/csrc/deepep/ops/op_host/cam_moe_dispatch_normal_tiling.cc
@@ -64,7 +64,7 @@ constexpr size_t MAX_GROUP_NAME_LENGTH = 128UL;
 constexpr int64_t MAX_EP_WORLD_SIZE = 384;
 constexpr int64_t MIN_EP_WORLD_SIZE = 2;
 constexpr int64_t MAX_TP_WORLD_SIZE = 2;
-constexpr int64_t BS_UPPER_BOUND = 65536;  // 最大bs
+constexpr int64_t BS_UPPER_BOUND = 131072;  // 最大bs
 
 constexpr uint32_t TILINGKEY_TP_WORLD_SIZE = 100;
 constexpr uint32_t TP_WORLD_SIZE_TWO = 2;


### PR DESCRIPTION
The A3 normal operator is modified to support a maximum of 128K long sequences.