### PR TITLE
bugfix: Add activation  setting to torch_causal_conv1d_update_npu

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d.py
@@ -1241,6 +1241,7 @@ def torch_causal_conv1d_update_npu(
     weight: torch.Tensor,
     conv_state_update: Optional[torch.Tensor] = None,
     bias: Optional[torch.Tensor] = None,
+    activation: Union[bool, str, None] = None,
 ):
     bsz, hidden_size, seq_len = hidden_state.shape
     state_len = conv_state.shape[-1]
@@ -1255,7 +1256,8 @@ def torch_causal_conv1d_update_npu(
         conv_state_update = hidden_states_new[:, :, -state_len:]
 
     out = torch.sum(hidden_states_new * weight, dim=-1, keepdim=True)
-    out = F.silu(out)
+    if activation in ["silu", "swish"]:
+        out = F.silu(out)
     out = out.to(hidden_state.dtype)
     return out, conv_state_update
 
@@ -1370,6 +1372,7 @@ def causal_conv1d_update_npu(
             conv_state_update,
             weight,
             bias=bias,
+            activation=activation,
         )
     else:
         _causal_conv1d_update_kernel[grid](


### PR DESCRIPTION
The `torch_causal_conv1d_update_npu` function hardcodes SiLU activation. When calling `Lfm2MoeShortConv` in LFM2-MoE, `activation=None` is passed. This function unconditionally applies SiLU activation and ignores the `activation` parameter.
For this configation:
python -m sglang.launch_server \
--model-path /home/weights/LiquidAI/LFM2.5-1.2B-Instruct \
--host 127.0.0.1 \
--port 8089 \
--attention-backend ascend \
--mem-fraction-static 0.9 \
--base-gpu-id 0 \
--tp 1 \
--disable-radix-cache \
--skip-server-warmup \

before:
<img width="382" height="107" alt="image" src="https://github.com/user-attachments/assets/d5dbf6ce-023c-4f00-92eb-87463634e86b" />
after:
<img width="295" height="122" alt="image" src="https://github.com/user-attachments/assets/f2e2aa31-f1c8-4468-ac5e-ef50eaed2760" />
