### PR TITLE
fix: only build deepep if deepep=ON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ output/
 *.dwo
 
 .codemate
+
+csrc/deepep/ops/cmake/
+csrc/deepep/ops/scripts/
+csrc/deepep/ops2/cmake/
+csrc/deepep/ops2/scripts/

--- a/build.sh
+++ b/build.sh
@@ -212,6 +212,8 @@ function build_memory_saver()
 
 function create_deepep_cmake()
 {
+    if [[ "$BUILD_DEEPEP_MODULE" != "ON" ]]; then return 0; fi
+
     cd csrc || exit
     chmod +x deepep_cmake_build.sh
     chmod +x deepep/build.sh


### PR DESCRIPTION
Changes:

- If `$BUILD_DEEPEP_MODULE!=ON` don't build deepep


Currently on A2 910B is i run `bash build.sh -a kernels` it will go to `create_deepep_cmake` and end up trying to copy a `CMakePresets.json` that doesnt exist resulting in a crash.

```error
[BuildOps] Building for ops: Ascend910_9382
msopgen gen -i ./AddCustom.json -c ai_core-Ascend910_9382 -f pytorch -lan cpp -out ops_Ascend910_9382
2026-06-01 16:04:43 (826132) - [ERROR] You are not the owner of path /workspace/sgl-kernel-npu/csrc/deepep/AddCustom.json. 
cp: target './ops_Ascend910_9382/op_host/' is not a directory
cp -rf ./ops/op_host/* ./ops_Ascend910_9382/op_host/
cp: target './ops_Ascend910_9382/op_kernel/' is not a directory
cp -rf ./ops/op_kernel/* ./ops_Ascend910_9382/op_kernel/
cp -rf ./ops/utils/op_host/* ./ops_Ascend910_9382/op_host/
cp -rf ./ops/utils/op_kernel/* ./ops_Ascend910_9382/op_kernel/
./ops built successfully
cp: cannot stat './ops_Ascend910_9382/cmake': No such file or directory
cp: cannot stat './ops_Ascend910_9382/CMakePresets.json': No such file or directory
ops_Ascend910_9382
sed: can't read ./ops/CMakePresets.json: No such file or directory
```