### PR TITLE
fused_rope_qk_mqa optimize & fix glm5 bf16 no bias

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/norm/fused_rope_qk_mqa.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/norm/fused_rope_qk_mqa.py
@@ -24,7 +24,6 @@ def fused_rope_qk_mqa_kernel_opt(
     stride_okt,
     stride_okh,
     stride_okd,
-    T,
     Hq: tl.constexpr,
     Hk: tl.constexpr,
     D_HEAD: tl.constexpr,
@@ -32,8 +31,6 @@ def fused_rope_qk_mqa_kernel_opt(
     IS_NEOX_STYLE: tl.constexpr,
 ):
     pid_t = tl.program_id(0)
-    if pid_t >= T:
-        return
 
     # -------- rotary indices
     d = tl.arange(0, D_ROPE // 2)
@@ -121,7 +118,6 @@ def fused_rope_qk_mqa(
             out_k.stride(0),
             out_k.stride(1),
             out_k.stride(2),
-            T=T,
             Hq=Hq,
             Hk=Hk,
             D_HEAD=D,

--- a/python/sgl_kernel_npu/sgl_kernel_npu/norm/fused_rope_qk_mqa.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/norm/fused_rope_qk_mqa.py
@@ -4,7 +4,7 @@ import triton.language as tl
 
 
 @triton.jit
-def fused_rope_qk_mqa_kernel(
+def fused_rope_qk_mqa_kernel_opt(
     query_ptr,  # [T, Hq, D]
     key_ptr,  # [T, Hk, D]
     cos_sin_ptr,  # [max_pos, D_ROPE]
@@ -24,16 +24,16 @@ def fused_rope_qk_mqa_kernel(
     stride_okt,
     stride_okh,
     stride_okd,
+    T,
+    Hq: tl.constexpr,
     Hk: tl.constexpr,
     D_HEAD: tl.constexpr,
     D_ROPE: tl.constexpr,
     IS_NEOX_STYLE: tl.constexpr,
 ):
     pid_t = tl.program_id(0)
-    pid_h = tl.program_id(1)
-
-    # MQA: key head broadcast
-    kh = pid_h % Hk
+    if pid_t >= T:
+        return
 
     # -------- rotary indices
     d = tl.arange(0, D_ROPE // 2)
@@ -44,46 +44,47 @@ def fused_rope_qk_mqa_kernel(
         idx_even = d * 2
         idx_odd = d * 2 + 1
 
-    # cos / sin
+    # cos / sin (shared across all heads for this position)
     cos = tl.load(cos_sin_ptr + pid_t * stride_ct + d * stride_cd)
     sin = tl.load(cos_sin_ptr + pid_t * stride_ct + (d + D_ROPE // 2) * stride_cd)
 
-    # ================= Q =================
-    q_base = query_ptr + pid_t * stride_qt + pid_h * stride_qh
+    # ================= Q (all Hq heads at once) =================
+    head_offs = tl.arange(0, Hq)
+    q_base = query_ptr + pid_t * stride_qt
 
-    q1 = tl.load(q_base + idx_even * stride_qd)
-    q2 = tl.load(q_base + idx_odd * stride_qd)
+    q1 = tl.load(q_base + head_offs[:, None] * stride_qh + idx_even[None, :] * stride_qd)
+    q2 = tl.load(q_base + head_offs[:, None] * stride_qh + idx_odd[None, :] * stride_qd)
 
-    q_out1 = (q1 * cos) - (q2 * sin)
-    q_out2 = (q1 * sin) + (q2 * cos)
+    q_out1 = (q1 * cos[None, :]) - (q2 * sin[None, :])
+    q_out2 = (q1 * sin[None, :]) + (q2 * cos[None, :])
 
-    oq_base = out_q_ptr + pid_t * stride_oqt + pid_h * stride_oqh
-    tl.store(oq_base + idx_even * stride_oqd, q_out1)
-    tl.store(oq_base + idx_odd * stride_oqd, q_out2)
+    oq_base = out_q_ptr + pid_t * stride_oqt
+    tl.store(oq_base + head_offs[:, None] * stride_oqh + idx_even[None, :] * stride_oqd, q_out1)
+    tl.store(oq_base + head_offs[:, None] * stride_oqh + idx_odd[None, :] * stride_oqd, q_out2)
 
-    # ================= K =================
-    k_base = key_ptr + pid_t * stride_kt + kh * stride_kh
-    k1 = tl.load(k_base + idx_even * stride_kd)
-    k2 = tl.load(k_base + idx_odd * stride_kd)
+    # ================= K (unique Hk key heads only) =================
+    kh_offs = tl.arange(0, Hk)
+    k_base = key_ptr + pid_t * stride_kt
 
-    k_out1 = (k1 * cos) - (k2 * sin)
-    k_out2 = (k1 * sin) + (k2 * cos)
+    k1 = tl.load(k_base + kh_offs[:, None] * stride_kh + idx_even[None, :] * stride_kd)
+    k2 = tl.load(k_base + kh_offs[:, None] * stride_kh + idx_odd[None, :] * stride_kd)
 
-    ok_base = out_k_ptr + pid_t * stride_okt + kh * stride_okh
-    tl.store(ok_base + idx_even * stride_okd, k_out1)
-    tl.store(ok_base + idx_odd * stride_okd, k_out2)
+    k_out1 = (k1 * cos[None, :]) - (k2 * sin[None, :])
+    k_out2 = (k1 * sin[None, :]) + (k2 * cos[None, :])
+
+    ok_base = out_k_ptr + pid_t * stride_okt
+    tl.store(ok_base + kh_offs[:, None] * stride_okh + idx_even[None, :] * stride_okd, k_out1)
+    tl.store(ok_base + kh_offs[:, None] * stride_okh + idx_odd[None, :] * stride_okd, k_out2)
 
     # ================= pass-through (compile-time pruning) =================
     if D_HEAD > D_ROPE:
         dp = tl.arange(0, D_HEAD - D_ROPE)
-        tl.store(
-            oq_base + (dp + D_ROPE) * stride_oqd,
-            tl.load(q_base + (dp + D_ROPE) * stride_qd),
-        )
-        tl.store(
-            ok_base + (dp + D_ROPE) * stride_okd,
-            tl.load(k_base + (dp + D_ROPE) * stride_kd),
-        )
+        # Q pass-through
+        q_pass = tl.load(q_base + head_offs[:, None] * stride_qh + (dp + D_ROPE)[None, :] * stride_qd)
+        tl.store(oq_base + head_offs[:, None] * stride_oqh + (dp + D_ROPE)[None, :] * stride_oqd, q_pass)
+        # K pass-through
+        k_pass = tl.load(k_base + kh_offs[:, None] * stride_kh + (dp + D_ROPE)[None, :] * stride_kd)
+        tl.store(ok_base + kh_offs[:, None] * stride_okh + (dp + D_ROPE)[None, :] * stride_okd, k_pass)
 
 
 def fused_rope_qk_mqa(
@@ -91,40 +92,41 @@ def fused_rope_qk_mqa(
     key,
     cos_sin,
     rotary_dim,
-    is_neox_style,  # [T, Hq, D]  # [T, Hk, D]  # [T, rotary_dim]
-):
+    is_neox_style):
     T, Hq, D = query.shape
     _, Hk, _ = key.shape
 
     out_q = torch.empty_like(query)
     out_k = torch.empty_like(key)
 
-    grid = (T, Hq)
+    grid = (T,)
 
-    fused_rope_qk_mqa_kernel[grid](
-        query,
-        key,
-        cos_sin,
-        out_q,
-        out_k,
-        query.stride(0),
-        query.stride(1),
-        query.stride(2),
-        key.stride(0),
-        key.stride(1),
-        key.stride(2),
-        cos_sin.stride(0),
-        cos_sin.stride(1),
-        out_q.stride(0),
-        out_q.stride(1),
-        out_q.stride(2),
-        out_k.stride(0),
-        out_k.stride(1),
-        out_k.stride(2),
-        Hk=Hk,
-        D_HEAD=D,
-        D_ROPE=rotary_dim,
-        IS_NEOX_STYLE=is_neox_style,
-    )
+    fused_rope_qk_mqa_kernel_opt[grid](
+            query,
+            key,
+            cos_sin,
+            out_q,
+            out_k,
+            query.stride(0),
+            query.stride(1),
+            query.stride(2),
+            key.stride(0),
+            key.stride(1),
+            key.stride(2),
+            cos_sin.stride(0),
+            cos_sin.stride(1),
+            out_q.stride(0),
+            out_q.stride(1),
+            out_q.stride(2),
+            out_k.stride(0),
+            out_k.stride(1),
+            out_k.stride(2),
+            T=T,
+            Hq=Hq,
+            Hk=Hk,
+            D_HEAD=D,
+            D_ROPE=rotary_dim,
+            IS_NEOX_STYLE=is_neox_style,
+        )
 
     return out_q, out_k

--- a/python/sgl_kernel_npu/sgl_kernel_npu/norm/fused_rope_qk_mqa.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/norm/fused_rope_qk_mqa.py
@@ -49,15 +49,23 @@ def fused_rope_qk_mqa_kernel_opt(
     head_offs = tl.arange(0, Hq)
     q_base = query_ptr + pid_t * stride_qt
 
-    q1 = tl.load(q_base + head_offs[:, None] * stride_qh + idx_even[None, :] * stride_qd)
+    q1 = tl.load(
+        q_base + head_offs[:, None] * stride_qh + idx_even[None, :] * stride_qd
+    )
     q2 = tl.load(q_base + head_offs[:, None] * stride_qh + idx_odd[None, :] * stride_qd)
 
     q_out1 = (q1 * cos[None, :]) - (q2 * sin[None, :])
     q_out2 = (q1 * sin[None, :]) + (q2 * cos[None, :])
 
     oq_base = out_q_ptr + pid_t * stride_oqt
-    tl.store(oq_base + head_offs[:, None] * stride_oqh + idx_even[None, :] * stride_oqd, q_out1)
-    tl.store(oq_base + head_offs[:, None] * stride_oqh + idx_odd[None, :] * stride_oqd, q_out2)
+    tl.store(
+        oq_base + head_offs[:, None] * stride_oqh + idx_even[None, :] * stride_oqd,
+        q_out1,
+    )
+    tl.store(
+        oq_base + head_offs[:, None] * stride_oqh + idx_odd[None, :] * stride_oqd,
+        q_out2,
+    )
 
     # ================= K (unique Hk key heads only) =================
     kh_offs = tl.arange(0, Hk)
@@ -70,26 +78,39 @@ def fused_rope_qk_mqa_kernel_opt(
     k_out2 = (k1 * sin[None, :]) + (k2 * cos[None, :])
 
     ok_base = out_k_ptr + pid_t * stride_okt
-    tl.store(ok_base + kh_offs[:, None] * stride_okh + idx_even[None, :] * stride_okd, k_out1)
-    tl.store(ok_base + kh_offs[:, None] * stride_okh + idx_odd[None, :] * stride_okd, k_out2)
+    tl.store(
+        ok_base + kh_offs[:, None] * stride_okh + idx_even[None, :] * stride_okd, k_out1
+    )
+    tl.store(
+        ok_base + kh_offs[:, None] * stride_okh + idx_odd[None, :] * stride_okd, k_out2
+    )
 
     # ================= pass-through (compile-time pruning) =================
     if D_HEAD > D_ROPE:
         dp = tl.arange(0, D_HEAD - D_ROPE)
         # Q pass-through
-        q_pass = tl.load(q_base + head_offs[:, None] * stride_qh + (dp + D_ROPE)[None, :] * stride_qd)
-        tl.store(oq_base + head_offs[:, None] * stride_oqh + (dp + D_ROPE)[None, :] * stride_oqd, q_pass)
+        q_pass = tl.load(
+            q_base + head_offs[:, None] * stride_qh + (dp + D_ROPE)[None, :] * stride_qd
+        )
+        tl.store(
+            oq_base
+            + head_offs[:, None] * stride_oqh
+            + (dp + D_ROPE)[None, :] * stride_oqd,
+            q_pass,
+        )
         # K pass-through
-        k_pass = tl.load(k_base + kh_offs[:, None] * stride_kh + (dp + D_ROPE)[None, :] * stride_kd)
-        tl.store(ok_base + kh_offs[:, None] * stride_okh + (dp + D_ROPE)[None, :] * stride_okd, k_pass)
+        k_pass = tl.load(
+            k_base + kh_offs[:, None] * stride_kh + (dp + D_ROPE)[None, :] * stride_kd
+        )
+        tl.store(
+            ok_base
+            + kh_offs[:, None] * stride_okh
+            + (dp + D_ROPE)[None, :] * stride_okd,
+            k_pass,
+        )
 
 
-def fused_rope_qk_mqa(
-    query,
-    key,
-    cos_sin,
-    rotary_dim,
-    is_neox_style):
+def fused_rope_qk_mqa(query, key, cos_sin, rotary_dim, is_neox_style):
     T, Hq, D = query.shape
     _, Hk, _ = key.shape
 
@@ -99,30 +120,30 @@ def fused_rope_qk_mqa(
     grid = (T,)
 
     fused_rope_qk_mqa_kernel_opt[grid](
-            query,
-            key,
-            cos_sin,
-            out_q,
-            out_k,
-            query.stride(0),
-            query.stride(1),
-            query.stride(2),
-            key.stride(0),
-            key.stride(1),
-            key.stride(2),
-            cos_sin.stride(0),
-            cos_sin.stride(1),
-            out_q.stride(0),
-            out_q.stride(1),
-            out_q.stride(2),
-            out_k.stride(0),
-            out_k.stride(1),
-            out_k.stride(2),
-            Hq=Hq,
-            Hk=Hk,
-            D_HEAD=D,
-            D_ROPE=rotary_dim,
-            IS_NEOX_STYLE=is_neox_style,
-        )
+        query,
+        key,
+        cos_sin,
+        out_q,
+        out_k,
+        query.stride(0),
+        query.stride(1),
+        query.stride(2),
+        key.stride(0),
+        key.stride(1),
+        key.stride(2),
+        cos_sin.stride(0),
+        cos_sin.stride(1),
+        out_q.stride(0),
+        out_q.stride(1),
+        out_q.stride(2),
+        out_k.stride(0),
+        out_k.stride(1),
+        out_k.stride(2),
+        Hq=Hq,
+        Hk=Hk,
+        D_HEAD=D,
+        D_ROPE=rotary_dim,
+        IS_NEOX_STYLE=is_neox_style,
+    )
 
     return out_q, out_k

--- a/python/sgl_kernel_npu/sgl_kernel_npu/norm/fused_split_qk_norm.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/norm/fused_split_qk_norm.py
@@ -115,16 +115,16 @@ def fused_split_qk_norm(
         k_nope,
         k_pe,
         q_a_layernorm.weight,
-        q_a_layernorm.bias,
+        q_a_layernorm.bias if hasattr(q_a_layernorm, "bias") else None,
         kv_a_layernorm.weight,
-        kv_a_layernorm.bias,
+        kv_a_layernorm.bias if hasattr(kv_a_layernorm, "bias") else None,
         total_hidden,
         q_lora_rank,
         kv_lora_rank,
         qk_rope_dim,
         eps,
-        q_a_layernorm.bias is not None,
-        kv_a_layernorm.bias is not None,
+        hasattr(q_a_layernorm, "bias") and q_a_layernorm.bias is not None,
+        hasattr(kv_a_layernorm, "bias") and kv_a_layernorm.bias is not None,
     )
 
     # Restore original shape by adding a sequence dimension

--- a/tests/python/sgl_kernel_npu/test_fused_rope_qk_mqa.py
+++ b/tests/python/sgl_kernel_npu/test_fused_rope_qk_mqa.py
@@ -1,0 +1,175 @@
+import torch
+from sgl_kernel_npu.norm.fused_rope_qk_mqa import fused_rope_qk_mqa
+
+def apply_rotary_emb(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    is_neox_style: bool,
+) -> torch.Tensor:
+    """
+    Args:
+        x: [num_tokens, num_heads, head_size]
+        cos: [num_tokens, head_size // 2]
+        sin: [num_tokens, head_size // 2]
+        is_neox_style: Whether to use the Neox-style or GPT-J-style rotary
+            positional embeddings.
+    """
+    cos = cos.unsqueeze(-2).to(x.dtype)
+    sin = sin.unsqueeze(-2).to(x.dtype)
+    if is_neox_style:
+        x1, x2 = torch.chunk(x, 2, dim=-1)
+    else:
+        x1 = x[..., ::2]
+        x2 = x[..., 1::2]
+    o1 = x1 * cos - x2 * sin
+    o2 = x2 * cos + x1 * sin
+    if is_neox_style:
+        return torch.cat((o1, o2), dim=-1)
+    else:
+        return torch.stack((o1, o2), dim=-1).flatten(-2)
+
+def forward_native(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos_sin,
+    head_size,
+    rotary_dim,
+    is_neox_style
+    ):
+    num_tokens = query.shape[0]
+    cos, sin = cos_sin.chunk(2, dim=-1)
+    query_shape = query.shape
+
+    query = query.view(num_tokens, -1, head_size)
+    query_rot = query[..., : rotary_dim]
+    query_pass = query[..., rotary_dim :]
+    query_rot = apply_rotary_emb(
+            query_rot, cos, sin, is_neox_style
+        )
+    query = torch.cat((query_rot, query_pass), dim=-1).reshape(query_shape)
+
+    key_shape = key.shape
+    key = key.view(num_tokens, -1, head_size)
+    key_rot = key[..., : rotary_dim]
+    key_pass = key[..., rotary_dim :]
+    key_rot = apply_rotary_emb(key_rot, cos, sin, is_neox_style)
+    key = torch.cat((key_rot, key_pass), dim=-1).reshape(key_shape)
+    return query, key
+
+
+def test_fused_rope_qk_mqa():
+    device = "npu"
+    test_cases = [
+        # token, q_heads, kv_heads, head_size, rotary_dim
+        (32, 8, 1, 64, 32),
+        (32, 8, 1, 32, 32),
+        (17, 16, 1, 128, 64),
+        (64, 32, 1, 128, 64),
+    ]
+
+
+    for is_neox_style in [
+        True,
+        False,
+    ]:
+
+        for (
+            num_tokens,
+            q_heads,
+            kv_heads,
+            head_size,
+            rotary_dim,
+        ) in test_cases:
+
+
+            print(
+                f"test "
+                f"neox={is_neox_style}, "
+                f"tokens={num_tokens}, "
+                f"heads={q_heads}, "
+                f"head={head_size}, "
+                f"rotary={rotary_dim}"
+            )
+
+
+            query = torch.randn(
+                num_tokens,
+                q_heads,
+                head_size,
+                device=device,
+                dtype=torch.float16,
+            )
+
+
+            key = torch.randn(
+                num_tokens,
+                kv_heads,
+                head_size,
+                device=device,
+                dtype=torch.float16,
+            )
+
+
+            cos = torch.randn(
+                num_tokens,
+                rotary_dim // 2,
+                device=device,
+                dtype=torch.float16,
+            )
+
+            sin = torch.randn(
+                num_tokens,
+                rotary_dim // 2,
+                device=device,
+                dtype=torch.float16,
+            )
+
+
+            cos_sin = torch.cat(
+                [
+                    cos,
+                    sin,
+                ],
+                dim=-1
+            )
+
+
+            # reference
+            q_ref, k_ref = forward_native(
+                query.clone(),
+                key.clone(),
+                cos_sin,
+                head_size,
+                rotary_dim,
+                is_neox_style,
+            )
+
+
+            # kernel
+            q_out, k_out = fused_rope_qk_mqa(
+                query.clone(),
+                key.clone(),
+                cos_sin,
+                rotary_dim,
+                is_neox_style,
+            )
+
+
+            torch.testing.assert_close(
+                q_out,
+                q_ref,
+            )
+
+
+            torch.testing.assert_close(
+                k_out,
+                k_ref,
+            )
+
+
+
+if __name__ == "__main__":
+    test_fused_rope_qk_mqa()
+
+

--- a/tests/python/sgl_kernel_npu/test_fused_rope_qk_mqa.py
+++ b/tests/python/sgl_kernel_npu/test_fused_rope_qk_mqa.py
@@ -1,6 +1,7 @@
 import torch
 from sgl_kernel_npu.norm.fused_rope_qk_mqa import fused_rope_qk_mqa
 
+
 def apply_rotary_emb(
     x: torch.Tensor,
     cos: torch.Tensor,
@@ -29,30 +30,29 @@ def apply_rotary_emb(
     else:
         return torch.stack((o1, o2), dim=-1).flatten(-2)
 
+
 def forward_native(
     query: torch.Tensor,
     key: torch.Tensor,
     cos_sin,
     head_size,
     rotary_dim,
-    is_neox_style
-    ):
+    is_neox_style,
+):
     num_tokens = query.shape[0]
     cos, sin = cos_sin.chunk(2, dim=-1)
     query_shape = query.shape
 
     query = query.view(num_tokens, -1, head_size)
-    query_rot = query[..., : rotary_dim]
-    query_pass = query[..., rotary_dim :]
-    query_rot = apply_rotary_emb(
-            query_rot, cos, sin, is_neox_style
-        )
+    query_rot = query[..., :rotary_dim]
+    query_pass = query[..., rotary_dim:]
+    query_rot = apply_rotary_emb(query_rot, cos, sin, is_neox_style)
     query = torch.cat((query_rot, query_pass), dim=-1).reshape(query_shape)
 
     key_shape = key.shape
     key = key.view(num_tokens, -1, head_size)
-    key_rot = key[..., : rotary_dim]
-    key_pass = key[..., rotary_dim :]
+    key_rot = key[..., :rotary_dim]
+    key_pass = key[..., rotary_dim:]
     key_rot = apply_rotary_emb(key_rot, cos, sin, is_neox_style)
     key = torch.cat((key_rot, key_pass), dim=-1).reshape(key_shape)
     return query, key
@@ -68,7 +68,6 @@ def test_fused_rope_qk_mqa():
         (64, 32, 1, 128, 64),
     ]
 
-
     for is_neox_style in [
         True,
         False,
@@ -82,7 +81,6 @@ def test_fused_rope_qk_mqa():
             rotary_dim,
         ) in test_cases:
 
-
             print(
                 f"test "
                 f"neox={is_neox_style}, "
@@ -92,7 +90,6 @@ def test_fused_rope_qk_mqa():
                 f"rotary={rotary_dim}"
             )
 
-
             query = torch.randn(
                 num_tokens,
                 q_heads,
@@ -101,7 +98,6 @@ def test_fused_rope_qk_mqa():
                 dtype=torch.float16,
             )
 
-
             key = torch.randn(
                 num_tokens,
                 kv_heads,
@@ -109,7 +105,6 @@ def test_fused_rope_qk_mqa():
                 device=device,
                 dtype=torch.float16,
             )
-
 
             cos = torch.randn(
                 num_tokens,
@@ -125,15 +120,13 @@ def test_fused_rope_qk_mqa():
                 dtype=torch.float16,
             )
 
-
             cos_sin = torch.cat(
                 [
                     cos,
                     sin,
                 ],
-                dim=-1
+                dim=-1,
             )
-
 
             # reference
             q_ref, k_ref = forward_native(
@@ -145,7 +138,6 @@ def test_fused_rope_qk_mqa():
                 is_neox_style,
             )
 
-
             # kernel
             q_out, k_out = fused_rope_qk_mqa(
                 query.clone(),
@@ -155,12 +147,10 @@ def test_fused_rope_qk_mqa():
                 is_neox_style,
             )
 
-
             torch.testing.assert_close(
                 q_out,
                 q_ref,
             )
-
 
             torch.testing.assert_close(
                 k_out,
@@ -168,8 +158,5 @@ def test_fused_rope_qk_mqa():
             )
 
 
-
 if __name__ == "__main__":
     test_fused_rope_qk_mqa()
-
-


### PR DESCRIPTION


test cast passed
```
python test_fused_rope_qk_mqa.py 
test neox=True, tokens=32, heads=8, head=64, rotary=32
/usr/local/python3.11.14/lib/python3.11/site-packages/sgl_kernel_npu/norm/fused_rope_qk_mqa.py:96: UserWarning: Cannot create tensor with interal format while allow_internel_format=False, tensor will be created with base format. (Triggered internally at build/CMakeFiles/torch_npu.dir/compiler_depend.ts:338.)
  out_q = torch.empty_like(query)
test neox=True, tokens=32, heads=8, head=32, rotary=32
test neox=True, tokens=17, heads=16, head=128, rotary=64
test neox=True, tokens=64, heads=32, head=128, rotary=64
test neox=False, tokens=32, heads=8, head=64, rotary=32
test neox=False, tokens=32, heads=8, head=32, rotary=32
test neox=False, tokens=17, heads=16, head=128, rotary=64
test neox=False, tokens=64, heads=32, head=128, rotary=64

```