### PR TITLE
refactor: separate submodule init and build, remove cuda deps from CI

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Mark repository safe
         run: |

--- a/.github/workflows/daily-build-test.yml
+++ b/.github/workflows/daily-build-test.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: true
+          submodules: recursive
 
       - name: Install dependencies
         run: |
@@ -93,6 +94,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           clean: true
+          submodules: recursive
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/internode.yml
+++ b/.github/workflows/internode.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -81,6 +81,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: true
+          submodules: recursive
 
       - name: Install dependencies
         run: |
@@ -431,6 +432,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: true
+          submodules: recursive
 
       - name: Install dependencies
         run: |
@@ -787,6 +789,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: true
+          submodules: recursive
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/push_build_cache.yml
+++ b/.github/workflows/push_build_cache.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Get build hash
         id: get_build_hash
@@ -86,6 +88,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Get build hash
         id: get_build_hash

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ If you need to access Ascend NPU computing resources for development or testing,
 
 ## Quick Start
 
+Before building from source, initialize the submodule(s):
+```bash
+git submodule update --init --recursive
+```
+
 DeepEP-Ascend: Ascend Implementation of DeepEP. [README](https://github.com/sgl-project/sgl-kernel-npu/blob/main/python/deep_ep/README.md)
 
 SGLang-Kernel-NPU: Other SGLang Kernels for Ascend NPU. [README](https://github.com/sgl-project/sgl-kernel-npu/blob/main/python/sgl_kernel_npu/README.md)

--- a/build.sh
+++ b/build.sh
@@ -151,7 +151,9 @@ function build_kernels()
     if [[ "$ONLY_BUILD_DEEPEP_KERNELs_MODULE" == "ON" ]]; then return 0; fi
     if [[ "$ONLY_BUILD_MEMORY_SAVER_MODULE" == "ON" ]]; then return 0; fi
 
-    check_submodules
+    if [[ "$BUILD_KERNELS_MODULE" == "ON" ]]; then
+        check_submodules
+    fi
 
     CMAKE_DIR=""
     BUILD_DIR="build"

--- a/build.sh
+++ b/build.sh
@@ -137,23 +137,11 @@ echo "outpath: ${OUTPUT_DIR}"
 
 COMPILE_OPTIONS=""
 
-function check_submodules()
-{
-    PTO_ISA_DIR="third-party/pto-isa"
-    if [[ -d "${PTO_ISA_DIR}/include/pto" ]]; then return 0; fi
-
-    echo "Missing submodule. Run 'git submodule update --init --recursive' before build.sh." 1>&2
-    exit 1
-}
 
 function build_kernels()
 {
     if [[ "$ONLY_BUILD_DEEPEP_KERNELs_MODULE" == "ON" ]]; then return 0; fi
     if [[ "$ONLY_BUILD_MEMORY_SAVER_MODULE" == "ON" ]]; then return 0; fi
-
-    if [[ "$BUILD_KERNELS_MODULE" == "ON" ]]; then
-        check_submodules
-    fi
 
     CMAKE_DIR=""
     BUILD_DIR="build"

--- a/build.sh
+++ b/build.sh
@@ -137,13 +137,13 @@ echo "outpath: ${OUTPUT_DIR}"
 
 COMPILE_OPTIONS=""
 
-function update_submodules()
+function check_submodules()
 {
     PTO_ISA_DIR="third-party/pto-isa"
     if [[ -d "${PTO_ISA_DIR}/include/pto" ]]; then return 0; fi
 
-    echo "Updating submodule: ${PTO_ISA_DIR}"
-    git submodule update --init --recursive "${PTO_ISA_DIR}"
+    echo "Missing submodule. Run 'git submodule update --init --recursive' before build.sh." 1>&2
+    exit 1
 }
 
 function build_kernels()
@@ -151,7 +151,7 @@ function build_kernels()
     if [[ "$ONLY_BUILD_DEEPEP_KERNELs_MODULE" == "ON" ]]; then return 0; fi
     if [[ "$ONLY_BUILD_MEMORY_SAVER_MODULE" == "ON" ]]; then return 0; fi
 
-    update_submodules
+    check_submodules
 
     CMAKE_DIR=""
     BUILD_DIR="build"

--- a/scripts/prepare_deepep_in_container.sh
+++ b/scripts/prepare_deepep_in_container.sh
@@ -17,11 +17,6 @@ done
 
 shift $((OPTIND -1))
 
-# build.sh now uses git to init submodules
-if [[ -n "${GITHUB_WORKSPACE:-}" ]]; then
-    git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-fi
-
 cd ${GITHUB_WORKSPACE}
 if [ -n "$BUILD_ARGS" ]; then
     bash build.sh -a "$BUILD_ARGS"

--- a/tests/python/deepep/run_ascend_testcase.sh
+++ b/tests/python/deepep/run_ascend_testcase.sh
@@ -79,7 +79,7 @@ while [ $attempt -lt $max_retries ]; do
 
     echo "============================================= build.sh debug ============================================="
     echo "build.sh sha256: $(sha256sum build.sh | awk '{print $1}')"
-    echo "build.sh submodule references:"
+    echo "build.sh submodule references: "
     grep -n "submodule\|pto-isa" build.sh || true
     echo "=========================================================================================================="
 

--- a/tests/python/deepep/run_ascend_testcase.sh
+++ b/tests/python/deepep/run_ascend_testcase.sh
@@ -6,6 +6,7 @@ mkdir -p $LOCAL_BUILD_DIR
 chmod -R 777 $LOCAL_BUILD_DIR
 
 echo "============================================= Copy code to local directory ============================================"
+echo "Running new version!"
 echo "Source path: $SGLANG_SOURCE_PATH"
 echo "Local build path: $LOCAL_BUILD_DIR"
 cp -r $SGLANG_SOURCE_PATH/* $LOCAL_BUILD_DIR/
@@ -26,7 +27,7 @@ pip config set global.extra-index-url "https://pypi.tuna.tsinghua.edu.cn/simple"
 pip config set global.trusted-host "${CACHING_URL} pypi.tuna.tsinghua.edu.cn"
 
 pip3 install kubernetes
-pip3 install xgrammar==0.1.25
+pip3 install --no-deps xgrammar==0.1.25
 
 unset https_proxy
 unset http_proxy

--- a/tests/python/deepep/run_ascend_testcase.sh
+++ b/tests/python/deepep/run_ascend_testcase.sh
@@ -6,7 +6,6 @@ mkdir -p $LOCAL_BUILD_DIR
 chmod -R 777 $LOCAL_BUILD_DIR
 
 echo "============================================= Copy code to local directory ============================================"
-echo "Running new version!"
 echo "Source path: $SGLANG_SOURCE_PATH"
 echo "Local build path: $LOCAL_BUILD_DIR"
 cp -r $SGLANG_SOURCE_PATH/* $LOCAL_BUILD_DIR/
@@ -77,12 +76,6 @@ while [ $attempt -lt $max_retries ]; do
     find ./csrc/deepep/ops2/build_out -type d -exec chmod 755 {} \; 2>/dev/null || true
     rm -rf ./output ./build ./csrc/deepep/ops2/build_out 2>/dev/null || true
     sleep 1
-
-    echo "============================================= build.sh debug ============================================="
-    echo "build.sh sha256: $(sha256sum build.sh | awk '{print $1}')"
-    echo "build.sh submodule references:"
-    grep -n "submodule\|pto-isa" build.sh || true
-    echo "=========================================================================================================="
 
     bash build.sh -a deepep2
     if ls ./output/deep_ep*.whl 1> /dev/null 2>&1; then

--- a/tests/python/deepep/run_ascend_testcase.sh
+++ b/tests/python/deepep/run_ascend_testcase.sh
@@ -79,7 +79,7 @@ while [ $attempt -lt $max_retries ]; do
 
     echo "============================================= build.sh debug ============================================="
     echo "build.sh sha256: $(sha256sum build.sh | awk '{print $1}')"
-    echo "build.sh submodule references: "
+    echo "build.sh submodule references:"
     grep -n "submodule\|pto-isa" build.sh || true
     echo "=========================================================================================================="
 

--- a/tests/python/deepep/run_ascend_testcase.sh
+++ b/tests/python/deepep/run_ascend_testcase.sh
@@ -77,6 +77,12 @@ while [ $attempt -lt $max_retries ]; do
     rm -rf ./output ./build ./csrc/deepep/ops2/build_out 2>/dev/null || true
     sleep 1
 
+    echo "============================================= build.sh debug ============================================="
+    echo "build.sh sha256: $(sha256sum build.sh | awk '{print $1}')"
+    echo "build.sh submodule references:"
+    grep -n "submodule\|pto-isa" build.sh || true
+    echo "=========================================================================================================="
+
     bash build.sh -a deepep2
     if ls ./output/deep_ep*.whl 1> /dev/null 2>&1; then
         echo "Build successful! Whl file found in local directory: $LOCAL_BUILD_DIR/output"


### PR DESCRIPTION
Before `git` was used in build.sh to init submodules. Now they are separated.

1) In the CI  it uses `with: submodules: recursive` to init them, and the build script remains unchanged.

2) For users they must run `git submodule update --init --recursive` before running `bash build.sh`.

Now also installs `xgrammar` without cuda dependencies
- Speeding up the multi node CI by over 20%