### PR TITLE
DeepEP: expand moe specifications

### DIFF
--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -575,7 +575,7 @@ jobs:
       - name: Run test low latency for hidden
         timeout-minutes: 10
         env:
-          HCCL_BUFFSIZE: 1913
+          HCCL_BUFFSIZE: 2200
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=2048
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=4096
@@ -710,7 +710,7 @@ jobs:
       - name: Run test mixed running for hidden
         timeout-minutes: 10
         env:
-          HCCL_BUFFSIZE: 2241
+          HCCL_BUFFSIZE: 2300
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=2048 --test-loop=100
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=4096 --test-loop=100
@@ -721,7 +721,7 @@ jobs:
       - name: Run test mixed running for experts
         timeout-minutes: 10
         env:
-          HCCL_BUFFSIZE: 3769
+          HCCL_BUFFSIZE: 7500
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2 --test-loop=100
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=512 --test-loop=100 --num-processes=8

--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -493,6 +493,7 @@ jobs:
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=4096
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=6144
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=7168
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=8192
 
       - name: Run test topk num intranode
         timeout-minutes: 10
@@ -509,6 +510,7 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2 --num-topk=1 --num-experts=2
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=512 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=1024 --num-processes=16
 
       - name: Run test intranode for active ranks
         timeout-minutes: 10
@@ -579,6 +581,7 @@ jobs:
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=4096
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=6144
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=7168
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=8192
 
       - name: Run test low latency for topk
         timeout-minutes: 10
@@ -713,6 +716,7 @@ jobs:
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=4096 --test-loop=100
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=6144 --test-loop=100
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=7168 --test-loop=100
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=8192 --test-loop=100
 
       - name: Run test mixed running for experts
         timeout-minutes: 10
@@ -721,6 +725,7 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2 --test-loop=100
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=512 --test-loop=100 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=1024 --test-loop=100 --num-processes=16
 
       - name: Run test mixed running for topk
         timeout-minutes: 10

--- a/csrc/deepep/ops/op_host/cam_moe_combine_normal_tiling.cc
+++ b/csrc/deepep/ops/op_host/cam_moe_combine_normal_tiling.cc
@@ -63,10 +63,10 @@ constexpr int64_t BS_UPPER_BOUND = 131072;
 
 constexpr uint32_t SYSTEM_NEED_WORKSPACE = 16 * 1024 * 1024;
 constexpr int32_t HCCL_BUFFER_SIZE_DEFAULT = 200 * 1024 * 1024;  // Bytes
-constexpr int64_t MOE_EXPERT_MAX_NUM = 512;
+constexpr int64_t MOE_EXPERT_MAX_NUM = 1024;
 constexpr int64_t K_MAX = 16;
 constexpr int64_t H_MIN = 1024;
-constexpr int64_t H_MAX = 7168;
+constexpr int64_t H_MAX = 8192;
 constexpr uint64_t MB_SIZE = 1024UL * 1024UL;
 constexpr uint64_t TRIPLE = 3;
 constexpr uint64_t WIN_ADDR_ALIGN = 512UL;

--- a/csrc/deepep/ops/op_host/cam_moe_dispatch_normal_tiling.cc
+++ b/csrc/deepep/ops/op_host/cam_moe_dispatch_normal_tiling.cc
@@ -75,12 +75,12 @@ constexpr int64_t BS_UPPER_BOUND = 131072;  // 最大bs
 
 constexpr uint32_t TILINGKEY_TP_WORLD_SIZE = 100;
 constexpr uint32_t TP_WORLD_SIZE_TWO = 2;
-constexpr int64_t MOE_EXPERT_MAX_NUM = 512;
+constexpr int64_t MOE_EXPERT_MAX_NUM = 1024;
 constexpr int64_t K_MAX = 16;
 constexpr uint32_t SYSTEM_NEED_WORKSPACE = 16 * 1024 * 1024;
 constexpr uint32_t WORKSPACE_ELEMENT_OFFSET = 512;
 constexpr int64_t H_MIN = 1024;
-constexpr int64_t H_MAX = 7168;
+constexpr int64_t H_MAX = 8192;
 constexpr uint64_t MB_SIZE = 1024UL * 1024UL;
 
 constexpr uint64_t TRIPLE = 3;

--- a/csrc/deepep/ops/op_host/dispatch_layout_tiling.cc
+++ b/csrc/deepep/ops/op_host/dispatch_layout_tiling.cc
@@ -37,7 +37,7 @@ constexpr uint32_t ATTR_LOCAL_RANKSIZE_INDEX = 4;
 constexpr uint32_t ATTR_PER_ROUND_TOKENS_INDEX = 5;
 constexpr uint32_t ATTR_RANK_ID_INDEX = 6;
 const int64_t MAX_COMM_WORLD_SIZE = 384;
-const int64_t MAX_MOE_EXPERTS_NUM = 512;
+const int64_t MAX_MOE_EXPERTS_NUM = 1024;
 const int64_t MAX_LOCAL_RANKSIZE = 8;
 
 constexpr uint32_t SYSTEM_NEED_WORKSPACE = 16 * 1024 * 1024;

--- a/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_multi_round.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_multi_round.h
@@ -213,7 +213,7 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitG
     GM_ADDR sendCostStatsOut)
 {
     recvXGM_.SetGlobalBuffer((__gm__ RecvXType *)recvX);
-    tokenSrcInfoGM_.SetGlobalBuffer((__gm__ SrcInfoType *)tokenSrcInfo);
+    tokenSrcInfoGM_.SetGlobalBuffer((__gm__ SrcInfoType *)tokenSrcInfo);  // expand_idx
     epRecvCountGM_.SetGlobalBuffer((__gm__ int32_t *)epRecvCount);
     tokenIdxGM_.SetGlobalBuffer((__gm__ int32_t *)tokenIdx);
     topkWeightsGM_.SetGlobalBuffer((__gm__ float *)topkWeights);
@@ -264,10 +264,11 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitR
         return;
     }
     uint32_t sendBlockLen = perCoreBlockNum_ * sizeof(int32_t);
+    uint32_t sendBlockAlignLen = Ceil(perCoreBlockNum_ * sizeof(int32_t), UB_32_ALIGN) * UB_32_ALIGN;
     tpipe_->Reset();
-    tpipe_->InitBuffer(tempRecvCountBuf_, sendBlockLen);     // 64B
-    tpipe_->InitBuffer(roundNeedSendCntBuf_, sendBlockLen);  // 64B
-    tpipe_->InitBuffer(roundSendOffsetBuf_, sendBlockLen);   // 64B
+    tpipe_->InitBuffer(tempRecvCountBuf_, sendBlockAlignLen);     // 64B
+    tpipe_->InitBuffer(roundNeedSendCntBuf_, sendBlockAlignLen);  // 64B
+    tpipe_->InitBuffer(roundSendOffsetBuf_, sendBlockAlignLen);   // 64B
 
     // 拷贝 epRecvCountGM_ 到 UB
     LocalTensor<int32_t> tempRecvCountTensor = tempRecvCountBuf_.Get<int32_t>();
@@ -291,7 +292,8 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitR
     // 创建 srcInfoLT_
     // 为了支持一轮最大8192 bs，这里按照一批BATCH_SRC_INFO_LEN个srcInfo拷贝，这样可以保证UB占用少
     uint32_t srcInfoLen = static_cast<uint32_t>(BATCH_SRC_INFO_CNT * TOKEN_SRC_INFO_LEN * sizeof(SrcInfoType));
-    tpipe_->InitBuffer(srcInfoBuf_, srcInfoLen);  // 128*3*4/1024=1.5KB
+    uint32_t srcInfoAlignLen = Ceil(srcInfoLen, UB_32_ALIGN) * UB_32_ALIGN;
+    tpipe_->InitBuffer(srcInfoBuf_, srcInfoAlignLen);  // 128*3*4/1024=1.5KB
     srcInfoLT_ = srcInfoBuf_.Get<SrcInfoType>();
 
     // 创建 setStatusLT_
@@ -323,8 +325,8 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitR
     // 创建topkWeightsLT_，存放每一轮每个核的权重信息
     uint32_t maxTopkWeightsLen = (perRoundTokens_ / aivNum_ + 1) * axisK_ * sizeof(float);
     tokenIdx32AlignLen_ = (perRoundTokens_ / aivNum_ + 1) * axisK_ * sizeof(int32_t);
-    tpipe_->InitBuffer(tokenIdxBuf_, tokenIdx32AlignLen_);
-    tpipe_->InitBuffer(topkWeightsBuf_, maxTopkWeightsLen);  // 512 分48核 需要352B
+    tpipe_->InitBuffer(tokenIdxBuf_, Ceil(tokenIdx32AlignLen_, UB_32_ALIGN) * UB_32_ALIGN);
+    tpipe_->InitBuffer(topkWeightsBuf_, Ceil(maxTopkWeightsLen, UB_32_ALIGN) * UB_32_ALIGN);  // 512 分48核 需要352B
     tokenIdxLT_ = tokenIdxBuf_.Get<int32_t>();
     topkWeightsLT_ = topkWeightsBuf_.Get<float>();
 }
@@ -414,7 +416,6 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::CopyB
             }
             ++roundActualSendCount;
         }
-
         roundSendOffsetLT_(blockIndex) += roundActualSendCount;
         roundNeedSendCntLT_(blockIndex) -= roundActualSendCount;
         needSendTokenCnt_ -= roundActualSendCount;
@@ -437,8 +438,10 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::CopyB
                                                                                              uint32_t srcTopkId,
                                                                                              uint32_t tkIndex)
 {
-    uint32_t tokenOffset = tkIndex * axisH_;
-    GM_ADDR dstGM = GetBufferAddrByRankId(srcRankId) + (srcTokenId * axisK_ + srcTopkId) * h512AlignRecvXLen_;
+    uint64_t tokenOffset = tkIndex * (uint64_t)axisH_;
+
+    GM_ADDR dstGM = (__gm__ uint8_t *)(reinterpret_cast<uint64_t>(GetBufferAddrByRankId(srcRankId)) +
+                                       (uint64_t)h512AlignRecvXLen_ * (srcTokenId * axisK_ + srcTopkId));
     GlobalTensor<XType> dstWindow;
     dstWindow.SetGlobalBuffer((__gm__ XType *)dstGM);
     DataCopyExtParams xOutCopyParams{1U, static_cast<uint32_t>(hRecvXTypeLen_), 0U, 0U, 0U};
@@ -510,6 +513,7 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::ReadB
     LocalTensor<float> weightedMulBufLocal = weightedMulBuf_.Get<float>();
     LocalTensor<float> sumFloatBufLocal = sumFloatBuf_.Get<float>();
     Duplicate(sumFloatBufLocal, static_cast<float>(0), axisH_);
+
     const DataCopyExtParams xOutCopyParams{1U, static_cast<uint32_t>(hRecvXTypeLen_), 0U, 0U, 0U};
     uint32_t xOutTokenIdx = recvXTokenIdx + xOutTokenOffset_;
 
@@ -519,8 +523,8 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::ReadB
             continue;
         }
         float scale = topkWeightsLT_.GetValue(topkWeightTokenIdx * axisK_ + topkId);
-        GM_ADDR localTokenAddr =
-            GetBufferAddrByRankId(epRankId_) + (recvXTokenIdx * axisK_ + topkId) * h512AlignRecvXLen_;
+        GM_ADDR localTokenAddr = (__gm__ uint8_t *)(GetBufferAddrByRankId(epRankId_) +
+                                                    (uint64_t)h512AlignRecvXLen_ * (recvXTokenIdx * axisK_ + topkId));
         GlobalTensor<XType> localTokenTensor;
         localTokenTensor.SetGlobalBuffer((__gm__ XType *)localTokenAddr);
 
@@ -529,6 +533,7 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::ReadB
         DataCopyPad(tmpToken, localTokenTensor, xOutCopyParams, copyPadExtParams);
         weightedSumQueue_.EnQue(tmpToken);
         tmpToken = weightedSumQueue_.DeQue<XType>();
+
         Cast(tokenFloatLocal, tmpToken, AscendC::RoundMode::CAST_NONE, axisH_);
         PipeBarrier<PIPE_V>();
         AscendC::Muls(weightedMulBufLocal, tokenFloatLocal, scale, axisH_);
@@ -540,7 +545,7 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::ReadB
     LocalTensor<XType> xOutLocal = xOutBuf_.Get<XType>();
     Cast(xOutLocal, sumFloatBufLocal, AscendC::RoundMode::CAST_RINT, axisH_);
     SyncFunc<AscendC::HardEvent::V_MTE3>();
-    DataCopyPad(xOutGlobal_[xOutTokenIdx * axisH_], xOutLocal, xOutCopyParams);
+    DataCopyPad(xOutGlobal_[xOutTokenIdx * (uint64_t)axisH_], xOutLocal, xOutCopyParams);
 }
 
 template <TemplateMC2TypeClass>

--- a/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal.h
@@ -728,7 +728,6 @@ __aicore__ inline void CamMoeDispatchNormal<CamTypeFunc>::ShareToOutputLongSeq()
         recvOffset = recvOffsetTensor(i);
 
         // 目标地址 = 专家全局起始 + B[es_idx]（源rank在专家内偏移） + r_in_srcrank_offset[c_idx]（轮次在源rank内偏移）
-        // int32_t rInSrcrankIndex = local_e * epRankSize * round + fromRank * round + roundIndex;
         int32_t rInSrcrankIndex = local_e * epRankSize + fromRank;
         int32_t expertGlobalOffset = expertGlobalOffsetTensor(local_e);
         int32_t srcrankInExpertOffset = srcrankInExpertOffsetTensor(i);
@@ -756,7 +755,7 @@ __aicore__ inline void CamMoeDispatchNormal<CamTypeFunc>::ShareToOutputLongSeq()
                 DataCopyPad(dynamicScalesOutGT[writeOffset + j], xOutFp32Tensor[hUBAlignSize / sizeof(float)],
                             floatDataCopyParams);
             }
-            dstTokenGT.SetGlobalBuffer((__gm__ ExpandXOutType *)(expandXOutGM) +  (uint64_t)h * (writeOffset + j), h);
+            dstTokenGT.SetGlobalBuffer((__gm__ ExpandXOutType *)(expandXOutGM) + (uint64_t)h * (writeOffset + j), h);
             DataCopyPad(dstTokenGT, xTmpTensor, expandXCopyParams);
             xQueue.FreeTensor(xTmpTensor);
         }

--- a/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal.h
@@ -658,7 +658,9 @@ __aicore__ inline void CamMoeDispatchNormal<CamTypeFunc>::WaitRoundStatus()
         Sum(tempRoundStateTensorLocal, stateTensorLocal, sumPerRankParams);
         SyncFunc<AscendC::HardEvent::V_S>();
         current = tempRoundStateTensorLocal.GetValue(0);
-        int64_t systemCycleAfter = AscendC::GetSystemCycle();
+        if (isEnableDiagnose) {
+            int64_t systemCycleAfter = AscendC::GetSystemCycle();
+        }
     }
 
     SyncFunc<AscendC::HardEvent::S_V>();
@@ -702,13 +704,7 @@ __aicore__ inline void CamMoeDispatchNormal<CamTypeFunc>::ShareToOutputLongSeq()
     DataCopyPadExtParams<int32_t> srcrankInExpertOffsetCopyPadExtParams{false, 0U, 0U, 0U};
     DataCopyPad(srcrankInExpertOffsetTensor, srcrankInExpertOffsetGT, srcrankInExpertOffsetParams,
                 srcrankInExpertOffsetCopyPadExtParams);
-
-    // tpipe_->InitBuffer(rInSrcrankOffsetBuf, round * moeExpertNum * sizeof(int32_t));
-    // rInSrcrankOffsetTensor = rInSrcrankOffsetBuf.Get<int32_t>();
-    // DataCopyExtParams CParams{1U, static_cast<uint32_t>(sizeof(int32_t) * moeExpertNum * round), 0U, 0U, 0U};
-    // DataCopyPadExtParams<int32_t> CCopyPadExtParams{false, 0U, 0U, 0U};
-    // DataCopyPad(rInSrcrankOffsetTensor, rInSrcrankOffsetGT, CParams, CCopyPadExtParams);
-    GetRInSrcrankOffsetForRound(roundIndex); // 仅读取本轮需要用到的offset
+    GetRInSrcrankOffsetForRound(roundIndex);  // 仅读取本轮需要用到的offset
 
     uint32_t fromRank, count, preCount, recvOffset, targetOffset, local_e;
     DataCopyPadExtParams<ExpandXOutType> copyPadExtParams{false, 0U, 0U, 0U};
@@ -742,6 +738,7 @@ __aicore__ inline void CamMoeDispatchNormal<CamTypeFunc>::ShareToOutputLongSeq()
         GM_ADDR recvStart =
             (__gm__ uint8_t *)(GetWindAddrByRankId(COMM_EP_IDX, fromRank)) + recvOffset * hOutGMAlignSize;
         GlobalTensor<ExpandXOutType> srcTokenGT, dstTokenGT;
+
         for (uint32_t j = 0; j < count; ++j) {
             srcTokenGT.SetGlobalBuffer((__gm__ ExpandXOutType *)(recvStart + j * hOutGMAlignSize));
             xTmpTensor = xQueue.AllocTensor<ExpandXOutType>();
@@ -759,10 +756,8 @@ __aicore__ inline void CamMoeDispatchNormal<CamTypeFunc>::ShareToOutputLongSeq()
                 DataCopyPad(dynamicScalesOutGT[writeOffset + j], xOutFp32Tensor[hUBAlignSize / sizeof(float)],
                             floatDataCopyParams);
             }
-
-            dstTokenGT.SetGlobalBuffer((__gm__ ExpandXOutType *)(expandXOutGM) + (writeOffset + j) * h, h);
+            dstTokenGT.SetGlobalBuffer((__gm__ ExpandXOutType *)(expandXOutGM) +  (uint64_t)h * (writeOffset + j), h);
             DataCopyPad(dstTokenGT, xTmpTensor, expandXCopyParams);
-
             xQueue.FreeTensor(xTmpTensor);
         }
     }

--- a/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal.h
@@ -63,6 +63,7 @@ private:
     __aicore__ inline void QuantInit();
     __aicore__ inline void ReduceMaxInplace(const LocalTensor<float> &srcLocal, uint32_t count);
     __aicore__ inline void QuantProcess();
+    __aicore__ inline void GetRInSrcrankOffsetForRound(int32_t index);
     __aicore__ inline GM_ADDR GetWindAddrByRankId(uint8_t ctxIdx, const int32_t rankId)
     {
         uint32_t curRankId = ((ctxIdx == COMM_EP_IDX) ? epRankId : tpRankId);
@@ -668,6 +669,18 @@ __aicore__ inline void CamMoeDispatchNormal<CamTypeFunc>::WaitRoundStatus()
 }
 
 template <CamTypeClass>
+__aicore__ inline void CamMoeDispatchNormal<CamTypeFunc>::GetRInSrcrankOffsetForRound(int32_t index)
+{
+    tpipe_->InitBuffer(rInSrcrankOffsetBuf, moeExpertNum * sizeof(int32_t));  // 4k
+    rInSrcrankOffsetTensor = rInSrcrankOffsetBuf.Get<int32_t>();
+
+    for (uint32_t i = 0; i < moeExpertNum; ++i) {
+        rInSrcrankOffsetTensor.SetValue(i, rInSrcrankOffsetGT.GetValue(i * round + index));
+    }
+    SyncFunc<AscendC::HardEvent::S_MTE2>();
+}
+
+template <CamTypeClass>
 __aicore__ inline void CamMoeDispatchNormal<CamTypeFunc>::ShareToOutputLongSeq()
 {
     if (startStatusId >= moeExpertNum) {
@@ -690,11 +703,12 @@ __aicore__ inline void CamMoeDispatchNormal<CamTypeFunc>::ShareToOutputLongSeq()
     DataCopyPad(srcrankInExpertOffsetTensor, srcrankInExpertOffsetGT, srcrankInExpertOffsetParams,
                 srcrankInExpertOffsetCopyPadExtParams);
 
-    tpipe_->InitBuffer(rInSrcrankOffsetBuf, round * moeExpertNum * sizeof(int32_t));
-    rInSrcrankOffsetTensor = rInSrcrankOffsetBuf.Get<int32_t>();
-    DataCopyExtParams CParams{1U, static_cast<uint32_t>(sizeof(int32_t) * moeExpertNum * round), 0U, 0U, 0U};
-    DataCopyPadExtParams<int32_t> CCopyPadExtParams{false, 0U, 0U, 0U};
-    DataCopyPad(rInSrcrankOffsetTensor, rInSrcrankOffsetGT, CParams, CCopyPadExtParams);
+    // tpipe_->InitBuffer(rInSrcrankOffsetBuf, round * moeExpertNum * sizeof(int32_t));
+    // rInSrcrankOffsetTensor = rInSrcrankOffsetBuf.Get<int32_t>();
+    // DataCopyExtParams CParams{1U, static_cast<uint32_t>(sizeof(int32_t) * moeExpertNum * round), 0U, 0U, 0U};
+    // DataCopyPadExtParams<int32_t> CCopyPadExtParams{false, 0U, 0U, 0U};
+    // DataCopyPad(rInSrcrankOffsetTensor, rInSrcrankOffsetGT, CParams, CCopyPadExtParams);
+    GetRInSrcrankOffsetForRound(roundIndex); // 仅读取本轮需要用到的offset
 
     uint32_t fromRank, count, preCount, recvOffset, targetOffset, local_e;
     DataCopyPadExtParams<ExpandXOutType> copyPadExtParams{false, 0U, 0U, 0U};
@@ -718,7 +732,8 @@ __aicore__ inline void CamMoeDispatchNormal<CamTypeFunc>::ShareToOutputLongSeq()
         recvOffset = recvOffsetTensor(i);
 
         // 目标地址 = 专家全局起始 + B[es_idx]（源rank在专家内偏移） + r_in_srcrank_offset[c_idx]（轮次在源rank内偏移）
-        int32_t rInSrcrankIndex = local_e * epRankSize * round + fromRank * round + roundIndex;
+        // int32_t rInSrcrankIndex = local_e * epRankSize * round + fromRank * round + roundIndex;
+        int32_t rInSrcrankIndex = local_e * epRankSize + fromRank;
         int32_t expertGlobalOffset = expertGlobalOffsetTensor(local_e);
         int32_t srcrankInExpertOffset = srcrankInExpertOffsetTensor(i);
         int32_t rInSrcrankOffset = rInSrcrankOffsetTensor(rInSrcrankIndex);

--- a/csrc/deepep/ops/op_kernel/notify_dispatch.h
+++ b/csrc/deepep/ops/op_kernel/notify_dispatch.h
@@ -66,7 +66,7 @@ public:
         maxBs_ = maxBs;
         recvTokensPerExpert_ = recvTokensPerExpert;
         if (round == 1) {
-            batchRounds = 1; // 没有开蚂蚁搬家，不需要多轮处理, 避免UB分配过大
+            batchRounds = 1;  // 没有开蚂蚁搬家，不需要多轮处理, 避免UB分配过大
         } else {
             if (numLocalExperts >= (EXPERT_NORMAL_NUM / 4)) {
                 batchRounds = BATCH_ROUND;

--- a/csrc/deepep/ops/op_kernel/notify_dispatch.h
+++ b/csrc/deepep/ops/op_kernel/notify_dispatch.h
@@ -44,7 +44,7 @@ class NotifyDispatch
     // Synchronization flag occupies length
     constexpr static int64_t FLAG_UNIT_INT_NUM = 4;
     constexpr static int64_t MAGIC_MASK = ~((1LL << 32) - 1);
-    constexpr static int32_t EXPERT_NORMAL_NUM = 256;
+    constexpr static int32_t EXPERT_NORMAL_NUM = 512;
     constexpr static int32_t BATCH_ROUND = 16;
 
 public:
@@ -65,10 +65,18 @@ public:
         recvOffset_ = recvOffset;
         maxBs_ = maxBs;
         recvTokensPerExpert_ = recvTokensPerExpert;
-        if (numLocalExperts >= (EXPERT_NORMAL_NUM / 2)) {
-            batchRounds = BATCH_ROUND;
+        if (round == 1) {
+            batchRounds = 1; // 没有开蚂蚁搬家，不需要多轮处理, 避免UB分配过大
         } else {
-            batchRounds = numExperts > EXPERT_NORMAL_NUM ? BATCH_ROUND : BATCH_ROUND * 2;
+            if (numLocalExperts >= (EXPERT_NORMAL_NUM / 4)) {
+                batchRounds = BATCH_ROUND;
+            } else if (numExperts > EXPERT_NORMAL_NUM) {  // >512
+                batchRounds = BATCH_ROUND / 2;
+            } else if (numExperts <= EXPERT_NORMAL_NUM / 2) {  // <=256
+                batchRounds = BATCH_ROUND * 2;
+            } else {  // 256< exp <= 512
+                batchRounds = BATCH_ROUND;
+            }
         }
         tokenPerExpertDataAlignLen = Ceil(batchRounds * numExperts * sizeof(int32_t), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
         sendDataOffsetAlignLen = Ceil(batchRounds * numExperts * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;


### PR DESCRIPTION
Changes:
1. Expanded the MoE specifications supported by intranode dispatch & combine on A3, with support for **up to 1024 experts, top-k up to 16, and hidden_size up to 8192**.
2. Adapted for long-sequence scenarios.
---
Tests
Verified numerically on Atlas A3.
```bash
python test_intranode.py --num-processes=16 --num-topk=16 --num-experts=1024 --hidden=8192 --num-tokens=4096
```
<img width="523" height="98" alt="image" src="https://github.com/user-attachments/assets/4f49c1b8-3fe9-4415-b4a6-df7e94f0e5d0" />
