### PR TITLE
add ops mode

### DIFF
--- a/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
@@ -221,21 +221,21 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             dtype=x.dtype,
             device=x.device,
         )
-        x = torch.cat((x, x_padding), dim=0)
+        x_padding = torch.cat((x, x_padding), dim=0)
         topk_padding = torch.empty(
             padding_size,
             topk_ids.size(1),
             dtype=topk_ids.dtype,
             device=topk_ids.device,
         )
-        topk_ids = torch.cat((topk_ids, topk_padding), dim=0)
+        topk_padding = torch.cat((topk_ids, topk_padding), dim=0)
         weight_padding = torch.empty(
             padding_size,
             topk_weights.size(1),
             dtype=topk_weights.dtype,
             device=topk_weights.device,
         )
-        topk_weights = torch.cat((topk_weights, weight_padding), dim=0)
+        weight_padding = torch.cat((topk_weights, weight_padding), dim=0)
 
         (
             packed_recv_x,
@@ -245,12 +245,12 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             packed_recv_layout_range,
             expand_scales,
         ) = self._npu_low_latency_dispatch(
-            x=x,
-            topk_idx=topk_ids,
+            x=x_padding,
+            topk_idx=topk_padding,
             num_experts=num_experts,
             quant_mode=3 if use_ue8m0 else 2 if use_fp8 else 0,
             comm_alg=self.comm_alg,
-            topk_weights=topk_weights,
+            topk_weights=weight_padding,
             x_active_mask=x_active_mask,
             num_max_dispatch_tokens_per_rank=num_max_dispatch_tokens_per_rank,
         )
@@ -264,6 +264,8 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             packed_recv_count,
             expand_scales,
             x_active_mask,
+            topk_padding,
+            weight_padding
         )
 
         event = EventOverlap(EventHandle())
@@ -300,27 +302,14 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             packed_recv_count,
             expand_scales,
             x_active_mask,
+            topk_padding,
+            weight_padding
         ) = handle
-        padding_size = num_max_dispatch_tokens_per_rank - topk_ids.size(0)
-        topk_padding = torch.empty(
-            padding_size,
-            topk_ids.size(1),
-            dtype=topk_ids.dtype,
-            device=topk_ids.device,
-        )
-        topk_ids = torch.cat((topk_ids, topk_padding), dim=0)
-        weight_padding = torch.empty(
-            padding_size,
-            topk_weights.size(1),
-            dtype=topk_weights.dtype,
-            device=topk_weights.device,
-        )
-        topk_weights = torch.cat((topk_weights, weight_padding), dim=0)
 
         combined_x = self._npu_low_latency_combine(
             x=x,
-            topk_idx=topk_ids,
-            topk_weights=topk_weights,
+            topk_idx=topk_padding,
+            topk_weights=weight_padding,
             assist_info_for_combine=src_info,
             ep_send_counts=layout_range,
             num_experts=num_experts,

--- a/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
@@ -204,6 +204,13 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
     ]:
 
         topk_ids = topk_idx.int()
+        x_active_mask = torch.zeros(
+            num_max_dispatch_tokens_per_rank,
+            dtype=torch.bool,
+            device=x.device,
+        )
+        x_active_mask[:x.size(0)] = True
+        padding_size = num_max_dispatch_tokens_per_rank - x.size(0)
         if self.comm_alg == "hierarchy":
             assert (
                 topk_weights is not None
@@ -214,13 +221,21 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             dtype=x.dtype,
             device=x.device,
         )
-        x_padding = torch.cat((x, x_padding), dim=0)
-        x_active_mask = torch.zeros(
-            num_max_dispatch_tokens_per_rank,
-            dtype=torch.bool,
-            device=x.device,
+        x = torch.cat((x, x_padding), dim=0)
+        topk_padding = torch.empty(
+            padding_size,
+            topk_ids.size(1),
+            dtype=topk_ids.dtype,
+            device=topk_ids.device,
         )
-        x_active_mask[:x.size(0)] = True
+        topk_ids = torch.cat((topk_ids, topk_padding), dim=0)
+        weight_padding = torch.empty(
+            padding_size,
+            topk_weights.size(1),
+            dtype=topk_weights.dtype,
+            device=topk_weights.device,
+        )
+        topk_weights = torch.cat((topk_weights, weight_padding), dim=0)
 
         (
             packed_recv_x,
@@ -230,7 +245,7 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             packed_recv_layout_range,
             expand_scales,
         ) = self._npu_low_latency_dispatch(
-            x=x_padding,
+            x=x,
             topk_idx=topk_ids,
             num_experts=num_experts,
             quant_mode=3 if use_ue8m0 else 2 if use_fp8 else 0,
@@ -275,6 +290,7 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
     ) -> Tuple[torch.Tensor, EventOverlap, Callable]:
 
         topk_ids = topk_idx.int()
+        src_num = topk_idx.size(0)
         (
             src_info,
             layout_range,
@@ -285,6 +301,21 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             expand_scales,
             x_active_mask,
         ) = handle
+        padding_size = num_max_dispatch_tokens_per_rank - topk_ids.size(0)
+        topk_padding = torch.empty(
+            padding_size,
+            topk_ids.size(1),
+            dtype=topk_ids.dtype,
+            device=topk_ids.device,
+        )
+        topk_ids = torch.cat((topk_ids, topk_padding), dim=0)
+        weight_padding = torch.empty(
+            padding_size,
+            topk_weights.size(1),
+            dtype=topk_weights.dtype,
+            device=topk_weights.device,
+        )
+        topk_weights = torch.cat((topk_weights, weight_padding), dim=0)
 
         combined_x = self._npu_low_latency_combine(
             x=x,
@@ -301,7 +332,7 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
 
         event = EventOverlap(EventHandle())
         hook = lambda *args, **kwargs: None
-
+        combined_x = combined_x[:src_num, :]
         return combined_x, event, hook
 
     def _npu_low_latency_dispatch(

--- a/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
@@ -265,7 +265,7 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             expand_scales,
             x_active_mask,
             topk_padding,
-            weight_padding
+            weight_padding,
         )
 
         event = EventOverlap(EventHandle())
@@ -303,7 +303,7 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             expand_scales,
             x_active_mask,
             topk_padding,
-            weight_padding
+            weight_padding,
         ) = handle
 
         combined_x = self._npu_low_latency_combine(

--- a/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
@@ -204,11 +204,23 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
     ]:
 
         topk_ids = topk_idx.int()
-        num_max_dispatch_tokens_per_rank = x.size(0)
         if self.comm_alg == "hierarchy":
             assert (
                 topk_weights is not None
             ), "When comm_alg='hierarchy', topk_weights can not be None"
+        x_padding = torch.empty(
+            padding_size,
+            x.size(1),
+            dtype=x.dtype,
+            device=x.device,
+        )
+        x_padding = torch.cat((x, x_padding), dim=0)
+        x_active_mask = torch.zeros(
+            num_max_dispatch_tokens_per_rank,
+            dtype=torch.bool,
+            device=x.device,
+        )
+        x_active_mask[:x.size(0)] = True
 
         (
             packed_recv_x,
@@ -218,12 +230,13 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             packed_recv_layout_range,
             expand_scales,
         ) = self._npu_low_latency_dispatch(
-            x=x,
+            x=x_padding,
             topk_idx=topk_ids,
             num_experts=num_experts,
             quant_mode=3 if use_ue8m0 else 2 if use_fp8 else 0,
             comm_alg=self.comm_alg,
             topk_weights=topk_weights,
+            x_active_mask=x_active_mask,
             num_max_dispatch_tokens_per_rank=num_max_dispatch_tokens_per_rank,
         )
 
@@ -235,6 +248,7 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             num_experts,
             packed_recv_count,
             expand_scales,
+            x_active_mask,
         )
 
         event = EventOverlap(EventHandle())
@@ -269,6 +283,7 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             num_experts,
             packed_recv_count,
             expand_scales,
+            x_active_mask,
         ) = handle
 
         combined_x = self._npu_low_latency_combine(
@@ -280,6 +295,7 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             num_experts=num_experts,
             comm_alg=self.comm_alg,
             expand_scales=expand_scales,
+            x_active_mask=x_active_mask,
             num_max_dispatch_tokens_per_rank=num_max_dispatch_tokens_per_rank,
         )
 
@@ -307,7 +323,6 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
 
         shared_expert_rank_num = int(os.getenv("MOE_SHARED_EXPERT_RANK_NUM", 0))
         expert_token_nums_type = int(os.getenv("MOE_EXPERT_TOKEN_NUMS_TYPE", 1))
-        global_bs = num_max_dispatch_tokens_per_rank * self.group_size
         if comm_alg == "hierarchy":
             assert (
                 shared_expert_num == 0
@@ -337,7 +352,6 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             shared_expert_rank_num=shared_expert_rank_num,
             quant_mode=quant_mode,
             expert_token_nums_type=expert_token_nums_type,
-            global_bs=global_bs,
             comm_alg=comm_alg,  # A3: 支持""，"fullmesh_v1"，"fullmesh_v2", "hierarchy"
         )
 
@@ -371,7 +385,6 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
     ):
 
         shared_expert_rank_num = int(os.getenv("MOE_SHARED_EXPERT_RANK_NUM", 0))
-        global_bs = num_max_dispatch_tokens_per_rank * self.group_size
         if comm_alg == "hierarchy":
             assert (
                 shared_expert_num == 0
@@ -395,7 +408,6 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             expert_shard_type=expert_shared_type,
             shared_expert_num=shared_expert_num,
             shared_expert_rank_num=shared_expert_rank_num,
-            global_bs=global_bs,
             comm_quant_mode=comm_quant_mode,
             comm_alg=comm_alg,  # A3: 支持""，"hierarchy"两种
         )

--- a/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
@@ -209,7 +209,7 @@ class OpsLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             dtype=torch.bool,
             device=x.device,
         )
-        x_active_mask[:x.size(0)] = True
+        x_active_mask[: x.size(0)] = True
         padding_size = num_max_dispatch_tokens_per_rank - x.size(0)
         if self.comm_alg == "hierarchy":
             assert (

--- a/tests/python/deepep/test_low_latency.py
+++ b/tests/python/deepep/test_low_latency.py
@@ -196,15 +196,13 @@ def test(
 
         # Check combine correctness
         if not all_to_all_mode:
-            (
-                src_info,
-                layout_range,
-                num_max_dispatch_tokens_per_rank,
-                hidden,
-                num_experts,
-                packed_recv_count,
-                expand_scales,
-            ) = handle
+            src_info = handle[0]
+            layout_range = handle[1]
+            num_max_dispatch_tokens_per_rank = handle[2]
+            hidden = handle[3]
+            num_experts = handle[4]
+            packed_recv_count = handle[5]
+            expand_scales = handle[6]
 
             out = torch.empty(
                 (aligned_num_tokens, hidden), dtype=torch.bfloat16, device="npu"
@@ -312,9 +310,17 @@ def test(
     for return_recv_hook in (False,):
         enable_neg_one = int(os.getenv("MOE_ENABLE_TOPK_NEG_ONE", 0))
         dist.barrier()
+        enable_topk_neg_one = os.getenv("MOE_ENABLE_TOPK_NEG_ONE", "").lower()
+
+        if enable_topk_neg_one == "ops":
+            dispatch_name = "MoeLowLatencyDispatchV2"
+            combine_name = "MoeLowLatencyCombineV2"
+        else:
+            dispatch_name = "MoeDistributeDispatchV2"
+            combine_name = "MoeDistributeCombineV2"
         dispatch_t, combine_t = bench_kineto(
             partial(test_func, zero_copy=False, return_recv_hook=return_recv_hook),
-            kernel_names=("MoeLowLatencyDispatchV2", "MoeLowLatencyCombineV2"),
+            kernel_names=(dispatch_name, combine_name),
             barrier_comm_profiling=True,
             suppress_kineto_output=True,
             num_kernels_per_period=2 if return_recv_hook else 1,

--- a/tests/python/deepep/test_low_latency.py
+++ b/tests/python/deepep/test_low_latency.py
@@ -315,11 +315,11 @@ def test(
         enable_topk_neg_one = os.getenv("MOE_ENABLE_TOPK_NEG_ONE", "").lower()
 
         if enable_topk_neg_one == "ops":
-            dispatch_name = "MoeLowLatencyDispatchV2"
-            combine_name = "MoeLowLatencyCombineV2"
-        else:
             dispatch_name = "MoeDistributeDispatchV2"
             combine_name = "MoeDistributeCombineV2"
+        else:
+            dispatch_name = "MoeLowLatencyDispatchV2"
+            combine_name = "MoeLowLatencyCombineV2"
         dispatch_t, combine_t = bench_kineto(
             partial(test_func, zero_copy=False, return_recv_hook=return_recv_hook),
             kernel_names=(dispatch_name, combine_name),

--- a/tests/python/deepep/test_low_latency.py
+++ b/tests/python/deepep/test_low_latency.py
@@ -291,6 +291,8 @@ def test(
             num_dispatch_comm_bytes += num_mxfp8_bytes * num_selections
         elif dispatch_use_fp8:
             num_dispatch_comm_bytes += num_fp8_bytes * num_selections
+        else:
+            num_dispatch_comm_bytes += num_bf16_bytes * num_selections
         num_combine_comm_bytes += num_bf16_bytes * num_selections
 
     # Dispatch + combine testing


### PR DESCRIPTION
The deepEP encapsulation mode is modified in the scenario where DEEP_USE_MODE is set to ops. The padding mode provided by the dispatchV4 operator in the ops-transformer repository is used to comply with the input parameters. The single-operator test result is as follows:


Average Dispatch bandwidth: 46.29 GB/s, avg_t=634.32 us 
Average Combine bandwidth: 54.02 GB/s, avg_t=543.55 us