### PR TITLE
Rename lowlatency

### DIFF
--- a/csrc/deepep/deep_ep.cpp
+++ b/csrc/deepep/deep_ep.cpp
@@ -893,7 +893,7 @@ Buffer::low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
         EP_HOST_ASSERT(isLayered == false);
         active_mask = (topk_idx >= 0).to(torch::kBool);
     }
-    EXEC_NPU_CMD(aclnnMoeDistributeDispatchV2,
+    EXEC_NPU_CMD(aclnnMoeLowLatencyDispatchV2,
                  x,                       // x
                  topk_idx,                // expertIds
                  scales,                  // scalesOptional
@@ -990,7 +990,7 @@ std::tuple<at::Tensor, std::optional<EventHandle>, std::optional<std::function<v
         EP_HOST_ASSERT(isLayered == false);
         x_active_mask = (expert_ids >= 0).to(torch::kBool);
     }
-    EXEC_NPU_CMD(aclnnMoeDistributeCombineV2, expand_x, expert_ids, expand_idx, ep_send_counts, expert_scales,
+    EXEC_NPU_CMD(aclnnMoeLowLatencyCombineV2, expand_x, expert_ids, expand_idx, ep_send_counts, expert_scales,
                  tp_send_counts, x_active_mask, activation_scale, weight_scale, group_list, expand_scales,
                  shared_expert_x, hcom_ep_name, num_ranks, rank, num_experts, hcom_tp_name, tp_world_size, tp_rankId,
                  expert_shared_type, shared_expert_num, shared_expert_rank_num, global_bs, out_dtype, comm_quant_mode,

--- a/csrc/deepep/ops/op_host/moe_distribute_combine_v2_def.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_combine_v2_def.cpp
@@ -1,10 +1,10 @@
 #include "register/op_def_registry.h"
 
 namespace ops {
-class MoeDistributeCombineV2 : public OpDef
+class MoeLowLatencyCombineV2 : public OpDef
 {
 public:
-    explicit MoeDistributeCombineV2(const char *name) : OpDef(name)
+    explicit MoeLowLatencyCombineV2(const char *name) : OpDef(name)
     {
         this->Input("expand_x")
             .ParamType(REQUIRED)
@@ -159,6 +159,6 @@ public:
     }
 };
 
-OP_ADD(MoeDistributeCombineV2);
+OP_ADD(MoeLowLatencyCombineV2);
 
 }  // namespace ops

--- a/csrc/deepep/ops/op_host/moe_distribute_combine_v2_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_combine_v2_tiling.cpp
@@ -1259,7 +1259,7 @@ ge::graphStatus TilingParseForMoeDistributeCombineV2(gert::TilingParseContext *c
     return ge::GRAPH_SUCCESS;
 }
 
-IMPL_OP_OPTILING(MoeDistributeCombineV2)
+IMPL_OP_OPTILING(MoeLowLatencyCombineV2)
     .Tiling(MoeDistributeCombineV2TilingFunc)
     .TilingParse<MoeDistributeCombineCompileInfo>(TilingParseForMoeDistributeCombineV2);
 }  // namespace optiling

--- a/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_def.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_def.cpp
@@ -1,10 +1,10 @@
 #include "register/op_def_registry.h"
 
 namespace ops {
-class MoeDistributeDispatchV2 : public OpDef
+class MoeLowLatencyDispatchV2 : public OpDef
 {
 public:
-    explicit MoeDistributeDispatchV2(const char *name) : OpDef(name)
+    explicit MoeLowLatencyDispatchV2(const char *name) : OpDef(name)
     {
         this->Input("x")
             .ParamType(REQUIRED)
@@ -88,6 +88,6 @@ public:
     }
 };
 
-OP_ADD(MoeDistributeDispatchV2);
+OP_ADD(MoeLowLatencyDispatchV2);
 
 }  // namespace ops

--- a/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
@@ -1367,7 +1367,7 @@ static ge::graphStatus TilingParseForMoeDistributeDispatchV2(gert::TilingParseCo
     return ge::GRAPH_SUCCESS;
 }
 
-IMPL_OP_OPTILING(MoeDistributeDispatchV2)
+IMPL_OP_OPTILING(MoeLowLatencyDispatchV2)
     .Tiling(MoeDistributeDispatchV2TilingFunc)
     .TilingParse<MoeDistributeDispatchCompileInfo>(TilingParseForMoeDistributeDispatchV2);
 }  // namespace optiling

--- a/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_combine_v2.cpp
+++ b/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_combine_v2.cpp
@@ -1,5 +1,5 @@
 #include "aclnn_moe_distribute_combine_v2.h"
-#include "aclnnInner_moe_distribute_combine_v2.h"
+#include "aclnnInner_moe_low_latency_combine_v2.h"
 #include <algorithm>
 #include "graph/types.h"
 #include <cstring>
@@ -15,7 +15,7 @@ enum NnopbaseHcclServerType {
     NNOPBASE_HCCL_SERVER_TYPE_END
 };
 
-extern aclnnStatus aclnnInnerMoeDistributeCombineV2GetWorkspaceSize(
+extern aclnnStatus aclnnInnerMoeLowLatencyCombineV2GetWorkspaceSize(
     const aclTensor *expandX, const aclTensor *expertIds, const aclTensor *assistInfoForCombine,
     const aclTensor *epSendCounts, const aclTensor *expertScales, const aclTensor *tpSendCounts,
     const aclTensor *xActiveMask, const aclTensor *activationScale, const aclTensor *weightScale,
@@ -28,12 +28,12 @@ extern aclnnStatus aclnnInnerMoeDistributeCombineV2GetWorkspaceSize(
     int64_t constExpertNum, const aclTensor *x, const aclTensor *sendCostStats, uint64_t *workspaceSize,
     aclOpExecutor **executor);
 
-extern aclnnStatus aclnnInnerMoeDistributeCombineV2(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,
+extern aclnnStatus aclnnInnerMoeLowLatencyCombineV2(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,
                                                     aclrtStream stream);
 
 extern "C" void __attribute__((weak)) NnopbaseSetHcclServerType(void *executor, NnopbaseHcclServerType sType);
 
-aclnnStatus aclnnMoeDistributeCombineV2GetWorkspaceSize(
+aclnnStatus aclnnMoeLowLatencyCombineV2GetWorkspaceSize(
     const aclTensor *expandX, const aclTensor *expertIds, const aclTensor *assistInfoForCombine,
     const aclTensor *epSendCounts, const aclTensor *expertScales, const aclTensor *tpSendCountsOptional,
     const aclTensor *xActiveMaskOptional, const aclTensor *activationScaleOptional,
@@ -44,7 +44,7 @@ aclnnStatus aclnnMoeDistributeCombineV2GetWorkspaceSize(
     char *commAlg, const aclTensor *xOut, const aclTensor *sendCostStats, uint64_t *workspaceSize,
     aclOpExecutor **executor)
 {
-    aclnnStatus getWorkspaceSizesRes = aclnnInnerMoeDistributeCombineV2GetWorkspaceSize(
+    aclnnStatus getWorkspaceSizesRes = aclnnInnerMoeLowLatencyCombineV2GetWorkspaceSize(
         expandX, expertIds, assistInfoForCombine, epSendCounts, expertScales, tpSendCountsOptional, xActiveMaskOptional,
         activationScaleOptional, weightScaleOptional, groupListOptional, expandScalesOptional, sharedExpertXOptional,
         nullptr, nullptr, nullptr, nullptr, nullptr, groupEp, epWorldSize, epRankId, moeExpertNum, groupTp, tpWorldSize,
@@ -65,10 +65,10 @@ aclnnStatus aclnnMoeDistributeCombineV2GetWorkspaceSize(
     return getWorkspaceSizesRes;
 }
 
-aclnnStatus aclnnMoeDistributeCombineV2(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,
+aclnnStatus aclnnMoeLowLatencyCombineV2(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,
                                         aclrtStream stream)
 {
-    return aclnnInnerMoeDistributeCombineV2(workspace, workspaceSize, executor, stream);
+    return aclnnInnerMoeLowLatencyCombineV2(workspace, workspaceSize, executor, stream);
 }
 
 #ifdef __cplusplus

--- a/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_combine_v2.h
+++ b/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_combine_v2.h
@@ -50,7 +50,7 @@ extern "C" {
  * @return aclnnStatus: 返回值，返回状态码
  *
  */
-__attribute__((visibility("default"))) aclnnStatus aclnnMoeDistributeCombineV2GetWorkspaceSize(
+__attribute__((visibility("default"))) aclnnStatus aclnnMoeLowLatencyCombineV2GetWorkspaceSize(
     const aclTensor *expandX, const aclTensor *expertIds, const aclTensor *assistInfoForCombine,
     const aclTensor *epSendCounts, const aclTensor *expertScales, const aclTensor *tpSendCountsOptional,
     const aclTensor *xActiveMaskOptional, const aclTensor *activationScaleOptional,
@@ -70,7 +70,7 @@ __attribute__((visibility("default"))) aclnnStatus aclnnMoeDistributeCombineV2Ge
  * @param [in] stream: acl stream流。
  * @return aclnnStatus: 返回状态码
  */
-__attribute__((visibility("default"))) aclnnStatus aclnnMoeDistributeCombineV2(void *workspace, uint64_t workspaceSize,
+__attribute__((visibility("default"))) aclnnStatus aclnnMoeLowLatencyCombineV2(void *workspace, uint64_t workspaceSize,
                                                                                aclOpExecutor *executor,
                                                                                aclrtStream stream);
 

--- a/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_dispatch_v2.cpp
+++ b/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_dispatch_v2.cpp
@@ -1,5 +1,5 @@
 #include "aclnn_moe_distribute_dispatch_v2.h"
-#include "aclnnInner_moe_distribute_dispatch_v2.h"
+#include "aclnnInner_moe_low_latency_dispatch_v2.h"
 #include <algorithm>
 #include "graph/types.h"
 #include <cstring>
@@ -16,7 +16,7 @@ enum NnopbaseHcclServerType {
     NNOPBASE_HCCL_SERVER_TYPE_END
 };
 
-extern aclnnStatus aclnnInnerMoeDistributeDispatchV2GetWorkspaceSize(
+extern aclnnStatus aclnnInnerMoeLowLatencyDispatchV2GetWorkspaceSize(
     const aclTensor *x, const aclTensor *expertIds, const aclTensor *scales, const aclTensor *xActiveMask,
     const aclTensor *elasticInfo, char *groupEp, int64_t epWorldSize, int64_t epRankId, int64_t moeExpertNum,
     char *groupTp, int64_t tpWorldSize, int64_t tpRankId, int64_t expertShardType, int64_t sharedExpertNum,
@@ -24,12 +24,12 @@ extern aclnnStatus aclnnInnerMoeDistributeDispatchV2GetWorkspaceSize(
     int64_t zeroExpertNum, int64_t copyExpertNum, int64_t constExpertNum, const aclTensor *expandX,
     const aclTensor *dynamicScales, const aclTensor *assist_info_for_combine, const aclTensor *expertTokensNums,
     const aclTensor *epRecvCounts, const aclTensor *tpRecvCounts, uint64_t *workspaceSize, aclOpExecutor **executor);
-extern aclnnStatus aclnnInnerMoeDistributeDispatchV2(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,
+extern aclnnStatus aclnnInnerMoeLowLatencyDispatchV2(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,
                                                      aclrtStream stream);
 
 extern "C" void __attribute__((weak)) NnopbaseSetHcclServerType(void *executor, NnopbaseHcclServerType sType);
 
-aclnnStatus aclnnMoeDistributeDispatchV2GetWorkspaceSize(
+aclnnStatus aclnnMoeLowLatencyDispatchV2GetWorkspaceSize(
     const aclTensor *x, const aclTensor *expertIds, const aclTensor *scalesOptional,
     const aclTensor *xActiveMaskOptional, char *groupEp, int64_t epWorldSize, int64_t epRankId, int64_t moeExpertNum,
     char *groupTp, int64_t tpWorldSize, int64_t tpRankId, int64_t expertShardType, int64_t sharedExpertNum,
@@ -38,7 +38,7 @@ aclnnStatus aclnnMoeDistributeDispatchV2GetWorkspaceSize(
     const aclTensor *expertTokenNumsOut, const aclTensor *epRecvCountsOut, const aclTensor *tpRecvCountsOut,
     uint64_t *workspaceSize, aclOpExecutor **executor)
 {
-    aclnnStatus getWorkspaceSizesRes = aclnnInnerMoeDistributeDispatchV2GetWorkspaceSize(
+    aclnnStatus getWorkspaceSizesRes = aclnnInnerMoeLowLatencyDispatchV2GetWorkspaceSize(
         x, expertIds, scalesOptional, xActiveMaskOptional, nullptr, groupEp, epWorldSize, epRankId, moeExpertNum,
         groupTp, tpWorldSize, tpRankId, expertShardType, sharedExpertNum, sharedExpertRankNum, quantMode, globalBs,
         expertTokenNumsType, commAlg, 0, 0, 0, expandXOut, dynamicScalesOut, assistInfoForCombineOut,
@@ -53,10 +53,10 @@ aclnnStatus aclnnMoeDistributeDispatchV2GetWorkspaceSize(
     return getWorkspaceSizesRes;
 }
 
-aclnnStatus aclnnMoeDistributeDispatchV2(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,
+aclnnStatus aclnnMoeLowLatencyDispatchV2(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,
                                          aclrtStream stream)
 {
-    return aclnnInnerMoeDistributeDispatchV2(workspace, workspaceSize, executor, stream);
+    return aclnnInnerMoeLowLatencyDispatchV2(workspace, workspaceSize, executor, stream);
 }
 #ifdef __cplusplus
 }

--- a/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_dispatch_v2.h
+++ b/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_dispatch_v2.h
@@ -48,7 +48,7 @@ extern "C" {
  * @return aclnnStatus: 返回值，返回状态码
  *
  */
-__attribute__((visibility("default"))) aclnnStatus aclnnMoeDistributeDispatchV2GetWorkspaceSize(
+__attribute__((visibility("default"))) aclnnStatus aclnnMoeLowLatencyDispatchV2GetWorkspaceSize(
     const aclTensor *x, const aclTensor *expertIds, const aclTensor *scalesOptional,
     const aclTensor *xActiveMaskOptional, char *groupEp, int64_t epWorldSize, int64_t epRankId, int64_t moeExpertNum,
     char *groupTp, int64_t tpWorldSize, int64_t tpRankId, int64_t expertShardType, int64_t sharedExpertNum,
@@ -66,7 +66,7 @@ __attribute__((visibility("default"))) aclnnStatus aclnnMoeDistributeDispatchV2G
  * @param [in] stream: acl stream流。
  * @return aclnnStatus: 返回状态码
  */
-__attribute__((visibility("default"))) aclnnStatus aclnnMoeDistributeDispatchV2(void *workspace, uint64_t workspaceSize,
+__attribute__((visibility("default"))) aclnnStatus aclnnMoeLowLatencyDispatchV2(void *workspace, uint64_t workspaceSize,
                                                                                 aclOpExecutor *executor,
                                                                                 aclrtStream stream);
 

--- a/csrc/deepep/ops/op_kernel/moe_low_latency_combine_v2.cpp
+++ b/csrc/deepep/ops/op_kernel/moe_low_latency_combine_v2.cpp
@@ -42,7 +42,7 @@ __aicore__ inline void ExecMoeDistributeCombineV2(GM_ADDR expandX, GM_ADDR exper
  *     20000: A2, 30000: A3, 50000: A5
  */
 
-extern "C" __global__ __aicore__ void moe_distribute_combine_v2(
+extern "C" __global__ __aicore__ void moe_low_latency_combine_v2(
     GM_ADDR expandX, GM_ADDR expertIds, GM_ADDR assistInfoForCombine, GM_ADDR epSendCount, GM_ADDR scales,
     GM_ADDR tpSendCount, GM_ADDR xActiveMask, GM_ADDR activationScale, GM_ADDR weightScale, GM_ADDR groupList,
     GM_ADDR expandScales, GM_ADDR sharedExpertX, GM_ADDR elasticInfo, GM_ADDR oriX, GM_ADDR constExpertAlpha1,

--- a/csrc/deepep/ops/op_kernel/moe_low_latency_dispatch_v2.cpp
+++ b/csrc/deepep/ops/op_kernel/moe_low_latency_dispatch_v2.cpp
@@ -27,7 +27,7 @@ using namespace MoeDistributeDispatchV2A5Impl;
  *     20000: A2, 30000: A3, 50000: A5
  */
 
-extern "C" __global__ __aicore__ void moe_distribute_dispatch_v2(GM_ADDR x, GM_ADDR expertIds, GM_ADDR scales,
+extern "C" __global__ __aicore__ void moe_low_latency_dispatch_v2(GM_ADDR x, GM_ADDR expertIds, GM_ADDR scales,
                                                                  GM_ADDR xActiveMask, GM_ADDR elasticInfo,
                                                                  GM_ADDR expandXOut, GM_ADDR dynamicScalesOut,
                                                                  GM_ADDR assistInfoOut, GM_ADDR expertTokenNumsOut,

--- a/csrc/deepep/ops/op_kernel/moe_low_latency_dispatch_v2.cpp
+++ b/csrc/deepep/ops/op_kernel/moe_low_latency_dispatch_v2.cpp
@@ -28,11 +28,11 @@ using namespace MoeDistributeDispatchV2A5Impl;
  */
 
 extern "C" __global__ __aicore__ void moe_low_latency_dispatch_v2(GM_ADDR x, GM_ADDR expertIds, GM_ADDR scales,
-                                                                 GM_ADDR xActiveMask, GM_ADDR elasticInfo,
-                                                                 GM_ADDR expandXOut, GM_ADDR dynamicScalesOut,
-                                                                 GM_ADDR assistInfoOut, GM_ADDR expertTokenNumsOut,
-                                                                 GM_ADDR epSendCountsOut, GM_ADDR tpSendCountsOut,
-                                                                 GM_ADDR workspaceGM, GM_ADDR tilingGM)
+                                                                  GM_ADDR xActiveMask, GM_ADDR elasticInfo,
+                                                                  GM_ADDR expandXOut, GM_ADDR dynamicScalesOut,
+                                                                  GM_ADDR assistInfoOut, GM_ADDR expertTokenNumsOut,
+                                                                  GM_ADDR epSendCountsOut, GM_ADDR tpSendCountsOut,
+                                                                  GM_ADDR workspaceGM, GM_ADDR tilingGM)
 {
     REGISTER_TILING_DEFAULT(MoeDistributeDispatchV2TilingData);
     TPipe pipe;

--- a/csrc/deepep/ops2/op_host/moe_distribute_combine_v2.cpp
+++ b/csrc/deepep/ops2/op_host/moe_distribute_combine_v2.cpp
@@ -22,10 +22,10 @@
 #include "register/op_def_registry.h"
 
 namespace ops {
-class MoeDistributeCombineV2 : public OpDef
+class MoeLowLatencyCombineV2 : public OpDef
 {
 public:
-    explicit MoeDistributeCombineV2(const char *name) : OpDef(name)
+    explicit MoeLowLatencyCombineV2(const char *name) : OpDef(name)
     {
         this->Input("expand_x")
             .ParamType(REQUIRED)
@@ -177,6 +177,6 @@ public:
     }
 };
 
-OP_ADD(MoeDistributeCombineV2);
+OP_ADD(MoeLowLatencyCombineV2);
 
 }  // namespace ops

--- a/csrc/deepep/ops2/op_host/moe_distribute_combine_v2_tiling.cc
+++ b/csrc/deepep/ops2/op_host/moe_distribute_combine_v2_tiling.cc
@@ -1440,7 +1440,7 @@ ge::graphStatus TilingParseForMoeDistributeCombineV2(gert::TilingParseContext *c
     return ge::GRAPH_SUCCESS;
 }
 
-IMPL_OP_OPTILING(MoeDistributeCombineV2)
+IMPL_OP_OPTILING(MoeLowLatencyCombineV2)
     .Tiling(MoeDistributeCombineV2TilingFunc)
     .TilingParse<MoeDistributeCombineCompileInfo>(TilingParseForMoeDistributeCombineV2);
 }  // namespace optiling

--- a/csrc/deepep/ops2/op_host/moe_distribute_dispatch_v2.cpp
+++ b/csrc/deepep/ops2/op_host/moe_distribute_dispatch_v2.cpp
@@ -22,10 +22,10 @@
 #include "register/op_def_registry.h"
 
 namespace ops {
-class MoeDistributeDispatchV2 : public OpDef
+class MoeLowLatencyDispatchV2 : public OpDef
 {
 public:
-    explicit MoeDistributeDispatchV2(const char *name) : OpDef(name)
+    explicit MoeLowLatencyDispatchV2(const char *name) : OpDef(name)
     {
         this->Input("x")
             .ParamType(REQUIRED)
@@ -124,6 +124,6 @@ public:
     }
 };
 
-OP_ADD(MoeDistributeDispatchV2);
+OP_ADD(MoeLowLatencyDispatchV2);
 
 }  // namespace ops

--- a/csrc/deepep/ops2/op_host/moe_distribute_dispatch_v2_tiling.cc
+++ b/csrc/deepep/ops2/op_host/moe_distribute_dispatch_v2_tiling.cc
@@ -1360,7 +1360,7 @@ ge::graphStatus TilingParseForMoeDistributeDispatchV2(gert::TilingParseContext *
     return ge::GRAPH_SUCCESS;
 }
 
-IMPL_OP_OPTILING(MoeDistributeDispatchV2)
+IMPL_OP_OPTILING(MoeLowLatencyDispatchV2)
     .Tiling(MoeDistributeDispatchV2TilingFunc)
     .TilingParse<MoeDistributeDispatchCompileInfo>(TilingParseForMoeDistributeDispatchV2);
 }  // namespace optiling

--- a/csrc/deepep/ops2/op_host/op_api/aclnn_moe_distribute_combine_v2.cpp
+++ b/csrc/deepep/ops2/op_host/op_api/aclnn_moe_distribute_combine_v2.cpp
@@ -17,7 +17,7 @@
 #include <cstdio>
 
 #include "aclnn_moe_distribute_combine_v2.h"
-#include "aclnnInner_moe_distribute_combine_v2.h"
+#include "aclnnInner_moe_low_latency_combine_v2.h"
 #include "graph/types.h"
 #include "aclnn/opdev/platform.h"
 
@@ -33,7 +33,7 @@ enum NnopbaseHcclServerType {
 
 extern "C" void __attribute__((weak)) NnopbaseSetHcclServerType(void *executor, NnopbaseHcclServerType sType);
 
-aclnnStatus aclnnMoeDistributeCombineV2GetWorkspaceSize(
+aclnnStatus aclnnMoeLowLatencyCombineV2GetWorkspaceSize(
     const aclTensor *expandX, const aclTensor *expertIds, const aclTensor *assistInfoForCombine,
     const aclTensor *epSendCounts, const aclTensor *expertScales, const aclTensor *tpSendCountsOptional,
     const aclTensor *xActiveMaskOptional, const aclTensor *activationScaleOptional,
@@ -51,7 +51,7 @@ aclnnStatus aclnnMoeDistributeCombineV2GetWorkspaceSize(
         groupListType, commAlg, 0, 0, 0, xOut, sendCostStats, workspaceSize, executor);
 }
 
-aclnnStatus aclnnMoeDistributeCombineV2(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,
+aclnnStatus aclnnMoeLowLatencyCombineV2(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,
                                         aclrtStream stream)
 {
     if (NnopbaseSetHcclServerType) {
@@ -62,7 +62,7 @@ aclnnStatus aclnnMoeDistributeCombineV2(void *workspace, uint64_t workspaceSize,
         }
     }
 
-    return aclnnInnerMoeDistributeCombineV2(workspace, workspaceSize, executor, stream);
+    return aclnnInnerMoeLowLatencyCombineV2(workspace, workspaceSize, executor, stream);
 }
 
 #ifdef __cplusplus

--- a/csrc/deepep/ops2/op_host/op_api/aclnn_moe_distribute_combine_v2.cpp
+++ b/csrc/deepep/ops2/op_host/op_api/aclnn_moe_distribute_combine_v2.cpp
@@ -43,7 +43,7 @@ aclnnStatus aclnnMoeLowLatencyCombineV2GetWorkspaceSize(
     int64_t sharedExpertRankNum, int64_t globalBs, int64_t outDtype, int64_t commQuantMode, int64_t groupListType,
     char *commAlg, aclTensor *xOut, const aclTensor *sendCostStats, uint64_t *workspaceSize, aclOpExecutor **executor)
 {
-    return aclnnInnerMoeDistributeCombineV2GetWorkspaceSize(
+    return aclnnInnerMoeLowLatencyCombineV2GetWorkspaceSize(
         expandX, expertIds, assistInfoForCombine, epSendCounts, expertScales, tpSendCountsOptional, xActiveMaskOptional,
         activationScaleOptional, weightScaleOptional, groupListOptional, expandScalesOptional, sharedExpertXOptional,
         nullptr, nullptr, nullptr, nullptr, nullptr, groupEp, epWorldSize, epRankId, moeExpertNum, groupTp, tpWorldSize,

--- a/csrc/deepep/ops2/op_host/op_api/aclnn_moe_distribute_combine_v2.h
+++ b/csrc/deepep/ops2/op_host/op_api/aclnn_moe_distribute_combine_v2.h
@@ -65,7 +65,7 @@ extern "C" {
  * @return aclnnStatus: 返回值，返回状态码
  *
  */
-__attribute__((visibility("default"))) aclnnStatus aclnnMoeDistributeCombineV2GetWorkspaceSize(
+__attribute__((visibility("default"))) aclnnStatus aclnnMoeLowLatencyCombineV2GetWorkspaceSize(
     const aclTensor *expandX, const aclTensor *expertIds, const aclTensor *assistInfoForCombine,
     const aclTensor *epSendCounts, const aclTensor *expertScales, const aclTensor *tpSendCountsOptional,
     const aclTensor *xActiveMaskOptional, const aclTensor *activationScaleOptional,
@@ -84,7 +84,7 @@ __attribute__((visibility("default"))) aclnnStatus aclnnMoeDistributeCombineV2Ge
  * @param [in] stream: acl stream流。
  * @return aclnnStatus: 返回状态码
  */
-__attribute__((visibility("default"))) aclnnStatus aclnnMoeDistributeCombineV2(void *workspace, uint64_t workspaceSize,
+__attribute__((visibility("default"))) aclnnStatus aclnnMoeLowLatencyCombineV2(void *workspace, uint64_t workspaceSize,
                                                                                aclOpExecutor *executor,
                                                                                aclrtStream stream);
 

--- a/csrc/deepep/ops2/op_host/op_api/aclnn_moe_distribute_dispatch_v2.cpp
+++ b/csrc/deepep/ops2/op_host/op_api/aclnn_moe_distribute_dispatch_v2.cpp
@@ -17,7 +17,7 @@
 #include <cstdio>
 
 #include "aclnn_moe_distribute_dispatch_v2.h"
-#include "aclnnInner_moe_distribute_dispatch_v2.h"
+#include "aclnnInner_moe_low_latency_dispatch_v2.h"
 #include "aclnn/opdev/platform.h"
 
 #ifdef __cplusplus
@@ -33,7 +33,7 @@ enum NnopbaseHcclServerType {
 
 extern "C" void __attribute__((weak)) NnopbaseSetHcclServerType(void *executor, NnopbaseHcclServerType sType);
 
-aclnnStatus aclnnMoeDistributeDispatchV2GetWorkspaceSize(
+aclnnStatus aclnnMoeLowLatencyDispatchV2GetWorkspaceSize(
     const aclTensor *x, const aclTensor *expertIds, const aclTensor *scalesOptional,
     const aclTensor *xActiveMaskOptional, char *groupEp, int64_t epWorldSize, int64_t epRankId, int64_t moeExpertNum,
     char *groupTp, int64_t tpWorldSize, int64_t tpRankId, int64_t expertShardType, int64_t sharedExpertNum,
@@ -42,14 +42,14 @@ aclnnStatus aclnnMoeDistributeDispatchV2GetWorkspaceSize(
     aclTensor *expertTokenNumsOut, aclTensor *epRecvCountsOut, aclTensor *tpRecvCountsOut, uint64_t *workspaceSize,
     aclOpExecutor **executor)
 {
-    return aclnnInnerMoeDistributeDispatchV2GetWorkspaceSize(
+    return aclnnInnerMoeLowLatencyDispatchV2GetWorkspaceSize(
         x, expertIds, scalesOptional, xActiveMaskOptional, nullptr, groupEp, epWorldSize, epRankId, moeExpertNum, "",
         tpWorldSize, tpRankId, expertShardType, sharedExpertNum, sharedExpertRankNum, quantMode, globalBs,
         expertTokenNumsType, commAlg, 0, 0, 0, expandXOut, dynamicScalesOut, assistInfoForCombineOut,
         expertTokenNumsOut, epRecvCountsOut, tpRecvCountsOut, workspaceSize, executor);
 }
 
-aclnnStatus aclnnMoeDistributeDispatchV2(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,
+aclnnStatus aclnnMoeLowLatencyDispatchV2(void *workspace, uint64_t workspaceSize, aclOpExecutor *executor,
                                          aclrtStream stream)
 {
     if (NnopbaseSetHcclServerType) {
@@ -60,7 +60,7 @@ aclnnStatus aclnnMoeDistributeDispatchV2(void *workspace, uint64_t workspaceSize
         }
     }
 
-    return aclnnInnerMoeDistributeDispatchV2(workspace, workspaceSize, executor, stream);
+    return aclnnInnerMoeLowLatencyDispatchV2(workspace, workspaceSize, executor, stream);
 }
 #ifdef __cplusplus
 }

--- a/csrc/deepep/ops2/op_host/op_api/aclnn_moe_distribute_dispatch_v2.h
+++ b/csrc/deepep/ops2/op_host/op_api/aclnn_moe_distribute_dispatch_v2.h
@@ -63,7 +63,7 @@ extern "C" {
  * @return aclnnStatus: 返回值，返回状态码
  *
  */
-__attribute__((visibility("default"))) aclnnStatus aclnnMoeDistributeDispatchV2GetWorkspaceSize(
+__attribute__((visibility("default"))) aclnnStatus aclnnMoeLowLatencyDispatchV2GetWorkspaceSize(
     const aclTensor *x, const aclTensor *expertIds, const aclTensor *scalesOptional,
     const aclTensor *xActiveMaskOptional, char *groupEp, int64_t epWorldSize, int64_t epRankId, int64_t moeExpertNum,
     char *groupTp, int64_t tpWorldSize, int64_t tpRankId, int64_t expertShardType, int64_t sharedExpertNum,
@@ -81,7 +81,7 @@ __attribute__((visibility("default"))) aclnnStatus aclnnMoeDistributeDispatchV2G
  * @param [in] stream: acl stream流。
  * @return aclnnStatus: 返回状态码
  */
-__attribute__((visibility("default"))) aclnnStatus aclnnMoeDistributeDispatchV2(void *workspace, uint64_t workspaceSize,
+__attribute__((visibility("default"))) aclnnStatus aclnnMoeLowLatencyDispatchV2(void *workspace, uint64_t workspaceSize,
                                                                                 aclOpExecutor *executor,
                                                                                 aclrtStream stream);
 

--- a/csrc/deepep/ops2/op_kernel/moe_low_latency_combine_v2.cpp
+++ b/csrc/deepep/ops2/op_kernel/moe_low_latency_combine_v2.cpp
@@ -34,7 +34,7 @@ using namespace MoeDistributeCombineA2Impl;
  3000  A2+layered
   100  quant
 */
-extern "C" __global__ __aicore__ void moe_distribute_combine_v2(
+extern "C" __global__ __aicore__ void moe_low_latency_combine_v2(
     GM_ADDR expandX, GM_ADDR expertIds, GM_ADDR assistInfoForCombine, GM_ADDR epSendCount, GM_ADDR scales,
     GM_ADDR tpSendCount, GM_ADDR xActiveMask, GM_ADDR activationScale, GM_ADDR weightScale, GM_ADDR groupList,
     GM_ADDR expandScales, GM_ADDR sharedExpertX, GM_ADDR elasticInfo, GM_ADDR oriX, GM_ADDR constExpertAlpha1,

--- a/csrc/deepep/ops2/op_kernel/moe_low_latency_dispatch_v2.cpp
+++ b/csrc/deepep/ops2/op_kernel/moe_low_latency_dispatch_v2.cpp
@@ -35,7 +35,7 @@ using namespace MoeDistributeDispatchA2Impl;
          10  isScales
           2  quantMode
 */
-extern "C" __global__ __aicore__ void moe_distribute_dispatch_v2(GM_ADDR x, GM_ADDR expertIds, GM_ADDR scales,
+extern "C" __global__ __aicore__ void moe_low_latency_dispatch_v2(GM_ADDR x, GM_ADDR expertIds, GM_ADDR scales,
                                                                  GM_ADDR xActiveMask, GM_ADDR elasticInfo,
                                                                  GM_ADDR expandXOut, GM_ADDR dynamicScalesOut,
                                                                  GM_ADDR assistInfoOut, GM_ADDR expertTokenNumsOut,

--- a/csrc/deepep/ops2/op_kernel/moe_low_latency_dispatch_v2.cpp
+++ b/csrc/deepep/ops2/op_kernel/moe_low_latency_dispatch_v2.cpp
@@ -36,11 +36,11 @@ using namespace MoeDistributeDispatchA2Impl;
           2  quantMode
 */
 extern "C" __global__ __aicore__ void moe_low_latency_dispatch_v2(GM_ADDR x, GM_ADDR expertIds, GM_ADDR scales,
-                                                                 GM_ADDR xActiveMask, GM_ADDR elasticInfo,
-                                                                 GM_ADDR expandXOut, GM_ADDR dynamicScalesOut,
-                                                                 GM_ADDR assistInfoOut, GM_ADDR expertTokenNumsOut,
-                                                                 GM_ADDR epSendCountsOut, GM_ADDR tpSendCountsOut,
-                                                                 GM_ADDR workspaceGM, GM_ADDR tilingGM)
+                                                                  GM_ADDR xActiveMask, GM_ADDR elasticInfo,
+                                                                  GM_ADDR expandXOut, GM_ADDR dynamicScalesOut,
+                                                                  GM_ADDR assistInfoOut, GM_ADDR expertTokenNumsOut,
+                                                                  GM_ADDR epSendCountsOut, GM_ADDR tpSendCountsOut,
+                                                                  GM_ADDR workspaceGM, GM_ADDR tilingGM)
 {
     REGISTER_TILING_DEFAULT(MoeDistributeDispatchV2TilingData);
     REGISTER_TILING_FOR_TILINGKEY("TILING_KEY_VAR >= 2000000000", MoeDistributeDispatchV2TilingData);

--- a/tests/python/deepep/test_dispatch_ffn_combine.py
+++ b/tests/python/deepep/test_dispatch_ffn_combine.py
@@ -475,10 +475,10 @@ def test(
         lambda: baseline_test(**baseline_args),
         (
             "aclnnInplaceOne_OnesLikeAiCore_OnesLike",
-            "MoeDistributeDispatchV2",
+            "MoeLowLatencyDispatchV2",
             "aclnnGroupedMatmulWeightNz_GroupedMatmul_GroupedMatmul",
             "DequantSwigluQuant",
-            "MoeDistributeCombineV2",
+            "MoeLowLatencyCombineV2",
         ),
         barrier_comm_profiling=True,
     )

--- a/tests/python/deepep/test_fused_deep_moe.py
+++ b/tests/python/deepep/test_fused_deep_moe.py
@@ -553,10 +553,10 @@ def test(
         lambda: baseline_test(**baseline_args),
         (
             "aclnnInplaceOne_OnesLikeAiCore_OnesLike",
-            "MoeDistributeDispatchV2",
+            "MoeLowLatencyDispatchV2",
             "aclnnGroupedMatmulWeightNz_GroupedMatmul_GroupedMatmul",
             "DequantSwigluQuant",
-            "MoeDistributeCombineV2",
+            "MoeLowLatencyCombineV2",
         ),
         barrier_comm_profiling=True,
     )

--- a/tests/python/deepep/test_low_latency.py
+++ b/tests/python/deepep/test_low_latency.py
@@ -314,7 +314,7 @@ def test(
         dist.barrier()
         dispatch_t, combine_t = bench_kineto(
             partial(test_func, zero_copy=False, return_recv_hook=return_recv_hook),
-            kernel_names=("MoeDistributeDispatchV2", "MoeDistributeCombineV2"),
+            kernel_names=("MoeLowLatencyDispatchV2", "MoeLowLatencyCombineV2"),
             barrier_comm_profiling=True,
             suppress_kineto_output=True,
             num_kernels_per_period=2 if return_recv_hook else 1,


### PR DESCRIPTION
Modify the v2 operator names in deepep to avoid conflicts with the dispatch and combine operators provided in the cann native ops-teansform repository.