### PR TITLE
feat(npu): add dsv4 chunked prefill compress triton kernel

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/attention/dsv4_chunked_compress.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/attention/dsv4_chunked_compress.py
@@ -8,12 +8,11 @@ from sgl_kernel_npu.utils.triton_utils import get_device_properties
 def _dsv4_chunked_prefill_compress_kernel(
     chunk_kv,
     chunk_score,
-    state_kv_score,
-    page_table,
+    state_kv_score_window,
     ape,
     out,
     PREFIX_LEN: tl.constexpr,
-    PAGE_SIZE: tl.constexpr,
+    STATE_BASE: tl.constexpr,
     RATIO: tl.constexpr,
     HEAD_DIM: tl.constexpr,
     COFF_D: tl.constexpr,
@@ -60,7 +59,7 @@ def _dsv4_chunked_prefill_compress_kernel(
             safe_chunk_local = tl.maximum(chunk_local, 0)
 
             if OVERLAP:
-                data_col = tl.where(is_prev, HEAD_DIM + head_cols, head_cols)
+                data_col = tl.where(is_prev, head_cols, HEAD_DIM + head_cols)
             else:
                 data_col = head_cols
             mask = src_mask & col_mask & ~zero_src
@@ -83,23 +82,15 @@ def _dsv4_chunked_prefill_compress_kernel(
             )
             chunk_score_vals += ape_vals
 
-            state_page_idx = tl.where(
-                from_state & ~zero_src, safe_src_global // PAGE_SIZE, 0
-            )
-            state_page = tl.load(
-                page_table + state_page_idx,
-                mask=src_mask & from_state & ~zero_src,
-                other=0,
-            )
-            state_slot = state_page * PAGE_SIZE + (safe_src_global % PAGE_SIZE)
-            state_base = state_slot * (2 * COFF_D)
+            state_row = tl.maximum(safe_src_global - STATE_BASE, 0)
+            state_offset = state_row * (2 * COFF_D)
             state_kv_vals = tl.load(
-                state_kv_score + state_base + data_col,
+                state_kv_score_window + state_offset + data_col,
                 mask=mask & from_state,
                 other=0.0,
             )
             state_score_vals = tl.load(
-                state_kv_score + state_base + COFF_D + data_col,
+                state_kv_score_window + state_offset + COFF_D + data_col,
                 mask=mask & from_state,
                 other=-float("inf"),
             )
@@ -145,22 +136,23 @@ def _dsv4_chunked_prefill_compress_kernel(
 def dsv4_chunked_prefill_compress(
     chunk_kv: torch.Tensor,
     chunk_score: torch.Tensor,
-    state_kv_score: torch.Tensor,
-    page_table: torch.Tensor,
+    state_kv_score_window: torch.Tensor,
     ape: torch.Tensor,
     *,
     prefix_len: int,
     chunk_len: int,
     ratio: int,
     overlap: bool,
-    page_size: int,
+    state_base: int,
 ) -> torch.Tensor:
     assert ratio in (4, 128), f"unsupported DeepSeek-V4 compress ratio: {ratio}"
     assert overlap == (ratio == 4), "DeepSeek-V4 overlap is only valid for ratio=4"
     assert chunk_kv.is_contiguous()
     assert chunk_score.is_contiguous()
-    assert state_kv_score.is_contiguous()
+    assert state_kv_score_window.is_contiguous()
     assert ape.is_contiguous()
+    assert 0 <= state_base <= prefix_len
+    assert state_kv_score_window.shape[-1] == 2 * ape.shape[1]
 
     n_out = (prefix_len + chunk_len) // ratio - prefix_len // ratio
     coff = 2 if overlap else 1
@@ -177,12 +169,11 @@ def dsv4_chunked_prefill_compress(
     _dsv4_chunked_prefill_compress_kernel[(num_programs,)](
         chunk_kv,
         chunk_score,
-        state_kv_score,
-        page_table,
+        state_kv_score_window,
         ape,
         out,
         PREFIX_LEN=prefix_len,
-        PAGE_SIZE=page_size,
+        STATE_BASE=state_base,
         RATIO=ratio,
         HEAD_DIM=head_dim,
         COFF_D=ape.shape[1],

--- a/python/sgl_kernel_npu/sgl_kernel_npu/attention/dsv4_chunked_compress.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/attention/dsv4_chunked_compress.py
@@ -20,88 +20,118 @@ def _dsv4_chunked_prefill_compress_kernel(
     BLOCK_SRC: tl.constexpr,
     BLOCK_D: tl.constexpr,
     N_OUT: tl.constexpr,
+    NUM_COL_BLOCKS: tl.constexpr,
     NUM_PROGRAMS: tl.constexpr,
     OVERLAP: tl.constexpr,
 ):
     pid = tl.program_id(0)
     cols = tl.arange(0, BLOCK_D)
-    srcs = tl.arange(0, BLOCK_SRC)
-    col_mask = cols < HEAD_DIM
     n_src = 2 * RATIO if OVERLAP else RATIO
     first_k = PREFIX_LEN // RATIO
+    num_tasks = N_OUT * NUM_COL_BLOCKS
 
-    for out_i in tl.range(pid, N_OUT, NUM_PROGRAMS):
+    for task in tl.range(pid, num_tasks, NUM_PROGRAMS):
+        out_i = task // NUM_COL_BLOCKS
+        col_block = task - out_i * NUM_COL_BLOCKS
         k = first_k + out_i
-        if OVERLAP:
-            is_prev = srcs[:, None] >= RATIO
-        else:
-            is_prev = srcs[:, None] < 0
-        ape_j = tl.where(is_prev, srcs[:, None] - RATIO, srcs[:, None])
-        src_global = tl.where(
-            is_prev,
-            (k - 1) * RATIO + ape_j,
-            k * RATIO + ape_j,
-        )
-        src_mask = srcs[:, None] < n_src
-        zero_src = is_prev & (k == 0) if OVERLAP else srcs[:, None] < 0
-        from_state = src_global < PREFIX_LEN
-        chunk_local = src_global - PREFIX_LEN
+        head_cols = col_block * BLOCK_D + cols
+        col_mask = head_cols < HEAD_DIM
 
-        if OVERLAP:
-            data_col = tl.where(~is_prev, HEAD_DIM + cols[None, :], cols[None, :])
-        else:
-            data_col = cols[None, :]
-        mask = src_mask & col_mask[None, :] & ~zero_src
+        acc = tl.full((BLOCK_D,), 0.0, tl.float32)
+        denom = tl.full((BLOCK_D,), 0.0, tl.float32)
+        score_max = tl.full((BLOCK_D,), -float("inf"), tl.float32)
 
-        chunk_offsets = chunk_local * COFF_D + data_col
-        chunk_kv_vals = tl.load(
-            chunk_kv + chunk_offsets,
-            mask=mask & ~from_state,
-            other=0.0,
-        )
-        chunk_score_vals = tl.load(
-            chunk_score + chunk_offsets,
-            mask=mask & ~from_state,
-            other=-float("inf"),
-        )
-        ape_vals = tl.load(
-            ape + ape_j * COFF_D + data_col,
-            mask=mask & ~from_state,
-            other=0.0,
-        )
-        chunk_score_vals += ape_vals
+        for src_i in tl.range(0, BLOCK_SRC):
+            src_mask = src_i < n_src
+            if OVERLAP:
+                is_prev = src_i >= RATIO
+            else:
+                is_prev = src_i < 0
+            ape_j = tl.where(is_prev, src_i - RATIO, src_i)
+            src_global = tl.where(
+                is_prev,
+                (k - 1) * RATIO + ape_j,
+                k * RATIO + ape_j,
+            )
+            zero_src = is_prev & (k == 0) if OVERLAP else src_i < 0
+            from_state = src_global < PREFIX_LEN
+            chunk_local = src_global - PREFIX_LEN
 
-        state_page = tl.load(
-            page_table + src_global // PAGE_SIZE,
-            mask=src_mask & from_state & ~zero_src,
-            other=0,
-        )
-        state_slot = state_page * PAGE_SIZE + (src_global % PAGE_SIZE)
-        state_base = state_slot * (2 * COFF_D)
-        state_kv_vals = tl.load(
-            state_kv_score + state_base + data_col,
-            mask=mask & from_state,
-            other=0.0,
-        )
-        state_score_vals = tl.load(
-            state_kv_score + state_base + COFF_D + data_col,
-            mask=mask & from_state,
-            other=-float("inf"),
-        )
+            if OVERLAP:
+                data_col = tl.where(~is_prev, HEAD_DIM + head_cols, head_cols)
+            else:
+                data_col = head_cols
+            mask = src_mask & col_mask & ~zero_src
 
-        kv_vals = tl.where(from_state, state_kv_vals, chunk_kv_vals).to(tl.float32)
-        score_vals = tl.where(from_state, state_score_vals, chunk_score_vals).to(
-            tl.float32
-        )
-        score_vals = tl.where(mask, score_vals, -float("inf"))
-        kv_vals = tl.where(mask, kv_vals, 0.0)
+            chunk_offsets = chunk_local * COFF_D + data_col
+            chunk_kv_vals = tl.load(
+                chunk_kv + chunk_offsets,
+                mask=mask & ~from_state,
+                other=0.0,
+            )
+            chunk_score_vals = tl.load(
+                chunk_score + chunk_offsets,
+                mask=mask & ~from_state,
+                other=-float("inf"),
+            )
+            ape_vals = tl.load(
+                ape + ape_j * COFF_D + data_col,
+                mask=mask & ~from_state,
+                other=0.0,
+            )
+            chunk_score_vals += ape_vals
 
-        score_max = tl.max(score_vals, axis=0)
-        weights = tl.exp(score_vals - score_max[None, :])
-        denom = tl.sum(weights, axis=0)
-        acc = tl.sum(kv_vals * weights, axis=0) / denom
+            state_page = tl.load(
+                page_table + src_global // PAGE_SIZE,
+                mask=src_mask & from_state & ~zero_src,
+                other=0,
+            )
+            state_slot = state_page * PAGE_SIZE + (src_global % PAGE_SIZE)
+            state_base = state_slot * (2 * COFF_D)
+            state_kv_vals = tl.load(
+                state_kv_score + state_base + data_col,
+                mask=mask & from_state,
+                other=0.0,
+            )
+            state_score_vals = tl.load(
+                state_kv_score + state_base + COFF_D + data_col,
+                mask=mask & from_state,
+                other=-float("inf"),
+            )
+
+            kv_vals = tl.where(from_state, state_kv_vals, chunk_kv_vals).to(
+                tl.float32
+            )
+            score_vals = tl.where(
+                from_state, state_score_vals, chunk_score_vals
+            ).to(tl.float32)
+            score_vals = tl.where(mask, score_vals, -float("inf"))
+            kv_vals = tl.where(mask, kv_vals, 0.0)
+
+            new_score_max = tl.maximum(score_max, score_vals)
+            old_delta = tl.where(
+                score_max == -float("inf"), 0.0, score_max - new_score_max
+            )
+            new_delta = tl.where(
+                score_vals == -float("inf"), 0.0, score_vals - new_score_max
+            )
+            old_scale = tl.where(
+                new_score_max == -float("inf"),
+                0.0,
+                tl.exp(old_delta),
+            )
+            new_scale = tl.where(
+                score_vals == -float("inf"),
+                0.0,
+                tl.exp(new_delta),
+            )
+            acc = acc * old_scale + kv_vals * new_scale
+            denom = denom * old_scale + new_scale
+            score_max = new_score_max
+
+        acc = acc / denom
         tl.store(
-            out + out_i * HEAD_DIM + cols,
+            out + out_i * HEAD_DIM + head_cols,
             acc.to(out.dtype.element_ty),
             mask=col_mask,
         )
@@ -135,9 +165,10 @@ def dsv4_chunked_prefill_compress(
         return out
 
     _, num_vectorcore = get_device_properties()
-    num_programs = min(n_out, num_vectorcore)
+    block_d = min(triton.next_power_of_2(head_dim), 64)
+    num_col_blocks = triton.cdiv(head_dim, block_d)
+    num_programs = min(n_out * num_col_blocks, num_vectorcore)
     block_src = triton.next_power_of_2(2 * ratio if overlap else ratio)
-    block_d = triton.next_power_of_2(head_dim)
     _dsv4_chunked_prefill_compress_kernel[(num_programs,)](
         chunk_kv,
         chunk_score,
@@ -153,6 +184,7 @@ def dsv4_chunked_prefill_compress(
         BLOCK_SRC=block_src,
         BLOCK_D=block_d,
         N_OUT=n_out,
+        NUM_COL_BLOCKS=num_col_blocks,
         NUM_PROGRAMS=num_programs,
         OVERLAP=overlap,
         num_warps=1,

--- a/python/sgl_kernel_npu/sgl_kernel_npu/attention/dsv4_chunked_compress.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/attention/dsv4_chunked_compress.py
@@ -56,14 +56,16 @@ def _dsv4_chunked_prefill_compress_kernel(
             zero_src = is_prev & (k == 0) if OVERLAP else src_i < 0
             from_state = src_global < PREFIX_LEN
             chunk_local = src_global - PREFIX_LEN
+            safe_src_global = tl.maximum(src_global, 0)
+            safe_chunk_local = tl.maximum(chunk_local, 0)
 
             if OVERLAP:
-                data_col = tl.where(~is_prev, HEAD_DIM + head_cols, head_cols)
+                data_col = tl.where(is_prev, HEAD_DIM + head_cols, head_cols)
             else:
                 data_col = head_cols
             mask = src_mask & col_mask & ~zero_src
 
-            chunk_offsets = chunk_local * COFF_D + data_col
+            chunk_offsets = safe_chunk_local * COFF_D + data_col
             chunk_kv_vals = tl.load(
                 chunk_kv + chunk_offsets,
                 mask=mask & ~from_state,
@@ -81,12 +83,15 @@ def _dsv4_chunked_prefill_compress_kernel(
             )
             chunk_score_vals += ape_vals
 
+            state_page_idx = tl.where(
+                from_state & ~zero_src, safe_src_global // PAGE_SIZE, 0
+            )
             state_page = tl.load(
-                page_table + src_global // PAGE_SIZE,
+                page_table + state_page_idx,
                 mask=src_mask & from_state & ~zero_src,
                 other=0,
             )
-            state_slot = state_page * PAGE_SIZE + (src_global % PAGE_SIZE)
+            state_slot = state_page * PAGE_SIZE + (safe_src_global % PAGE_SIZE)
             state_base = state_slot * (2 * COFF_D)
             state_kv_vals = tl.load(
                 state_kv_score + state_base + data_col,

--- a/python/sgl_kernel_npu/sgl_kernel_npu/attention/dsv4_chunked_compress.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/attention/dsv4_chunked_compress.py
@@ -95,12 +95,10 @@ def _dsv4_chunked_prefill_compress_kernel(
                 other=-float("inf"),
             )
 
-            kv_vals = tl.where(from_state, state_kv_vals, chunk_kv_vals).to(
+            kv_vals = tl.where(from_state, state_kv_vals, chunk_kv_vals).to(tl.float32)
+            score_vals = tl.where(from_state, state_score_vals, chunk_score_vals).to(
                 tl.float32
             )
-            score_vals = tl.where(
-                from_state, state_score_vals, chunk_score_vals
-            ).to(tl.float32)
             score_vals = tl.where(mask, score_vals, -float("inf"))
             kv_vals = tl.where(mask, kv_vals, 0.0)
 

--- a/python/sgl_kernel_npu/sgl_kernel_npu/attention/dsv4_chunked_compress.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/attention/dsv4_chunked_compress.py
@@ -125,7 +125,8 @@ def _dsv4_chunked_prefill_compress_kernel(
             denom = denom * old_scale + new_scale
             score_max = new_score_max
 
-        acc = acc / denom
+        safe_denom = tl.where(denom == 0.0, 1.0, denom)
+        acc = acc / safe_denom
         tl.store(
             out + out_i * HEAD_DIM + head_cols,
             acc.to(out.dtype.element_ty),

--- a/python/sgl_kernel_npu/sgl_kernel_npu/attention/dsv4_chunked_compress.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/attention/dsv4_chunked_compress.py
@@ -159,9 +159,9 @@ def dsv4_chunked_prefill_compress(
         f"chunk_kv col-dim {chunk_kv.shape[1]} != ape col-dim {ape.shape[1]}; "
         "chunk_kv must use the same column packing as ape (2*HEAD_DIM in overlap mode)"
     )
-    assert chunk_score.shape[1] == ape.shape[1], (
-        f"chunk_score col-dim {chunk_score.shape[1]} != ape col-dim {ape.shape[1]}"
-    )
+    assert (
+        chunk_score.shape[1] == ape.shape[1]
+    ), f"chunk_score col-dim {chunk_score.shape[1]} != ape col-dim {ape.shape[1]}"
 
     n_out = (prefix_len + chunk_len) // ratio - prefix_len // ratio
     coff = 2 if overlap else 1

--- a/python/sgl_kernel_npu/sgl_kernel_npu/attention/dsv4_chunked_compress.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/attention/dsv4_chunked_compress.py
@@ -152,6 +152,16 @@ def dsv4_chunked_prefill_compress(
     assert ape.is_contiguous()
     assert 0 <= state_base <= prefix_len
     assert state_kv_score_window.shape[-1] == 2 * ape.shape[1]
+    # In overlap mode chunk_kv/chunk_score use a 2*HEAD_DIM packed column layout
+    # (prev-half in [:HEAD_DIM], current-half in [HEAD_DIM:]), matching ape.shape[1].
+    # Non-overlap mode uses HEAD_DIM columns, also matching ape.shape[1].
+    assert chunk_kv.shape[1] == ape.shape[1], (
+        f"chunk_kv col-dim {chunk_kv.shape[1]} != ape col-dim {ape.shape[1]}; "
+        "chunk_kv must use the same column packing as ape (2*HEAD_DIM in overlap mode)"
+    )
+    assert chunk_score.shape[1] == ape.shape[1], (
+        f"chunk_score col-dim {chunk_score.shape[1]} != ape col-dim {ape.shape[1]}"
+    )
 
     n_out = (prefix_len + chunk_len) // ratio - prefix_len // ratio
     coff = 2 if overlap else 1

--- a/python/sgl_kernel_npu/sgl_kernel_npu/attention/dsv4_chunked_compress.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/attention/dsv4_chunked_compress.py
@@ -1,0 +1,160 @@
+import torch
+import triton
+import triton.language as tl
+from sgl_kernel_npu.utils.triton_utils import get_device_properties
+
+
+@triton.jit
+def _dsv4_chunked_prefill_compress_kernel(
+    chunk_kv,
+    chunk_score,
+    state_kv_score,
+    page_table,
+    ape,
+    out,
+    PREFIX_LEN: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    RATIO: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    COFF_D: tl.constexpr,
+    BLOCK_SRC: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    N_OUT: tl.constexpr,
+    NUM_PROGRAMS: tl.constexpr,
+    OVERLAP: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    cols = tl.arange(0, BLOCK_D)
+    srcs = tl.arange(0, BLOCK_SRC)
+    col_mask = cols < HEAD_DIM
+    n_src = 2 * RATIO if OVERLAP else RATIO
+    first_k = PREFIX_LEN // RATIO
+
+    for out_i in tl.range(pid, N_OUT, NUM_PROGRAMS):
+        k = first_k + out_i
+        if OVERLAP:
+            is_prev = srcs[:, None] >= RATIO
+        else:
+            is_prev = srcs[:, None] < 0
+        ape_j = tl.where(is_prev, srcs[:, None] - RATIO, srcs[:, None])
+        src_global = tl.where(
+            is_prev,
+            (k - 1) * RATIO + ape_j,
+            k * RATIO + ape_j,
+        )
+        src_mask = srcs[:, None] < n_src
+        zero_src = is_prev & (k == 0) if OVERLAP else srcs[:, None] < 0
+        from_state = src_global < PREFIX_LEN
+        chunk_local = src_global - PREFIX_LEN
+
+        if OVERLAP:
+            data_col = tl.where(~is_prev, HEAD_DIM + cols[None, :], cols[None, :])
+        else:
+            data_col = cols[None, :]
+        mask = src_mask & col_mask[None, :] & ~zero_src
+
+        chunk_offsets = chunk_local * COFF_D + data_col
+        chunk_kv_vals = tl.load(
+            chunk_kv + chunk_offsets,
+            mask=mask & ~from_state,
+            other=0.0,
+        )
+        chunk_score_vals = tl.load(
+            chunk_score + chunk_offsets,
+            mask=mask & ~from_state,
+            other=-float("inf"),
+        )
+        ape_vals = tl.load(
+            ape + ape_j * COFF_D + data_col,
+            mask=mask & ~from_state,
+            other=0.0,
+        )
+        chunk_score_vals += ape_vals
+
+        state_page = tl.load(
+            page_table + src_global // PAGE_SIZE,
+            mask=src_mask & from_state & ~zero_src,
+            other=0,
+        )
+        state_slot = state_page * PAGE_SIZE + (src_global % PAGE_SIZE)
+        state_base = state_slot * (2 * COFF_D)
+        state_kv_vals = tl.load(
+            state_kv_score + state_base + data_col,
+            mask=mask & from_state,
+            other=0.0,
+        )
+        state_score_vals = tl.load(
+            state_kv_score + state_base + COFF_D + data_col,
+            mask=mask & from_state,
+            other=-float("inf"),
+        )
+
+        kv_vals = tl.where(from_state, state_kv_vals, chunk_kv_vals).to(tl.float32)
+        score_vals = tl.where(from_state, state_score_vals, chunk_score_vals).to(
+            tl.float32
+        )
+        score_vals = tl.where(mask, score_vals, -float("inf"))
+        kv_vals = tl.where(mask, kv_vals, 0.0)
+
+        score_max = tl.max(score_vals, axis=0)
+        weights = tl.exp(score_vals - score_max[None, :])
+        denom = tl.sum(weights, axis=0)
+        acc = tl.sum(kv_vals * weights, axis=0) / denom
+        tl.store(
+            out + out_i * HEAD_DIM + cols,
+            acc.to(out.dtype.element_ty),
+            mask=col_mask,
+        )
+
+
+def dsv4_chunked_prefill_compress(
+    chunk_kv: torch.Tensor,
+    chunk_score: torch.Tensor,
+    state_kv_score: torch.Tensor,
+    page_table: torch.Tensor,
+    ape: torch.Tensor,
+    *,
+    prefix_len: int,
+    chunk_len: int,
+    ratio: int,
+    overlap: bool,
+    page_size: int,
+) -> torch.Tensor:
+    assert ratio in (4, 128), f"unsupported DeepSeek-V4 compress ratio: {ratio}"
+    assert overlap == (ratio == 4), "DeepSeek-V4 overlap is only valid for ratio=4"
+    assert chunk_kv.is_contiguous()
+    assert chunk_score.is_contiguous()
+    assert state_kv_score.is_contiguous()
+    assert ape.is_contiguous()
+
+    n_out = (prefix_len + chunk_len) // ratio - prefix_len // ratio
+    coff = 2 if overlap else 1
+    head_dim = ape.shape[1] // coff
+    out = torch.empty((n_out, head_dim), dtype=chunk_kv.dtype, device=chunk_kv.device)
+    if n_out == 0:
+        return out
+
+    _, num_vectorcore = get_device_properties()
+    num_programs = min(n_out, num_vectorcore)
+    block_src = triton.next_power_of_2(2 * ratio if overlap else ratio)
+    block_d = triton.next_power_of_2(head_dim)
+    _dsv4_chunked_prefill_compress_kernel[(num_programs,)](
+        chunk_kv,
+        chunk_score,
+        state_kv_score,
+        page_table,
+        ape,
+        out,
+        PREFIX_LEN=prefix_len,
+        PAGE_SIZE=page_size,
+        RATIO=ratio,
+        HEAD_DIM=head_dim,
+        COFF_D=ape.shape[1],
+        BLOCK_SRC=block_src,
+        BLOCK_D=block_d,
+        N_OUT=n_out,
+        NUM_PROGRAMS=num_programs,
+        OVERLAP=overlap,
+        num_warps=1,
+    )
+    return out

--- a/tests/python/sgl_kernel_npu/test_dsv4_chunked_compress.py
+++ b/tests/python/sgl_kernel_npu/test_dsv4_chunked_compress.py
@@ -171,7 +171,9 @@ def run_case(
     torch.testing.assert_close(out_cpu, ref, atol=atol, rtol=rtol)
     max_diff = (out_cpu - ref).abs().max().item() if ref.numel() else 0.0
     dtype_tag = "fp32" if dtype == torch.float32 else "bf16"
-    print(f"[PASS] {case.name}[{dtype_tag}]: shape={tuple(ref.shape)} max_diff={max_diff:.6g}")
+    print(
+        f"[PASS] {case.name}[{dtype_tag}]: shape={tuple(ref.shape)} max_diff={max_diff:.6g}"
+    )
 
 
 def run_equivalence_case(
@@ -210,7 +212,9 @@ def run_equivalence_case(
     # Non-chunked reference: prefix=0, all 2*ratio tokens. Yields [k=0, k=1].
     nc_case = CaseConfig(f"{name}_nc", ratio, 0, total_len, head_dim, page_size)
     empty_state = torch.empty((0, 2 * coff * head_dim), dtype=torch.float32)
-    ref_all = reference_chunked_compress(kv_full, score_full, empty_state, 0, ape, nc_case)
+    ref_all = reference_chunked_compress(
+        kv_full, score_full, empty_state, 0, ape, nc_case
+    )
     ref_k1 = ref_all[1]
 
     # Chunked kernel: prefix=ratio, only second half. Must yield one output == k=1.
@@ -298,8 +302,12 @@ def main():
     # reference (prefix_len=0, full 2*ratio tokens). Catches convention bugs
     # that the self-referential reference_chunked_compress would miss.
     run_equivalence_case("overlap_ratio4_hd16", 4, 16, 4, device, args.atol, args.rtol)
-    run_equivalence_case("overlap_ratio4_hd128", 4, 128, 4, device, args.atol, args.rtol)
-    run_equivalence_case("non_overlap_ratio128_hd16", 128, 16, 16, device, args.atol, args.rtol)
+    run_equivalence_case(
+        "overlap_ratio4_hd128", 4, 128, 4, device, args.atol, args.rtol
+    )
+    run_equivalence_case(
+        "non_overlap_ratio128_hd16", 128, 16, 16, device, args.atol, args.rtol
+    )
     run_equivalence_case(
         "non_overlap_ratio128_hd128", 128, 128, 16, device, args.atol, args.rtol
     )

--- a/tests/python/sgl_kernel_npu/test_dsv4_chunked_compress.py
+++ b/tests/python/sgl_kernel_npu/test_dsv4_chunked_compress.py
@@ -84,11 +84,11 @@ def reference_chunked_compress(
 
             if overlap:
                 if is_prev:
-                    kv_row = kv_row[:d]
-                    score_row = score_row[:d]
-                else:
                     kv_row = kv_row[d:]
                     score_row = score_row[d:]
+                else:
+                    kv_row = kv_row[:d]
+                    score_row = score_row[:d]
             kv_rows.append(kv_row)
             score_rows.append(score_row)
 

--- a/tests/python/sgl_kernel_npu/test_dsv4_chunked_compress.py
+++ b/tests/python/sgl_kernel_npu/test_dsv4_chunked_compress.py
@@ -184,16 +184,17 @@ def run_equivalence_case(
     device: torch.device,
     atol: float,
     rtol: float,
+    extra_chunks: int = 0,
 ) -> None:
     """Cross-validate chunked path against the non-chunked reference.
 
-    Uses total_len = 2*ratio tokens. The non-chunked reference processes
-    everything at once (prefix_len=0, chunk_len=2*ratio) and returns two
-    compressed outputs; we take k=1. The chunked kernel receives only the
-    second half (prefix_len=ratio, chunk_len=ratio) and must agree on k=1.
-    This catches any convention mismatch between the kernel and the non-chunked
-    _overlap_transform path that would be invisible to the self-referential
-    reference_chunked_compress check.
+    With extra_chunks=0 (default): total_len=2*ratio, prefix_len=ratio,
+    chunk_len=ratio → kernel emits n_out=1, validated against non-chunked k=1.
+
+    With extra_chunks=N: total_len=(2+N)*ratio, prefix_len=ratio,
+    chunk_len=(1+N)*ratio → kernel emits n_out=1+N, all outputs validated
+    against the non-chunked reference. This exercises the out_i loop and the
+    store address arithmetic (out + out_i * HEAD_DIM) for out_i > 0.
     """
     from sgl_kernel_npu.attention.dsv4_chunked_compress import (
         dsv4_chunked_prefill_compress,
@@ -201,23 +202,24 @@ def run_equivalence_case(
 
     overlap = ratio == 4
     coff = 2 if overlap else 1
-    total_len = 2 * ratio
     prefix_len = ratio
-    chunk_len = ratio
+    chunk_len = (1 + extra_chunks) * ratio
+    total_len = prefix_len + chunk_len
+    n_out_expected = chunk_len // ratio  # == 1 + extra_chunks
 
     kv_full = torch.randn(total_len, coff * head_dim, dtype=torch.float32)
     score_full = torch.randn(total_len, coff * head_dim, dtype=torch.float32) * 0.3
     ape = torch.randn(ratio, coff * head_dim, dtype=torch.float32) * 0.5
 
-    # Non-chunked reference: prefix=0, all 2*ratio tokens. Yields [k=0, k=1].
+    # Non-chunked reference: prefix=0, all total_len tokens. Yields outputs k=0..n_out.
+    # We compare against outputs k=1..n_out (the part the chunked kernel covers).
     nc_case = CaseConfig(f"{name}_nc", ratio, 0, total_len, head_dim, page_size)
     empty_state = torch.empty((0, 2 * coff * head_dim), dtype=torch.float32)
     ref_all = reference_chunked_compress(
         kv_full, score_full, empty_state, 0, ape, nc_case
     )
-    ref_k1 = ref_all[1]
+    ref_chunked = ref_all[1:]  # shape (n_out_expected, head_dim)
 
-    # Chunked kernel: prefix=ratio, only second half. Must yield one output == k=1.
     page_table = make_page_table(total_len, page_size)
     state_pool = fill_state_pool(
         kv_full, score_full, ape, prefix_len, ratio, page_table, page_size
@@ -239,10 +241,13 @@ def run_equivalence_case(
     )
     torch.npu.synchronize()
     out_cpu = out.cpu()
-    assert out_cpu.shape[0] == 1, f"expected 1 output, got {out_cpu.shape[0]}"
-    torch.testing.assert_close(out_cpu[0], ref_k1, atol=atol, rtol=rtol)
-    diff = (out_cpu[0] - ref_k1).abs().max().item()
-    print(f"[PASS] equivalence/{name}: max_diff={diff:.6g}")
+    assert out_cpu.shape[0] == n_out_expected, (
+        f"expected {n_out_expected} outputs, got {out_cpu.shape[0]}"
+    )
+    torch.testing.assert_close(out_cpu, ref_chunked, atol=atol, rtol=rtol)
+    diff = (out_cpu - ref_chunked).abs().max().item()
+    suffix = f"_x{1 + extra_chunks}" if extra_chunks else ""
+    print(f"[PASS] equivalence/{name}{suffix}: n_out={n_out_expected} max_diff={diff:.6g}")
 
 
 def main():
@@ -279,6 +284,11 @@ def main():
         CaseConfig("n_out_zero_non_overlap", 128, 128, 64, 16, 16),
         # prefix_len=4, chunk_len=2, ratio=4 → (4+2)//4 - 4//4 = 1-1 = 0
         CaseConfig("n_out_zero_overlap", 4, 4, 2, 16, 4),
+        # ── overlap with prefix_len exactly a multiple of ratio and n_out > 0.
+        # k=1: prev sources [0,4) all from state, current sources [4,8) all from chunk —
+        # a clean state/chunk partition that no other case covers.
+        CaseConfig("overlap_aligned_prefix_multi_out", 4, 4, 8, 16, 4),
+        CaseConfig("overlap_aligned_prefix_multi_out_hd128", 4, 4, 8, 128, 4),
     ]
     for case in fp32_cases:
         run_case(case, device, args.atol, args.rtol, dtype=torch.float32)
@@ -310,6 +320,35 @@ def main():
     )
     run_equivalence_case(
         "non_overlap_ratio128_hd128", 128, 128, 16, device, args.atol, args.rtol
+    )
+
+    # ── Multi-output equivalence: extra_chunks=2 → n_out=3, validates
+    # out_i loop and store address (out + out_i * HEAD_DIM) for out_i > 0.
+    run_equivalence_case(
+        "overlap_ratio4_hd16", 4, 16, 4, device, args.atol, args.rtol, extra_chunks=2
+    )
+    run_equivalence_case(
+        "overlap_ratio4_hd128", 4, 128, 4, device, args.atol, args.rtol, extra_chunks=2
+    )
+    run_equivalence_case(
+        "non_overlap_ratio128_hd16",
+        128,
+        16,
+        16,
+        device,
+        args.atol,
+        args.rtol,
+        extra_chunks=2,
+    )
+    run_equivalence_case(
+        "non_overlap_ratio128_hd128",
+        128,
+        128,
+        16,
+        device,
+        args.atol,
+        args.rtol,
+        extra_chunks=2,
     )
 
     print("All DeepSeek-V4 chunked compress Triton tests passed.")

--- a/tests/python/sgl_kernel_npu/test_dsv4_chunked_compress.py
+++ b/tests/python/sgl_kernel_npu/test_dsv4_chunked_compress.py
@@ -114,7 +114,13 @@ def reference_chunked_compress(
     return torch.stack(outs, dim=0)
 
 
-def run_case(case: CaseConfig, device: torch.device, atol: float, rtol: float):
+def run_case(
+    case: CaseConfig,
+    device: torch.device,
+    atol: float,
+    rtol: float,
+    dtype: torch.dtype = torch.float32,
+):
     from sgl_kernel_npu.attention.dsv4_chunked_compress import (
         dsv4_chunked_prefill_compress,
     )
@@ -123,6 +129,7 @@ def run_case(case: CaseConfig, device: torch.device, atol: float, rtol: float):
     coff = 2 if overlap else 1
     total_len = case.prefix_len + case.chunk_len
 
+    # Reference always runs in fp32 for numerical accuracy.
     kv_full = torch.randn(total_len, coff * case.head_dim, dtype=torch.float32)
     score_full = torch.randn(total_len, coff * case.head_dim, dtype=torch.float32) * 0.3
     ape = torch.randn(case.ratio, coff * case.head_dim, dtype=torch.float32) * 0.5
@@ -147,11 +154,12 @@ def run_case(case: CaseConfig, device: torch.device, atol: float, rtol: float):
     ref = reference_chunked_compress(
         kv_full, score_full, state_window, state_base, ape, case
     )
+    # Kernel runs with the requested dtype; output is cast back to fp32 for comparison.
     out = dsv4_chunked_prefill_compress(
-        kv_full[case.prefix_len :].contiguous().to(device),
-        score_full[case.prefix_len :].contiguous().to(device),
-        state_window.contiguous().to(device),
-        ape.contiguous().to(device),
+        kv_full[case.prefix_len :].contiguous().to(dtype).to(device),
+        score_full[case.prefix_len :].contiguous().to(dtype).to(device),
+        state_window.contiguous().to(dtype).to(device),
+        ape.contiguous().to(dtype).to(device),
         prefix_len=case.prefix_len,
         chunk_len=case.chunk_len,
         ratio=case.ratio,
@@ -159,10 +167,78 @@ def run_case(case: CaseConfig, device: torch.device, atol: float, rtol: float):
         state_base=state_base,
     )
     torch.npu.synchronize()
-    out_cpu = out.cpu()
+    out_cpu = out.cpu().float()
     torch.testing.assert_close(out_cpu, ref, atol=atol, rtol=rtol)
     max_diff = (out_cpu - ref).abs().max().item() if ref.numel() else 0.0
-    print(f"[PASS] {case.name}: shape={tuple(ref.shape)} max_diff={max_diff:.6g}")
+    dtype_tag = "fp32" if dtype == torch.float32 else "bf16"
+    print(f"[PASS] {case.name}[{dtype_tag}]: shape={tuple(ref.shape)} max_diff={max_diff:.6g}")
+
+
+def run_equivalence_case(
+    name: str,
+    ratio: int,
+    head_dim: int,
+    page_size: int,
+    device: torch.device,
+    atol: float,
+    rtol: float,
+) -> None:
+    """Cross-validate chunked path against the non-chunked reference.
+
+    Uses total_len = 2*ratio tokens. The non-chunked reference processes
+    everything at once (prefix_len=0, chunk_len=2*ratio) and returns two
+    compressed outputs; we take k=1. The chunked kernel receives only the
+    second half (prefix_len=ratio, chunk_len=ratio) and must agree on k=1.
+    This catches any convention mismatch between the kernel and the non-chunked
+    _overlap_transform path that would be invisible to the self-referential
+    reference_chunked_compress check.
+    """
+    from sgl_kernel_npu.attention.dsv4_chunked_compress import (
+        dsv4_chunked_prefill_compress,
+    )
+
+    overlap = ratio == 4
+    coff = 2 if overlap else 1
+    total_len = 2 * ratio
+    prefix_len = ratio
+    chunk_len = ratio
+
+    kv_full = torch.randn(total_len, coff * head_dim, dtype=torch.float32)
+    score_full = torch.randn(total_len, coff * head_dim, dtype=torch.float32) * 0.3
+    ape = torch.randn(ratio, coff * head_dim, dtype=torch.float32) * 0.5
+
+    # Non-chunked reference: prefix=0, all 2*ratio tokens. Yields [k=0, k=1].
+    nc_case = CaseConfig(f"{name}_nc", ratio, 0, total_len, head_dim, page_size)
+    empty_state = torch.empty((0, 2 * coff * head_dim), dtype=torch.float32)
+    ref_all = reference_chunked_compress(kv_full, score_full, empty_state, 0, ape, nc_case)
+    ref_k1 = ref_all[1]
+
+    # Chunked kernel: prefix=ratio, only second half. Must yield one output == k=1.
+    page_table = make_page_table(total_len, page_size)
+    state_pool = fill_state_pool(
+        kv_full, score_full, ape, prefix_len, ratio, page_table, page_size
+    )
+    state_base = max(0, (prefix_len // ratio - (1 if overlap else 0)) * ratio)
+    state_window = gather_state_window(
+        state_pool, page_table, state_base, prefix_len, page_size
+    )
+    out = dsv4_chunked_prefill_compress(
+        kv_full[prefix_len:].contiguous().to(device),
+        score_full[prefix_len:].contiguous().to(device),
+        state_window.contiguous().to(device),
+        ape.contiguous().to(device),
+        prefix_len=prefix_len,
+        chunk_len=chunk_len,
+        ratio=ratio,
+        overlap=overlap,
+        state_base=state_base,
+    )
+    torch.npu.synchronize()
+    out_cpu = out.cpu()
+    assert out_cpu.shape[0] == 1, f"expected 1 output, got {out_cpu.shape[0]}"
+    torch.testing.assert_close(out_cpu[0], ref_k1, atol=atol, rtol=rtol)
+    diff = (out_cpu[0] - ref_k1).abs().max().item()
+    print(f"[PASS] equivalence/{name}: max_diff={diff:.6g}")
 
 
 def main():
@@ -182,14 +258,52 @@ def main():
 
     torch.manual_seed(args.seed)
     device = torch.device("npu")
-    cases = [
+
+    # ── fp32 baseline cases (original) ───────────────────────────────────────
+    fp32_cases = [
         CaseConfig("overlap_k0_mixed_state", 4, 2, 6, 16, 4),
         CaseConfig("overlap_unaligned_followup", 4, 6, 6, 16, 4),
         CaseConfig("non_overlap_remainder_complete", 128, 50, 80, 16, 16),
         CaseConfig("non_overlap_boundary_followup", 128, 128, 256, 16, 16),
+        # ── Item 9: head_dim=128 exercises the multi-col-block path (BLOCK_D=64,
+        #    NUM_COL_BLOCKS=2). This is DSV4's actual attention head_dim.
+        CaseConfig("overlap_hd128_k0_mixed_state", 4, 2, 6, 128, 4),
+        CaseConfig("overlap_hd128_followup", 4, 6, 6, 128, 4),
+        CaseConfig("non_overlap_hd128_boundary", 128, 128, 256, 128, 16),
+        # ── Item 9: n_out=0 early-return path
+        # prefix_len=128, chunk_len=64, ratio=128 → (128+64)//128 - 128//128 = 1-1 = 0
+        CaseConfig("n_out_zero_non_overlap", 128, 128, 64, 16, 16),
+        # prefix_len=4, chunk_len=2, ratio=4 → (4+2)//4 - 4//4 = 1-1 = 0
+        CaseConfig("n_out_zero_overlap", 4, 4, 2, 16, 4),
     ]
-    for case in cases:
-        run_case(case, device, args.atol, args.rtol)
+    for case in fp32_cases:
+        run_case(case, device, args.atol, args.rtol, dtype=torch.float32)
+
+    # ── bf16 cases (Item 2) ───────────────────────────────────────────────────
+    # bf16 has ~3 decimal digits of precision; kernel accumulates in fp32
+    # internally, so tolerance of 2e-2 covers the round-trip cast error.
+    BF16_ATOL, BF16_RTOL = 2e-2, 1e-2
+    bf16_cases = [
+        CaseConfig("bf16_overlap_k0_mixed_state", 4, 2, 6, 16, 4),
+        CaseConfig("bf16_overlap_unaligned_followup", 4, 6, 6, 16, 4),
+        CaseConfig("bf16_non_overlap_boundary", 128, 128, 256, 16, 16),
+        CaseConfig("bf16_overlap_hd128", 4, 2, 6, 128, 4),
+        CaseConfig("bf16_non_overlap_hd128", 128, 128, 256, 128, 16),
+    ]
+    for case in bf16_cases:
+        run_case(case, device, BF16_ATOL, BF16_RTOL, dtype=torch.bfloat16)
+
+    # ── Item 5: chunked vs non-chunked equivalence ────────────────────────────
+    # Same input, chunked kernel (prefix_len=ratio) must agree with non-chunked
+    # reference (prefix_len=0, full 2*ratio tokens). Catches convention bugs
+    # that the self-referential reference_chunked_compress would miss.
+    run_equivalence_case("overlap_ratio4_hd16", 4, 16, 4, device, args.atol, args.rtol)
+    run_equivalence_case("overlap_ratio4_hd128", 4, 128, 4, device, args.atol, args.rtol)
+    run_equivalence_case("non_overlap_ratio128_hd16", 128, 16, 16, device, args.atol, args.rtol)
+    run_equivalence_case(
+        "non_overlap_ratio128_hd128", 128, 128, 16, device, args.atol, args.rtol
+    )
+
     print("All DeepSeek-V4 chunked compress Triton tests passed.")
 
 

--- a/tests/python/sgl_kernel_npu/test_dsv4_chunked_compress.py
+++ b/tests/python/sgl_kernel_npu/test_dsv4_chunked_compress.py
@@ -19,7 +19,7 @@ def make_page_table(total_len: int, page_size: int) -> torch.Tensor:
     return torch.arange(num_pages, dtype=torch.int64)
 
 
-def fill_state(
+def fill_state_pool(
     kv_full: torch.Tensor,
     score_full: torch.Tensor,
     ape: torch.Tensor,
@@ -39,11 +39,25 @@ def fill_state(
     return state
 
 
+def gather_state_window(
+    state_pool: torch.Tensor,
+    page_table: torch.Tensor,
+    state_base: int,
+    prefix_len: int,
+    page_size: int,
+) -> torch.Tensor:
+    if prefix_len <= state_base:
+        return state_pool.new_empty((0, state_pool.shape[-1]))
+    gps = torch.arange(state_base, prefix_len, dtype=torch.long)
+    slots = page_table[gps // page_size].to(torch.long) * page_size + (gps % page_size)
+    return state_pool[slots].contiguous()
+
+
 def reference_chunked_compress(
     kv_full: torch.Tensor,
     score_full: torch.Tensor,
-    state_kv_score: torch.Tensor,
-    page_table: torch.Tensor,
+    state_kv_score_window: torch.Tensor,
+    state_base: int,
     ape: torch.Tensor,
     case: CaseConfig,
 ) -> torch.Tensor:
@@ -73,10 +87,9 @@ def reference_chunked_compress(
 
             gp = (k - 1) * case.ratio + j if is_prev else k * case.ratio + j
             if gp < prefix_len:
-                slot = int(page_table[gp // case.page_size]) * case.page_size
-                slot += gp % case.page_size
-                kv_row = state_kv_score[slot, :coff_d]
-                score_row = state_kv_score[slot, coff_d:]
+                state_row = gp - state_base
+                kv_row = state_kv_score_window[state_row, :coff_d]
+                score_row = state_kv_score_window[state_row, coff_d:]
             else:
                 local_idx = gp - prefix_len
                 kv_row = chunk_kv[local_idx]
@@ -84,11 +97,11 @@ def reference_chunked_compress(
 
             if overlap:
                 if is_prev:
-                    kv_row = kv_row[d:]
-                    score_row = score_row[d:]
-                else:
                     kv_row = kv_row[:d]
                     score_row = score_row[:d]
+                else:
+                    kv_row = kv_row[d:]
+                    score_row = score_row[d:]
             kv_rows.append(kv_row)
             score_rows.append(score_row)
 
@@ -114,7 +127,7 @@ def run_case(case: CaseConfig, device: torch.device, atol: float, rtol: float):
     score_full = torch.randn(total_len, coff * case.head_dim, dtype=torch.float32) * 0.3
     ape = torch.randn(case.ratio, coff * case.head_dim, dtype=torch.float32) * 0.5
     page_table = make_page_table(total_len, case.page_size)
-    state = fill_state(
+    state_pool = fill_state_pool(
         kv_full,
         score_full,
         ape,
@@ -123,19 +136,27 @@ def run_case(case: CaseConfig, device: torch.device, atol: float, rtol: float):
         page_table,
         case.page_size,
     )
+    state_base = max(
+        0,
+        (case.prefix_len // case.ratio - (1 if overlap else 0)) * case.ratio,
+    )
+    state_window = gather_state_window(
+        state_pool, page_table, state_base, case.prefix_len, case.page_size
+    )
 
-    ref = reference_chunked_compress(kv_full, score_full, state, page_table, ape, case)
+    ref = reference_chunked_compress(
+        kv_full, score_full, state_window, state_base, ape, case
+    )
     out = dsv4_chunked_prefill_compress(
         kv_full[case.prefix_len :].contiguous().to(device),
         score_full[case.prefix_len :].contiguous().to(device),
-        state.contiguous().to(device),
-        page_table.contiguous().to(device),
+        state_window.contiguous().to(device),
         ape.contiguous().to(device),
         prefix_len=case.prefix_len,
         chunk_len=case.chunk_len,
         ratio=case.ratio,
         overlap=overlap,
-        page_size=case.page_size,
+        state_base=state_base,
     )
     torch.npu.synchronize()
     out_cpu = out.cpu()

--- a/tests/python/sgl_kernel_npu/test_dsv4_chunked_compress.py
+++ b/tests/python/sgl_kernel_npu/test_dsv4_chunked_compress.py
@@ -1,0 +1,176 @@
+import argparse
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass
+class CaseConfig:
+    name: str
+    ratio: int
+    prefix_len: int
+    chunk_len: int
+    head_dim: int
+    page_size: int
+
+
+def make_page_table(total_len: int, page_size: int) -> torch.Tensor:
+    num_pages = (total_len + page_size - 1) // page_size + 2
+    return torch.arange(num_pages, dtype=torch.int64)
+
+
+def fill_state(
+    kv_full: torch.Tensor,
+    score_full: torch.Tensor,
+    ape: torch.Tensor,
+    prefix_len: int,
+    ratio: int,
+    page_table: torch.Tensor,
+    page_size: int,
+) -> torch.Tensor:
+    coff_d = kv_full.shape[1]
+    state = kv_full.new_empty((page_table.numel() * page_size, 2 * coff_d))
+    state[:, :coff_d].zero_()
+    state[:, coff_d:].fill_(float("-inf"))
+    for gp in range(prefix_len):
+        slot = int(page_table[gp // page_size]) * page_size + gp % page_size
+        state[slot, :coff_d] = kv_full[gp]
+        state[slot, coff_d:] = score_full[gp] + ape[gp % ratio]
+    return state
+
+
+def reference_chunked_compress(
+    kv_full: torch.Tensor,
+    score_full: torch.Tensor,
+    state_kv_score: torch.Tensor,
+    page_table: torch.Tensor,
+    ape: torch.Tensor,
+    case: CaseConfig,
+) -> torch.Tensor:
+    overlap = case.ratio == 4
+    coff_d = kv_full.shape[1]
+    d = case.head_dim
+    prefix_len = case.prefix_len
+    chunk_kv = kv_full[prefix_len : prefix_len + case.chunk_len]
+    chunk_score = score_full[prefix_len : prefix_len + case.chunk_len]
+    first_k = prefix_len // case.ratio
+    last_k_exclusive = (prefix_len + case.chunk_len) // case.ratio
+    outs = []
+
+    for k in range(first_k, last_k_exclusive):
+        kv_rows = []
+        score_rows = []
+        n_src = 2 * case.ratio if overlap else case.ratio
+        for src_i in range(n_src):
+            is_prev = overlap and src_i >= case.ratio
+            j = src_i - case.ratio if is_prev else src_i
+            if is_prev and k == 0:
+                kv_row = kv_full.new_zeros((d,))
+                score_row = kv_full.new_full((d,), float("-inf"))
+                kv_rows.append(kv_row)
+                score_rows.append(score_row)
+                continue
+
+            gp = (k - 1) * case.ratio + j if is_prev else k * case.ratio + j
+            if gp < prefix_len:
+                slot = int(page_table[gp // case.page_size]) * case.page_size
+                slot += gp % case.page_size
+                kv_row = state_kv_score[slot, :coff_d]
+                score_row = state_kv_score[slot, coff_d:]
+            else:
+                local_idx = gp - prefix_len
+                kv_row = chunk_kv[local_idx]
+                score_row = chunk_score[local_idx] + ape[j]
+
+            if overlap:
+                if is_prev:
+                    kv_row = kv_row[:d]
+                    score_row = score_row[:d]
+                else:
+                    kv_row = kv_row[d:]
+                    score_row = score_row[d:]
+            kv_rows.append(kv_row)
+            score_rows.append(score_row)
+
+        kv_stack = torch.stack(kv_rows, dim=0)
+        score_stack = torch.stack(score_rows, dim=0)
+        outs.append((kv_stack * score_stack.softmax(dim=0)).sum(dim=0))
+
+    if not outs:
+        return kv_full.new_empty((0, d))
+    return torch.stack(outs, dim=0)
+
+
+def run_case(case: CaseConfig, device: torch.device, atol: float, rtol: float):
+    from sgl_kernel_npu.attention.dsv4_chunked_compress import (
+        dsv4_chunked_prefill_compress,
+    )
+
+    overlap = case.ratio == 4
+    coff = 2 if overlap else 1
+    total_len = case.prefix_len + case.chunk_len
+
+    kv_full = torch.randn(total_len, coff * case.head_dim, dtype=torch.float32)
+    score_full = torch.randn(total_len, coff * case.head_dim, dtype=torch.float32) * 0.3
+    ape = torch.randn(case.ratio, coff * case.head_dim, dtype=torch.float32) * 0.5
+    page_table = make_page_table(total_len, case.page_size)
+    state = fill_state(
+        kv_full,
+        score_full,
+        ape,
+        case.prefix_len,
+        case.ratio,
+        page_table,
+        case.page_size,
+    )
+
+    ref = reference_chunked_compress(kv_full, score_full, state, page_table, ape, case)
+    out = dsv4_chunked_prefill_compress(
+        kv_full[case.prefix_len :].contiguous().to(device),
+        score_full[case.prefix_len :].contiguous().to(device),
+        state.contiguous().to(device),
+        page_table.contiguous().to(device),
+        ape.contiguous().to(device),
+        prefix_len=case.prefix_len,
+        chunk_len=case.chunk_len,
+        ratio=case.ratio,
+        overlap=overlap,
+        page_size=case.page_size,
+    )
+    torch.npu.synchronize()
+    out_cpu = out.cpu()
+    torch.testing.assert_close(out_cpu, ref, atol=atol, rtol=rtol)
+    max_diff = (out_cpu - ref).abs().max().item() if ref.numel() else 0.0
+    print(f"[PASS] {case.name}: shape={tuple(ref.shape)} max_diff={max_diff:.6g}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--atol", type=float, default=1e-4)
+    parser.add_argument("--rtol", type=float, default=1e-4)
+    parser.add_argument("--seed", type=int, default=20260521)
+    args = parser.parse_args()
+
+    try:
+        import torch_npu  # noqa: F401
+    except ImportError as exc:
+        raise SystemExit(f"Import failed: {exc}") from exc
+
+    if not torch.npu.is_available():
+        raise SystemExit("NPU device not available")
+
+    torch.manual_seed(args.seed)
+    device = torch.device("npu")
+    cases = [
+        CaseConfig("overlap_k0_mixed_state", 4, 2, 6, 16, 4),
+        CaseConfig("overlap_unaligned_followup", 4, 6, 6, 16, 4),
+        CaseConfig("non_overlap_remainder_complete", 128, 50, 80, 16, 16),
+        CaseConfig("non_overlap_boundary_followup", 128, 128, 256, 16, 16),
+    ]
+    for case in cases:
+        run_case(case, device, args.atol, args.rtol)
+    print("All DeepSeek-V4 chunked compress Triton tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/sgl_kernel_npu/test_dsv4_chunked_compress.py
+++ b/tests/python/sgl_kernel_npu/test_dsv4_chunked_compress.py
@@ -241,13 +241,15 @@ def run_equivalence_case(
     )
     torch.npu.synchronize()
     out_cpu = out.cpu()
-    assert out_cpu.shape[0] == n_out_expected, (
-        f"expected {n_out_expected} outputs, got {out_cpu.shape[0]}"
-    )
+    assert (
+        out_cpu.shape[0] == n_out_expected
+    ), f"expected {n_out_expected} outputs, got {out_cpu.shape[0]}"
     torch.testing.assert_close(out_cpu, ref_chunked, atol=atol, rtol=rtol)
     diff = (out_cpu - ref_chunked).abs().max().item()
     suffix = f"_x{1 + extra_chunks}" if extra_chunks else ""
-    print(f"[PASS] equivalence/{name}{suffix}: n_out={n_out_expected} max_diff={diff:.6g}")
+    print(
+        f"[PASS] equivalence/{name}{suffix}: n_out={n_out_expected} max_diff={diff:.6g}"
+    )
 
 
 def main():


### PR DESCRIPTION
## Motivation

DSv4 chunked prefill previously had no correct kernel primitive for follow-up
chunks (`prefix_len > 0`): the compressor fell back to incorrect tensor slicing
that ignored already-stored state. This PR adds `dsv4_chunked_prefill_compress`,
a Triton kernel that provides the low-level compress op needed by follow-up
chunks on Ascend NPU, enabling the sglang-side compressor to handle all chunked
prefill scenarios correctly.

Companion sglang PR: sgl-project/sglang#<TODO> (DSv4 compressor integration)

## Modifications

**`python/sgl_kernel_npu/sgl_kernel_npu/attention/dsv4_chunked_compress.py`** (new)

- Triton kernel `_dsv4_chunked_prefill_compress_kernel` with persistent-kernel
  scheduling (`pid → (out_i, col_block)` task grid)
- Supports two compress ratios: `ratio=4` (overlap mode, 2×RATIO sources per
  compressed token) and `ratio=128` (non-overlap mode, RATIO sources)
- Online softmax accumulation (`acc / denom / score_max`) avoids materializing
  the full score matrix, reducing register pressure on NPU UB
- `state_base` parameter: caller pre-gathers the relevant state-pool window;
  kernel addresses rows via `src_global - STATE_BASE` without a page-table
  lookup inside the kernel
- Column-dim assertions on `chunk_kv`/`chunk_score` to catch layout mismatches
  at call time (overlap mode requires `2×HEAD_DIM` packed columns)

**`tests/python/sgl_kernel_npu/test_dsv4_chunked_compress.py`** (new)

- fp32 and bf16 cases for both overlap (`ratio=4`) and non-overlap (`ratio=128`)
  modes, `head_dim ∈ {16, 128}` (production DSv4 value)
- `n_out=0` early-return path (both modes)
- `overlap_aligned_prefix_multi_out`: `prefix_len % ratio == 0` with `n_out > 0`,
  covering clean state/chunk source partition previously untested
- Equivalence tests (`run_equivalence_case`): chunked kernel output vs
  non-chunked PyTorch reference — catches convention bugs invisible to the
  self-referential reference
- Multi-output equivalence (`extra_chunks=2`, `n_out=3`): validates
  `out + out_i * HEAD_DIM` store-address arithmetic for `out_i > 0`

## Accuracy Tests

TBD — end-to-end DeepSeek-V4 accuracy on Ascend 910C to be supplemented.

Unit-level correctness is covered by `test_dsv4_chunked_compress.py`:
- Self-referential reference (pure-PyTorch golden) vs kernel: fp32 `atol=1e-4`,
  bf16 `atol=2e-2`
- External-anchor equivalence: chunked kernel vs non-chunked reference on
  `total_len = {2,4}×ratio` sequences
```plaintext
python tests/python/sgl_kernel_npu/test_dsv4_chunked_compress.py 
[PASS] overlap_k0_mixed_state[fp32]: shape=(2, 16) max_diff=1.19209e-07
[PASS] overlap_unaligned_followup[fp32]: shape=(2, 16) max_diff=1.19209e-07
[PASS] non_overlap_remainder_complete[fp32]: shape=(1, 16) max_diff=6.70552e-08
[PASS] non_overlap_boundary_followup[fp32]: shape=(2, 16) max_diff=7.45058e-08
[PASS] overlap_hd128_k0_mixed_state[fp32]: shape=(2, 128) max_diff=1.78814e-07
[PASS] overlap_hd128_followup[fp32]: shape=(2, 128) max_diff=1.78814e-07
[PASS] non_overlap_hd128_boundary[fp32]: shape=(2, 128) max_diff=1.19209e-07
[PASS] n_out_zero_non_overlap[fp32]: shape=(0, 16) max_diff=0
[PASS] n_out_zero_overlap[fp32]: shape=(0, 16) max_diff=0
[PASS] overlap_aligned_prefix_multi_out[fp32]: shape=(2, 16) max_diff=2.38419e-07
[PASS] overlap_aligned_prefix_multi_out_hd128[fp32]: shape=(2, 128) max_diff=2.38419e-07
[PASS] bf16_overlap_k0_mixed_state[bf16]: shape=(2, 16) max_diff=0.00363982
[PASS] bf16_overlap_unaligned_followup[bf16]: shape=(2, 16) max_diff=0.00505608
[PASS] bf16_non_overlap_boundary[bf16]: shape=(2, 16) max_diff=0.000751406
[PASS] bf16_overlap_hd128[bf16]: shape=(2, 128) max_diff=0.0065254
[PASS] bf16_non_overlap_hd128[bf16]: shape=(2, 128) max_diff=0.0011231
[PASS] equivalence/overlap_ratio4_hd16: n_out=1 max_diff=1.19209e-07
[PASS] equivalence/overlap_ratio4_hd128: n_out=1 max_diff=3.57628e-07
[PASS] equivalence/non_overlap_ratio128_hd16: n_out=1 max_diff=4.47035e-08
[PASS] equivalence/non_overlap_ratio128_hd128: n_out=1 max_diff=8.9407e-08
[PASS] equivalence/overlap_ratio4_hd16_x3: n_out=3 max_diff=1.19209e-07
[PASS] equivalence/overlap_ratio4_hd128_x3: n_out=3 max_diff=3.57628e-07
[PASS] equivalence/non_overlap_ratio128_hd16_x3: n_out=3 max_diff=5.96046e-08
[PASS] equivalence/non_overlap_ratio128_hd128_x3: n_out=3 max_diff=1.49012e-07
```

## Benchmarking and Profiling

N/A for this PR — `dsv4_chunked_compress` is a correctness primitive for a
previously broken code path (follow-up chunks produced wrong outputs). End-to-end
throughput benchmarks will be tracked in the companion sglang PR after
correctness is established on Ascend 910C.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://sglang.readthedocs.io/en/latest/developer/development_guide_v1.html#formatting-your-code-with-pre-commit) guide.
- [ ] Add unit tests according to the [Run and add unit tests](https://sglang.readthedocs.io/en/latest/developer/development_guide_v1.html#running-and-adding-tests) guide.
- [ ] Update documentation according to [Write documentations](https://sglang.readthedocs.io/en/latest/developer/development_guide_v1.html#writing-documentation) guide.
- [ ] Provide accuracy and speed benchmark results if this PR introduces new models or operators.
- [ ] Follow the SGLang code style [guidance](https://sglang.readthedocs.io/en/latest/developer/development_guide_v1.html#code-style).