### PR TITLE
Remove DEEP_NORMAL_MODE_USE_INT8_QUANT and use the config field instead

### DIFF
--- a/csrc/deepep/config.hpp
+++ b/csrc/deepep/config.hpp
@@ -13,6 +13,7 @@ struct Config {
     int num_max_nvl_chunked_recv_tokens;
     int num_max_rdma_chunked_send_tokens;
     int num_max_rdma_chunked_recv_tokens;
+    std::string normal_quant_type; 
 
     Config(int num_sms, int num_max_nvl_chunked_send_tokens, int num_max_nvl_chunked_recv_tokens,
            int num_max_rdma_chunked_send_tokens, int num_max_rdma_chunked_recv_tokens)
@@ -20,7 +21,8 @@ struct Config {
           num_max_nvl_chunked_send_tokens(num_max_nvl_chunked_send_tokens),
           num_max_nvl_chunked_recv_tokens(num_max_nvl_chunked_recv_tokens),
           num_max_rdma_chunked_send_tokens(num_max_rdma_chunked_send_tokens),
-          num_max_rdma_chunked_recv_tokens(num_max_rdma_chunked_recv_tokens)
+          num_max_rdma_chunked_recv_tokens(num_max_rdma_chunked_recv_tokens),
+          normal_quant_type("bf16") {} 
     {}
 
     size_t get_nvl_buffer_size_hint(size_t hidden_bytes, int num_ranks) const

--- a/csrc/deepep/config.hpp
+++ b/csrc/deepep/config.hpp
@@ -13,7 +13,7 @@ struct Config {
     int num_max_nvl_chunked_recv_tokens;
     int num_max_rdma_chunked_send_tokens;
     int num_max_rdma_chunked_recv_tokens;
-    std::string normal_quant_type; 
+    std::string normal_quant_type = "bf16";
 
     Config(int num_sms, int num_max_nvl_chunked_send_tokens, int num_max_nvl_chunked_recv_tokens,
            int num_max_rdma_chunked_send_tokens, int num_max_rdma_chunked_recv_tokens)
@@ -22,7 +22,6 @@ struct Config {
           num_max_nvl_chunked_recv_tokens(num_max_nvl_chunked_recv_tokens),
           num_max_rdma_chunked_send_tokens(num_max_rdma_chunked_send_tokens),
           num_max_rdma_chunked_recv_tokens(num_max_rdma_chunked_recv_tokens),
-          normal_quant_type("bf16")
     {}
 
     size_t get_nvl_buffer_size_hint(size_t hidden_bytes, int num_ranks) const

--- a/csrc/deepep/config.hpp
+++ b/csrc/deepep/config.hpp
@@ -22,7 +22,7 @@ struct Config {
           num_max_nvl_chunked_recv_tokens(num_max_nvl_chunked_recv_tokens),
           num_max_rdma_chunked_send_tokens(num_max_rdma_chunked_send_tokens),
           num_max_rdma_chunked_recv_tokens(num_max_rdma_chunked_recv_tokens),
-          normal_quant_type("bf16") {} 
+          normal_quant_type("bf16")
     {}
 
     size_t get_nvl_buffer_size_hint(size_t hidden_bytes, int num_ranks) const

--- a/csrc/deepep/pybind_extension.cpp
+++ b/csrc/deepep/pybind_extension.cpp
@@ -21,7 +21,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
              py::arg("num_max_nvl_chunked_send_tokens") = 6, py::arg("num_max_nvl_chunked_recv_tokens") = 256,
              py::arg("num_max_rdma_chunked_send_tokens") = 6, py::arg("num_max_rdma_chunked_recv_tokens") = 256)
         .def("get_nvl_buffer_size_hint", &deep_ep::Config::get_nvl_buffer_size_hint)
-        .def("get_rdma_buffer_size_hint", &deep_ep::Config::get_rdma_buffer_size_hint);
+        .def("get_rdma_buffer_size_hint", &deep_ep::Config::get_rdma_buffer_size_hint)
         .def_readwrite("normal_quant_type", &deep_ep::Config::normal_quant_type);
     m.def("get_low_latency_rdma_size_hint", &deep_ep::get_low_latency_rdma_size_hint);
 

--- a/csrc/deepep/pybind_extension.cpp
+++ b/csrc/deepep/pybind_extension.cpp
@@ -22,6 +22,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
              py::arg("num_max_rdma_chunked_send_tokens") = 6, py::arg("num_max_rdma_chunked_recv_tokens") = 256)
         .def("get_nvl_buffer_size_hint", &deep_ep::Config::get_nvl_buffer_size_hint)
         .def("get_rdma_buffer_size_hint", &deep_ep::Config::get_rdma_buffer_size_hint);
+        .def_readwrite("normal_quant_type", &deep_ep::Config::normal_quant_type);
     m.def("get_low_latency_rdma_size_hint", &deep_ep::get_low_latency_rdma_size_hint);
 
     pybind11::class_<deep_ep::EventHandle>(m, "EventHandle")

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -309,8 +309,6 @@ class Buffer:
 
         # Default config
         config = self.get_dispatch_config(self.group_size) if config is None else config
-        quant_type = config.normal_quant_type.lower()
-        use_quant = quant_type in ("fp8", "int8")  # or more precise mapping
 
         # Internode
         if self.runtime.get_num_rdma_ranks() > 1:
@@ -334,6 +332,8 @@ class Buffer:
         if isinstance(x, tuple):
             raise NotImplementedError("Not support fp8")
         x_scales = None
+        quant_type = config.normal_quant_type.lower()
+        use_quant = quant_type in ("fp8", "int8")  # or more precise mapping
 
         if handle is not None:
             raise NotImplementedError(
@@ -434,6 +434,8 @@ class Buffer:
         if isinstance(x, tuple):
             raise NotImplementedError("Not support fp8")
         x_scales = None
+        quant_type = config.normal_quant_type.lower()
+        use_quant = quant_type in ("fp8", "int8")  # or more precise mapping
 
         if handle is not None:
             raise NotImplementedError(
@@ -583,6 +585,8 @@ class Buffer:
         Normally, you should not directly call this function.
         """
         x, x_scales = x if isinstance(x, tuple) else (x, None)
+        quant_type = config.normal_quant_type.lower()
+        use_quant = quant_type in ("fp8", "int8")  # or more precise mapping
         if handle is not None:
             raise NotImplementedError(
                 "Optional communication handle is not supported yet."

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -333,7 +333,7 @@ class Buffer:
             raise NotImplementedError("Not support fp8")
         x_scales = None
         quant_type = config.normal_quant_type.lower()
-        use_quant = quant_type in ("fp8", "int8")  # or more precise mapping
+        use_quant = quant_type in ("fp8", "int8")
 
         if handle is not None:
             raise NotImplementedError(
@@ -435,7 +435,7 @@ class Buffer:
             raise NotImplementedError("Not support fp8")
         x_scales = None
         quant_type = config.normal_quant_type.lower()
-        use_quant = quant_type in ("fp8", "int8")  # or more precise mapping
+        use_quant = quant_type in ("fp8", "int8")
 
         if handle is not None:
             raise NotImplementedError(
@@ -586,7 +586,7 @@ class Buffer:
         """
         x, x_scales = x if isinstance(x, tuple) else (x, None)
         quant_type = config.normal_quant_type.lower()
-        use_quant = quant_type in ("fp8", "int8")  # or more precise mapping
+        use_quant = quant_type in ("fp8", "int8")
         if handle is not None:
             raise NotImplementedError(
                 "Optional communication handle is not supported yet."

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -585,7 +585,6 @@ class Buffer:
         Normally, you should not directly call this function.
         """
         x, x_scales = x if isinstance(x, tuple) else (x, None)
-        use_quant = os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT") == "1"
         if handle is not None:
             raise NotImplementedError(
                 "Optional communication handle is not supported yet."

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -252,7 +252,6 @@ class Buffer:
         expert_alignment: int = 1,
         num_worst_tokens: int = 0,
         config: Optional[Config] = None,
-        use_quant: Optional[bool] = None,
         previous_event: Optional[EventOverlap] = None,
         async_finish: bool = False,
         allocate_on_comm_stream: bool = False,
@@ -289,7 +288,6 @@ class Buffer:
             num_worst_tokens: the worst number of tokens to receive, if specified, there will be no CPU sync, and it
                 will be CUDA-graph compatible. Please also notice that this flag is for intranode only.
             config: the performance tuning config.
-            use_quant: use quant or not.
             previous_event: the event to wait before actually executing the kernel.
             async_finish: the current stream will not wait for the communication kernels to be finished if set.
             allocate_on_comm_stream: control whether all the allocated tensors' ownership to be on the communication stream.
@@ -311,6 +309,8 @@ class Buffer:
 
         # Default config
         config = self.get_dispatch_config(self.group_size) if config is None else config
+        quant_type = config.normal_quant_type.lower()
+        use_quant = quant_type in ("fp8", "int8")  # or more precise mapping
 
         # Internode
         if self.runtime.get_num_rdma_ranks() > 1:
@@ -325,7 +325,6 @@ class Buffer:
                 topk_weights,
                 expert_alignment,
                 config,
-                use_quant,
                 previous_event,
                 async_finish,
                 allocate_on_comm_stream,
@@ -568,7 +567,6 @@ class Buffer:
         topk_weights: Optional[torch.Tensor] = None,
         expert_alignment: int = 1,
         config: Optional[Config] = None,
-        use_quant: Optional[bool] = None,
         previous_event: Optional[EventOverlap] = None,
         async_finish: bool = False,
         allocate_on_comm_stream: bool = False,

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -252,6 +252,7 @@ class Buffer:
         expert_alignment: int = 1,
         num_worst_tokens: int = 0,
         config: Optional[Config] = None,
+        use_quant: Optional[bool] = None,
         previous_event: Optional[EventOverlap] = None,
         async_finish: bool = False,
         allocate_on_comm_stream: bool = False,
@@ -288,6 +289,7 @@ class Buffer:
             num_worst_tokens: the worst number of tokens to receive, if specified, there will be no CPU sync, and it
                 will be CUDA-graph compatible. Please also notice that this flag is for intranode only.
             config: the performance tuning config.
+            use_quant: use quant or not.
             previous_event: the event to wait before actually executing the kernel.
             async_finish: the current stream will not wait for the communication kernels to be finished if set.
             allocate_on_comm_stream: control whether all the allocated tensors' ownership to be on the communication stream.
@@ -323,6 +325,7 @@ class Buffer:
                 topk_weights,
                 expert_alignment,
                 config,
+                use_quant,
                 previous_event,
                 async_finish,
                 allocate_on_comm_stream,
@@ -332,7 +335,6 @@ class Buffer:
         if isinstance(x, tuple):
             raise NotImplementedError("Not support fp8")
         x_scales = None
-        use_quant = os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT") == "1"
 
         if handle is not None:
             raise NotImplementedError(
@@ -411,6 +413,7 @@ class Buffer:
         expert_alignment: int = 1,
         num_worst_tokens: int = 0,
         config: Optional[Config] = None,
+        use_quant: Optional[bool] = None,
         previous_event: Optional[EventOverlap] = None,
         async_finish: bool = False,
         allocate_on_comm_stream: bool = False,
@@ -432,7 +435,6 @@ class Buffer:
         if isinstance(x, tuple):
             raise NotImplementedError("Not support fp8")
         x_scales = None
-        use_quant = os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT") == "1"
 
         if handle is not None:
             raise NotImplementedError(
@@ -566,6 +568,7 @@ class Buffer:
         topk_weights: Optional[torch.Tensor] = None,
         expert_alignment: int = 1,
         config: Optional[Config] = None,
+        use_quant: Optional[bool] = None,
         previous_event: Optional[EventOverlap] = None,
         async_finish: bool = False,
         allocate_on_comm_stream: bool = False,

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -412,7 +412,6 @@ class Buffer:
         expert_alignment: int = 1,
         num_worst_tokens: int = 0,
         config: Optional[Config] = None,
-        use_quant: Optional[bool] = None,
         previous_event: Optional[EventOverlap] = None,
         async_finish: bool = False,
         allocate_on_comm_stream: bool = False,


### PR DESCRIPTION
### Motivation
Launching speculative decoding in sglang with one quantized model and one unquantized model previously required hacky workarounds due to the global `DEEP_NORMAL_MODE_USE_INT8_QUANT` environment variable. This PR removes that environment variable and replaces it with a per‑config field, allowing each model to specify its own quantization type for dispatch/combine.

### Changes
- Added `std::string normal_quant_type` to the C++ `Config` struct (default `"bf16"`)
- Updated `Buffer.dispatch`, `notify_verify`, and `internode_dispatch` to read `config.normal_quant_type` instead of the env var
- Removed all logic referencing `DEEP_NORMAL_MODE_USE_INT8_QUANT`
- Exposed the new field to Python via `def_readwrite` in the pybind11 bindings

### Impact
- Enables clean speculative decoding with mixed quantization (e.g., w4a8 target + unquantized draft)
- Eliminates race conditions / overwriting issues when multiple models share a process
- Backward compatible – the old environment variable is simply ignored; default behaviour remains `bf16`

### Related PR
- sglang: [#26408](https://github.com/sgl-project/sglang/pull/26408) – propagates the quant type from the dispatcher to the config