### PR TITLE
Fix low_latency dispatch&combine checks with bs condition

### DIFF
--- a/csrc/deepep/ops/op_kernel/moe_distribute_combine_v2.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_combine_v2.h
@@ -698,14 +698,17 @@ __aicore__ inline void MoeDistributeCombineV2<TemplateMC2TypeFunc>::AlltoAllBuff
         scaleDupLocalTensor_ = mulBuf_.Get<float>();
         scaleDivFloatTensor_ = xAbsBuf_.Get<float>();
     }
-    if (axisBS_ != 0 && isInputTokenMaskFlag_) {
+    if (axisBS_ == 0) {
+        return;
+    }
+    if (isInputTokenMaskFlag_) {
         axisBsAlignSize_ = Ceil(axisBS_ * sizeof(bool), UB_ALIGN) * UB_ALIGN;
         tpipe_->InitBuffer(xActMaskTBuf_, axisBsAlignSize_);
         tpipe_->InitBuffer(xActMaskCastTBuf_, axisBsAlignSize_ * sizeof(half));
         tpipe_->InitBuffer(xActMaskSumTBuf_, axisBsAlignSize_ * sizeof(half));
         TokenMaskCalCnt();  // 计算一维mask
     }
-    if (axisBS_ != 0 && isInputExpertMaskFlag_) {
+    if (isInputExpertMaskFlag_) {
         tpipe_->InitBuffer(tokenTargetTBuf_, Ceil(axisBS_ * sizeof(half), UB_ALIGN) * UB_ALIGN);
         tpipe_->InitBuffer(validBsIndexTBuf_, Ceil(axisBS_ * sizeof(int32_t), UB_ALIGN) * UB_ALIGN);
         tpipe_->InitBuffer(expertMaskBuf_, Ceil(axisBS_ * axisK_ * sizeof(bool), UB_ALIGN) * UB_ALIGN);

--- a/csrc/deepep/ops/op_kernel/moe_distribute_combine_v2.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_combine_v2.h
@@ -698,14 +698,14 @@ __aicore__ inline void MoeDistributeCombineV2<TemplateMC2TypeFunc>::AlltoAllBuff
         scaleDupLocalTensor_ = mulBuf_.Get<float>();
         scaleDivFloatTensor_ = xAbsBuf_.Get<float>();
     }
-    if (isInputTokenMaskFlag_) {
+    if (axisBS_ != 0 && isInputTokenMaskFlag_) {
         axisBsAlignSize_ = Ceil(axisBS_ * sizeof(bool), UB_ALIGN) * UB_ALIGN;
         tpipe_->InitBuffer(xActMaskTBuf_, axisBsAlignSize_);
         tpipe_->InitBuffer(xActMaskCastTBuf_, axisBsAlignSize_ * sizeof(half));
         tpipe_->InitBuffer(xActMaskSumTBuf_, axisBsAlignSize_ * sizeof(half));
         TokenMaskCalCnt();  // 计算一维mask
     }
-    if (isInputExpertMaskFlag_) {
+    if (axisBS_ != 0 && isInputExpertMaskFlag_) {
         tpipe_->InitBuffer(tokenTargetTBuf_, Ceil(axisBS_ * sizeof(half), UB_ALIGN) * UB_ALIGN);
         tpipe_->InitBuffer(validBsIndexTBuf_, Ceil(axisBS_ * sizeof(int32_t), UB_ALIGN) * UB_ALIGN);
         tpipe_->InitBuffer(expertMaskBuf_, Ceil(axisBS_ * axisK_ * sizeof(bool), UB_ALIGN) * UB_ALIGN);

--- a/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2.h
@@ -881,10 +881,10 @@ __aicore__ inline void MoeDistributeDispatchV2<TemplateMC2TypeFunc>::AlltoAllDis
 {
     activeMaskBsCnt_ = axisBS_;
     sendToMoeExpTokenCnt_ = axisBS_ * axisK_;
-    if (isTokenMaskFlag_) {
+    if (axisBS_ != 0 && isTokenMaskFlag_) {
         TokenActiveMaskCal();
     }
-    if (isExpertMaskFlag_) {
+    if (axisBS_ != 0 && isExpertMaskFlag_) {
         ExpertActiveMaskCal();
     }
 

--- a/csrc/deepep/ops2/op_host/moe_distribute_combine_v2_tiling.cc
+++ b/csrc/deepep/ops2/op_host/moe_distribute_combine_v2_tiling.cc
@@ -655,12 +655,6 @@ static bool CheckAttrs(const gert::TilingContext *context, MoeDistributeCombineV
                 "bs=%ld, epWorldSize=%u.",
                 *globalBsPtr, expertIdsDim0, epWorldSize),
         return false);
-    OP_TILING_CHECK(((*globalBsPtr > (expertIdsDim0 * static_cast<int64_t>(epWorldSize))) && isActiveMask),
-                    OP_LOGE(nodeName,
-                            "Different bs on different rank cannot work when isActiveMask=true, globalBS=%ld, "
-                            "bs=%ld, epWorldSize=%u.",
-                            *globalBsPtr, expertIdsDim0, epWorldSize),
-                    return false);
 
     tilingData.moeDistributeCombineV2Info.globalBs = static_cast<uint32_t>(*globalBsPtr);
     if (*globalBsPtr == 0) {

--- a/csrc/deepep/ops2/op_host/moe_distribute_dispatch_v2_tiling.cc
+++ b/csrc/deepep/ops2/op_host/moe_distribute_dispatch_v2_tiling.cc
@@ -660,12 +660,6 @@ static ge::graphStatus CheckAttrs(gert::TilingContext *context, const char *node
                 "bs=%ld, epWorldSize=%u.",
                 *globalBsPtr, xDim0, epWorldSize),
         return ge::GRAPH_FAILED);
-    OP_TILING_CHECK(((*globalBsPtr > (xDim0 * static_cast<int64_t>(epWorldSize))) && isActiveMask),
-                    OP_LOGE(nodeName,
-                            "Different bs on different rank cannot work when isActiveMask=true, globalBS=%ld, "
-                            "bs=%ld, epWorldSize=%u.",
-                            *globalBsPtr, xDim0, epWorldSize),
-                    return ge::GRAPH_FAILED);
     if (*globalBsPtr == 0) {
         tilingData.moeDistributeDispatchV2Info.globalBs = static_cast<uint32_t>(xDim0) * epWorldSize;
     } else {

--- a/csrc/deepep/ops2/op_kernel/moe_distribute_combine_v2.h
+++ b/csrc/deepep/ops2/op_kernel/moe_distribute_combine_v2.h
@@ -279,10 +279,10 @@ __aicore__ inline void MoeDistributeCombineV2<TemplateMC2TypeA2Func>::Init(
 
     BuffInit();
 
-    if (isInputTokenMaskFlag_) {
+    if (axisBS_ != 0 && isInputTokenMaskFlag_) {
         TokenActiveMaskCal();  // 计算一维mask
     }
-    if (isInputExpertMaskFlag_) {
+    if (axisBS_ != 0 && isInputExpertMaskFlag_) {
         tpipe_->InitBuffer(expertMaskBuf_, Ceil(axisBS_ * axisK_ * sizeof(bool), UB_ALIGN) * UB_ALIGN);
         expertMaskTensor_ = expertMaskBuf_.Get<bool>();
         DataCopyPadExtParams<bool> maskCopyPadParams{false, 0U, 0U, 0U};

--- a/csrc/deepep/ops2/op_kernel/moe_distribute_combine_v2_single.h
+++ b/csrc/deepep/ops2/op_kernel/moe_distribute_combine_v2_single.h
@@ -496,14 +496,14 @@ __aicore__ inline void MoeDistributeCombineV2Single<TemplateMC2TypeA2SingleFunc>
         scaleDupLocalTensor_ = mulBuf_.Get<float>();
         scaleDivFloatTensor_ = xAbsBuf_.Get<float>();
     }
-    if (isInputTokenMaskFlag_) {
+    if (axisBS_ != 0 && isInputTokenMaskFlag_) {
         axisBsAlignSize_ = Ceil(axisBS_ * sizeof(bool), UB_ALIGN) * UB_ALIGN;
         tpipe_->InitBuffer(xActMaskTBuf_, axisBsAlignSize_);
         tpipe_->InitBuffer(xActMaskCastTBuf_, axisBsAlignSize_ * sizeof(half));
         tpipe_->InitBuffer(xActMaskSumTBuf_, axisBsAlignSize_ * sizeof(half));
         TokenMaskCalCnt();  // 计算一维mask
     }
-    if (isInputExpertMaskFlag_) {
+    if (axisBS_ != 0 && isInputExpertMaskFlag_) {
         tpipe_->InitBuffer(tokenTargetTBuf_, Ceil(axisBS_ * sizeof(half), UB_ALIGN) * UB_ALIGN);
         tpipe_->InitBuffer(vaildBsIndexTBuf_, Ceil(axisBS_ * sizeof(int32_t), UB_ALIGN) * UB_ALIGN);
         tokenTargetTensor_ = tokenTargetTBuf_.Get<half>();

--- a/csrc/deepep/ops2/op_kernel/moe_distribute_combine_v2_single.h
+++ b/csrc/deepep/ops2/op_kernel/moe_distribute_combine_v2_single.h
@@ -496,14 +496,17 @@ __aicore__ inline void MoeDistributeCombineV2Single<TemplateMC2TypeA2SingleFunc>
         scaleDupLocalTensor_ = mulBuf_.Get<float>();
         scaleDivFloatTensor_ = xAbsBuf_.Get<float>();
     }
-    if (axisBS_ != 0 && isInputTokenMaskFlag_) {
+    if (axisBS_ == 0) {
+        return;
+    }
+    if (isInputTokenMaskFlag_) {
         axisBsAlignSize_ = Ceil(axisBS_ * sizeof(bool), UB_ALIGN) * UB_ALIGN;
         tpipe_->InitBuffer(xActMaskTBuf_, axisBsAlignSize_);
         tpipe_->InitBuffer(xActMaskCastTBuf_, axisBsAlignSize_ * sizeof(half));
         tpipe_->InitBuffer(xActMaskSumTBuf_, axisBsAlignSize_ * sizeof(half));
         TokenMaskCalCnt();  // 计算一维mask
     }
-    if (axisBS_ != 0 && isInputExpertMaskFlag_) {
+    if (isInputExpertMaskFlag_) {
         tpipe_->InitBuffer(tokenTargetTBuf_, Ceil(axisBS_ * sizeof(half), UB_ALIGN) * UB_ALIGN);
         tpipe_->InitBuffer(vaildBsIndexTBuf_, Ceil(axisBS_ * sizeof(int32_t), UB_ALIGN) * UB_ALIGN);
         tokenTargetTensor_ = tokenTargetTBuf_.Get<half>();

--- a/csrc/deepep/ops2/op_kernel/moe_distribute_dispatch_v2.h
+++ b/csrc/deepep/ops2/op_kernel/moe_distribute_dispatch_v2.h
@@ -314,7 +314,7 @@ __aicore__ inline void MoeDistributeDispatchV2<TemplateMC2TypeA2Func>::Init(
     baseBuffOffset_ += xActiveMaskSize_;
     gatherMaskTensor_ = gatherMaskTensorInt8.template ReinterpretCast<uint32_t>();
 
-    if (isExpertMaskFlag_) {
+    if (axisBS_ != 0 && isExpertMaskFlag_) {
         ExpertActiveMaskCal();
     }
 

--- a/csrc/deepep/ops2/op_kernel/moe_distribute_dispatch_v2_single.h
+++ b/csrc/deepep/ops2/op_kernel/moe_distribute_dispatch_v2_single.h
@@ -795,11 +795,11 @@ __aicore__ inline void MoeDistributeDispatchV2Single<TemplateMC2TypeA2SingleFunc
     CAM_PRINT("[AlltoAllDispatch1] rank:%d, aivId:%d ...\n", epRankId_, aivId_);
     activeMaskBsCnt_ = axisBS_;
     sendToMoeExpTokenCnt_ = axisBS_ * axisK_;
-    if (isTokenMaskFlag_) {
+    if (axisBS_ != 0 && isTokenMaskFlag_) {
         TokenActiveMaskCal();
     }
     CAM_PRINT("[AlltoAllDispatch2] rank:%d, aivId:%d, isTokenMaskFlag_:%d ...\n", epRankId_, aivId_, isTokenMaskFlag_);
-    if (isExpertMaskFlag_) {
+    if (axisBS_ != 0 && isExpertMaskFlag_) {
         ExpertActiveMaskCal();
     }
     CAM_PRINT("[AlltoAllDispatch3] rank:%d, aivId:%d, isExpertMaskFlag_:%d ...\n", epRankId_, aivId_,


### PR DESCRIPTION
Fix low_latency dispatch&combine checks by adding axisBS_ != 0 condition when enbale mask for topk=-1