### PR TITLE
feat: add fused_remap_deepep Triton kernel for DeepEP shared expert fusion

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/moe/fused_remap_deepep.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/moe/fused_remap_deepep.py
@@ -1,0 +1,99 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _fused_remap_deepep_kernel(
+    topk_ids_ptr,
+    topk_weights_ptr,
+    out_ids_ptr,
+    out_weights_ptr,
+    N,
+    K,
+    K_PLUS_N,
+    num_local_routed,
+    num_local_experts,
+    ep_rank,
+    shared_weight,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    if row >= N:
+        return
+
+    cols = tl.arange(0, BLOCK)
+    mask = cols < K_PLUS_N
+    is_routed = cols < K
+
+    safe_cols = tl.where(is_routed, cols, tl.zeros_like(cols))
+
+    routed_ids = tl.load(topk_ids_ptr + row * K + safe_cols, mask=is_routed, other=0)
+    remapped_ids = routed_ids + routed_ids // num_local_routed
+
+    shared_idx = cols - K
+    shared_ids = ep_rank * num_local_experts + num_local_routed + shared_idx
+
+    final_ids = tl.where(is_routed, remapped_ids, shared_ids)
+    tl.store(out_ids_ptr + row * K_PLUS_N + cols, final_ids, mask=mask)
+
+    routed_weights = tl.load(
+        topk_weights_ptr + row * K + safe_cols, mask=is_routed, other=0.0
+    )
+    final_weights = tl.where(is_routed, routed_weights, shared_weight)
+    tl.store(out_weights_ptr + row * K_PLUS_N + cols, final_weights, mask=mask)
+
+
+def fused_remap_deepep(
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    num_fused_shared_experts: int,
+    num_physical_routed_experts: int,
+    ep_rank: int,
+    ep_size: int,
+    routed_scaling_factor: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused Triton kernel: expand routed topk with shared experts and remap
+    to DeepEP interleaved layout.
+
+    Args:
+        topk_ids: [N, K] routed expert IDs (int).
+        topk_weights: [N, K] routed expert weights (float).
+        num_fused_shared_experts: number of shared experts to fuse.
+        num_physical_routed_experts: total physical routed experts across EP.
+        ep_rank: expert parallel rank of this worker.
+        ep_size: expert parallel world size.
+        routed_scaling_factor: scaling factor for routed experts (0 or 1 means no scaling).
+    """
+    if topk_ids.shape[0] == 0:
+        return topk_ids, topk_weights
+
+    num_local_routed = num_physical_routed_experts // ep_size
+    num_local_experts = num_local_routed + num_fused_shared_experts
+
+    N = topk_ids.shape[0]
+    K = topk_ids.shape[1]
+    K_PLUS_N = K + num_fused_shared_experts
+
+    shared_weight = 1.0 if not routed_scaling_factor else 1.0 / routed_scaling_factor
+
+    out_ids = topk_ids.new_empty((N, K_PLUS_N), dtype=topk_ids.dtype)
+    out_weights = topk_weights.new_empty((N, K_PLUS_N), dtype=topk_weights.dtype)
+
+    BLOCK = max(32, K_PLUS_N)
+    _fused_remap_deepep_kernel[(N,)](
+        topk_ids,
+        topk_weights,
+        out_ids,
+        out_weights,
+        N=N,
+        K=K,
+        K_PLUS_N=K_PLUS_N,
+        num_local_routed=num_local_routed,
+        num_local_experts=num_local_experts,
+        ep_rank=ep_rank,
+        shared_weight=shared_weight,
+        BLOCK=BLOCK,
+    )
+
+    return out_ids, out_weights

--- a/python/sgl_kernel_npu/sgl_kernel_npu/moe/fused_remap_deepep.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/moe/fused_remap_deepep.py
@@ -11,7 +11,7 @@ def _fused_remap_deepep_kernel(
     out_weights_ptr,
     N,
     K,
-    K_PLUS_N,
+    TOTAL_COLS,
     num_local_routed,
     num_local_experts,
     ep_rank,
@@ -23,7 +23,7 @@ def _fused_remap_deepep_kernel(
         return
 
     cols = tl.arange(0, BLOCK)
-    mask = cols < K_PLUS_N
+    mask = cols < TOTAL_COLS
     is_routed = cols < K
 
     safe_cols = tl.where(is_routed, cols, tl.zeros_like(cols))
@@ -35,13 +35,13 @@ def _fused_remap_deepep_kernel(
     shared_ids = ep_rank * num_local_experts + num_local_routed + shared_idx
 
     final_ids = tl.where(is_routed, remapped_ids, shared_ids)
-    tl.store(out_ids_ptr + row * K_PLUS_N + cols, final_ids, mask=mask)
+    tl.store(out_ids_ptr + row * TOTAL_COLS + cols, final_ids, mask=mask)
 
     routed_weights = tl.load(
         topk_weights_ptr + row * K + safe_cols, mask=is_routed, other=0.0
     )
     final_weights = tl.where(is_routed, routed_weights, shared_weight)
-    tl.store(out_weights_ptr + row * K_PLUS_N + cols, final_weights, mask=mask)
+    tl.store(out_weights_ptr + row * TOTAL_COLS + cols, final_weights, mask=mask)
 
 
 def fused_remap_deepep(
@@ -66,21 +66,25 @@ def fused_remap_deepep(
         routed_scaling_factor: scaling factor for routed experts (0 or 1 means no scaling).
     """
     if topk_ids.shape[0] == 0:
-        return topk_ids, topk_weights
+        total_cols = topk_ids.shape[1] + num_fused_shared_experts
+        return (
+            topk_ids.new_empty((0, total_cols), dtype=topk_ids.dtype),
+            topk_weights.new_empty((0, total_cols), dtype=topk_weights.dtype),
+        )
 
     num_local_routed = num_physical_routed_experts // ep_size
     num_local_experts = num_local_routed + num_fused_shared_experts
 
     N = topk_ids.shape[0]
     K = topk_ids.shape[1]
-    K_PLUS_N = K + num_fused_shared_experts
+    TOTAL_COLS = K + num_fused_shared_experts
 
     shared_weight = 1.0 if not routed_scaling_factor else 1.0 / routed_scaling_factor
 
-    out_ids = topk_ids.new_empty((N, K_PLUS_N), dtype=topk_ids.dtype)
-    out_weights = topk_weights.new_empty((N, K_PLUS_N), dtype=topk_weights.dtype)
+    out_ids = topk_ids.new_empty((N, TOTAL_COLS), dtype=topk_ids.dtype)
+    out_weights = topk_weights.new_empty((N, TOTAL_COLS), dtype=topk_weights.dtype)
 
-    BLOCK = max(32, K_PLUS_N)
+    BLOCK = max(32, triton.next_power_of_2(TOTAL_COLS))
     _fused_remap_deepep_kernel[(N,)](
         topk_ids,
         topk_weights,
@@ -88,7 +92,7 @@ def fused_remap_deepep(
         out_weights,
         N=N,
         K=K,
-        K_PLUS_N=K_PLUS_N,
+        TOTAL_COLS=TOTAL_COLS,
         num_local_routed=num_local_routed,
         num_local_experts=num_local_experts,
         ep_rank=ep_rank,

--- a/tests/python/sgl_kernel_npu/test_fused_remap_deepep.py
+++ b/tests/python/sgl_kernel_npu/test_fused_remap_deepep.py
@@ -129,8 +129,8 @@ def test_fused_remap_deepep_empty():
         routed_scaling_factor=2.5,
     )
 
-    assert out_ids.shape[0] == 0
-    assert out_weights.shape[0] == 0
+    assert out_ids.shape == (0, 7)
+    assert out_weights.shape == (0, 7)
 
 
 if __name__ == "__main__":

--- a/tests/python/sgl_kernel_npu/test_fused_remap_deepep.py
+++ b/tests/python/sgl_kernel_npu/test_fused_remap_deepep.py
@@ -1,0 +1,140 @@
+import numpy as np
+import torch
+from sgl_kernel_npu.moe.fused_remap_deepep import fused_remap_deepep
+
+
+def _reference_fused_remap_deepep(
+    topk_ids,
+    topk_weights,
+    num_fused_shared_experts,
+    num_physical_routed_experts,
+    ep_rank,
+    ep_size,
+    routed_scaling_factor,
+):
+    N, K = topk_ids.shape
+    num_local_routed = num_physical_routed_experts // ep_size
+    num_local_experts = num_local_routed + num_fused_shared_experts
+
+    out_ids = torch.zeros(N, K + num_fused_shared_experts, dtype=topk_ids.dtype)
+    out_weights = torch.zeros(N, K + num_fused_shared_experts, dtype=topk_weights.dtype)
+
+    shared_weight = 1.0 if not routed_scaling_factor else 1.0 / routed_scaling_factor
+
+    for row in range(N):
+        for col in range(K + num_fused_shared_experts):
+            if col < K:
+                routed_id = topk_ids[row, col].item()
+                out_ids[row, col] = routed_id + routed_id // num_local_routed
+                out_weights[row, col] = topk_weights[row, col].item()
+            else:
+                shared_idx = col - K
+                out_ids[row, col] = (
+                    ep_rank * num_local_experts + num_local_routed + shared_idx
+                )
+                out_weights[row, col] = shared_weight
+
+    return out_ids, out_weights
+
+
+def test_fused_remap_deepep_basic():
+    N, K = 4, 6
+    num_fused_shared = 1
+    num_physical_routed = 256
+    ep_rank = 0
+    ep_size = 16
+    routed_scaling_factor = 2.5
+
+    topk_ids = torch.randint(0, 16, (N, K), dtype=torch.int32).npu()
+    topk_weights = torch.rand(N, K, dtype=torch.float32).npu()
+
+    out_ids, out_weights = fused_remap_deepep(
+        topk_ids,
+        topk_weights,
+        num_fused_shared_experts=num_fused_shared,
+        num_physical_routed_experts=num_physical_routed,
+        ep_rank=ep_rank,
+        ep_size=ep_size,
+        routed_scaling_factor=routed_scaling_factor,
+    )
+
+    ref_ids, ref_weights = _reference_fused_remap_deepep(
+        topk_ids.cpu(),
+        topk_weights.cpu(),
+        num_fused_shared,
+        num_physical_routed,
+        ep_rank,
+        ep_size,
+        routed_scaling_factor,
+    )
+
+    np.testing.assert_array_equal(out_ids.cpu().numpy(), ref_ids.numpy())
+    np.testing.assert_allclose(
+        out_weights.cpu().numpy(),
+        ref_weights.numpy(),
+        rtol=1e-6,
+    )
+
+
+def test_fused_remap_deepep_multi_shared():
+    N, K = 8, 6
+    num_fused_shared = 3
+    num_physical_routed = 256
+    ep_rank = 3
+    ep_size = 16
+    routed_scaling_factor = 0.0
+
+    topk_ids = torch.randint(0, 16, (N, K), dtype=torch.int32).npu()
+    topk_weights = torch.rand(N, K, dtype=torch.float32).npu()
+
+    out_ids, out_weights = fused_remap_deepep(
+        topk_ids,
+        topk_weights,
+        num_fused_shared_experts=num_fused_shared,
+        num_physical_routed_experts=num_physical_routed,
+        ep_rank=ep_rank,
+        ep_size=ep_size,
+        routed_scaling_factor=routed_scaling_factor,
+    )
+
+    ref_ids, ref_weights = _reference_fused_remap_deepep(
+        topk_ids.cpu(),
+        topk_weights.cpu(),
+        num_fused_shared,
+        num_physical_routed,
+        ep_rank,
+        ep_size,
+        routed_scaling_factor,
+    )
+
+    np.testing.assert_array_equal(out_ids.cpu().numpy(), ref_ids.numpy())
+    np.testing.assert_allclose(
+        out_weights.cpu().numpy(),
+        ref_weights.numpy(),
+        rtol=1e-6,
+    )
+
+
+def test_fused_remap_deepep_empty():
+    topk_ids = torch.zeros(0, 6, dtype=torch.int32).npu()
+    topk_weights = torch.zeros(0, 6, dtype=torch.float32).npu()
+
+    out_ids, out_weights = fused_remap_deepep(
+        topk_ids,
+        topk_weights,
+        num_fused_shared_experts=1,
+        num_physical_routed_experts=256,
+        ep_rank=0,
+        ep_size=16,
+        routed_scaling_factor=2.5,
+    )
+
+    assert out_ids.shape[0] == 0
+    assert out_weights.shape[0] == 0
+
+
+if __name__ == "__main__":
+    test_fused_remap_deepep_basic()
+    test_fused_remap_deepep_multi_shared()
+    test_fused_remap_deepep_empty()
+    print("All tests passed!")


### PR DESCRIPTION
## Summary
- Add `fused_remap_deepep` Triton kernel under `moe/` — fuses routed topk expansion with shared experts and remaps IDs to DeepEP interleaved layout
- Decoupled from sglang internals: `ep_rank`, `ep_size`, `routed_scaling_factor` are passed as explicit parameters instead of importing from sglang's `parallel_state`
- Include unit tests covering: basic case (1 shared expert), multiple shared experts, and empty batch

## Context
Extracted from [sglang PR #26155](https://github.com/sgl-project/sglang/pull/26155) (NPU DeepEP fused shared experts). The kernel was originally inline in sglang's `topk.py` and is being moved to sgl-kernel-npu following the project convention of keeping kernel code in the independent repo.