### PR TITLE
feat: PTO chunk gdn support H=12, 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ output/
 *.dwo
 
 .codemate
+
+csrc/deepep/ops/cmake/
+csrc/deepep/ops/scripts/
+csrc/deepep/ops2/cmake/
+csrc/deepep/ops2/scripts/

--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,3 @@ output/
 *.dwo
 
 .codemate
-
-csrc/deepep/ops/cmake/
-csrc/deepep/ops/scripts/
-csrc/deepep/ops2/cmake/
-csrc/deepep/ops2/scripts/

--- a/csrc/mega_chunk_gdn/op_host/mega_chunk_gdn.cpp
+++ b/csrc/mega_chunk_gdn/op_host/mega_chunk_gdn.cpp
@@ -17,8 +17,9 @@ constexpr int64_t kHeadDim = 128;
 
 bool is_supported_head_pair(int64_t value_heads, int64_t key_heads)
 {
-    return (value_heads == 16 || value_heads == 24 || value_heads == 32 || value_heads == 48 || value_heads == 64) &&
-           value_heads % key_heads == 0;
+    return value_heads % key_heads == 0 &&
+           (value_heads == 8 || value_heads == 12 || value_heads == 16 || value_heads == 24 || value_heads == 32 ||
+            value_heads == 48 || value_heads == 64);
 }
 
 void check_shape(const at::Tensor &q, const at::Tensor &k, const at::Tensor &v, const at::Tensor &g,

--- a/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
@@ -460,10 +460,8 @@ GDN_KERNEL_NAME(GM_ADDR q_ptr, GM_ADDR k_ptr, GM_ADDR v_ptr, GM_ADDR g_in_ptr, G
         return
 
     switch (num_heads) {
-        // DISPATCH_MEGA_H(2);
-        // DISPATCH_MEGA_H(4);
-        // DISPATCH_MEGA_H(8);
-        // DISPATCH_MEGA_H(12);
+        DISPATCH_MEGA_H(8);
+        DISPATCH_MEGA_H(12);
         DISPATCH_MEGA_H(16);
         DISPATCH_MEGA_H(24);
         DISPATCH_MEGA_H(32);

--- a/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
@@ -87,8 +87,10 @@ AICORE inline void mega_transpose_TH_to_HT(__gm__ T *src, __gm__ T *dst, int64_t
     constexpr int32_t BLOCK = 128;
     constexpr int32_t H = static_cast<int32_t>(H_val);
     constexpr int32_t ES = static_cast<int32_t>(sizeof(T));
+    constexpr int32_t AlignBytes = 32;
+    constexpr int32_t AlignRows = AlignBytes / ES;
     constexpr int32_t MinTransposeCols = 16;
-    constexpr int32_t AlignElems = ((32 / ES) > MinTransposeCols) ? (32 / ES) : MinTransposeCols;
+    constexpr int32_t AlignElems = (AlignRows > MinTransposeCols) ? AlignRows : MinTransposeCols;
     constexpr int32_t HP = ((H + AlignElems - 1) / AlignElems) * AlignElems;
     constexpr int32_t SRC_UB = 0;
     constexpr int32_t DST_UB = SRC_UB + BLOCK * HP * ES;
@@ -104,11 +106,42 @@ AICORE inline void mega_transpose_TH_to_HT(__gm__ T *src, __gm__ T *dst, int64_t
 
     using UBRow = Tile<TileType::Vec, T, 1, BLOCK, BLayout::RowMajor, 1, BLOCK, SLayout::NoneBox, 512>;
     using UBRowDyn = Tile<TileType::Vec, T, 1, BLOCK, BLayout::RowMajor, DYNAMIC, DYNAMIC, SLayout::NoneBox, 512>;
+    using UBHeadDyn = Tile<TileType::Vec, T, AlignRows, BLOCK, BLayout::ColMajor, 1, DYNAMIC, SLayout::NoneBox, 512>;
 
     using Gm2D = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
     using Gm1D = Shape<1, 1, 1, 1, DYNAMIC>;
     using GmSrcS = Stride<1, 1, 1, H, 1>;
+    using GmHeadS = Stride<1, 1, 1, 1, H>;
     using GmS1 = Stride<1, 1, 1, 1, 1>;
+
+    if constexpr (H < MinTransposeCols) {
+        int64_t num_tok_blocks = (T_len + BLOCK - 1) / BLOCK;
+        for (int64_t bi = static_cast<int64_t>(cid); bi < num_tok_blocks; bi += static_cast<int64_t>(block_num)) {
+            int64_t t0 = bi * BLOCK;
+            int32_t valid = (t0 + BLOCK <= T_len) ? BLOCK : static_cast<int32_t>(T_len - t0);
+
+            for (int32_t h = 0; h < H; ++h) {
+                Gm1D gs;
+                gs.shape[4] = valid;
+                UBHeadDyn row(valid);
+                TASSIGN(row, SRC_UB);
+                {
+                    // DN layout makes each token a one-element burst with stride H.
+                    GlobalTensor<T, Gm1D, GmHeadS, Layout::DN> gm(src + t0 * H + h, gs);
+                    TLOAD(row, gm);
+                }
+                set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+                wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+                {
+                    GlobalTensor<T, Gm1D, GmS1, Layout::DN> gm(dst + h * T_len + t0, gs);
+                    TSTORE(gm, row);
+                }
+                set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+                wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+            }
+        }
+        return;
+    }
 
     UBSrcFull ub_src;
     TASSIGN(ub_src, SRC_UB);

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/mega_chunk_gdn.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/mega_chunk_gdn.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 import torch
 
-SUPPORTED_HEAD = (16, 24, 32, 48, 64)
 HEAD_DIM = 128
 CHUNK_SIZE = 128
 

--- a/tests/python/sgl_kernel_npu/test_chunk_gdn_pto.py
+++ b/tests/python/sgl_kernel_npu/test_chunk_gdn_pto.py
@@ -12,6 +12,10 @@ def _has_npu() -> bool:
 pytestmark = pytest.mark.skipif(not _has_npu(), reason="NPU is required")
 
 SUPPORTED_HEAD_CONFIGS = [
+    pytest.param(8, 2, id="H8-Hg2"),
+    pytest.param(8, 4, id="H8-Hg4"),
+    pytest.param(8, 8, id="H8-Hg8"),
+    pytest.param(12, 4, id="H12-Hg4"),
     pytest.param(16, 4, id="H16-Hg4"),
     pytest.param(16, 8, id="H16-Hg8"),
     pytest.param(16, 16, id="H16-Hg16"),
@@ -19,26 +23,6 @@ SUPPORTED_HEAD_CONFIGS = [
     pytest.param(32, 4, id="H32-Hg4"),
     pytest.param(32, 8, id="H32-Hg8"),
     pytest.param(32, 16, id="H32-Hg16"),
-    pytest.param(32, 32, id="H32-Hg32"),
-    pytest.param(48, 8, id="H48-Hg8"),
-    pytest.param(48, 12, id="H48-Hg12"),
-    pytest.param(48, 16, id="H48-Hg16"),
-    pytest.param(64, 4, id="H64-Hg4"),
-    pytest.param(64, 8, id="H64-Hg8"),
-    pytest.param(64, 16, id="H64-Hg16"),
-]
-
-DEFAULT_HEAD_CONFIGS = [
-    pytest.param(16, 4, id="H16-Hg4"),
-    pytest.param(24, 8, id="H24-Hg8"),
-    pytest.param(32, 8, id="H32-Hg8"),
-    pytest.param(48, 16, id="H48-Hg16"),
-    pytest.param(64, 16, id="H64-Hg16"),
-]
-
-INITIAL_STATE_HEAD_CONFIGS = [
-    pytest.param(16, 4, id="H16-Hg4"),
-    pytest.param(32, 8, id="H32-Hg8"),
     pytest.param(48, 16, id="H48-Hg16"),
     pytest.param(64, 16, id="H64-Hg16"),
 ]
@@ -57,7 +41,7 @@ def _assert_close(name: str, actual: torch.Tensor, expected: torch.Tensor) -> No
 
 
 def _native_reference(
-    q, k, v, g, beta, cu_seqlens, initial_state=None, output_final_state=False
+    q, k, v, g, beta, cu_seqlens, initial_state=None, output_final_state=True
 ):
     if q.shape[2] != v.shape[2]:
         assert v.shape[2] % q.shape[2] == 0
@@ -102,23 +86,16 @@ def _native_reference(
     )
 
 
-@pytest.mark.parametrize(
-    ("total_tokens", "cu_list"),
-    [
-        (129, None),
-        (256, [0, 96, 128, 256]),
-        (2560, [0, 96, 128, 2560]),
-    ],
-)
-@pytest.mark.parametrize(("num_value_heads", "num_key_heads"), DEFAULT_HEAD_CONFIGS)
-def test_mega_chunk_gdn_e2e(total_tokens, cu_list, num_value_heads, num_key_heads):
+def test_mega_chunk_gdn_no_initial_state():
     if not hasattr(torch.ops.npu, "mega_chunk_gdn"):
         pytest.skip("mega_chunk_gdn op is not registered")
 
     torch.manual_seed(0)
     device = torch.device("npu")
-    H = num_value_heads
-    Hg = num_key_heads
+    total_tokens = 129
+    cu_list = None
+    H = 16
+    Hg = 4
     D = 128
 
     q_cpu = F.normalize(torch.randn(1, total_tokens, Hg, D), p=2, dim=-1).to(
@@ -136,79 +113,6 @@ def test_mega_chunk_gdn_e2e(total_tokens, cu_list, num_value_heads, num_key_head
     v = v_cpu.to(device)
     g = g_cpu.to(device)
     beta = beta_cpu.to(device)
-    cu = (
-        None
-        if cu_list is None
-        else torch.tensor(cu_list, dtype=torch.long, device=device)
-    )
-    scale = D**-0.5
-
-    _, actual, _, _, _, _, _ = run_mega_chunk_gdn(
-        q=q,
-        k=k,
-        v=v,
-        g=g,
-        beta=beta,
-        scale=scale,
-        initial_state=None,
-        output_final_state=False,
-        cu_seqlens=cu,
-    )
-    torch.npu.synchronize()
-
-    expected, _ = _native_reference(q_cpu, k_cpu, v_cpu, g_cpu, beta_cpu, cu_list)
-    _assert_close("mega_vs_native", actual, expected)
-
-
-@pytest.mark.parametrize(
-    ("total_tokens", "cu_list"),
-    [
-        (129, None),
-        (256, [0, 96, 128, 256]),
-    ],
-)
-@pytest.mark.parametrize(
-    ("num_value_heads", "num_key_heads"), INITIAL_STATE_HEAD_CONFIGS
-)
-@pytest.mark.parametrize("state_kind", ["zero", "random"])
-def test_mega_chunk_gdn_initial_state(
-    total_tokens, cu_list, num_value_heads, num_key_heads, state_kind
-):
-    if not hasattr(torch.ops.npu, "mega_chunk_gdn"):
-        pytest.skip("mega_chunk_gdn op is not registered")
-
-    torch.manual_seed(1)
-    device = torch.device("npu")
-    H = num_value_heads
-    Hg = num_key_heads
-    D = 128
-    num_sequences = 1 if cu_list is None else len(cu_list) - 1
-
-    q_cpu = F.normalize(torch.randn(1, total_tokens, Hg, D), p=2, dim=-1).to(
-        torch.float16
-    )
-    k_cpu = F.normalize(torch.randn(1, total_tokens, Hg, D), p=2, dim=-1).to(
-        torch.float16
-    )
-    v_cpu = torch.randn(1, total_tokens, H, D, dtype=torch.float16)
-    g_cpu = F.logsigmoid(torch.randn(1, total_tokens, H, dtype=torch.float32))
-    beta_cpu = torch.rand(1, total_tokens, H, dtype=torch.float16)
-    if state_kind == "zero":
-        h0_cpu = torch.zeros(num_sequences, H, D, D, dtype=torch.float16)
-    else:
-        h0_cpu = (0.1 * torch.randn(num_sequences, H, D, D)).to(torch.float16)
-
-    q = q_cpu.to(device)
-    k = k_cpu.to(device)
-    v = v_cpu.to(device)
-    g = g_cpu.to(device)
-    beta = beta_cpu.to(device)
-    h0 = h0_cpu.to(device)
-    cu = (
-        None
-        if cu_list is None
-        else torch.tensor(cu_list, dtype=torch.long, device=device)
-    )
     scale = D**-0.5
 
     _, actual, _, actual_final_state, _, _, _ = run_mega_chunk_gdn(
@@ -218,9 +122,9 @@ def test_mega_chunk_gdn_initial_state(
         g=g,
         beta=beta,
         scale=scale,
-        initial_state=h0,
+        initial_state=None,
         output_final_state=True,
-        cu_seqlens=cu,
+        cu_seqlens=None,
     )
     torch.npu.synchronize()
 
@@ -231,12 +135,12 @@ def test_mega_chunk_gdn_initial_state(
         g_cpu,
         beta_cpu,
         cu_list,
-        initial_state=h0_cpu,
+        initial_state=None,
         output_final_state=True,
     )
-    _assert_close(f"mega_vs_native_{state_kind}", actual, expected)
+    _assert_close(f"mega_no_initial_state_H{H}_Hg{Hg}", actual, expected)
     _assert_close(
-        f"mega_final_state_vs_native_{state_kind}",
+        f"mega_no_initial_state_final_state_H{H}_Hg{Hg}",
         actual_final_state,
         expected_final_state,
     )

--- a/tests/python/sgl_kernel_npu/test_chunk_gdn_pto.py
+++ b/tests/python/sgl_kernel_npu/test_chunk_gdn_pto.py
@@ -20,7 +20,6 @@ SUPPORTED_HEAD_CONFIGS = [
     pytest.param(16, 8, id="H16-Hg8"),
     pytest.param(16, 16, id="H16-Hg16"),
     pytest.param(24, 8, id="H24-Hg8"),
-    pytest.param(32, 4, id="H32-Hg4"),
     pytest.param(32, 8, id="H32-Hg8"),
     pytest.param(32, 16, id="H32-Hg16"),
     pytest.param(48, 16, id="H48-Hg16"),
@@ -153,8 +152,8 @@ def test_mega_chunk_gdn_all_supported_head_configs(num_value_heads, num_key_head
 
     torch.manual_seed(2)
     device = torch.device("npu")
-    total_tokens = 129
-    cu_list = [0, 64, total_tokens]
+    cu_list = [0, 22, 1333]
+    total_tokens = cu_list[-1]
     num_sequences = len(cu_list) - 1
     H = num_value_heads
     Hg = num_key_heads


### PR DESCRIPTION
Add separate path for transpose when H<16

Now support bold entries:

Format: (num val heads, num key heads)
  | Global $H_v$ | TP=1 | TP=2 | TP=4 | TP=8 |
  |---:|---|---|---|---|
  | 16 | **(16,16)** | **(8,8)** | (4,4) | (2,2) |
  | 32 | **(32,16)** | **(16,8)** | **(8,4)** | (4,2) |
  | 48 | **(48,16)** | **(24,8)** | **(12,4)** | (6,2) |
  | 64 | **(64,16)** | **(32,8)** | **(16,4)** | **(8,2)** |


TODO:

For even smaller H=2,4,6 there are some MTE problems in WY kernel. Need to look in to alignment, padding, MTE instruction configuration