### PR TITLE
ci: restore build cache for PR CI, with A2 wheel fix

### DIFF
--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -83,7 +83,7 @@ jobs:
           clean: true
           submodules: recursive
 
-- name: Get build hash
+      - name: Get build hash
         id: get_build_hash
         run: |
           BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
@@ -95,7 +95,7 @@ jobs:
           [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
           echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
 
-- name: Restore build cache
+      - name: Restore build cache
         id: cache-build
         uses: runs-on/cache@v4
         with:
@@ -453,7 +453,7 @@ jobs:
           clean: true
           submodules: recursive
 
-- name: Get build hash
+      - name: Get build hash
         id: get_build_hash
         run: |
           BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
@@ -465,7 +465,7 @@ jobs:
           [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
           echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
 
-- name: Restore build cache
+      - name: Restore build cache
         id: cache-build
         uses: runs-on/cache@v4
         with:
@@ -834,7 +834,7 @@ jobs:
           clean: true
           submodules: recursive
 
-- name: Get build hash
+      - name: Get build hash
         id: get_build_hash
         run: |
           BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
@@ -846,7 +846,7 @@ jobs:
           [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
           echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
 
-- name: Restore build cache
+      - name: Restore build cache
         id: cache-build
         uses: runs-on/cache@v4
         with:

--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -83,6 +83,25 @@ jobs:
           clean: true
           submodules: recursive
 
+- name: Get build hash
+        id: get_build_hash
+        run: |
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
+            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+
+          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+
+- name: Restore build cache
+        id: cache-build
+        uses: runs-on/cache@v4
+        with:
+          path: output
+          key: sgl-kernel-npu-build-v2-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+
       - name: Install dependencies
         run: |
           # speed up by using infra cache services
@@ -433,6 +452,25 @@ jobs:
         with:
           clean: true
           submodules: recursive
+
+- name: Get build hash
+        id: get_build_hash
+        run: |
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
+            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+
+          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+
+- name: Restore build cache
+        id: cache-build
+        uses: runs-on/cache@v4
+        with:
+          path: output
+          key: sgl-kernel-npu-build-v2-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
 
       - name: Install dependencies
         run: |
@@ -795,6 +833,25 @@ jobs:
         with:
           clean: true
           submodules: recursive
+
+- name: Get build hash
+        id: get_build_hash
+        run: |
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
+            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+
+          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+
+- name: Restore build cache
+        id: cache-build
+        uses: runs-on/cache@v4
+        with:
+          path: output
+          key: sgl-kernel-npu-build-v2-${{ runner.os }}-a2-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/push_build_cache.yml
+++ b/.github/workflows/push_build_cache.yml
@@ -45,12 +45,23 @@ jobs:
             -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
           echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
 
+          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+          echo "Resolved CANN version: $CANN_VERSION (raw: $CANN_RAW)"
+
       - name: Restore build cache
         id: cache-build
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a3-cann8.5.0-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
 
       - name: Install dependencies
         if: steps.cache-build.outputs.cache-hit != 'true'
@@ -98,12 +109,23 @@ jobs:
             -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
           echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
 
+          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+          echo "Resolved CANN version: $CANN_VERSION (raw: $CANN_RAW)"
+
       - name: Restore build cache
         id: cache-build
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v1-${{ runner.os }}-a2-cann8.5.0-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
 
       - name: Install dependencies
         if: steps.cache-build.outputs.cache-hit != 'true'

--- a/.github/workflows/push_build_cache.yml
+++ b/.github/workflows/push_build_cache.yml
@@ -56,12 +56,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install dependencies
+          key: sgl-kernel-npu-build-v2-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
 
       - name: Install dependencies
         if: steps.cache-build.outputs.cache-hit != 'true'
@@ -120,12 +115,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install dependencies
+          key: sgl-kernel-npu-build-v2-${{ runner.os }}-a2-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
 
       - name: Install dependencies
         if: steps.cache-build.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

#479 rolled back the PR-side cache wiring after #469's cache scheme broke `test-build-deepep-a2`. The push-side workflow file (`push_build_cache.yml`) was kept on main but still has the original bugs. This PR reintroduces the cache for PR CI with both bugs fixed and the CANN-version mismatch resolved.

### `push_build_cache.yml`

- **A2 build now runs `bash build.sh -a deepep2`.** The bare invocation defaults to `BUILD_DEEPEP_OPS=ON` + `SOC_VERSION=Ascend910_9382`, i.e. an **A3** wheel — so the A2 cache entry used to contain an A3 wheel, which is what caused `test-build-deepep-a2` to fail when restoring from the cache.
- Rename Build step labels to `Build (a3)` / `Build (a2)`. The previous `deepep2 for a3` was self-contradictory.
- Bump cache key `v1` → `v2` so already-poisoned v1 entries on main are not reused.

### `pr-test-npu.yml`

- Re-add `Get build hash` / `Restore build cache` to `test-all-build`, `test-build-deepep-a3`, `test-build-deepep-a2`.
- `Prepare Deepep` skips `bash build.sh` and installs the cached wheel when `cache-hit`; otherwise falls back to the original `prepare_deepep_in_container.sh` path.
- Cache keys use `v2` and the CANN tag in the key (`cann8.5.0`) matches both `push_build_cache.yml`'s container and `pr-test-npu.yml`'s containers on current main (after #479).

No container images, test definitions, or other workflows are touched.

## Test plan

- [ ] First PR after merge: all three NPU jobs cache-miss on v2, fall back to `prepare_deepep_in_container.sh`, and succeed
- [ ] After a subsequent `main` push, `push_build_cache.yml` populates v2 entries for both A3 and A2 (note: A2 entry is now an actual A2 wheel)
- [ ] A later PR run hits the v2 cache; `test-build-deepep-a2` installs the A2 wheel and tests pass
- [ ] No regression in `test-all-build` / `test-build-deepep-a3` cache reuse (both share the a3 cache key, both install only `deep_ep*.whl`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)