### PR TITLE
ci: add runs-on/cache to skip C++ rebuild on PR CI

### DIFF
--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -61,7 +61,7 @@ jobs:
       )
     runs-on: linux-aarch64-a3-16
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.3.rc1-a3-ubuntu22.04-py3.11
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-a3-ubuntu22.04-py3.11
     env:
       TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
       PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
@@ -94,7 +94,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a3-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a3-cann8.5.0-${{ steps.get_build_hash.outputs.BUILD_HASH }}
 
       - name: Install dependencies
         run: |
@@ -432,7 +432,7 @@ jobs:
       )
     runs-on: linux-aarch64-a3-16
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.3.rc1-a3-ubuntu22.04-py3.11
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-a3-ubuntu22.04-py3.11
     env:
       TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
       PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
@@ -465,7 +465,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a3-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a3-cann8.5.0-${{ steps.get_build_hash.outputs.BUILD_HASH }}
 
       - name: Install dependencies
         run: |
@@ -803,7 +803,7 @@ jobs:
       )
     runs-on: linux-aarch64-a2-8
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.3.rc1-910b-ubuntu22.04-py3.11
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-910b-ubuntu22.04-py3.11
     env:
       TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
       PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
@@ -836,7 +836,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a2-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a2-cann8.5.0-${{ steps.get_build_hash.outputs.BUILD_HASH }}
 
       - name: Install dependencies
         run: |
@@ -1102,7 +1102,7 @@ jobs:
     with:
       soc_version: a2
       runner: linux-aarch64-a2-0
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.3.rc1-910b-ubuntu22.04-py3.11'
+      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-910b-ubuntu22.04-py3.11'
       test_config_name: ${{ matrix.test_config.name }}
       node_size: ${{ matrix.test_config.node_size }}
       test_case: ${{ matrix.test_config.test_case }}

--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -82,6 +82,20 @@ jobs:
         with:
           clean: true
 
+      - name: Get build hash
+        id: get_build_hash
+        run: |
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
+            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+
+      - name: Restore build cache
+        id: cache-build
+        uses: runs-on/cache@v4
+        with:
+          path: output
+          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a3-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+
       - name: Install dependencies
         run: |
           # speed up by using infra cache services
@@ -94,7 +108,14 @@ jobs:
           bash scripts/npu_ci_install_dependency.sh
 
       - name: Prepare Deepep
-        run: bash scripts/prepare_deepep_in_container.sh
+        run: |
+          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+            pip install ${GITHUB_WORKSPACE}/output/deep_ep*.whl --no-cache-dir
+            cd "$(pip show deep-ep | awk '/^Location:/ {print $2}')"
+            ln -s deep_ep/deep_ep_cpp*.so || true
+          else
+            bash scripts/prepare_deepep_in_container.sh
+          fi
 
       - name: Run test intranode
         timeout-minutes: 10
@@ -432,6 +453,20 @@ jobs:
         with:
           clean: true
 
+      - name: Get build hash
+        id: get_build_hash
+        run: |
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
+            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+
+      - name: Restore build cache
+        id: cache-build
+        uses: runs-on/cache@v4
+        with:
+          path: output
+          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a3-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+
       - name: Install dependencies
         run: |
           # speed up by using infra cache services
@@ -444,7 +479,14 @@ jobs:
           bash scripts/npu_ci_install_dependency.sh
 
       - name: Prepare Deepep
-        run: bash scripts/prepare_deepep_in_container.sh -a deepep
+        run: |
+          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+            pip install ${GITHUB_WORKSPACE}/output/deep_ep*.whl --no-cache-dir
+            cd "$(pip show deep-ep | awk '/^Location:/ {print $2}')"
+            ln -s deep_ep/deep_ep_cpp*.so || true
+          else
+            bash scripts/prepare_deepep_in_container.sh -a deepep
+          fi
 
       - name: Run test intranode
         timeout-minutes: 10
@@ -782,6 +824,20 @@ jobs:
         with:
           clean: true
 
+      - name: Get build hash
+        id: get_build_hash
+        run: |
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
+            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+
+      - name: Restore build cache
+        id: cache-build
+        uses: runs-on/cache@v4
+        with:
+          path: output
+          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a2-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+
       - name: Install dependencies
         run: |
           # speed up by using infra cache services
@@ -794,7 +850,14 @@ jobs:
           bash scripts/npu_ci_install_dependency.sh
 
       - name: Prepare Deepep
-        run: bash scripts/prepare_deepep_in_container.sh -a deepep2
+        run: |
+          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+            pip install ${GITHUB_WORKSPACE}/output/deep_ep*.whl --no-cache-dir
+            cd "$(pip show deep-ep | awk '/^Location:/ {print $2}')"
+            ln -s deep_ep/deep_ep_cpp*.so || true
+          else
+            bash scripts/prepare_deepep_in_container.sh -a deepep2
+          fi
 
       - name: Run test intranode
         timeout-minutes: 10

--- a/.github/workflows/push_build_cache.yml
+++ b/.github/workflows/push_build_cache.yml
@@ -21,7 +21,7 @@ jobs:
     name: build-cache-a3
     runs-on: linux-aarch64-a3-16
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.3.rc1-a3-ubuntu22.04-py3.11
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-a3-ubuntu22.04-py3.11
     env:
       TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
       PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
@@ -48,7 +48,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a3-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a3-cann8.5.0-${{ steps.get_build_hash.outputs.BUILD_HASH }}
 
       - name: Install dependencies
         if: steps.cache-build.outputs.cache-hit != 'true'
@@ -72,7 +72,7 @@ jobs:
     name: build-cache-a2
     runs-on: linux-aarch64-a2-8
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.3.rc1-910b-ubuntu22.04-py3.11
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.5.0-910b-ubuntu22.04-py3.11
     env:
       TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
       PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
@@ -99,7 +99,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a2-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a2-cann8.5.0-${{ steps.get_build_hash.outputs.BUILD_HASH }}
 
       - name: Install dependencies
         if: steps.cache-build.outputs.cache-hit != 'true'

--- a/.github/workflows/push_build_cache.yml
+++ b/.github/workflows/push_build_cache.yml
@@ -1,0 +1,120 @@
+name: Cache Build Artifacts (Ascend NPU)
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "build.sh"
+      - "cmake/**"
+      - "csrc/**"
+      - "python/**"
+      - "CMakeLists.txt"
+      - "scripts/npu_ci_install_dependency.sh"
+  workflow_dispatch:
+
+concurrency:
+  group: build-cache-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-cache-a3:
+    name: build-cache-a3
+    runs-on: linux-aarch64-a3-16
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.3.rc1-a3-ubuntu22.04-py3.11
+    env:
+      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+    steps:
+      - name: Clean git config
+        run: |
+          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
+          git config --global --unset "$CONFIG_KEY" || true
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get build hash
+        id: get_build_hash
+        run: |
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
+            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+
+      - name: Restore build cache
+        id: cache-build
+        uses: runs-on/cache@v4
+        with:
+          path: output
+          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a3-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+
+      - name: Install dependencies
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        run: |
+          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+          pip config set global.trusted-host ${CACHING_URL}
+          pip install uv
+          bash scripts/npu_ci_install_dependency.sh
+
+      - name: Build (deepep2 for a3)
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        run: |
+          env -i PATH=${PATH} bash --login -c "
+            export LD_LIBRARY_PATH=${ASCEND_HOME_PATH}/runtime/lib64/stub:${LD_LIBRARY_PATH} && \
+            bash build.sh
+          "
+
+  build-cache-a2:
+    name: build-cache-a2
+    runs-on: linux-aarch64-a2-8
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:8.3.rc1-910b-ubuntu22.04-py3.11
+    env:
+      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+    steps:
+      - name: Clean git config
+        run: |
+          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
+          git config --global --unset "$CONFIG_KEY" || true
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get build hash
+        id: get_build_hash
+        run: |
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
+            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+
+      - name: Restore build cache
+        id: cache-build
+        uses: runs-on/cache@v4
+        with:
+          path: output
+          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a2-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+
+      - name: Install dependencies
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        run: |
+          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+          pip config set global.trusted-host ${CACHING_URL}
+          pip install uv
+          bash scripts/npu_ci_install_dependency.sh
+
+      - name: Build (deepep2 for a2)
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        run: |
+          env -i PATH=${PATH} bash --login -c "
+            export LD_LIBRARY_PATH=${ASCEND_HOME_PATH}/runtime/lib64/stub:${LD_LIBRARY_PATH} && \
+            bash build.sh
+          "


### PR DESCRIPTION
## Summary

- Add `.github/workflows/push_build_cache.yml`: builds and caches compiled artifacts (`output/*.whl`) on every `main` branch push when C++ sources change
- Modify `.github/workflows/pr-test-npu.yml`: restore the build cache before compilation in all three NPU jobs (`test-all-build`, `test-build-deepep-a3`, `test-build-deepep-a2`); skip `bash build.sh` when cache hits, directly install the cached `.whl`

**Motivation**: Every PR CI run currently triggers a full C++ rebuild of DeepEP kernels even when `csrc/`, `cmake/`, `python/`, `build.sh`, and `CMakeLists.txt` are unchanged. This adds significant wait time to every PR.

**Cache key strategy**: `sha256` hash of `csrc/`, `cmake/`, `python/`, `build.sh`, and `CMakeLists.txt`, scoped per OS and hardware type (`a3` / `a2`). Cache is only invalidated when C++ sources actually change.

**Why `runs-on/cache@v4`**: The compiled artifacts may exceed GitHub Actions' native 10 GB cache limit. `runs-on/cache@v4` is API-compatible with `actions/cache` but removes the size cap. This is the same approach used in [vllm-project/vllm-ascend#8333](https://github.com/vllm-project/vllm-ascend/pull/8333).

## Test plan

- [ ] Verify `push_build_cache.yml` triggers on `main` push and writes cache successfully
- [ ] Verify PR CI restores cache and skips compilation when sources are unchanged
- [ ] Verify PR CI falls back to full build when cache misses (first run or after csrc changes)
- [ ] Verify all existing NPU tests still pass after cache-based install

🤖 Generated with [Claude Code](https://claude.com/claude-code)