### PR TITLE
[Typo] fix typo in shift_numel assertion message

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/norm/scale_shift.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/norm/scale_shift.py
@@ -148,7 +148,7 @@ def fused_scale_shift(
     ), f"Scale size must be 1 or {hidden_size}, got {scale_numel}"
     assert (
         shift_numel == 1 or shift_numel == hidden_size or shift_numel == x_numel
-    ), f"Scale size must be 1, {hidden_size} or {x_numel}, got {shift_numel}"
+    ), f"Shift size must be 1, {hidden_size} or {x_numel}, got {shift_numel}"
 
     output = torch.empty_like(x)
 


### PR DESCRIPTION
Fixes a copy-paste typo in the assertion error message for shift_numel. 
The original log erroneously printed ```Scale size must be ...``` instead of ```Shift size must be ...```.