### PR TITLE
Add sigmoid activation support to the NPU layernorm gated kernel

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/layernorm_gated.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/layernorm_gated.py
@@ -171,6 +171,7 @@ def _layer_norm_fwd_1pass_kernel_npu(
     HAS_Z: tl.constexpr,
     NORM_BEFORE_GATE: tl.constexpr,
     IS_RMS_NORM: tl.constexpr,
+    ACTIVATION: tl.constexpr,
 ):
     # Map the program id to the row of X and Y it should compute.
     pid_m = tl.program_id(0)
@@ -205,7 +206,10 @@ def _layer_norm_fwd_1pass_kernel_npu(
                 tl.float32
             )
             if not NORM_BEFORE_GATE:
-                x *= z * tl.sigmoid(z)
+                if ACTIVATION == "sigmoid":
+                    x *= tl.sigmoid(z)
+                else:
+                    x *= z * tl.sigmoid(z)
 
         # Compute statistics per row
         if not IS_RMS_NORM:
@@ -232,7 +236,10 @@ def _layer_norm_fwd_1pass_kernel_npu(
 
         # Post-gate
         if HAS_Z and NORM_BEFORE_GATE:
-            y *= z * tl.sigmoid(z)
+            if ACTIVATION == "sigmoid":
+                y *= tl.sigmoid(z)
+            else:
+                y *= z * tl.sigmoid(z)
 
         # Store output
         y_ptrs = Y + rows[:, None] * stride_y_row + cols[None, :] + group * N
@@ -284,8 +291,10 @@ def layer_norm_fwd_npu(
     if group_size > BLOCK_N:
         raise RuntimeError("Feature dim too large.")
 
-    # Choose BLOCK_M: e.g., 16, 32, 64 — depends on NPU vector core capacity
-    BLOCK_M = 48
+    # Choose BLOCK_M, capping the [BLOCK_M, BLOCK_N] fp32 tile to a fixed
+    # element budget so the Unified Buffer does not overflow at large BLOCK_N.
+    TILE_ELEM_BUDGET = 4096
+    BLOCK_M = max(1, min(48, TILE_ELEM_BUDGET // BLOCK_N))
     _, num_vectorcore = get_device_properties()
     num_blocks_m = min(triton.cdiv(M, BLOCK_M), num_vectorcore)
 
@@ -309,6 +318,7 @@ def layer_norm_fwd_npu(
         BLOCK_N=BLOCK_N,
         NORM_BEFORE_GATE=norm_before_gate,
         IS_RMS_NORM=is_rms_norm,
+        ACTIVATION=activation,
         # Remove multibuffer if not needed
     )
     return out, mean, rstd


### PR DESCRIPTION
  ## Background

  The NPU layernorm gated kernel currently only supports SiLU (`z * sigmoid(z)`) as the gating activation 
  function. However, some model architectures require pure sigmoid activation (`sigmoid(z)`) instead of   
  SiLU. Additionally, when `BLOCK_N` is large, the `[BLOCK_M, BLOCK_N]` fp32 tile exceeds the NPU Unified 
  Buffer capacity, causing runtime overflow errors.

  ## Changes

  1. **Add sigmoid activation support**: Introduce an `ACTIVATION` compile-time constant parameter to     
  `_layer_norm_fwd_1pass_kernel_npu`, allowing selection of pure sigmoid gating via `activation="sigmoid"`
   instead of the default SiLU.

  2. **Dynamic BLOCK_M calculation**: Replace the fixed `BLOCK_M=48` with a dynamic calculation based on  
  `TILE_ELEM_BUDGET=4096`, ensuring `BLOCK_M * BLOCK_N` does not exceed the Unified Buffer element budget,
   preventing memory overflow with large `BLOCK_N` values.

  ## Problems Solved

  - Supports model architectures requiring sigmoid activation (e.g., certain linear attention variants),  
  expanding the kernel's applicability
  - Fixes Unified Buffer overflow when `BLOCK_N` is large, improving kernel robustness across different   
  feature dimensions

  ## Scope

  - `sgl_kernel_npu/fla/layernorm_gated.py`
  - No impact on existing default behavior (default remains SiLU activation)