### PR TITLE
ci: The MOE test cases use the A3 resources of the 752t, while other …

### DIFF
--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -288,7 +288,7 @@ jobs:
         github.event.pull_request.draft == false &&
         (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
       )
-    runs-on: linux-aarch64-a3-16
+    runs-on: ["linux-aarch64-a3-16", "752t"]
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
     env:
@@ -702,7 +702,7 @@ jobs:
         github.event.pull_request.draft == false &&
         (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
       )
-    runs-on: linux-aarch64-a3-16
+    runs-on: ["linux-aarch64-a3-16", "752t"]
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
     env:

--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -288,7 +288,7 @@ jobs:
         github.event.pull_request.draft == false &&
         (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
       )
-    runs-on: ["linux-aarch64-a3-16", "752t"]
+    runs-on: ["linux-aarch64-a3-16", "a3-752t"]
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
     env:
@@ -702,7 +702,7 @@ jobs:
         github.event.pull_request.draft == false &&
         (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
       )
-    runs-on: ["linux-aarch64-a3-16", "752t"]
+    runs-on: ["linux-aarch64-a3-16", "a3-752t"]
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
     env:


### PR DESCRIPTION
The current cluster resources are insufficient, and we plan to integrate another A3 cluster for high availability (HA).

There is an issue: the new A3 cluster cannot run MOE test cases, so the `runner` tag needs to be added.

MOE test cases use 752t A3 resources; other A3 test cases are shared with 560t resources.