### PR TITLE
ci: fix a2 build-cache writing A3 wheel under the A2 key

### DIFF
--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -94,7 +94,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a3-cann8.5.0-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+          key: sgl-kernel-npu-build-v2-${{ runner.os }}-a3-cann8.5.0-${{ steps.get_build_hash.outputs.BUILD_HASH }}
 
       - name: Install dependencies
         run: |
@@ -465,7 +465,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a3-cann8.5.0-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+          key: sgl-kernel-npu-build-v2-${{ runner.os }}-a3-cann8.5.0-${{ steps.get_build_hash.outputs.BUILD_HASH }}
 
       - name: Install dependencies
         run: |
@@ -842,7 +842,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a2-cann8.5.0-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+          key: sgl-kernel-npu-build-v2-${{ runner.os }}-a2-cann8.5.0-${{ steps.get_build_hash.outputs.BUILD_HASH }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/push_build_cache.yml
+++ b/.github/workflows/push_build_cache.yml
@@ -48,7 +48,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a3-cann8.5.0-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+          key: sgl-kernel-npu-build-v2-${{ runner.os }}-a3-cann8.5.0-${{ steps.get_build_hash.outputs.BUILD_HASH }}
 
       - name: Install dependencies
         if: steps.cache-build.outputs.cache-hit != 'true'
@@ -60,7 +60,7 @@ jobs:
           pip install uv
           bash scripts/npu_ci_install_dependency.sh
 
-      - name: Build (deepep2 for a3)
+      - name: Build (a3)
         if: steps.cache-build.outputs.cache-hit != 'true'
         run: |
           env -i PATH=${PATH} bash --login -c "
@@ -99,7 +99,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a2-cann8.5.0-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+          key: sgl-kernel-npu-build-v2-${{ runner.os }}-a2-cann8.5.0-${{ steps.get_build_hash.outputs.BUILD_HASH }}
 
       - name: Install dependencies
         if: steps.cache-build.outputs.cache-hit != 'true'
@@ -111,10 +111,10 @@ jobs:
           pip install uv
           bash scripts/npu_ci_install_dependency.sh
 
-      - name: Build (deepep2 for a2)
+      - name: Build (a2)
         if: steps.cache-build.outputs.cache-hit != 'true'
         run: |
           env -i PATH=${PATH} bash --login -c "
             export LD_LIBRARY_PATH=${ASCEND_HOME_PATH}/runtime/lib64/stub:${LD_LIBRARY_PATH} && \
-            bash build.sh
+            bash build.sh -a deepep2
           "


### PR DESCRIPTION
## Summary

Follow-up to #469. The new `push_build_cache.yml` workflow has a bug in its A2 job: it runs a bare `bash build.sh`, but `build.sh` defaults to `BUILD_DEEPEP_OPS=ON` and `SOC_VERSION=Ascend910_9382` — i.e. it builds an **A3** wheel. That A3 wheel is then stored under the A2 cache key, and any subsequent PR run of `test-build-deepep-a2` restores it and tries to load A3 kernels on A2 hardware.

This PR fixes three things:

1. **`build-cache-a2`**: invoke `bash build.sh -a deepep2` so the wheel actually targets the A2 SOC (`Ascend910B1`, `csrc/deepep/ops2`).
2. **Step labels**: rename the misleading `Build (deepep2 for a3)` / `Build (deepep2 for a2)` to `Build (a3)` / `Build (a2)`.
3. **Cache key bump v1 → v2** in both `push_build_cache.yml` and the three `pr-test-npu.yml` jobs, so the already-poisoned v1 A2 entry on `main` (written by every `main` push since #469 merged) is not reused.

## Test plan

- [ ] First PR that touches `csrc/`/`cmake/`/`python/`/`build.sh`/`CMakeLists.txt` cache-misses on v2 and falls back to full build for all three NPU jobs
- [ ] After a subsequent `main` push, `push_build_cache.yml` populates v2 entries for both A3 and A2
- [ ] A later PR run hits the v2 cache; `test-build-deepep-a2` installs the A2 wheel and tests pass on A2 hardware
- [ ] No regression in `test-all-build` / `test-build-deepep-a3` cache reuse

🤖 Generated with [Claude Code](https://claude.com/claude-code)