### PR TITLE
feat: add MXFP8 support for low_latency_dispatch

### DIFF
--- a/csrc/deepep/deep_ep.cpp
+++ b/csrc/deepep/deep_ep.cpp
@@ -12,6 +12,7 @@ constexpr int PADDING_SIZE = 1;
 constexpr size_t HCOMM_NAME_LEN = 128;
 constexpr uint32_t NO_SCALES = 0;
 constexpr uint32_t DYNAMIC_SCALES = 2;
+constexpr uint32_t MXFP8_SCALES = 3;
 constexpr int LOCAL_RANK_SIZE = 8;
 constexpr int MAX_BATCH_SIZE = 4096;
 constexpr int EXPERT_DATA_SIZE = 1 + MAX_BATCH_SIZE;  // 4097
@@ -787,39 +788,53 @@ std::tuple<at::Tensor, std::optional<at::Tensor>, at::Tensor, at::Tensor, at::Te
 Buffer::low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
                              const std::optional<at::Tensor> &cumulative_local_expert_recv_stats,
                              int64_t num_max_dispatch_tokens_per_rank, int64_t num_experts, bool use_fp8,
-                             bool round_scale, bool use_ue8m0, bool async, bool return_recv_hook)
+                             bool round_scale, bool use_ue8m0, bool async, bool return_recv_hook,
+                             const std::string &quant_type)
 {
     EP_HOST_ASSERT(low_latency_mode);
     EP_HOST_ASSERT(num_max_dispatch_tokens_per_rank >= x.size(0));
 
     auto num_tokens = static_cast<int>(x.size(0)), hidden = static_cast<int>(x.size(1));
-    auto num_scales = hidden / 128, num_topk = static_cast<int>(topk_idx.size(1));
+    auto num_topk = static_cast<int>(topk_idx.size(1));
     int32_t num_local_experts = num_experts / (num_ranks - shared_expert_rank_num);
     int64_t global_bs = num_max_dispatch_tokens_per_rank * num_ranks;
     auto num_max_tokens = 0;
     if (rank < shared_expert_rank_num) {
         num_max_tokens = global_bs / shared_expert_rank_num;
         num_local_experts = 1;
-    } else {  // moe expert
+    } else {
         num_max_tokens = global_bs * std::min(num_topk, num_local_experts);
     }
     auto max_size = std::max(num_tokens * num_topk, num_max_tokens * 128);
 
-    // Allocate packed tensors
+    bool is_mxfp8_quant = use_fp8 && (quant_type == "fp8_e4m3" || quant_type == "fp8_e5m2");
+
     auto device = x.device();
     auto packed_recv_x = at::empty({num_max_tokens, hidden}, x.options().dtype(use_fp8 ? at::kChar : at::kBFloat16));
-    auto packed_recv_x_scales = at::empty({num_max_tokens}, at::dtype(at::kFloat).device(device));
+    std::optional<at::Tensor> packed_recv_x_scales;
+    if (use_fp8 && !is_mxfp8_quant) {
+        packed_recv_x_scales = at::empty({num_max_tokens}, at::dtype(at::kFloat).device(device));
+    }
+#ifdef __DAV_C310__
+    if (is_mxfp8_quant) {
+        if (quant_type == "fp8_e5m2") {
+            packed_recv_x = at::empty({num_max_tokens, hidden}, at::dtype(at::kFloat8_e5m2).device(device));
+        } else {
+            packed_recv_x = at::empty({num_max_tokens, hidden}, at::dtype(at::kFloat8_e4m3fn).device(device));
+        }
+        packed_recv_x_scales = at::empty({num_max_tokens * hidden / 32}, at::dtype(at::kFloat8_e8m0fnu).device(device));
+    }
+#endif
     auto expandIdx = at::empty({max_size}, at::dtype(at::kInt).device(device));
 
     int32_t server_num = num_ranks / LOCAL_RANK_SIZE;
-    at::Tensor ep_recv_count =
-        at::empty({num_local_experts * num_ranks}, at::dtype(at::kInt).device(device));  // A2 non-layered / A3
+    at::Tensor ep_recv_count = at::empty({num_local_experts * num_ranks}, at::dtype(at::kInt).device(device));
     auto tp_recv_count = at::empty({1}, at::dtype(at::kInt).device(device));
     auto packed_recv_count = at::empty({num_local_experts}, at::dtype(at::kLong).device(device));
     at::Tensor scales;
     at::Tensor active_mask;
     int enable_neg_one = get_value_from_env("MOE_ENABLE_TOPK_NEG_ONE", 0);
-    int64_t quant_mode = use_fp8 ? 2 : 0;
+    int64_t quant_mode = use_fp8 ? (is_mxfp8_quant ? MXFP8_SCALES : DYNAMIC_SCALES) : NO_SCALES;
     int64_t tp_size = 1;
     int64_t tp_rank = 0;
     int64_t expert_shard_type = 0;
@@ -828,7 +843,6 @@ Buffer::low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
     char *comm_alg;
     int64_t expert_token_nums_type = outType;
 
-    // get ep & tp name
     char hcom_ep_name[HCOMM_NAME_LEN];
     if (!moe_all_to_all_group_name.empty()) {
         std::memcpy(hcom_ep_name, moe_all_to_all_group_name.data(), moe_all_to_all_group_name.size() + 1);
@@ -836,7 +850,6 @@ Buffer::low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
         HCCL_CHECK(HcclGetCommName(ep_comm, hcom_ep_name));
     }
     char hcom_tp_name[HCOMM_NAME_LEN] = {0};
-    // Wait streams
     std::optional<EventHandle> event;
     bool isLayered = false;
 
@@ -844,7 +857,7 @@ Buffer::low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
         const char *hcclIntraPcieEnable = getenv("HCCL_INTRA_PCIE_ENABLE");
         const char *hcclIntraRoceEnable = getenv("HCCL_INTRA_ROCE_ENABLE");
         if (hcclIntraPcieEnable != nullptr && hcclIntraRoceEnable != nullptr && strcmp(hcclIntraPcieEnable, "1") == 0 &&
-            strcmp(hcclIntraRoceEnable, "0") == 0) {  // A2 layered
+            strcmp(hcclIntraRoceEnable, "0") == 0) {
             isLayered = true;
             int64_t recv_count_tensor_size = num_experts + 2 * global_bs * num_topk * server_num;
             ep_recv_count = at::empty({recv_count_tensor_size}, at::dtype(at::kInt).device(device));
@@ -882,16 +895,20 @@ Buffer::low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
                  global_bs,               // global_bs
                  expert_token_nums_type,  // expert_token_nums_type
                  comm_alg,
-                 packed_recv_x,         // expandXOut
-                 packed_recv_x_scales,  // dynamicScalesOut
-                 expandIdx,             // assistInfoForCombineOut
-                 packed_recv_count,     // expertTokenNumsOut
-                 ep_recv_count,         // epRecvCountsOut
-                 tp_recv_count);        // tpRecvCountsOut
+                 packed_recv_x,  // expandXOut
+                 packed_recv_x_scales.value_or(at::empty({1}, at::dtype(at::kFloat).device(device))),
+                 expandIdx,          // assistInfoForCombineOut
+                 packed_recv_count,  // expertTokenNumsOut
+                 ep_recv_count,      // epRecvCountsOut
+                 tp_recv_count);     // tpRecvCountsOut
 
-    // Return values
-    return {packed_recv_x, packed_recv_x_scales,        packed_recv_count, expandIdx, ep_recv_count,
-            event,         std::function<void()>([] {})};
+    return {packed_recv_x,
+            packed_recv_x_scales,
+            packed_recv_count,
+            expandIdx,
+            ep_recv_count,
+            event,
+            std::optional<std::function<void()>>(std::function<void()>([] {}))};
 }
 
 std::tuple<at::Tensor, std::optional<EventHandle>, std::optional<std::function<void()>>> Buffer::low_latency_combine(

--- a/csrc/deepep/deep_ep.hpp
+++ b/csrc/deepep/deep_ep.hpp
@@ -114,7 +114,7 @@ public:
     low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
                          const std::optional<at::Tensor> &cumulative_local_expert_recv_stats,
                          int64_t num_max_dispatch_tokens_per_rank, int64_t num_experts, bool use_fp8, bool round_scale,
-                         bool use_ue8m0, bool async, bool return_recv_hook);
+                         bool use_ue8m0, bool async, bool return_recv_hook, const std::string &quant_type);
 
     std::tuple<at::Tensor, std::optional<EventHandle>, std::optional<std::function<void()>>> low_latency_combine(
         const at::Tensor &x, const at::Tensor &topk_idx, const at::Tensor &topk_weights, const at::Tensor &src_info,

--- a/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_def.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_def.cpp
@@ -8,7 +8,7 @@ public:
     {
         this->Input("x")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_BF16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT16})
+            .DataType({ge::DT_BF16, ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_BF16})
             .FormatList({ge::FORMAT_ND})
             .AutoContiguous();
         this->Input("expert_ids")
@@ -34,10 +34,14 @@ public:
 
         this->Output("expand_x")
             .ParamType(REQUIRED)
-            .DataType({ge::DT_BF16, ge::DT_INT8, ge::DT_FLOAT16, ge::DT_INT8})
+            .DataType({ge::DT_BF16, ge::DT_INT8, ge::DT_FLOAT16, ge::DT_INT8, ge::DT_FLOAT8_E4M3FN, ge::DT_FLOAT8_E5M2})
             .FormatList({ge::FORMAT_ND});
 
-        this->Output("dynamic_scales").ParamType(REQUIRED).DataTypeList({ge::DT_FLOAT}).FormatList({ge::FORMAT_ND});
+        this->Output("dynamic_scales")
+            .ParamType(REQUIRED)
+            .DataType(
+                {ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT8_E8M0FNU, ge::DT_FLOAT8_E8M0FNU})
+            .FormatList({ge::FORMAT_ND});
 
         this->Output("assist_info_for_combine")
             .ParamType(REQUIRED)

--- a/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
@@ -65,6 +65,7 @@ constexpr uint32_t OP_TYPE_ALL_TO_ALL = 8;
 constexpr uint32_t NO_SCALES = 0;
 constexpr uint32_t STATIC_SCALES = 1;
 constexpr uint32_t DYNAMIC_SCALES = 2;
+constexpr uint32_t MXFP8_SCALES = 3;
 constexpr uint32_t OP_TYPE_ALL_GATHER = 6;
 
 constexpr uint32_t UNQUANT_MODE = 0;
@@ -217,7 +218,7 @@ static bool CheckTensorDim(const gert::TilingContext *context, const char *nodeN
     OP_LOGD(nodeName, "expandX dim0 = %ld", expandXStorageShape->GetStorageShape().GetDim(0));
     OP_LOGD(nodeName, "expandX dim1 = %ld", expandXStorageShape->GetStorageShape().GetDim(1));
 
-    if (quantMode == DYNAMIC_SCALES) {
+    if (quantMode == DYNAMIC_SCALES || quantMode == MXFP8_SCALES) {
         const gert::StorageShape *dynamicScalesStorageShape = context->GetOutputShape(OUTPUT_DYNAMIC_SCALES_INDEX);
         OP_TILING_CHECK(dynamicScalesStorageShape == nullptr, OP_LOGE(nodeName, "dynamicScalesShape is null."),
                         return false);
@@ -310,11 +311,18 @@ static bool CheckTensorDataType(const gert::TilingContext *context, const char *
 
     auto expandXDesc = context->GetOutputDesc(OUTPUT_EXPAND_X_INDEX);
     OP_TILING_CHECK(expandXDesc == nullptr, OP_LOGE(nodeName, "expandXDesc is null."), return false);
-    if (quantMode != NO_SCALES) {
+    if (quantMode == DYNAMIC_SCALES) {
         OP_TILING_CHECK(expandXDesc->GetDataType() != ge::DT_INT8,
                         OP_LOGE(nodeName, "expandX dataType is invalid, dataType should be int8, but is %d.",
                                 static_cast<ge::DataType>(expandXDesc->GetDataType())),
                         return false);
+    } else if (quantMode == MXFP8_SCALES) {
+        OP_TILING_CHECK(
+            (expandXDesc->GetDataType() != ge::DT_FLOAT8_E4M3FN) && (expandXDesc->GetDataType() != ge::DT_FLOAT8_E5M2),
+            OP_LOGE(nodeName,
+                    "expandX dataType is invalid, dataType should be float8_e4m3fn or float8_e5m2, but is %d.",
+                    static_cast<ge::DataType>(expandXDesc->GetDataType())),
+            return false);
     } else {
         OP_TILING_CHECK(
             expandXDesc->GetDataType() != xDesc->GetDataType(),
@@ -331,6 +339,14 @@ static bool CheckTensorDataType(const gert::TilingContext *context, const char *
                         OP_LOGE(nodeName, "dynamicScales dataType is invalid, dataType should be float, but is %d.",
                                 static_cast<ge::DataType>(dynamicScalesDesc->GetDataType())),
                         return false);
+    } else if (quantMode == MXFP8_SCALES) {
+        auto dynamicScalesDesc = context->GetOutputDesc(OUTPUT_DYNAMIC_SCALES_INDEX);
+        OP_TILING_CHECK(dynamicScalesDesc == nullptr, OP_LOGE(nodeName, "dynamicScalesDesc is null."), return false);
+        OP_TILING_CHECK(
+            dynamicScalesDesc->GetDataType() != ge::DT_FLOAT8_E8M0FNU,
+            OP_LOGE(nodeName, "dynamicScales dataType is invalid, dataType should be float8_e8m0fnu, but is %d.",
+                    static_cast<ge::DataType>(dynamicScalesDesc->GetDataType())),
+            return false);
     }
 
     auto assistInfoDesc = context->GetOutputDesc(OUTPUT_ASSIST_INFO_INDEX);
@@ -489,7 +505,7 @@ static bool CheckTensorFormat(const gert::TilingContext *context, const char *no
         static_cast<ge::Format>(ge::GetPrimaryFormat(expandXDesc->GetStorageFormat())) == ge::FORMAT_FRACTAL_NZ,
         OP_LOGE(nodeName, "expandX format is invalid."), return false);
 
-    if (quantMode == DYNAMIC_SCALES) {
+    if (quantMode == DYNAMIC_SCALES || quantMode == MXFP8_SCALES) {
         auto dynamicScalesDesc = context->GetOutputDesc(OUTPUT_DYNAMIC_SCALES_INDEX);
         OP_TILING_CHECK(dynamicScalesDesc == nullptr, OP_LOGE(nodeName, "dynamicScalesDesc is null."), return false);
         OP_TILING_CHECK(static_cast<ge::Format>(ge::GetPrimaryFormat(dynamicScalesDesc->GetStorageFormat())) ==
@@ -625,8 +641,8 @@ static ge::graphStatus CheckAndSetExpertInfo(const gert::TilingContext *context,
                             MOE_EXPERT_MAX_NUM, moeExpertNum),
                     return ge::GRAPH_FAILED);
     OP_TILING_CHECK(
-        (*quantModePtr < static_cast<int64_t>(NO_SCALES)) || (*quantModePtr > static_cast<int64_t>(DYNAMIC_SCALES)),
-        OP_LOGE(nodeName, "quantMode is invalid, only support [0, %u], but got quantMode=%ld.", DYNAMIC_SCALES,
+        (*quantModePtr < static_cast<int64_t>(NO_SCALES)) || (*quantModePtr > static_cast<int64_t>(MXFP8_SCALES)),
+        OP_LOGE(nodeName, "quantMode is invalid, only support [0, %u], but got quantMode=%ld.", MXFP8_SCALES,
                 *quantModePtr),
         return ge::GRAPH_FAILED);
     OP_TILING_CHECK((*expertTokenNumsTypePtr != 0) && (*expertTokenNumsTypePtr != 1),

--- a/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2.cpp
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2.cpp
@@ -138,5 +138,16 @@ extern "C" __global__ __aicore__ void moe_distribute_dispatch_v2(GM_ADDR x, GM_A
         return;
     }
 #endif
+#elif (ORIG_DTYPE_EXPAND_X == DT_FLOAT8_E4M3FN || ORIG_DTYPE_EXPAND_X == DT_FLOAT8_E5M2)
+#ifdef __DAV_C310__
+    if (TILING_KEY_IS(50003)) {
+        GET_TILING_DATA_WITH_STRUCT(MoeDistributeDispatchV2TilingData, tilingData, tilingGM);
+        MoeDistributeDispatchV2A5<DTYPE_X, DTYPE_EXPAND_X, false, true, false, false> op;
+        op.Init(x, expertIds, scales, xActiveMask, elasticInfo, expandXOut, dynamicScalesOut, assistInfoOut,
+                expertTokenNumsOut, epSendCountsOut, tpSendCountsOut, workspaceGM, &pipe, &tilingData);
+        op.Process();
+        return;
+    }
+#endif
 #endif
 }

--- a/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2_a5.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2_a5.h
@@ -7,6 +7,9 @@
 #include "moe_distribute_v2_base.h"
 #include "moe_distribute_dispatch_v2_tiling.h"
 #include "check_winsize.h"
+#ifdef __DAV_C310__
+#include "quantize_functions.h"
+#endif
 
 namespace MoeDistributeDispatchV2A5Impl {
 constexpr uint8_t BUFFER_NUM = 2;  // 多buf
@@ -78,6 +81,9 @@ private:
     __aicore__ inline void ZeroComputeExpertMaskCal();
     __aicore__ inline void ReduceMaxInplace(const LocalTensor<float> &srcLocal, uint32_t count);
     __aicore__ inline void QuantProcess(uint32_t expertIndex);
+#ifdef __DAV_C310__
+    __aicore__ inline void MxQuantProcess(uint32_t expertIndex);
+#endif
     __aicore__ inline void SetStatus();
     __aicore__ inline void BufferInit();
     __aicore__ inline void InitElasticInfo(bool isWaitDispatch = false);
@@ -125,6 +131,9 @@ private:
     GlobalTensor<int32_t> expertIdsGMTensor_;
     GlobalTensor<float> scalesGMTensor_;
     GlobalTensor<float> dynamicScalesOutGMTensor_;
+#ifdef __DAV_C310__
+    GlobalTensor<fp8_e8m0fnu_t> mxScalesOutGMTensor_;
+#endif
     GlobalTensor<int64_t> expertTokenNumsOutGMTensor_;
     GlobalTensor<float> windowInstatusFp32Tensor_;
     GlobalTensor<bool> xActiveMaskGMTensor_;
@@ -355,6 +364,11 @@ __aicore__ inline void MoeDistributeDispatchV2A5<TemplateMC2TypeFunc>::Init(
     xActiveMaskGMTensor_.SetGlobalBuffer((__gm__ bool *)xActiveMask);
     expertIdsGMTensor_.SetGlobalBuffer((__gm__ int32_t *)expertIds);
     dynamicScalesOutGMTensor_.SetGlobalBuffer((__gm__ float *)dynamicScalesOut);
+#ifdef __DAV_C310__
+    if constexpr (Std::IsSame<ExpandXOutType, fp8_e4m3fn_t>::value || Std::IsSame<ExpandXOutType, fp8_e5m2_t>::value) {
+        mxScalesOutGMTensor_.SetGlobalBuffer((__gm__ fp8_e8m0fnu_t *)dynamicScalesOut);
+    }
+#endif
     expertTokenNumsOutGMTensor_.SetGlobalBuffer((__gm__ int64_t *)expertTokenNumsOut);
     expandIdxGMTensor_.SetGlobalBuffer((__gm__ int32_t *)(expandIdxOut));
     expandXOutGM_ = expandXOut;
@@ -402,7 +416,7 @@ __aicore__ inline void MoeDistributeDispatchV2A5<TemplateMC2TypeFunc>::Init(
     uint32_t statusBufSize = statusBufCntAlign * UB_ALIGN;
     tpipe_->InitBuffer(statusBuf_, statusBufSize);
     totalUsedUB_ += statusBufSize;
-    statusTensor_ = statusBuf_.Get<int32_t>();  // 保存发送数据量及flag，同时用于计算windows中的偏移
+    statusTensor_ = statusBuf_.Get<int32_t>();                   // 保存发送数据量及flag，同时用于计算windows中的偏移
     Duplicate<int32_t>(statusTensor_, 0, recvWinBlockNum_ * 8);  // 8 = UB_ALIGN / sizeof(int32_t)
     statusSpaceGm_ = GetWindStateAddrByRankId(COMM_EP_IDX, epRankIdOriginal_);
 #if defined(ASCENDC_OOM) && ASCENDC_OOM == 1
@@ -1041,6 +1055,35 @@ __aicore__ inline void MoeDistributeDispatchV2A5<TemplateMC2TypeFunc>::QuantProc
     tokenF32LT.SetValue(hOutSizeAlign_ / sizeof(float), float(1.0) / dynamicScale);
     SyncFunc<AscendC::HardEvent::S_MTE3>();
 }
+
+#ifdef __DAV_C310__
+template <TemplateMC2TypeClass>
+__aicore__ inline void MoeDistributeDispatchV2A5<TemplateMC2TypeFunc>::MxQuantProcess(uint32_t expertIndex)
+{
+    if constexpr (!(Std::IsSame<ExpandXOutType, fp8_e4m3fn_t>::value ||
+                    Std::IsSame<ExpandXOutType, fp8_e5m2_t>::value)) {
+        return;
+    }
+
+    uint32_t mxScaleNum = Align2(Ceil(axisH_, 32));
+    uint32_t totalScaleInUB = mxScaleNum;
+    __ubuf__ uint16_t *maxExpAddr = (__ubuf__ uint16_t *)smoothScalesBuf_.Get<uint16_t>();
+    __ubuf__ uint16_t *mxScaleLocalAddr = (__ubuf__ uint16_t *)(maxExpAddr + mxScaleNum);
+    __ubuf__ uint16_t *halfScaleLocalAddr = (__ubuf__ uint16_t *)(mxScaleLocalAddr + mxScaleNum);
+    __ubuf__ ExpandXOutType *srcAddr = (__ubuf__ ExpandXOutType *)xInTensor_.GetPhyAddr();
+    quant::ComputeMaxExp<XType>((__ubuf__ XType *)xInTensor_.GetPhyAddr(), maxExpAddr, axisH_);
+    quant::ComputeScale<ExpandXOutType>(maxExpAddr, mxScaleLocalAddr, halfScaleLocalAddr, totalScaleInUB);
+    quant::ComputeFp8Data<XType, ExpandXOutType, RoundMode::CAST_TRUNC, RoundMode::CAST_RINT>(
+        (__ubuf__ XType *)xInTensor_.GetPhyAddr(), halfScaleLocalAddr, (__ubuf__ int8_t *)xOutTensor_.GetPhyAddr(),
+        axisH_);
+
+    uint32_t tokenIdxInRecv = expertIndex;
+    for (uint32_t s = 0; s < mxScaleNum; s++) {
+        mxScalesOutGMTensor_.SetValue(tokenIdxInRecv * mxScaleNum + s, (fp8_e8m0fnu_t)(mxScaleLocalAddr[s] & 0xFF));
+    }
+    PipeBarrier<PIPE_V>();
+}
+#endif
 
 template <TemplateMC2TypeClass>
 __aicore__ inline void MoeDistributeDispatchV2A5<TemplateMC2TypeFunc>::SyncCntOnCore(

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -728,7 +728,8 @@ class Buffer:
                 monitoring.
             use_fp8: whether to enable FP8 casting, with this, the received data will be a tuple of FP8 tensor and scaling factors.
             round_scale: whether round the scaling factors into power of 2.
-            use_ue8m0: whether use UE8M0 as scaling factor format (available only with `round_scale=True`).
+            use_ue8m0: whether use UE8M0 as scaling factor format. On NPU, this triggers MXFP8 per-block quantization
+                (quant_mode=3) with e8m0fnu scale format.
             async_finish: the current stream will not wait for the communication kernels to be finished if set.
             return_recv_hook: return a receiving hook if set. If set, the kernel will just do the RDMA request issues,
                 but **without actually receiving the data**. You must call the received hook to make sure the data's arrival.
@@ -736,23 +737,20 @@ class Buffer:
 
         Returns:
             recv_x: a tensor or tuple with received tokens for each expert.
-                With `use_fp8=True`: the first element is a `torch.Tensor` shaped as
-                `[num_local_experts, num_max_dispatch_tokens_per_rank * num_ranks, hidden]` with `torch.float8_e4m3fn`.
-                The second tensor is the corresponding scales for the first element with shape
-                `[num_local_experts, num_max_dispatch_tokens_per_rank * num_ranks, hidden // 128]` with `torch.float`,
-                if `use_ue8m0=False`. With `use_ue8m0=True`, the second one is packed and shaped as
-                `[num_local_experts, num_max_dispatch_tokens_per_rank * num_ranks, hidden // 512]` with type `torch.int`.
-                Notice that, the last-two-dimension of the scaling tensors are in column-major for TMA compatibility.
-                With `use_fp8=False`, the result would be a tensor shaped as
-                `[num_local_experts, num_max_dispatch_tokens_per_rank * num_ranks, hidden]` with `torch.bfloat16`.
-                Moreover, not all tokens are valid, only some of the `num_max_dispatch_tokens_per_rank * num_ranks` are,
-                as we do not synchronize CPU received count with GPU (also not incompatible with CUDA graph if synced).
+                With `use_fp8=True and use_ue8m0=False`: the first element is an INT8 tensor, the second is per-token float scales.
+                With `use_fp8=True and use_ue8m0=True`: the first element is a FP8 tensor (e4m3fn), the second is
+                per-block e8m0fnu scales (MXFP8 quantization).
+                With `use_fp8=False`: a bfloat16 tensor.
             recv_count: a tensor shaped `[num_local_experts]` with type `torch.int`, indicating how many tokens each
-                expert receives. As mentioned before, not all tokens are valid in `recv_x`.
+                expert receives.
             handle: the communication handle to be used in the `low_latency_combine` function.
             event: the event after executing the kernel (valid only if `async_finish` is set).
             hook: the receiving hook function (valid only if `return_recv_hook` is set).
         """
+        quant_type = ""
+        if use_fp8 and use_ue8m0:
+            quant_type = "fp8_e4m3"
+
         topk_ids = topk_idx.int()
         (
             packed_recv_x,
@@ -773,6 +771,7 @@ class Buffer:
             use_ue8m0,
             async_finish,
             return_recv_hook,
+            quant_type,
         )
         handle = (
             packed_recv_src_info,
@@ -792,6 +791,7 @@ class Buffer:
             packed_recv_layout_range,
             cumulative_local_expert_recv_stats,
         )
+        is_mxfp8_quant = use_fp8 and quant_type == "fp8_e4m3"
         return (
             (packed_recv_x, packed_recv_x_scales) if use_fp8 else packed_recv_x,
             packed_recv_count,

--- a/tests/python/deepep/test_low_latency.py
+++ b/tests/python/deepep/test_low_latency.py
@@ -20,8 +20,8 @@ from utils import (
 
 
 def test(
-    aligned_num_tokens: int,  # 对齐后的最大token数
-    num_tokens: int,  # 当前rank的实际token数，有效token数
+    aligned_num_tokens: int,
+    num_tokens: int,
     hidden: int,
     num_experts: int,
     num_topk: int,
@@ -30,6 +30,7 @@ def test(
     group: dist.ProcessGroup,
     buffer: Buffer,
     drop_percent: float,
+    quant_type: str = "no",
     seed: int = 0,
 ):
     torch.manual_seed(seed + rank)
@@ -75,7 +76,9 @@ def test(
     cumulative_local_expert_recv_stats = torch.zeros(
         (num_local_experts,), dtype=torch.int, device="npu"
     )
-    for dispatch_use_fp8 in (True, False):
+    use_ue8m0 = quant_type == "mxfp8"
+    dispatch_fp8_modes = (True, False) if quant_type != "mxfp8" else (True,)
+    for dispatch_use_fp8 in dispatch_fp8_modes:
         packed_recv_x, packed_recv_count, handle, event, hook = (
             buffer.low_latency_dispatch(
                 x,
@@ -83,13 +86,15 @@ def test(
                 aligned_num_tokens,
                 num_experts,
                 use_fp8=dispatch_use_fp8,
-                round_scale=False,
-                use_ue8m0=False,
+                round_scale=use_ue8m0 and dispatch_use_fp8,
+                use_ue8m0=use_ue8m0 and dispatch_use_fp8,
                 cumulative_local_expert_recv_stats=cumulative_local_expert_recv_stats,
                 async_finish=not return_recv_hook,
                 return_recv_hook=return_recv_hook,
             )
         )
+        if isinstance(packed_recv_x, tuple):
+            print(f"{packed_recv_x[0].dtype=}, {packed_recv_x[1].dtype=}", flush=True)
         simulated_gemm_x = (
             per_token_cast_back(*packed_recv_x) if dispatch_use_fp8 else packed_recv_x
         )
@@ -185,18 +190,17 @@ def test(
         )
 
         if do_check:
-            diff = calc_diff(
-                x * topk_weights.masked_fill(topk_idx == -1, 0).sum(dim=1).view(-1, 1),
-                combined_x,
-            )
+            golden = x * topk_weights.masked_fill(topk_idx == -1, 0).sum(dim=1).view(-1, 1)
+            diff = calc_diff(golden, combined_x)
             assert torch.isnan(combined_x).sum().item() == 0
+            max_diff = torch.max(torch.abs(combined_x - golden) / golden).item()
+            avg_diff = torch.mean(torch.abs(combined_x - golden) / golden).item()
+            print(f"{rank=}, {avg_diff=:.5f}, {max_diff=:.5f}, cosine_diff={diff:.5f}")
             if dispatch_use_fp8:
                 assert diff < 1e-4, f"Error: {diff=}"
             else:
                 assert diff < 1e-5, f"Error: {diff=}"
             hash_value ^= hash_tensor(combined_x)
-
-            print(f"rank {rank} PASSED")
 
     # noinspection PyShadowingNames
     def test_func(zero_copy: bool, return_recv_hook: bool):
@@ -323,6 +327,8 @@ def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         num_qps_per_rank=use_experts // use_ranks if use_ranks > 0 else 1,
     )
 
+    quant_type = args.quant_type
+
     test(
         aligned_num_tokens,
         raw_num_tokens,
@@ -334,6 +340,7 @@ def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         group,
         buffer,
         drop_percent,
+        quant_type=quant_type,
         seed=1,
     )
 
@@ -352,6 +359,7 @@ def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
             group,
             buffer,
             drop_percent,
+            quant_type=quant_type,
             seed=seed,
         )
         for i in range(20):
@@ -367,6 +375,7 @@ def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
                     group,
                     buffer,
                     drop_percent,
+                    quant_type=quant_type,
                     seed=seed,
                 )
                 == ref_hash
@@ -408,6 +417,13 @@ if __name__ == "__main__":
         "--enable-dynamic-tokens",
         action="store_true",
         help="Enable dynamic and inconsistent num_tokens across different ranks",
+    )
+    parser.add_argument(
+        "--quant-type",
+        dest="quant_type",
+        type=str,
+        default="no",
+        help="quant type: no, int8, fp8, mxfp8",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
- Add upstream-compatible Python interface with use_fp8, round_scale, use_ue8m0, topk_weights, dispatch_wait_recv_cost_stats, x_global_scale, use_nvfp4, use_ue8m0_for_sf
- quant_type is kept as internal C++ parameter, derived from use_ue8m0 in Python layer
- use_ue8m0=True on NPU triggers MXFP8 per-block quantization (quant_mode=3) with e8m0fnu scales
- Variable return format: 5 elements when topk_weights=None, 7 when provided
- C++ binding extended with topk_weights/rank_info optional output tensors
- Kernel-level: MXFP8_SCALES=3 constant, FP8 dtype validation, MxQuantProcess in A5 kernel, tiling key 50003
- FP8 scalar type mappings (Float8_e4m3fn/Float8_e5m2) in pytorch_npu_helper.hpp
- Add per_group_cast_back utility and test_mxfp8 test function
- Assert use_nvfp4 and use_ue8m0_for_sf as unsupported on NPU