### PR TITLE
improve performance for fused gdn gating and solve tril

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/fused_gdn_gating.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/fused_gdn_gating.py
@@ -3,12 +3,12 @@ from typing import Tuple
 import torch
 import triton
 import triton.language as tl
-import triton.runtime.driver as driver
+from sgl_kernel_npu.fla.utils import get_vectorcore_num
+
+UNIFIED_BUFFER_SIZE = 1572864
 
 
-# g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
-# beta_output = b.sigmoid()
-@triton.jit(do_not_specialize=["batch", "seq_len"])
+@triton.jit
 def fused_gdn_gating_kernel(
     g,
     beta_output,
@@ -16,37 +16,41 @@ def fused_gdn_gating_kernel(
     a,
     b,
     dt_bias,
-    batch,
     seq_len,
     NUM_HEADS: tl.constexpr,
+    NUM_BATCHES: tl.constexpr,
     beta: tl.constexpr,
     threshold: tl.constexpr,
     BLK_HEADS: tl.constexpr,
+    COL_ITER: tl.constexpr,
+    BLK_BATCHES: tl.constexpr,
+    ROW_ITER: tl.constexpr,
 ):
-    core, i_s, i_d = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_s = tl.program_id(0), tl.program_id(1)
+    for row_idx in range(0, ROW_ITER):
+        batch_off = i_b * ROW_ITER * BLK_BATCHES + row_idx * BLK_BATCHES + tl.arange(0, BLK_BATCHES)
 
-    head_off = i_d * BLK_HEADS + tl.arange(0, BLK_HEADS)
-    mask = head_off < NUM_HEADS
+        for col_idx in range(0, COL_ITER):
+            head_off = col_idx * BLK_HEADS + tl.arange(0, BLK_HEADS)
 
-    blk_A_log = tl.load(A_log + head_off, mask=mask)
-    blk_bias = tl.load(dt_bias + head_off, mask=mask)
+            off = batch_off[:, None] * seq_len * NUM_HEADS + i_s * NUM_HEADS + head_off[None, :]
+            head_mask = head_off < NUM_HEADS
+            mask = head_mask[None, :] & (batch_off[:, None] < NUM_BATCHES)
 
-    for i_b in tl.range(core, batch, tl.num_programs(0)):
-        off = i_b * seq_len * NUM_HEADS + i_s * NUM_HEADS + head_off
+            blk_A_log = tl.load(A_log + head_off, mask=head_mask)
+            blk_a = tl.load(a + off, mask=mask)
+            blk_b = tl.load(b + off, mask=mask)
+            blk_bias = tl.load(dt_bias + head_off, mask=head_mask)
 
-        blk_a = tl.load(a + off, mask=mask)
-        blk_b = tl.load(b + off, mask=mask)
+            x = blk_a.to(tl.float32) + blk_bias.to(tl.float32)[None, :]
+            softplus_x = tl.where(beta * x <= threshold, (1 / beta) * tl.log(1 + tl.exp(beta * x)), x)
 
-        x = blk_a.to(tl.float32) + blk_bias.to(tl.float32)
-        softplus_x = tl.where(
-            beta * x <= threshold, (1 / beta) * tl.log(1 + tl.exp(beta * x)), x
-        )
+            blk_g = -tl.exp(blk_A_log.to(tl.float32)) * softplus_x
+            tl.store(g + off, blk_g.to(g.dtype.element_ty), mask=mask)
 
-        blk_g = -tl.exp(blk_A_log.to(tl.float32)) * softplus_x
-        blk_beta_output = tl.sigmoid(blk_b.to(tl.float32))
-
-        tl.store(g + off, blk_g.to(g.dtype.element_ty), mask=mask)
-        tl.store(beta_output + off, blk_beta_output.to(b.dtype.element_ty), mask=mask)
+            # compute beta_output = sigmoid(b)
+            blk_beta_output = tl.sigmoid(blk_b.to(tl.float32))
+            tl.store(beta_output + off, blk_beta_output.to(beta_output.dtype.element_ty), mask=mask)
 
 
 def fused_gdn_gating_npu(
@@ -56,22 +60,35 @@ def fused_gdn_gating_npu(
     dt_bias: torch.Tensor,
     beta: float = 1.0,
     threshold: float = 20.0,
-):
+) -> tuple[torch.Tensor, torch.Tensor]:
     batch, num_heads = a.shape
     seq_len = 1
 
+    num_cores = get_vectorcore_num()
+
+    BLK_HEADS = 8
+    COL_ITER = triton.cdiv(num_heads, BLK_HEADS)
+
+    elem_size = a.element_size()
+    max_ub_batches = int((UNIFIED_BUFFER_SIZE * 0.95) / (BLK_HEADS * elem_size))
+    if batch <= num_cores:
+        progs = batch
+        BLK_BATCHES = 1
+        ROW_ITER = 1
+    else:
+        progs = num_cores
+        FACTOR = 8 * num_heads
+        calc_blk_batches = (
+            triton.next_power_of_2(triton.cdiv(int(UNIFIED_BUFFER_SIZE * 0.95), FACTOR * BLK_HEADS * elem_size)) // 2
+        )
+        BLK_BATCHES = max(1, min(calc_blk_batches, max_ub_batches, 64))
+        row_per_core = triton.cdiv(batch, progs)
+        ROW_ITER = triton.cdiv(row_per_core, BLK_BATCHES)
+
     g = torch.empty(1, batch, num_heads, dtype=torch.float32, device=a.device)
-    beta_output = torch.empty(1, batch, num_heads, dtype=torch.float32, device=b.device)
+    beta_output = torch.empty(1, batch, num_heads, dtype=b.dtype, device=b.device)
 
-    device = torch.npu.current_device()
-    num_cores = driver.active.utils.get_device_properties(device)["num_vectorcore"]
-
-    grid = (
-        triton.cdiv(num_cores, triton.cdiv(num_heads, 8)),
-        seq_len,
-        triton.cdiv(num_heads, 8),
-    )
-
+    grid = (progs, seq_len)
     fused_gdn_gating_kernel[grid](
         g,
         beta_output,
@@ -79,14 +96,15 @@ def fused_gdn_gating_npu(
         a,
         b,
         dt_bias,
-        batch,
         seq_len,
         num_heads,
+        batch,
         beta,
         threshold,
-        8,
-        multibuffer=True,
-        num_warps=1,
+        BLK_HEADS=BLK_HEADS,
+        COL_ITER=COL_ITER,
+        BLK_BATCHES=BLK_BATCHES,
+        ROW_ITER=ROW_ITER,
     )
     return g, beta_output
 

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/fused_gdn_gating.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/fused_gdn_gating.py
@@ -3,7 +3,7 @@ from typing import Tuple
 import torch
 import triton
 import triton.language as tl
-from sgl_kernel_npu.fla.utils import get_vectorcore_num
+from sgl_kernel_npu.utils.triton_utils import get_device_properties
 
 UNIFIED_BUFFER_SIZE = 1572864
 
@@ -64,7 +64,7 @@ def fused_gdn_gating_npu(
     batch, num_heads = a.shape
     seq_len = 1
 
-    num_cores = get_vectorcore_num()
+    num_cores = get_device_properties()[1]
 
     BLK_HEADS = 8
     COL_ITER = triton.cdiv(num_heads, BLK_HEADS)

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/l2norm.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/l2norm.py
@@ -9,7 +9,7 @@ import torch.nn as nn
 import triton
 import triton.language as tl
 import triton.runtime.driver as driver
-from sgl_kernel_npu.fla.utils import input_guard
+from sgl_kernel_npu.fla.utils import input_guard, get_vectorcore_num
 
 BT_LIST = [8, 16, 32, 64, 128]
 
@@ -93,7 +93,7 @@ def l2norm_fwd(
         NB = triton.cdiv(T, 2048)
 
         bt = 109
-        num_core = get_npu_properties()["num_vectorcore"]
+        num_core = get_vectorcore_num()
         main_bs = triton.cdiv(T, num_core)
         grid = (num_core,)
 

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/l2norm.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/l2norm.py
@@ -9,7 +9,8 @@ import torch.nn as nn
 import triton
 import triton.language as tl
 import triton.runtime.driver as driver
-from sgl_kernel_npu.fla.utils import input_guard, get_vectorcore_num
+from sgl_kernel_npu.fla.utils import input_guard
+from sgl_kernel_npu.utils.triton_utils import get_device_properties
 
 BT_LIST = [8, 16, 32, 64, 128]
 
@@ -93,7 +94,7 @@ def l2norm_fwd(
         NB = triton.cdiv(T, 2048)
 
         bt = 109
-        num_core = get_vectorcore_num()
+        num_core = get_device_properties()[1]
         main_bs = triton.cdiv(T, num_core)
         grid = (num_core,)
 

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/solve_tril.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/solve_tril.py
@@ -471,6 +471,136 @@ def merge_16x16_to_64x64_inverse_kernel_reorder_all_masked(
         tl.store(ptr_Ai, zero_block, mask=mask_store)
 
 
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@triton.jit(do_not_specialize=["T"])
+def merge_16x16_to_64x64_inverse_kernel(
+    A,
+    Ad,
+    Ai,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t_val = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+        i_t = i_t_val
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    # Base pointers (already offset by batch and head)
+    A += (bos * H + i_h) * 64
+    Ad += (bos * H + i_h) * 16
+    Ai += (bos * H + i_h) * 64
+
+    # load Ai_22 (Ad block at row i_t * 64 + 16, col 0, 16 * 16)
+    offs_m = i_t * 64 + 16 + tl.arange(0, 16)
+    offs_n = tl.arange(0, 16)
+    mask_Ad = (offs_m[:, None] < T) & (offs_n[None, :] < 16)
+    ptr_Ad = Ad + offs_m[:, None] * (H * 16) + offs_n[None, :]
+    Ai_22 = tl.load(ptr_Ad, mask=mask_Ad, other=0.0).to(tl.float32)
+
+    # load A_21 (A block at row i_t * 64 + 16, col 0, 16 * 16)
+    mask_A = (offs_m[:, None] < T) & (offs_n[None, :] < 64)
+    ptr_A = A + offs_m[:, None] * (H * 64) + offs_n[None, :]
+    A_21 = tl.load(ptr_A, mask=mask_A, other=0.0).to(tl.float32)
+    tmp = tl.dot(Ai_22, A_21, input_precision="ieee")
+
+    # load Ai_11 (Ad block at row i_t * 64, col 0, 16 * 16)
+    offs_m = i_t * 64 + tl.arange(0, 16)
+    offs_n = tl.arange(0, 16)
+    mask_Ad = (offs_m[:, None] < T) & (offs_n[None, :] < 16)
+    ptr_Ad = Ad + offs_m[:, None] * (H * 16) + offs_n[None, :]
+    Ai_11 = tl.load(ptr_Ad, mask=mask_Ad, other=0.0).to(tl.float32)
+
+    Ai_21 = -tl.dot(tmp, Ai_11, input_precision="ieee")
+
+    # load Ai_44 (Ad block at row i_t * 64 + 48, col 0, 16 * 16)
+    offs_m = i_t * 64 + 48 + tl.arange(0, 16)
+    offs_n = tl.arange(0, 16)
+    mask_Ad = (offs_m[:, None] < T) & (offs_n[None, :] < 16)
+    ptr_Ad = Ad + offs_m[:, None] * (H * 16) + offs_n[None, :]
+    Ai_44 = tl.load(ptr_Ad, mask=mask_Ad, other=0.0).to(tl.float32)
+
+    # load A_43 (Ad block at row i_t * 64 + 48, col 32, 16 * 16)
+    offs_n = 32 + tl.arange(0, 16)
+    mask_A = (offs_m[:, None] < T) & (offs_n[None, :] < 64)
+    ptr_A = A + offs_m[:, None] * (H * 64) + offs_n[None, :]
+    A_43 = tl.load(ptr_A, mask=mask_A, other=0.0).to(tl.float32)
+    tmp = tl.dot(Ai_44, A_43, input_precision="ieee")
+
+    # load Ai_33 (Ad block at row i_t * 64 + 32, col 0, 16 * 16)
+    offs_m = i_t * 64 + 32 + tl.arange(0, 16)
+    offs_n = tl.arange(0, 16)
+    mask_Ad = (offs_m[:, None] < T) & (offs_n[None, :] < 16)
+    ptr_Ad = Ad + offs_m[:, None] * (H * 16) + offs_n[None, :]
+    Ai_33 = tl.load(ptr_Ad, mask=mask_Ad, other=0.0).to(tl.float32)
+
+    Ai_43 = -tl.dot(tmp, Ai_33, input_precision="ieee")
+
+    # build Ai_22_32 (32 * 32)
+    Ai_22_32 = tl.zeros((32, 32), tl.float32)
+    Ai_22_32 = tl.insert_slice(Ai_22_32, Ai_33, (0, 0), (16, 16), (1, 1))
+    Ai_22_32 = tl.insert_slice(Ai_22_32, Ai_44, (16, 16), (16, 16), (1, 1))
+    Ai_22_32 = tl.insert_slice(Ai_22_32, Ai_43, (16, 0), (16, 16), (1, 1))
+
+    # load A_21_32 (A block at row i_t * 64 + 32, col 0, 32 * 32)
+    offs_m = i_t * 64 + 32 + tl.arange(0, 32)
+    offs_n = tl.arange(0, 32)
+    mask_A = (offs_m[:, None] < T) & (offs_n[None, :] < 64)
+    ptr_A = A + offs_m[:, None] * (H * 64) + offs_n[None, :]
+    A_21_32 = tl.load(ptr_A, mask=mask_A, other=0.0).to(tl.float32)
+    tmp = tl.dot(Ai_22_32, A_21_32, input_precision="ieee")
+
+    # build Ai_11_32 (32 * 32)
+    Ai_11_32 = tl.zeros((32, 32), tl.float32)
+    Ai_11_32 = tl.insert_slice(Ai_11_32, Ai_11, (0, 0), (16, 16), (1, 1))
+    Ai_11_32 = tl.insert_slice(Ai_11_32, Ai_22, (16, 16), (16, 16), (1, 1))
+    Ai_11_32 = tl.insert_slice(Ai_11_32, Ai_21, (16, 0), (16, 16), (1, 1))
+
+    Ai_21_32 = -tl.dot(tmp, Ai_11_32, input_precision="ieee")
+
+    # store Ai_11_32 to (i_t * 64, 0)
+    offs_m = i_t * 64 + tl.arange(0, 32)
+    offs_n = tl.arange(0, 32)
+    mask_store = (offs_m[:, None] < T) & (offs_n[None, :] < 64)
+    ptr_Ai = Ai + offs_m[:, None] * (H * 64) + offs_n[None, :]
+    tl.store(ptr_Ai, Ai_11_32.to(ptr_Ai.dtype.element_ty, fp_downcast_rounding="rtne"), mask=mask_store)
+
+    # store Ai_22_32 to (i_t * 64 + 32, 32)
+    offs_m = i_t * 64 + 32 + tl.arange(0, 32)
+    offs_n = 32 + tl.arange(0, 32)
+    mask_store = (offs_m[:, None] < T) & (offs_n[None, :] < 64)
+    ptr_Ai = Ai + offs_m[:, None] * (H * 64) + offs_n[None, :]
+    tl.store(ptr_Ai, Ai_22_32.to(ptr_Ai.dtype.element_ty, fp_downcast_rounding="rtne"), mask=mask_store)
+
+    # store Ai_21_32 to (i_t * 64 + 32, 32)
+    offs_n = tl.arange(0, 32)
+    mask_store = (offs_m[:, None] < T) & (offs_n[None, :] < 64)
+    ptr_Ai = Ai + offs_m[:, None] * (H * 64) + offs_n[None, :]
+    tl.store(ptr_Ai, Ai_21_32.to(ptr_Ai.dtype.element_ty, fp_downcast_rounding="rtne"), mask=mask_store)
+
+    # zero out the upper-right 32 * 32 block (rows 0 ~ 31, cols 32 ~ 63)
+    offs_m = i_t * 64 + tl.arange(0, 32)
+    offs_n = 32 + tl.arange(0, 32)
+    mask_store = (offs_m[:, None] < T) & (offs_n[None, :] < BT)
+    ptr_Ai = Ai + offs_m[:, None] * (H * BT) + offs_n[None, :]
+    zero_block = tl.zeros((32, 32), dtype=ptr_Ai.dtype.element_ty)
+    tl.store(ptr_Ai, zero_block, mask=mask_store)
+
+
 def solve_tril_npu(
     A: torch.Tensor,
     cu_seqlens: Optional[torch.Tensor] = None,
@@ -528,28 +658,24 @@ def solve_tril_npu(
     merge_fn = (
         merge_16x16_to_32x32_inverse_kernel
         if BT == 32
-        else merge_16x16_to_64x64_inverse_kernel_reorder_all_masked
+        else merge_16x16_to_64x64_inverse_kernel
     )
     chunk_indices = (
         prepare_chunk_indices(cu_seqlens, BT) if cu_seqlens is not None else None
     )
     NT = len(chunk_indices) if cu_seqlens is not None else triton.cdiv(T, BT)
     if BT != 32:
-        CHUNKS_PER_PROGRAM = min(NT, 2048)
-        num_programs = triton.cdiv(NT, CHUNKS_PER_PROGRAM)
-        merge_fn[num_programs, B * H](
-            A=A,
-            Ad=Ad,
-            Ai=Ai,
-            cu_seqlens=cu_seqlens,
-            chunk_indices=chunk_indices,
-            T=T,
-            H=H,
-            BT=BT,
-            num_warps=4,
-            num_stages=3,
-            CHUNKS_PER_PROGRAM=CHUNKS_PER_PROGRAM,
-            NT=NT,
+        merge_fn[NT, B * H](
+        A=A,
+        Ad=Ad,
+        Ai=Ai,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        BT=BT,
+        num_warps=4,
+        num_stages=3,
         )
     else:
         merge_fn[NT, B * H](

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
@@ -15,7 +15,7 @@ import triton.language.extra.libdevice as tldevice
 
 is_gather_supported = hasattr(triton.language, "gather")
 SUPPRESS_LEVEL = int(os.getenv("GDN_RECOMPUTE_SUPPRESS_LEVEL", "0"))
-NUM_VECTORCORE = -1
+_NUM_VECTORCORE = -1
 
 if os.environ.get("FLA_USE_FAST_OPS", "0") == "1":
     exp = tldevice.fast_expf

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
@@ -10,10 +10,12 @@ from typing import Any, Callable, Dict, Optional, Tuple
 import torch
 import triton
 import triton.language as tl
+import triton.runtime.driver as driver
 import triton.language.extra.libdevice as tldevice
 
 is_gather_supported = hasattr(triton.language, "gather")
 SUPPRESS_LEVEL = int(os.getenv("GDN_RECOMPUTE_SUPPRESS_LEVEL", "0"))
+NUM_VECTORCORE = -1
 
 if os.environ.get("FLA_USE_FAST_OPS", "0") == "1":
     exp = tldevice.fast_expf
@@ -440,3 +442,15 @@ def fused_qkvzba_split_reshape_cat(
         rows_per_iter,
     )
     return mixed_qkv, z, b, a
+
+
+def get_npu_properties():
+    device = torch.npu.current_device()
+    return driver.active.utils.get_device_properties(device)
+
+
+def get_vectorcore_num():
+    global _NUM_VECTORCORE
+    if _NUM_VECTORCORE == -1:
+        _NUM_VECTORCORE = get_npu_properties()["num_vectorcore"]
+    return _NUM_VECTORCORE

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
@@ -10,12 +10,10 @@ from typing import Any, Callable, Dict, Optional, Tuple
 import torch
 import triton
 import triton.language as tl
-import triton.runtime.driver as driver
 import triton.language.extra.libdevice as tldevice
 
 is_gather_supported = hasattr(triton.language, "gather")
 SUPPRESS_LEVEL = int(os.getenv("GDN_RECOMPUTE_SUPPRESS_LEVEL", "0"))
-_NUM_VECTORCORE = -1
 
 if os.environ.get("FLA_USE_FAST_OPS", "0") == "1":
     exp = tldevice.fast_expf
@@ -442,15 +440,3 @@ def fused_qkvzba_split_reshape_cat(
         rows_per_iter,
     )
     return mixed_qkv, z, b, a
-
-
-def get_npu_properties():
-    device = torch.npu.current_device()
-    return driver.active.utils.get_device_properties(device)
-
-
-def get_vectorcore_num():
-    global _NUM_VECTORCORE
-    if _NUM_VECTORCORE == -1:
-        _NUM_VECTORCORE = get_npu_properties()["num_vectorcore"]
-    return _NUM_VECTORCORE


### PR DESCRIPTION
improve performance for fused gdn gating and solve tril

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/zhaoz/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/zhaoz/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
.font5
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;}
tr
	{mso-height-source:auto;
	mso-ruby-visibility:none;}
col
	{mso-width-source:auto;
	mso-ruby-visibility:none;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{text-align:center;}
ruby
	{ruby-align:left;}
rt
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-char-type:none;
	display:none;}
-->

</head>

<body link="#0563C1" vlink="#954F72">


16k   input | before | after
-- | -- | --
fused_gdn_gating_kernel | 294.846 | 64.281
_16x16_to_64x64_inverse_kernel_reorder_all_masked | 1506.65 | 732.855



</body>

</html>

