### PR TITLE
fix solve tril

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/solve_tril.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/solve_tril.py
@@ -84,7 +84,7 @@ def solve_tril_16x16_kernel_paral(
     for i in range(1, 16):
 
         nblks_vec16 = -al.extract_slice(
-            local_ori_A, (i, 0), (1, 16 * N_BLOCKS), (16 * N_BLOCKS, 1)
+            local_ori_A, (i, 0), (1, 16 * N_BLOCKS), (1, 1)
         )
         b_a = tl.reshape(nblks_vec16, (N_BLOCKS, 16))
 
@@ -191,7 +191,7 @@ def solve_tril_16x16_kernel_paral_v3(
         for i in range(1, 16):
 
             nblks_vec16 = -al.extract_slice(
-                local_ori_A, (i, 0), (1, 16 * N_BLOCKS), (16 * N_BLOCKS, 1)
+                local_ori_A, (i, 0), (1, 16 * N_BLOCKS), (1, 1)
             )
             b_a = tl.reshape(nblks_vec16, (N_BLOCKS, 16))
 

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/solve_tril.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/solve_tril.py
@@ -83,9 +83,7 @@ def solve_tril_16x16_kernel_paral(
     o_i = tl.arange(0, 16)
     for i in range(1, 16):
 
-        nblks_vec16 = -al.extract_slice(
-            local_ori_A, (i, 0), (1, 16 * N_BLOCKS), (1, 1)
-        )
+        nblks_vec16 = -al.extract_slice(local_ori_A, (i, 0), (1, 16 * N_BLOCKS), (1, 1))
         b_a = tl.reshape(nblks_vec16, (N_BLOCKS, 16))
 
         dot_tmp = tl.trans(b_a[:, :, None] * b_A, (1, 0, 2))


### PR DESCRIPTION
according to doc
strides: tensor-rank number of strides specifying subsampling **in each dimension**.
using 16 * N_BLOCKS is ok for A3, but breaks A5.

acc
Qwen/Qwen3.6-35B-A3B ceval
official: 90.0
this pr: 89.8
