### PR TITLE
add fused_qkvzba_split_reshape_cat_contiguous_kernel

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
@@ -609,7 +609,6 @@ def fused_qkvzba_split_reshape_cat_contiguous(
     batch, seq_len = mixed_qkvz.shape[0], 1
     total_rows = batch * seq_len
 
-
     total_q = num_heads_qk * head_qk
     total_k = num_heads_qk * head_qk
     total_v = num_heads_v * head_v

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
@@ -618,7 +618,7 @@ def fused_qkvzba_split_reshape_cat_contiguous(
         num_heads_v,
         head_qk,
         head_v,
-        batch,  #
+        batch,
         num_warps=1,
         num_stages=3,
     )

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
@@ -223,6 +223,13 @@ MAX_ROWS_PER_ITER = 64
 UB_SPECIFICATION = 85
 
 
+# =============================================================================
+# Fused kernel — reads INTERLEAVED input format
+# Used by Qwen3-Next whose checkpoint stores fused in_proj_qkvz weights
+# in per-head-group interleaved layout:
+#   [g0_q, g0_k, g0_v, g0_z, g1_q, g1_k, g1_v, g1_z, ...]
+# =============================================================================
+
 @triton.jit(do_not_specialize=["total_rows", "rows_per_vec"])
 def fused_qkvzba_split_reshape_cat_kernel(
     mixed_qkv,
@@ -439,189 +446,6 @@ def fused_qkvzba_split_reshape_cat(
         ba_out_row_stride,
         rows_per_iter,
     )
-    return mixed_qkv, z, b, a
-
-
-# =============================================================================
-# Fused kernel — reads INTERLEAVED input format
-# Used by Qwen3-Next whose checkpoint stores fused in_proj_qkvz weights
-# in per-head-group interleaved layout:
-#   [g0_q, g0_k, g0_v, g0_z, g1_q, g1_k, g1_v, g1_z, ...]
-# =============================================================================
-
-@triton.jit
-def fused_qkvzba_split_reshape_cat_contiguous_kernel(
-    mixed_qkv,
-    z,
-    b,
-    a,
-    mixed_qkvz,
-    mixed_ba,
-    NUM_HEADS_QK: tl.constexpr,
-    NUM_HEADS_V: tl.constexpr,
-    HEAD_QK: tl.constexpr,
-    HEAD_V: tl.constexpr,
-    batch_size,
-):
-    pid = tl.program_id(0)
-    num_pids = tl.num_programs(0)
-
-    V_PER_GROUP: tl.constexpr = NUM_HEADS_V // NUM_HEADS_QK
-
-    # ── Input dimensions (contiguous layout) ──
-    TOTAL_Q: tl.constexpr = NUM_HEADS_QK * HEAD_QK
-    TOTAL_K: tl.constexpr = NUM_HEADS_QK * HEAD_QK
-    TOTAL_V: tl.constexpr = NUM_HEADS_V * HEAD_V
-    TOTAL_QKVZ: tl.constexpr = TOTAL_Q + TOTAL_K + TOTAL_V + TOTAL_V
-    TOTAL_BA: tl.constexpr = NUM_HEADS_V * 2
-
-    # ── Output dimensions ──
-    QKV_DIM_T: tl.constexpr = TOTAL_Q + TOTAL_K + TOTAL_V
-
-    total_tasks = batch_size * NUM_HEADS_QK
-
-    for task_id in tl.range(pid, total_tasks, num_pids):
-
-        i_bs = task_id // NUM_HEADS_QK
-        i_qk = task_id % NUM_HEADS_QK
-
-        # ── Read from contiguous input ──
-        # q for head group i_qk: in the all_q region, offset i_qk * HEAD_QK
-        blk_q_ptr = (
-            mixed_qkvz + i_bs * TOTAL_QKVZ + i_qk * HEAD_QK + tl.arange(0, HEAD_QK)
-        )
-        # k for head group i_qk: in the all_k region
-        blk_k_ptr = (
-            mixed_qkvz
-            + i_bs * TOTAL_QKVZ
-            + TOTAL_Q
-            + i_qk * HEAD_QK
-            + tl.arange(0, HEAD_QK)
-        )
-        # v for head group i_qk: in the all_v region
-        blk_v_ptr = (
-            mixed_qkvz
-            + i_bs * TOTAL_QKVZ
-            + TOTAL_Q
-            + TOTAL_K
-            + i_qk * V_PER_GROUP * HEAD_V
-            + tl.arange(0, V_PER_GROUP * HEAD_V)
-        )
-        # z for head group i_qk: in the all_z region
-        blk_z_ptr = (
-            mixed_qkvz
-            + i_bs * TOTAL_QKVZ
-            + TOTAL_Q
-            + TOTAL_K
-            + TOTAL_V
-            + i_qk * V_PER_GROUP * HEAD_V
-            + tl.arange(0, V_PER_GROUP * HEAD_V)
-        )
-
-        # ── Write to output (identical layout to the interleaved kernel) ──
-        blk_q_st_ptr = (
-            mixed_qkv + i_bs * QKV_DIM_T + i_qk * HEAD_QK + tl.arange(0, HEAD_QK)
-        )
-        blk_k_st_ptr = (
-            mixed_qkv
-            + i_bs * QKV_DIM_T
-            + NUM_HEADS_QK * HEAD_QK
-            + i_qk * HEAD_QK
-            + tl.arange(0, HEAD_QK)
-        )
-        blk_v_st_ptr = (
-            mixed_qkv
-            + i_bs * QKV_DIM_T
-            + NUM_HEADS_QK * HEAD_QK * 2
-            + i_qk * V_PER_GROUP * HEAD_V
-            + tl.arange(0, V_PER_GROUP * HEAD_V)
-        )
-        blk_z_st_ptr = (
-            z
-            + i_bs * NUM_HEADS_V * HEAD_V
-            + i_qk * V_PER_GROUP * HEAD_V
-            + tl.arange(0, V_PER_GROUP * HEAD_V)
-        )
-
-        tl.store(blk_q_st_ptr, tl.load(blk_q_ptr))
-        tl.store(blk_k_st_ptr, tl.load(blk_k_ptr))
-        tl.store(blk_v_st_ptr, tl.load(blk_v_ptr))
-        tl.store(blk_z_st_ptr, tl.load(blk_z_ptr))
-
-        for i in tl.static_range(V_PER_GROUP):
-            blk_b_ptr = mixed_ba + i_bs * TOTAL_BA + i_qk * V_PER_GROUP + i
-            blk_b_st_ptr = b + i_bs * NUM_HEADS_V + i_qk * V_PER_GROUP + i
-            tl.store(blk_b_st_ptr, tl.load(blk_b_ptr))
-
-        for i in tl.static_range(V_PER_GROUP):
-            blk_a_ptr = (
-                mixed_ba + i_bs * TOTAL_BA + NUM_HEADS_V + i_qk * V_PER_GROUP + i
-            )
-            blk_a_st_ptr = a + i_bs * NUM_HEADS_V + i_qk * V_PER_GROUP + i
-            tl.store(blk_a_st_ptr, tl.load(blk_a_ptr))
-
-
-def fused_qkvzba_split_reshape_cat_contiguous(
-    mixed_qkvz,
-    mixed_ba,
-    num_heads_qk,
-    num_heads_v,
-    head_qk,
-    head_v,
-):
-    """Fused split/reshape/cat for CONTIGUOUS input format (Qwen3.5).
-
-    Input layout:
-        mixed_qkvz: [all_q | all_k | all_v | all_z]
-        mixed_ba:   [all_b | all_a]
-
-    Output layout (same as fused_qkvzba_split_reshape_cat):
-        mixed_qkv: [all_q | all_k | all_v]  (z stripped)
-        z: [num_v_heads, head_v]
-        b: [num_v_heads]
-        a: [num_v_heads]
-    """
-    batch, seq_len = mixed_qkvz.shape[0], 1
-    qkv_dim_t = num_heads_qk * head_qk * 2 + num_heads_v * head_v
-    mixed_qkv = torch.empty(
-        [batch * seq_len, qkv_dim_t],
-        dtype=mixed_qkvz.dtype,
-        device=mixed_qkvz.device,
-    )
-    z = torch.empty(
-        [batch * seq_len, num_heads_v, head_v],
-        dtype=mixed_qkvz.dtype,
-        device=mixed_qkvz.device,
-    )
-    b = torch.empty(
-        [batch * seq_len, num_heads_v],
-        dtype=mixed_ba.dtype,
-        device=mixed_ba.device,
-    )
-    a = torch.empty_like(b)
-    num_vectorcore = get_device_properties()[1]
-
-    total_tasks = batch * num_heads_qk
-    grid_size = min(num_vectorcore, total_tasks)
-    grid_size = max(1, grid_size)
-
-    grid = (grid_size,)
-    fused_qkvzba_split_reshape_cat_contiguous_kernel[grid](
-        mixed_qkv,
-        z,
-        b,
-        a,
-        mixed_qkvz,
-        mixed_ba,
-        num_heads_qk,
-        num_heads_v,
-        head_qk,
-        head_v,
-        batch,
-        num_warps=1,
-        num_stages=3,
-    )
-
     return mixed_qkv, z, b, a
 
 

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
@@ -458,9 +458,12 @@ def fused_qkvzba_split_reshape_cat(
 #
 # Output format is identical to the interleaved kernel (same downstream consumer).
 # =============================================================================
+MAX_ROWS_PER_ITER = 256
+UB_SPECIFICATION = 85
+
 
 @triton.jit
-def fused_qkvzba_split_reshape_cat_contiguous_kernel(
+def fused_qkvzba_split_reshape_cat_contiguous_kernel_optimized(
     mixed_qkv,
     z,
     b,
@@ -471,95 +474,127 @@ def fused_qkvzba_split_reshape_cat_contiguous_kernel(
     NUM_HEADS_V: tl.constexpr,
     HEAD_QK: tl.constexpr,
     HEAD_V: tl.constexpr,
-    batch_size,
+    total_rows,
+    rows_per_vec,
+    QKVZ_ROW_STRIDE: tl.constexpr,
+    BA_ROW_STRIDE: tl.constexpr,
+    QKV_ROW_STRIDE: tl.constexpr,
+    Z_ROW_STRIDE: tl.constexpr,
+    BA_OUT_ROW_STRIDE: tl.constexpr,
+    ROWS_PER_ITER: tl.constexpr,
 ):
-    pid = tl.program_id(0)
-    num_pids = tl.num_programs(0)
+    vec_id = tl.program_id(0)
 
+    # ── Input dimensions (contiguous layout) ──
     V_PER_GROUP: tl.constexpr = NUM_HEADS_V // NUM_HEADS_QK
+    V_DIM_PER_GROUP: tl.constexpr = V_PER_GROUP * HEAD_V
 
     TOTAL_Q: tl.constexpr = NUM_HEADS_QK * HEAD_QK
     TOTAL_K: tl.constexpr = NUM_HEADS_QK * HEAD_QK
     TOTAL_V: tl.constexpr = NUM_HEADS_V * HEAD_V
-    TOTAL_QKVZ: tl.constexpr = TOTAL_Q + TOTAL_K + TOTAL_V + TOTAL_V
-    TOTAL_BA: tl.constexpr = NUM_HEADS_V * 2
-    QKV_DIM_T: tl.constexpr = TOTAL_Q + TOTAL_K + TOTAL_V
+    TOTAL_QK: tl.constexpr = TOTAL_Q + TOTAL_K
+    TOTAL_QKV: tl.constexpr = TOTAL_Q + TOTAL_K + TOTAL_V
 
-    total_tasks = batch_size * NUM_HEADS_QK
+    row_start = vec_id * rows_per_vec
+    row_end = tl.minimum(row_start + rows_per_vec, total_rows)
+    row_offset = row_start
 
-    for task_id in tl.range(pid, total_tasks, num_pids):
+    iter_count = (row_end - row_start + ROWS_PER_ITER - 1) // ROWS_PER_ITER
 
-        i_bs = task_id // NUM_HEADS_QK
-        i_qk = task_id % NUM_HEADS_QK
+    for _ in tl.range(iter_count):
 
-        blk_q_ptr = (
-            mixed_qkvz + i_bs * TOTAL_QKVZ + i_qk * HEAD_QK + tl.arange(0, HEAD_QK)
-        )
-        blk_k_ptr = (
-            mixed_qkvz
-            + i_bs * TOTAL_QKVZ
-            + TOTAL_Q
-            + i_qk * HEAD_QK
-            + tl.arange(0, HEAD_QK)
-        )
-        blk_v_ptr = (
-            mixed_qkvz
-            + i_bs * TOTAL_QKVZ
-            + TOTAL_Q
-            + TOTAL_K
-            + i_qk * V_PER_GROUP * HEAD_V
-            + tl.arange(0, V_PER_GROUP * HEAD_V)
-        )
-        blk_z_ptr = (
-            mixed_qkvz
-            + i_bs * TOTAL_QKVZ
-            + TOTAL_Q
-            + TOTAL_K
-            + TOTAL_V
-            + i_qk * V_PER_GROUP * HEAD_V
-            + tl.arange(0, V_PER_GROUP * HEAD_V)
-        )
+        row_indices = tl.arange(0, ROWS_PER_ITER) + row_offset
+        row_mask = row_indices < row_end
 
-        blk_q_st_ptr = (
-            mixed_qkv + i_bs * QKV_DIM_T + i_qk * HEAD_QK + tl.arange(0, HEAD_QK)
-        )
-        blk_k_st_ptr = (
-            mixed_qkv
-            + i_bs * QKV_DIM_T
-            + NUM_HEADS_QK * HEAD_QK
-            + i_qk * HEAD_QK
-            + tl.arange(0, HEAD_QK)
-        )
-        blk_v_st_ptr = (
-            mixed_qkv
-            + i_bs * QKV_DIM_T
-            + NUM_HEADS_QK * HEAD_QK * 2
-            + i_qk * V_PER_GROUP * HEAD_V
-            + tl.arange(0, V_PER_GROUP * HEAD_V)
-        )
-        blk_z_st_ptr = (
-            z
-            + i_bs * NUM_HEADS_V * HEAD_V
-            + i_qk * V_PER_GROUP * HEAD_V
-            + tl.arange(0, V_PER_GROUP * HEAD_V)
-        )
+        for head_id in tl.static_range(NUM_HEADS_QK):
 
-        tl.store(blk_q_st_ptr, tl.load(blk_q_ptr))
-        tl.store(blk_k_st_ptr, tl.load(blk_k_ptr))
-        tl.store(blk_v_st_ptr, tl.load(blk_v_ptr))
-        tl.store(blk_z_st_ptr, tl.load(blk_z_ptr))
+            q_range = tl.arange(0, HEAD_QK)
+            q_src_offset = head_id * HEAD_QK
 
-        for i in tl.static_range(V_PER_GROUP):
-            blk_b_ptr = mixed_ba + i_bs * TOTAL_BA + i_qk * V_PER_GROUP + i
-            blk_b_st_ptr = b + i_bs * NUM_HEADS_V + i_qk * V_PER_GROUP + i
-            tl.store(blk_b_st_ptr, tl.load(blk_b_ptr))
-
-        for i in tl.static_range(V_PER_GROUP):
-            blk_a_ptr = (
-                mixed_ba + i_bs * TOTAL_BA + NUM_HEADS_V + i_qk * V_PER_GROUP + i
+            q_src = (
+                row_indices[:, None] * QKVZ_ROW_STRIDE + q_src_offset + q_range[None, :]
             )
-            blk_a_st_ptr = a + i_bs * NUM_HEADS_V + i_qk * V_PER_GROUP + i
-            tl.store(blk_a_st_ptr, tl.load(blk_a_ptr))
+            q_dst = (
+                row_indices[:, None] * QKV_ROW_STRIDE
+                + head_id * HEAD_QK
+                + q_range[None, :]
+            )
+
+            q_data = tl.load(mixed_qkvz + q_src, mask=row_mask[:, None])
+            tl.store(mixed_qkv + q_dst, q_data, mask=row_mask[:, None])
+
+            k_src_offset = TOTAL_Q + head_id * HEAD_QK
+            k_src = (
+                row_indices[:, None] * QKVZ_ROW_STRIDE + k_src_offset + q_range[None, :]
+            )
+            k_dst = (
+                row_indices[:, None] * QKV_ROW_STRIDE
+                + TOTAL_Q
+                + head_id * HEAD_QK
+                + q_range[None, :]
+            )
+
+            k_data = tl.load(mixed_qkvz + k_src, mask=row_mask[:, None])
+            tl.store(mixed_qkv + k_dst, k_data, mask=row_mask[:, None])
+
+            v_range = tl.arange(0, V_DIM_PER_GROUP)
+            v_src_offset = TOTAL_QK + head_id * V_DIM_PER_GROUP
+
+            v_src = (
+                row_indices[:, None] * QKVZ_ROW_STRIDE + v_src_offset + v_range[None, :]
+            )
+            v_dst = (
+                row_indices[:, None] * QKV_ROW_STRIDE
+                + TOTAL_QK
+                + head_id * V_DIM_PER_GROUP
+                + v_range[None, :]
+            )
+
+            v_data = tl.load(mixed_qkvz + v_src, mask=row_mask[:, None])
+            tl.store(mixed_qkv + v_dst, v_data, mask=row_mask[:, None])
+
+            z_src_offset = TOTAL_QKV + head_id * V_DIM_PER_GROUP
+            z_src = (
+                row_indices[:, None] * QKVZ_ROW_STRIDE + z_src_offset + v_range[None, :]
+            )
+            z_dst = (
+                row_indices[:, None] * Z_ROW_STRIDE
+                + head_id * V_DIM_PER_GROUP
+                + v_range[None, :]
+            )
+
+            z_data = tl.load(mixed_qkvz + z_src, mask=row_mask[:, None])
+            tl.store(z + z_dst, z_data, mask=row_mask[:, None])
+
+            ba_range = tl.arange(0, V_PER_GROUP)
+            b_src_offset = head_id * V_PER_GROUP
+
+            b_src = (
+                row_indices[:, None] * BA_ROW_STRIDE + b_src_offset + ba_range[None, :]
+            )
+            b_dst = (
+                row_indices[:, None] * BA_OUT_ROW_STRIDE
+                + head_id * V_PER_GROUP
+                + ba_range[None, :]
+            )
+
+            b_data = tl.load(mixed_ba + b_src, mask=row_mask[:, None])
+            tl.store(b + b_dst, b_data, mask=row_mask[:, None])
+
+            a_src_offset = NUM_HEADS_V + head_id * V_PER_GROUP
+            a_src = (
+                row_indices[:, None] * BA_ROW_STRIDE + a_src_offset + ba_range[None, :]
+            )
+            a_dst = (
+                row_indices[:, None] * BA_OUT_ROW_STRIDE
+                + head_id * V_PER_GROUP
+                + ba_range[None, :]
+            )
+
+            a_data = tl.load(mixed_ba + a_src, mask=row_mask[:, None])
+            tl.store(a + a_dst, a_data, mask=row_mask[:, None])
+
+        row_offset += ROWS_PER_ITER
 
 
 def fused_qkvzba_split_reshape_cat_contiguous(
@@ -570,22 +605,23 @@ def fused_qkvzba_split_reshape_cat_contiguous(
     head_qk,
     head_v,
 ):
-    """Fused split/reshape/cat for CONTIGUOUS input format (Qwen3.5).
 
-    Input layout:
-        mixed_qkvz: [all_q | all_k | all_v | all_z]
-        mixed_ba:   [all_b | all_a]
-
-    Output layout (same as fused_qkvzba_split_reshape_cat):
-        mixed_qkv: [all_q | all_k | all_v]  (z stripped)
-        z: [num_v_heads, head_v]
-        b: [num_v_heads]
-        a: [num_v_heads]
-    """
     batch, seq_len = mixed_qkvz.shape[0], 1
-    qkv_dim_t = num_heads_qk * head_qk * 2 + num_heads_v * head_v
+    total_rows = batch * seq_len
+
+
+    total_q = num_heads_qk * head_qk
+    total_k = num_heads_qk * head_qk
+    total_v = num_heads_v * head_v
+
+    qkvz_row_stride = total_q + total_k + total_v + total_v
+    ba_row_stride = num_heads_v * 2
+    qkv_row_stride = total_q + total_k + total_v
+    z_row_stride = num_heads_v * head_v
+    ba_out_row_stride = num_heads_v
+
     mixed_qkv = torch.empty(
-        [batch * seq_len, qkv_dim_t],
+        [batch * seq_len, qkv_row_stride],
         dtype=mixed_qkvz.dtype,
         device=mixed_qkvz.device,
     )
@@ -600,14 +636,31 @@ def fused_qkvzba_split_reshape_cat_contiguous(
         device=mixed_ba.device,
     )
     a = torch.empty_like(b)
-    num_vectorcore = get_device_properties()[1]
 
-    total_tasks = batch * num_heads_qk
-    grid_size = min(num_vectorcore, total_tasks)
+    num_vectorcore = get_device_properties()[1]
+    grid_size = min(num_vectorcore, total_rows)
     grid_size = max(1, grid_size)
 
+    ub_size_bytes = UB_SPECIFICATION * 1024
+    dtype_size = mixed_qkvz.element_size()
+
+    elements_per_row = (
+        qkvz_row_stride
+        + ba_row_stride
+        + qkv_row_stride
+        + z_row_stride
+        + ba_out_row_stride * 2
+    )
+
+    rows_per_iter = max(1, int(ub_size_bytes * 0.75 // (elements_per_row * dtype_size)))
+    rows_per_iter = triton.next_power_of_2(rows_per_iter)
+    rows_per_iter = min(rows_per_iter, MAX_ROWS_PER_ITER)
+
+    rows_per_vec = triton.cdiv(total_rows, grid_size)
+    rows_per_vec = max(rows_per_vec, rows_per_iter)
+
     grid = (grid_size,)
-    fused_qkvzba_split_reshape_cat_contiguous_kernel[grid](
+    fused_qkvzba_split_reshape_cat_contiguous_kernel_optimized[grid](
         mixed_qkv,
         z,
         b,
@@ -618,9 +671,14 @@ def fused_qkvzba_split_reshape_cat_contiguous(
         num_heads_v,
         head_qk,
         head_v,
-        batch,
-        num_warps=1,
-        num_stages=3,
+        total_rows,
+        rows_per_vec,
+        qkvz_row_stride,
+        ba_row_stride,
+        qkv_row_stride,
+        z_row_stride,
+        ba_out_row_stride,
+        rows_per_iter,
     )
 
     return mixed_qkv, z, b, a

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
@@ -440,3 +440,363 @@ def fused_qkvzba_split_reshape_cat(
         rows_per_iter,
     )
     return mixed_qkv, z, b, a
+
+
+# =============================================================================
+# Fused kernel — reads INTERLEAVED input format
+# Used by Qwen3-Next whose checkpoint stores fused in_proj_qkvz weights
+# in per-head-group interleaved layout:
+#   [g0_q, g0_k, g0_v, g0_z, g1_q, g1_k, g1_v, g1_z, ...]
+# =============================================================================
+
+@triton.jit
+def fused_qkvzba_split_reshape_cat_contiguous_kernel(
+    mixed_qkv,
+    z,
+    b,
+    a,
+    mixed_qkvz,
+    mixed_ba,
+    NUM_HEADS_QK: tl.constexpr,
+    NUM_HEADS_V: tl.constexpr,
+    HEAD_QK: tl.constexpr,
+    HEAD_V: tl.constexpr,
+    batch_size,
+):
+    pid = tl.program_id(0)
+    num_pids = tl.num_programs(0)
+
+    V_PER_GROUP: tl.constexpr = NUM_HEADS_V // NUM_HEADS_QK
+
+    # ── Input dimensions (contiguous layout) ──
+    TOTAL_Q: tl.constexpr = NUM_HEADS_QK * HEAD_QK
+    TOTAL_K: tl.constexpr = NUM_HEADS_QK * HEAD_QK
+    TOTAL_V: tl.constexpr = NUM_HEADS_V * HEAD_V
+    TOTAL_QKVZ: tl.constexpr = TOTAL_Q + TOTAL_K + TOTAL_V + TOTAL_V
+    TOTAL_BA: tl.constexpr = NUM_HEADS_V * 2
+
+    # ── Output dimensions ──
+    QKV_DIM_T: tl.constexpr = TOTAL_Q + TOTAL_K + TOTAL_V
+
+    total_tasks = batch_size * NUM_HEADS_QK
+
+    for task_id in tl.range(pid, total_tasks, num_pids):
+
+        i_bs = task_id // NUM_HEADS_QK
+        i_qk = task_id % NUM_HEADS_QK
+
+        # ── Read from contiguous input ──
+        # q for head group i_qk: in the all_q region, offset i_qk * HEAD_QK
+        blk_q_ptr = (
+            mixed_qkvz + i_bs * TOTAL_QKVZ + i_qk * HEAD_QK + tl.arange(0, HEAD_QK)
+        )
+        # k for head group i_qk: in the all_k region
+        blk_k_ptr = (
+            mixed_qkvz
+            + i_bs * TOTAL_QKVZ
+            + TOTAL_Q
+            + i_qk * HEAD_QK
+            + tl.arange(0, HEAD_QK)
+        )
+        # v for head group i_qk: in the all_v region
+        blk_v_ptr = (
+            mixed_qkvz
+            + i_bs * TOTAL_QKVZ
+            + TOTAL_Q
+            + TOTAL_K
+            + i_qk * V_PER_GROUP * HEAD_V
+            + tl.arange(0, V_PER_GROUP * HEAD_V)
+        )
+        # z for head group i_qk: in the all_z region
+        blk_z_ptr = (
+            mixed_qkvz
+            + i_bs * TOTAL_QKVZ
+            + TOTAL_Q
+            + TOTAL_K
+            + TOTAL_V
+            + i_qk * V_PER_GROUP * HEAD_V
+            + tl.arange(0, V_PER_GROUP * HEAD_V)
+        )
+
+        # ── Write to output (identical layout to the interleaved kernel) ──
+        blk_q_st_ptr = (
+            mixed_qkv + i_bs * QKV_DIM_T + i_qk * HEAD_QK + tl.arange(0, HEAD_QK)
+        )
+        blk_k_st_ptr = (
+            mixed_qkv
+            + i_bs * QKV_DIM_T
+            + NUM_HEADS_QK * HEAD_QK
+            + i_qk * HEAD_QK
+            + tl.arange(0, HEAD_QK)
+        )
+        blk_v_st_ptr = (
+            mixed_qkv
+            + i_bs * QKV_DIM_T
+            + NUM_HEADS_QK * HEAD_QK * 2
+            + i_qk * V_PER_GROUP * HEAD_V
+            + tl.arange(0, V_PER_GROUP * HEAD_V)
+        )
+        blk_z_st_ptr = (
+            z
+            + i_bs * NUM_HEADS_V * HEAD_V
+            + i_qk * V_PER_GROUP * HEAD_V
+            + tl.arange(0, V_PER_GROUP * HEAD_V)
+        )
+
+        tl.store(blk_q_st_ptr, tl.load(blk_q_ptr))
+        tl.store(blk_k_st_ptr, tl.load(blk_k_ptr))
+        tl.store(blk_v_st_ptr, tl.load(blk_v_ptr))
+        tl.store(blk_z_st_ptr, tl.load(blk_z_ptr))
+
+        for i in tl.static_range(V_PER_GROUP):
+            blk_b_ptr = mixed_ba + i_bs * TOTAL_BA + i_qk * V_PER_GROUP + i
+            blk_b_st_ptr = b + i_bs * NUM_HEADS_V + i_qk * V_PER_GROUP + i
+            tl.store(blk_b_st_ptr, tl.load(blk_b_ptr))
+
+        for i in tl.static_range(V_PER_GROUP):
+            blk_a_ptr = (
+                mixed_ba + i_bs * TOTAL_BA + NUM_HEADS_V + i_qk * V_PER_GROUP + i
+            )
+            blk_a_st_ptr = a + i_bs * NUM_HEADS_V + i_qk * V_PER_GROUP + i
+            tl.store(blk_a_st_ptr, tl.load(blk_a_ptr))
+
+
+def fused_qkvzba_split_reshape_cat_contiguous(
+    mixed_qkvz,
+    mixed_ba,
+    num_heads_qk,
+    num_heads_v,
+    head_qk,
+    head_v,
+):
+    """Fused split/reshape/cat for CONTIGUOUS input format (Qwen3.5).
+
+    Input layout:
+        mixed_qkvz: [all_q | all_k | all_v | all_z]
+        mixed_ba:   [all_b | all_a]
+
+    Output layout (same as fused_qkvzba_split_reshape_cat):
+        mixed_qkv: [all_q | all_k | all_v]  (z stripped)
+        z: [num_v_heads, head_v]
+        b: [num_v_heads]
+        a: [num_v_heads]
+    """
+    batch, seq_len = mixed_qkvz.shape[0], 1
+    qkv_dim_t = num_heads_qk * head_qk * 2 + num_heads_v * head_v
+    mixed_qkv = torch.empty(
+        [batch * seq_len, qkv_dim_t],
+        dtype=mixed_qkvz.dtype,
+        device=mixed_qkvz.device,
+    )
+    z = torch.empty(
+        [batch * seq_len, num_heads_v, head_v],
+        dtype=mixed_qkvz.dtype,
+        device=mixed_qkvz.device,
+    )
+    b = torch.empty(
+        [batch * seq_len, num_heads_v],
+        dtype=mixed_ba.dtype,
+        device=mixed_ba.device,
+    )
+    a = torch.empty_like(b)
+    num_vectorcore = get_device_properties()[1]
+
+    total_tasks = batch * num_heads_qk
+    grid_size = min(num_vectorcore, total_tasks)
+    grid_size = max(1, grid_size)
+
+    grid = (grid_size,)
+    fused_qkvzba_split_reshape_cat_contiguous_kernel[grid](
+        mixed_qkv,
+        z,
+        b,
+        a,
+        mixed_qkvz,
+        mixed_ba,
+        num_heads_qk,
+        num_heads_v,
+        head_qk,
+        head_v,
+        batch,
+        num_warps=1,
+        num_stages=3,
+    )
+
+    return mixed_qkv, z, b, a
+
+
+# =============================================================================
+# Fused kernel — reads CONTIGUOUS input format
+# Used by Qwen3.5 whose checkpoint stores in_proj_qkv and in_proj_z separately.
+# After MergedColumnParallelLinear loads them, the matmul output is contiguous:
+#   mixed_qkvz: [all_q | all_k | all_v | all_z]
+#   mixed_ba:   [all_b | all_a]
+#
+# Output format is identical to the interleaved kernel (same downstream consumer).
+# =============================================================================
+
+@triton.jit
+def fused_qkvzba_split_reshape_cat_contiguous_kernel(
+    mixed_qkv,
+    z,
+    b,
+    a,
+    mixed_qkvz,
+    mixed_ba,
+    NUM_HEADS_QK: tl.constexpr,
+    NUM_HEADS_V: tl.constexpr,
+    HEAD_QK: tl.constexpr,
+    HEAD_V: tl.constexpr,
+    batch_size,
+):
+    pid = tl.program_id(0)
+    num_pids = tl.num_programs(0)
+
+    V_PER_GROUP: tl.constexpr = NUM_HEADS_V // NUM_HEADS_QK
+
+    TOTAL_Q: tl.constexpr = NUM_HEADS_QK * HEAD_QK
+    TOTAL_K: tl.constexpr = NUM_HEADS_QK * HEAD_QK
+    TOTAL_V: tl.constexpr = NUM_HEADS_V * HEAD_V
+    TOTAL_QKVZ: tl.constexpr = TOTAL_Q + TOTAL_K + TOTAL_V + TOTAL_V
+    TOTAL_BA: tl.constexpr = NUM_HEADS_V * 2
+    QKV_DIM_T: tl.constexpr = TOTAL_Q + TOTAL_K + TOTAL_V
+
+    total_tasks = batch_size * NUM_HEADS_QK
+
+    for task_id in tl.range(pid, total_tasks, num_pids):
+
+        i_bs = task_id // NUM_HEADS_QK
+        i_qk = task_id % NUM_HEADS_QK
+
+        blk_q_ptr = (
+            mixed_qkvz + i_bs * TOTAL_QKVZ + i_qk * HEAD_QK + tl.arange(0, HEAD_QK)
+        )
+        blk_k_ptr = (
+            mixed_qkvz
+            + i_bs * TOTAL_QKVZ
+            + TOTAL_Q
+            + i_qk * HEAD_QK
+            + tl.arange(0, HEAD_QK)
+        )
+        blk_v_ptr = (
+            mixed_qkvz
+            + i_bs * TOTAL_QKVZ
+            + TOTAL_Q
+            + TOTAL_K
+            + i_qk * V_PER_GROUP * HEAD_V
+            + tl.arange(0, V_PER_GROUP * HEAD_V)
+        )
+        blk_z_ptr = (
+            mixed_qkvz
+            + i_bs * TOTAL_QKVZ
+            + TOTAL_Q
+            + TOTAL_K
+            + TOTAL_V
+            + i_qk * V_PER_GROUP * HEAD_V
+            + tl.arange(0, V_PER_GROUP * HEAD_V)
+        )
+
+        blk_q_st_ptr = (
+            mixed_qkv + i_bs * QKV_DIM_T + i_qk * HEAD_QK + tl.arange(0, HEAD_QK)
+        )
+        blk_k_st_ptr = (
+            mixed_qkv
+            + i_bs * QKV_DIM_T
+            + NUM_HEADS_QK * HEAD_QK
+            + i_qk * HEAD_QK
+            + tl.arange(0, HEAD_QK)
+        )
+        blk_v_st_ptr = (
+            mixed_qkv
+            + i_bs * QKV_DIM_T
+            + NUM_HEADS_QK * HEAD_QK * 2
+            + i_qk * V_PER_GROUP * HEAD_V
+            + tl.arange(0, V_PER_GROUP * HEAD_V)
+        )
+        blk_z_st_ptr = (
+            z
+            + i_bs * NUM_HEADS_V * HEAD_V
+            + i_qk * V_PER_GROUP * HEAD_V
+            + tl.arange(0, V_PER_GROUP * HEAD_V)
+        )
+
+        tl.store(blk_q_st_ptr, tl.load(blk_q_ptr))
+        tl.store(blk_k_st_ptr, tl.load(blk_k_ptr))
+        tl.store(blk_v_st_ptr, tl.load(blk_v_ptr))
+        tl.store(blk_z_st_ptr, tl.load(blk_z_ptr))
+
+        for i in tl.static_range(V_PER_GROUP):
+            blk_b_ptr = mixed_ba + i_bs * TOTAL_BA + i_qk * V_PER_GROUP + i
+            blk_b_st_ptr = b + i_bs * NUM_HEADS_V + i_qk * V_PER_GROUP + i
+            tl.store(blk_b_st_ptr, tl.load(blk_b_ptr))
+
+        for i in tl.static_range(V_PER_GROUP):
+            blk_a_ptr = (
+                mixed_ba + i_bs * TOTAL_BA + NUM_HEADS_V + i_qk * V_PER_GROUP + i
+            )
+            blk_a_st_ptr = a + i_bs * NUM_HEADS_V + i_qk * V_PER_GROUP + i
+            tl.store(blk_a_st_ptr, tl.load(blk_a_ptr))
+
+
+def fused_qkvzba_split_reshape_cat_contiguous(
+    mixed_qkvz,
+    mixed_ba,
+    num_heads_qk,
+    num_heads_v,
+    head_qk,
+    head_v,
+):
+    """Fused split/reshape/cat for CONTIGUOUS input format (Qwen3.5).
+
+    Input layout:
+        mixed_qkvz: [all_q | all_k | all_v | all_z]
+        mixed_ba:   [all_b | all_a]
+
+    Output layout (same as fused_qkvzba_split_reshape_cat):
+        mixed_qkv: [all_q | all_k | all_v]  (z stripped)
+        z: [num_v_heads, head_v]
+        b: [num_v_heads]
+        a: [num_v_heads]
+    """
+    batch, seq_len = mixed_qkvz.shape[0], 1
+    qkv_dim_t = num_heads_qk * head_qk * 2 + num_heads_v * head_v
+    mixed_qkv = torch.empty(
+        [batch * seq_len, qkv_dim_t],
+        dtype=mixed_qkvz.dtype,
+        device=mixed_qkvz.device,
+    )
+    z = torch.empty(
+        [batch * seq_len, num_heads_v, head_v],
+        dtype=mixed_qkvz.dtype,
+        device=mixed_qkvz.device,
+    )
+    b = torch.empty(
+        [batch * seq_len, num_heads_v],
+        dtype=mixed_ba.dtype,
+        device=mixed_ba.device,
+    )
+    a = torch.empty_like(b)
+    num_vectorcore = get_device_properties()[1]
+
+    total_tasks = batch * num_heads_qk
+    grid_size = min(num_vectorcore, total_tasks)
+    grid_size = max(1, grid_size)
+
+    grid = (grid_size,)
+    fused_qkvzba_split_reshape_cat_contiguous_kernel[grid](
+        mixed_qkv,
+        z,
+        b,
+        a,
+        mixed_qkvz,
+        mixed_ba,
+        num_heads_qk,
+        num_heads_v,
+        head_qk,
+        head_v,
+        batch,  #
+        num_warps=1,
+        num_stages=3,
+    )
+
+    return mixed_qkv, z, b, a

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
@@ -459,12 +459,10 @@ def fused_qkvzba_split_reshape_cat(
 #
 # Output format is identical to the interleaved kernel (same downstream consumer).
 # =============================================================================
-MAX_ROWS_PER_ITER = 256
-UB_SPECIFICATION = 85
 
 
 @triton.jit
-def fused_qkvzba_split_reshape_cat_contiguous_kernel_optimized(
+def fused_qkvzba_split_reshape_cat_contiguous_kernel(
     mixed_qkv,
     z,
     b,
@@ -483,18 +481,13 @@ def fused_qkvzba_split_reshape_cat_contiguous_kernel_optimized(
     Z_ROW_STRIDE: tl.constexpr,
     BA_OUT_ROW_STRIDE: tl.constexpr,
     ROWS_PER_ITER: tl.constexpr,
+    BLOCK_SIZE_COL: tl.constexpr,
 ):
     vec_id = tl.program_id(0)
-
-    # ── Input dimensions (contiguous layout) ──
-    V_PER_GROUP: tl.constexpr = NUM_HEADS_V // NUM_HEADS_QK
-    V_DIM_PER_GROUP: tl.constexpr = V_PER_GROUP * HEAD_V
 
     TOTAL_Q: tl.constexpr = NUM_HEADS_QK * HEAD_QK
     TOTAL_K: tl.constexpr = NUM_HEADS_QK * HEAD_QK
     TOTAL_V: tl.constexpr = NUM_HEADS_V * HEAD_V
-    TOTAL_QK: tl.constexpr = TOTAL_Q + TOTAL_K
-    TOTAL_QKV: tl.constexpr = TOTAL_Q + TOTAL_K + TOTAL_V
 
     row_start = vec_id * rows_per_vec
     row_end = tl.minimum(row_start + rows_per_vec, total_rows)
@@ -503,97 +496,81 @@ def fused_qkvzba_split_reshape_cat_contiguous_kernel_optimized(
     iter_count = (row_end - row_start + ROWS_PER_ITER - 1) // ROWS_PER_ITER
 
     for _ in tl.range(iter_count):
-
         row_indices = tl.arange(0, ROWS_PER_ITER) + row_offset
         row_mask = row_indices < row_end
 
-        for head_id in tl.static_range(NUM_HEADS_QK):
+        for col_start in tl.static_range(0, TOTAL_Q, BLOCK_SIZE_COL):
+            col_range = tl.arange(0, BLOCK_SIZE_COL) + col_start
+            col_mask = col_range < TOTAL_Q
+            combined_mask = row_mask[:, None] & col_mask[None, :]
 
-            q_range = tl.arange(0, HEAD_QK)
-            q_src_offset = head_id * HEAD_QK
+            q_src = row_indices[:, None] * QKVZ_ROW_STRIDE + col_range[None, :]
+            q_dst = row_indices[:, None] * QKV_ROW_STRIDE + col_range[None, :]
 
-            q_src = (
-                row_indices[:, None] * QKVZ_ROW_STRIDE + q_src_offset + q_range[None, :]
-            )
-            q_dst = (
-                row_indices[:, None] * QKV_ROW_STRIDE
-                + head_id * HEAD_QK
-                + q_range[None, :]
-            )
+            q_data = tl.load(mixed_qkvz + q_src, mask=combined_mask)
+            tl.store(mixed_qkv + q_dst, q_data, mask=combined_mask)
 
-            q_data = tl.load(mixed_qkvz + q_src, mask=row_mask[:, None])
-            tl.store(mixed_qkv + q_dst, q_data, mask=row_mask[:, None])
+        for col_start in tl.static_range(0, TOTAL_K, BLOCK_SIZE_COL):
+            col_range = tl.arange(0, BLOCK_SIZE_COL) + col_start
+            col_mask = col_range < TOTAL_K
+            combined_mask = row_mask[:, None] & col_mask[None, :]
 
-            k_src_offset = TOTAL_Q + head_id * HEAD_QK
             k_src = (
-                row_indices[:, None] * QKVZ_ROW_STRIDE + k_src_offset + q_range[None, :]
+                row_indices[:, None] * QKVZ_ROW_STRIDE + TOTAL_Q + col_range[None, :]
             )
-            k_dst = (
-                row_indices[:, None] * QKV_ROW_STRIDE
-                + TOTAL_Q
-                + head_id * HEAD_QK
-                + q_range[None, :]
-            )
+            k_dst = row_indices[:, None] * QKV_ROW_STRIDE + TOTAL_Q + col_range[None, :]
 
-            k_data = tl.load(mixed_qkvz + k_src, mask=row_mask[:, None])
-            tl.store(mixed_qkv + k_dst, k_data, mask=row_mask[:, None])
+            k_data = tl.load(mixed_qkvz + k_src, mask=combined_mask)
+            tl.store(mixed_qkv + k_dst, k_data, mask=combined_mask)
 
-            v_range = tl.arange(0, V_DIM_PER_GROUP)
-            v_src_offset = TOTAL_QK + head_id * V_DIM_PER_GROUP
+        for col_start in tl.static_range(0, TOTAL_V, BLOCK_SIZE_COL):
+            col_range = tl.arange(0, BLOCK_SIZE_COL) + col_start
+            col_mask = col_range < TOTAL_V
+            combined_mask = row_mask[:, None] & col_mask[None, :]
 
             v_src = (
-                row_indices[:, None] * QKVZ_ROW_STRIDE + v_src_offset + v_range[None, :]
+                row_indices[:, None] * QKVZ_ROW_STRIDE
+                + TOTAL_Q
+                + TOTAL_K
+                + col_range[None, :]
             )
             v_dst = (
                 row_indices[:, None] * QKV_ROW_STRIDE
-                + TOTAL_QK
-                + head_id * V_DIM_PER_GROUP
-                + v_range[None, :]
+                + TOTAL_Q
+                + TOTAL_K
+                + col_range[None, :]
             )
 
-            v_data = tl.load(mixed_qkvz + v_src, mask=row_mask[:, None])
-            tl.store(mixed_qkv + v_dst, v_data, mask=row_mask[:, None])
+            v_data = tl.load(mixed_qkvz + v_src, mask=combined_mask)
+            tl.store(mixed_qkv + v_dst, v_data, mask=combined_mask)
 
-            z_src_offset = TOTAL_QKV + head_id * V_DIM_PER_GROUP
+        for col_start in tl.static_range(0, TOTAL_V, BLOCK_SIZE_COL):
+            col_range = tl.arange(0, BLOCK_SIZE_COL) + col_start
+            col_mask = col_range < TOTAL_V
+            combined_mask = row_mask[:, None] & col_mask[None, :]
+
             z_src = (
-                row_indices[:, None] * QKVZ_ROW_STRIDE + z_src_offset + v_range[None, :]
+                row_indices[:, None] * QKVZ_ROW_STRIDE
+                + TOTAL_Q
+                + TOTAL_K
+                + TOTAL_V
+                + col_range[None, :]
             )
-            z_dst = (
-                row_indices[:, None] * Z_ROW_STRIDE
-                + head_id * V_DIM_PER_GROUP
-                + v_range[None, :]
-            )
+            z_dst = row_indices[:, None] * Z_ROW_STRIDE + col_range[None, :]
 
-            z_data = tl.load(mixed_qkvz + z_src, mask=row_mask[:, None])
-            tl.store(z + z_dst, z_data, mask=row_mask[:, None])
+            z_data = tl.load(mixed_qkvz + z_src, mask=combined_mask)
+            tl.store(z + z_dst, z_data, mask=combined_mask)
 
-            ba_range = tl.arange(0, V_PER_GROUP)
-            b_src_offset = head_id * V_PER_GROUP
+        ba_range = tl.arange(0, NUM_HEADS_V)
+        b_src = row_indices[:, None] * BA_ROW_STRIDE + ba_range[None, :]
+        b_dst = row_indices[:, None] * BA_OUT_ROW_STRIDE + ba_range[None, :]
 
-            b_src = (
-                row_indices[:, None] * BA_ROW_STRIDE + b_src_offset + ba_range[None, :]
-            )
-            b_dst = (
-                row_indices[:, None] * BA_OUT_ROW_STRIDE
-                + head_id * V_PER_GROUP
-                + ba_range[None, :]
-            )
+        b_data = tl.load(mixed_ba + b_src, mask=row_mask[:, None])
+        tl.store(b + b_dst, b_data, mask=row_mask[:, None])
 
-            b_data = tl.load(mixed_ba + b_src, mask=row_mask[:, None])
-            tl.store(b + b_dst, b_data, mask=row_mask[:, None])
-
-            a_src_offset = NUM_HEADS_V + head_id * V_PER_GROUP
-            a_src = (
-                row_indices[:, None] * BA_ROW_STRIDE + a_src_offset + ba_range[None, :]
-            )
-            a_dst = (
-                row_indices[:, None] * BA_OUT_ROW_STRIDE
-                + head_id * V_PER_GROUP
-                + ba_range[None, :]
-            )
-
-            a_data = tl.load(mixed_ba + a_src, mask=row_mask[:, None])
-            tl.store(a + a_dst, a_data, mask=row_mask[:, None])
+        a_src = row_indices[:, None] * BA_ROW_STRIDE + NUM_HEADS_V + ba_range[None, :]
+        a_data = tl.load(mixed_ba + a_src, mask=row_mask[:, None])
+        tl.store(a + b_dst, a_data, mask=row_mask[:, None])
 
         row_offset += ROWS_PER_ITER
 
@@ -605,8 +582,8 @@ def fused_qkvzba_split_reshape_cat_contiguous(
     num_heads_v,
     head_qk,
     head_v,
+    block_size_col=1024,
 ):
-
     batch, seq_len = mixed_qkvz.shape[0], 1
     total_rows = batch * seq_len
 
@@ -641,18 +618,11 @@ def fused_qkvzba_split_reshape_cat_contiguous(
     grid_size = min(num_vectorcore, total_rows)
     grid_size = max(1, grid_size)
 
-    ub_size_bytes = UB_SPECIFICATION * 1024
     dtype_size = mixed_qkvz.element_size()
+    ub_size_bytes = UB_SPECIFICATION * 1024
 
-    elements_per_row = (
-        qkvz_row_stride
-        + ba_row_stride
-        + qkv_row_stride
-        + z_row_stride
-        + ba_out_row_stride * 2
-    )
-
-    rows_per_iter = max(1, int(ub_size_bytes * 0.75 // (elements_per_row * dtype_size)))
+    target_elements_per_iter = (ub_size_bytes * 0.4) // dtype_size
+    rows_per_iter = max(1, int(target_elements_per_iter // block_size_col))
     rows_per_iter = triton.next_power_of_2(rows_per_iter)
     rows_per_iter = min(rows_per_iter, MAX_ROWS_PER_ITER)
 
@@ -660,7 +630,7 @@ def fused_qkvzba_split_reshape_cat_contiguous(
     rows_per_vec = max(rows_per_vec, rows_per_iter)
 
     grid = (grid_size,)
-    fused_qkvzba_split_reshape_cat_contiguous_kernel_optimized[grid](
+    fused_qkvzba_split_reshape_cat_contiguous_kernel[grid](
         mixed_qkv,
         z,
         b,
@@ -679,6 +649,8 @@ def fused_qkvzba_split_reshape_cat_contiguous(
         z_row_stride,
         ba_out_row_stride,
         rows_per_iter,
+        block_size_col,
     )
 
     return mixed_qkv, z, b, a
+

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
@@ -230,6 +230,7 @@ UB_SPECIFICATION = 85
 #   [g0_q, g0_k, g0_v, g0_z, g1_q, g1_k, g1_v, g1_z, ...]
 # =============================================================================
 
+
 @triton.jit(do_not_specialize=["total_rows", "rows_per_vec"])
 def fused_qkvzba_split_reshape_cat_kernel(
     mixed_qkv,

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
@@ -653,4 +653,3 @@ def fused_qkvzba_split_reshape_cat_contiguous(
     )
 
     return mixed_qkv, z, b, a
-

--- a/tests/python/sgl_kernel_npu/test_qkvzba_split_reshape_cat.py
+++ b/tests/python/sgl_kernel_npu/test_qkvzba_split_reshape_cat.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn.functional as F
 from sgl_kernel_npu.fla.utils import (
     fused_qkvzba_split_reshape_cat,
+    fused_qkvzba_split_reshape_cat_contiguous,
     fused_qkvzba_split_reshape_cat_torch,
 )
 
@@ -144,3 +145,127 @@ def test_fused_qkvzba(
     assert_close("z", ref_z, tri_z, 0.005, err_atol=1e-6)
     assert_close("b", ref_b, tri_b, 0.005, err_atol=1e-6)
     assert_close("a", ref_a, tri_a, 0.005, err_atol=1e-6)
+
+
+def fused_qkvzba_split_reshape_cat_torch_contiguous(qkvz, ba, batch, num_k_heads, num_v_heads, head_dim):
+    """
+    Reference implementation.
+    """
+    total_q = num_k_heads * head_dim
+    total_k = num_k_heads * head_dim
+    total_v = num_v_heads * head_dim
+
+    q = qkvz[:, 0:total_q]
+    k = qkvz[:, total_q : total_q + total_k]
+    v = qkvz[:, total_q + total_k : total_q + total_k + total_v]
+    z_data = qkvz[:, total_q + total_k + total_v :]
+
+    mixed_qkv_ref = torch.cat([q, k, v], dim=-1)
+
+    z_ref = z_data.reshape(batch, num_v_heads, head_dim)
+    b_ref = ba[:, 0:num_v_heads]
+    a_ref = ba[:, num_v_heads:]
+
+    return mixed_qkv_ref, z_ref, b_ref, a_ref
+
+
+@pytest.mark.parametrize(
+    ("B", "num_heads_qk", "num_heads_v", "head_qk", "head_v", "dtype"),
+    [
+        pytest.param(
+            *test,
+            id="B{}-num_heads_qk{}-num_heads_v{}-head_qk{}-head_v{}-{}".format(*test),
+        )
+        for test in [
+            # Original small cases (for robustness)
+            (1, 4, 8, 128, 128, torch.float16),
+            (2, 4, 8, 128, 128, torch.float16),
+            (1, 4, 8, 128, 128, torch.bfloat16),
+            (2, 4, 8, 128, 128, torch.bfloat16),
+            (1, 4, 8, 128, 128, torch.float32),
+            (2, 4, 8, 128, 128, torch.float32),
+            (31480, 8, 24, 128, 128, torch.float32),
+        ]
+    ],
+)
+@pytest.mark.skipif(
+    os.getenv("SKIP_TEST_FUSED_QKVZBA_CONTIGUOUS") == "1",
+    reason="Skipping test_fused_qkvzba_contiguous because SKIP_TEST_FUSED_QKVZBA_CONTIGUOUS is set",
+)
+def test_fused_qkvzba_contiguous(
+    B: int,
+    num_heads_qk: int,
+    num_heads_v: int,
+    head_qk: int,
+    head_v: int,
+    dtype: torch.dtype,
+):
+    if head_v not in [64, 128, 256]:
+        pytest.skip(reason="fused_qkvzba only supports head_v in [64,128,256]")
+
+    torch.manual_seed(42)
+    torch.npu.manual_seed_all(42)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+
+    total_q = num_heads_qk * head_qk
+    total_k = num_heads_qk * head_qk
+    total_v = num_heads_v * head_v
+    qkvz_dim = total_q + total_k + total_v + total_v
+    ba_dim = num_heads_v * 2
+
+    projected_states_qkvz = torch.randn((B, qkvz_dim), device=device, dtype=dtype)
+    projected_states_ba = torch.randn((B, ba_dim), device=device, dtype=dtype)
+
+    tri_mixed_qkv, tri_z, tri_b, tri_a = None, None, None, None
+    begin_time = 0
+    for i in range(LAUNCH_CNT):
+        if i == 1 or LAUNCH_CNT == 1:
+            torch.npu.synchronize()
+            begin_time = time.time()
+
+        tri_mixed_qkv, tri_z, tri_b, tri_a = fused_qkvzba_split_reshape_cat_contiguous(
+            projected_states_qkvz.clone(),
+            projected_states_ba.clone(),
+            num_heads_qk,
+            num_heads_v,
+            head_qk,
+            head_v,
+        )
+
+    torch.npu.synchronize()
+    use_time = time.time() - begin_time
+    avg_time = use_time * 1000 / (LAUNCH_CNT - 1) if LAUNCH_CNT > 1 else use_time * 1000
+    print(f"[DEBUG] fused_qkvzba_contiguous (target) using time: {avg_time:.2f} ms")
+
+    ref_mixed_qkv, ref_z, ref_b, ref_a = None, None, None, None
+    begin_time = 0
+    for i in range(LAUNCH_CNT):
+        if i == 1 or LAUNCH_CNT == 1:
+            torch.npu.synchronize()
+            begin_time = time.time()
+
+        ref_mixed_qkv, ref_z, ref_b, ref_a = fused_qkvzba_split_reshape_cat_torch_contiguous(
+            projected_states_qkvz,
+            projected_states_ba,
+            B,
+            num_heads_qk,
+            num_heads_v,
+            head_v,
+        )
+
+    torch.npu.synchronize()
+    use_time = time.time() - begin_time
+    avg_time = use_time * 1000 / (LAUNCH_CNT - 1) if LAUNCH_CNT > 1 else use_time * 1000
+    print(f"[DEBUG] fused_qkvzba_contiguous (torch ref) using time: {avg_time:.2f} ms")
+
+    # --- Verification ---
+    print_diff("mixed_qkv", ref_mixed_qkv, tri_mixed_qkv, 0.005)
+    print_diff("z", ref_z.flatten(), tri_z.flatten(), 0.005)
+    print_diff("b", ref_b.flatten(), tri_b.flatten(), 0.005)
+    print_diff("a", ref_a.flatten(), tri_a.flatten(), 0.005)
+
+    assert_close("mixed_qkv", ref_mixed_qkv, tri_mixed_qkv, 0.005, err_atol=1e-6)
+    assert_close("z", ref_z.flatten(), tri_z.flatten(), 0.005, err_atol=1e-6)
+    assert_close("b", ref_b.flatten(), tri_b.flatten(), 0.005, err_atol=1e-6)
+    assert_close("a", ref_a.flatten(), tri_a.flatten(), 0.005, err_atol=1e-6)
+

--- a/tests/python/sgl_kernel_npu/test_qkvzba_split_reshape_cat.py
+++ b/tests/python/sgl_kernel_npu/test_qkvzba_split_reshape_cat.py
@@ -244,13 +244,15 @@ def test_fused_qkvzba_contiguous(
             torch.npu.synchronize()
             begin_time = time.time()
 
-        ref_mixed_qkv, ref_z, ref_b, ref_a = fused_qkvzba_split_reshape_cat_torch_contiguous(
-            projected_states_qkvz,
-            projected_states_ba,
-            B,
-            num_heads_qk,
-            num_heads_v,
-            head_v,
+        ref_mixed_qkv, ref_z, ref_b, ref_a = (
+            fused_qkvzba_split_reshape_cat_torch_contiguous(
+                projected_states_qkvz,
+                projected_states_ba,
+                B,
+                num_heads_qk,
+                num_heads_v,
+                head_v,
+            )
         )
 
     torch.npu.synchronize()
@@ -268,4 +270,3 @@ def test_fused_qkvzba_contiguous(
     assert_close("z", ref_z.flatten(), tri_z.flatten(), 0.005, err_atol=1e-6)
     assert_close("b", ref_b.flatten(), tri_b.flatten(), 0.005, err_atol=1e-6)
     assert_close("a", ref_a.flatten(), tri_a.flatten(), 0.005, err_atol=1e-6)
-

--- a/tests/python/sgl_kernel_npu/test_qkvzba_split_reshape_cat.py
+++ b/tests/python/sgl_kernel_npu/test_qkvzba_split_reshape_cat.py
@@ -147,7 +147,9 @@ def test_fused_qkvzba(
     assert_close("a", ref_a, tri_a, 0.005, err_atol=1e-6)
 
 
-def fused_qkvzba_split_reshape_cat_torch_contiguous(qkvz, ba, batch, num_k_heads, num_v_heads, head_dim):
+def fused_qkvzba_split_reshape_cat_torch_contiguous(
+    qkvz, ba, batch, num_k_heads, num_v_heads, head_dim
+):
     """
     Reference implementation.
     """


### PR DESCRIPTION
support seqlen>65536
enhance performance from 25μ to 12μ shape 64 bs* 6144 dim, per ops
<img width="191" height="92" alt="image" src="https://github.com/user-attachments/assets/f5c3b6c2-04ef-4442-8935-b009b43d020d" />
<img width="904" height="93" alt="image" src="https://github.com/user-attachments/assets/93f5ed2b-bc47-4ebb-b1fe-3ec68273b789" />
accuracy 35B gsm8k (evalscope without thinking) 96%, ceval 90%
for Prefill stage, performance enhance a lot for 31480 bs.