### PR TITLE
[CI] Introduce uv to accelerate pip install

### DIFF
--- a/.github/workflows/daily-build-test.yml
+++ b/.github/workflows/daily-build-test.yml
@@ -25,6 +25,7 @@ jobs:
       TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
       PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
       GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
 
     steps:
       - name: Clean git config
@@ -47,6 +48,7 @@ jobs:
           sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
           pip config set global.index-url http://${CACHING_URL}/pypi/simple
           pip config set global.trusted-host ${CACHING_URL}
+          pip install uv
           bash scripts/npu_ci_install_dependency.sh
 
       - name: Prepare Deepep
@@ -82,6 +84,7 @@ jobs:
       TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
       PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
       GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
 
     steps:
       - name: Clean workspace and checkout
@@ -97,6 +100,7 @@ jobs:
           sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
           pip config set global.index-url http://${CACHING_URL}/pypi/simple
           pip config set global.trusted-host ${CACHING_URL}
+          pip install uv
           bash scripts/npu_ci_install_dependency.sh
 
       - name: Prepare Deepep

--- a/.github/workflows/internode.yml
+++ b/.github/workflows/internode.yml
@@ -53,12 +53,12 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          pip3 install -i https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple jinja2-cli
+          pip3 install uv
+          uv pip install --system -i https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple jinja2-cli
 
       - name: Install kubernetes
         run: |
-          # Install kubernetes
-          pip3 install -i https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple kubernetes
+          uv pip install --system -i https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple kubernetes
           cp $KUBECTL /usr/local/sbin/
 
       - name: Create K8s Namespace

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,8 @@ jobs:
 
       - name: Install pre-commit hook
         run: |
-          python -m pip install pre-commit
+          python -m pip install uv
+          uv pip install --system pre-commit
           pre-commit install
 
       - name: Linting

--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -66,6 +66,7 @@ jobs:
       TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
       PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
       GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
     steps:
       - name: Clean git config
         run: |
@@ -88,6 +89,7 @@ jobs:
           sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
           pip config set global.index-url http://${CACHING_URL}/pypi/simple
           pip config set global.trusted-host ${CACHING_URL}
+          pip install uv
 
           bash scripts/npu_ci_install_dependency.sh
 
@@ -414,6 +416,7 @@ jobs:
       TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
       PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
       GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
     steps:
       - name: Clean git config
         run: |
@@ -436,6 +439,7 @@ jobs:
           sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
           pip config set global.index-url http://${CACHING_URL}/pypi/simple
           pip config set global.trusted-host ${CACHING_URL}
+          pip install uv
 
           bash scripts/npu_ci_install_dependency.sh
 
@@ -762,6 +766,7 @@ jobs:
       TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
       PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
       GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
     steps:
       - name: Clean git config
         run: |
@@ -784,6 +789,7 @@ jobs:
           sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
           pip config set global.index-url http://${CACHING_URL}/pypi/simple
           pip config set global.trusted-host ${CACHING_URL}
+          pip install uv
 
           bash scripts/npu_ci_install_dependency.sh
 

--- a/scripts/npu_ci_install_dependency.sh
+++ b/scripts/npu_ci_install_dependency.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 export ARCHITECT="$(arch)"
 export DEBIAN_FRONTEND="noninteractive"
 export PIP_INSTALL="python3 -m pip install --no-cache-dir"
+export UV_PIP_INSTALL="uv pip install"
 
 
 ### Dependency Versions
@@ -67,8 +68,12 @@ export LC_ALL=en_US.UTF-8
 
 ## Python packages
 ${PIP_INSTALL} --upgrade pip
+${PIP_INSTALL} uv
+export UV_NO_CACHE=true
+export UV_SYSTEM_PYTHON=true
+export UV_INDEX_STRATEGY=unsafe-best-match
 # Pin wheel to 0.45.1, REF: https://github.com/pypa/wheel/issues/662
-${PIP_INSTALL} \
+${UV_PIP_INSTALL} \
     wheel==0.45.1 \
     pybind11 \
     pyyaml \
@@ -80,11 +85,12 @@ ${PIP_INSTALL} \
 
 ### Install pytorch
 ## torch
-${PIP_INSTALL} \
+${UV_PIP_INSTALL} \
     torch==${TORCH_VERSION} \
     torchvision==${TORCHVISION_VERSION} \
     torchaudio==${TORCH_VERSION} \
     --index-url ${TORCH_CACHE_URL:="https://download.pytorch.org/whl/cpu"} \
     --extra-index-url ${PYPI_CACHE_URL:="https://pypi.org/simple/"}
 ## torch_npu
+# GitCode does not allow UV downloads.
 ${PIP_INSTALL} ${TORCH_NPU_URL}


### PR DESCRIPTION
## What this PR does / why we need it?

Integrates uv to significantly accelerate pip install execution in CI workflows.



## Changes

| File | Change |
|---|---|
| `scripts/npu_ci_install_dependency.sh` | Core change. Introduce `UV_PIP_INSTALL` for regular packages; keep `PIP_INSTALL` for GitCode downloads |
| `.github/workflows/pr-test-npu.yml` | Add `UV_INDEX_URL` env var + `pip install uv` (3 jobs) |
| `.github/workflows/daily-build-test.yml` | Same as above (2 jobs) |
| `.github/workflows/lint.yml` | `pip install pre-commit` → `uv pip install pre-commit` |
| `.github/workflows/internode.yml` | `pip3 install` → `uv pip install` for jinja2-cli and kubernetes |

## Why GitCode URL stays on pip

GitCode does not support UV downloads. torch_npu wheels are hosted on GitCode, so `${PIP_INSTALL}` is preserved for that specific step.

effect:
2m41s -> 59s
<img width="2500" height="907" alt="image" src="https://github.com/user-attachments/assets/d69e451f-767a-4b59-b926-a5405fe27496" />
<img width="2482" height="894" alt="image" src="https://github.com/user-attachments/assets/09b610b3-7db5-4107-bc3b-23be7c93613f" />

