### PR TITLE
fix of current build.sh cannot handle multiple CANN installation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -95,9 +95,18 @@ fi
 echo "Use SOC_VERSION: $SOC_VERSION"
 
 ### Get Current CANN Toolkit Installation Path
-_CANN_TOOLKIT_INSTALL_PATH=$(cat /etc/Ascend/ascend_cann_install.info | grep "Toolkit_InstallPath" | awk -F'=' '{print $2}')
-source ${_CANN_TOOLKIT_INSTALL_PATH}/set_env.sh
-echo -e "\e[1;32mDetected CANN Toolkit Installation Path: ${_CANN_TOOLKIT_INSTALL_PATH}\e[0m"
+# Honor a pre-set ASCEND_HOME_PATH so the user's already-sourced CANN wins.
+# Only fall back to /etc/Ascend/ascend_cann_install.info (which records the
+# system-wide CANN installer's path) when no environment is configured.
+# Without this, multi-user hosts where another user's root install wrote to
+# the registry will silently override the current user's CANN.
+if [[ -z "${ASCEND_HOME_PATH:-}" ]]; then
+    _CANN_TOOLKIT_INSTALL_PATH=$(cat /etc/Ascend/ascend_cann_install.info | grep "Toolkit_InstallPath" | awk -F'=' '{print $2}')
+    source ${_CANN_TOOLKIT_INSTALL_PATH}/set_env.sh
+    echo -e "\e[1;32mAuto-detected CANN Toolkit Installation Path: ${_CANN_TOOLKIT_INSTALL_PATH}\e[0m"
+else
+    echo -e "\e[1;32mUsing pre-set ASCEND_HOME_PATH: ${ASCEND_HOME_PATH}\e[0m"
+fi
 echo -e "\e[1;33mDouble Checking Environment Variables:\e[0m"
 echo -e "\e[1;32mASCEND_HOME_PATH: ${ASCEND_HOME_PATH}\e[0m"
 echo -e "\e[1;32mASCEND_TOOLKIT_HOME: ${ASCEND_TOOLKIT_HOME}\e[0m"


### PR DESCRIPTION
On a server which has multiple CANN installation, the ASCEND_HOME_PATH is set for differentiating. 

But for now build.sh:97-99 unconditionally reads /etc/Ascend/ascend_cann_install.info and sources its set_env.sh, silently overriding any ASCEND_HOME_PATH the user has already exported.

This breaks on multi-user hosts where:
  - /etc/Ascend/ascend_cann_install.info was written by user A's root install of CANN at one path
  - user B has their own CANN install in ~/CANN/... and sources its set_env.sh before running 'bash build.sh'

Fix: only auto-detect when ASCEND_HOME_PATH is unset.  If ASCEND_HOME_PATH is set, go with ASCEND_HOME_PATH

