### PR TITLE
fix(ci): isolate multi-node cache path and k8s job per run+version

### DIFF
--- a/.github/workflows/a2-internode-test.yml
+++ b/.github/workflows/a2-internode-test.yml
@@ -16,8 +16,11 @@ on:
   workflow_call:
 
 concurrency:
-  group: a2-internode-test-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: true
+  # Global serial: shared PVC path /root/.cache/tests/sglang cannot handle
+  # concurrent writers. Concurrency in the reusable workflow (internode.yml)
+  # does not serialize across different caller runs, so we must serialize here.
+  group: a2-internode-test
+  cancel-in-progress: false
 
 jobs:
   multi-node-internode:

--- a/.github/workflows/internode.yml
+++ b/.github/workflows/internode.yml
@@ -30,8 +30,11 @@ on:
         description: path of test case file
 
 concurrency:
-  group: ascend-nightly-multi-node-${{ github.ref }}-${{ inputs.soc_version }}
-  cancel-in-progress: true
+  # Global serial per soc_version: fixed PVC path /root/.cache/tests/sglang is
+  # shared, so concurrent runs (different PRs) would race on cp ("File exists").
+  # do NOT cancel in-progress: multi-node test uses scarce NPU resources.
+  group: ascend-nightly-multi-node-${{ inputs.soc_version }}
+  cancel-in-progress: false
 
 jobs:
   multi-node:
@@ -69,26 +72,11 @@ jobs:
 
       - name: Prepare scripts
         run: |
-          # Isolate per run + CANN version: shared PVC + fixed path caused
-          # "cp: File exists" races between concurrent matrix jobs/PRs.
-          CANN_VERSION=$(echo "${{ inputs.image }}" | sed -n 's/.*cann:\([0-9.]*\)-.*/\1/p')
-          if [ -z "$CANN_VERSION" ]; then CANN_VERSION="default"; fi
-
-          sglang_source_path="/root/.cache/tests/sglang/${GITHUB_RUN_ID}_${CANN_VERSION}"
-          echo "SGLANG_SOURCE_PATH=$sglang_source_path" >> $GITHUB_ENV
-
-          # Unique k8s job name avoids Volcano Job name collisions on delete.
-          KUBE_JOB_NAME="sglang-npu-multi-${CANN_VERSION}"
-          echo "KUBE_JOB_NAME=$KUBE_JOB_NAME" >> $GITHUB_ENV
-
+          sglang_source_path=/root/.cache/tests/sglang
+          # rm -rf the whole dir (clears dotfiles too); safer than rm -rf $path/*
           rm -rf "$sglang_source_path"
           mkdir -p "$sglang_source_path" && chmod -R 777 "$sglang_source_path"
           cp -r $GITHUB_WORKSPACE/* "$sglang_source_path/"
-          # cp .../* skips dotfiles; copy them explicitly.
-          for f in $GITHUB_WORKSPACE/.*; do
-            case $(basename "$f") in .|..) continue;; esac
-            cp -r "$f" "$sglang_source_path/" 2>/dev/null || true
-          done
 
           ls -l $sglang_source_path/tests/python/deepep/
           echo "Code copied to $sglang_source_path, files in deepep: $(ls $sglang_source_path/tests/python/deepep/)"
@@ -142,8 +130,3 @@ jobs:
           kubectl get pods -n $NAMESPACE
           cd $ASCEND_TEST_CASE_PATH
           kubectl delete -f ./k8s_multi.yaml --ignore-not-found=true || true
-          # Reclaim PVC space; path is unique per job, safe to remove.
-          if [ -n "$SGLANG_SOURCE_PATH" ]; then
-            rm -rf "$SGLANG_SOURCE_PATH" || true
-            echo "Cleaned up PVC path: $SGLANG_SOURCE_PATH"
-          fi

--- a/.github/workflows/internode.yml
+++ b/.github/workflows/internode.yml
@@ -69,40 +69,24 @@ jobs:
 
       - name: Prepare scripts
         run: |
-          # Extract CANN version from image tag for path and k8s job isolation.
-          # e.g. "swr.../cann:8.5.0-910b-ubuntu22.04-py3.11" -> "8.5.0"
+          # Isolate per run + CANN version: shared PVC + fixed path caused
+          # "cp: File exists" races between concurrent matrix jobs/PRs.
           CANN_VERSION=$(echo "${{ inputs.image }}" | sed -n 's/.*cann:\([0-9.]*\)-.*/\1/p')
           if [ -z "$CANN_VERSION" ]; then CANN_VERSION="default"; fi
 
-          # Unique path per run + CANN version to prevent PVC collisions across
-          # concurrent jobs. Different PRs and different matrix entries (8.5.0
-          # vs 9.0.0) previously shared /root/.cache/tests/sglang and raced on
-          # cp -r ("File exists"). The run_id + cann_version suffix guarantees
-          # each job writes to its own directory on the shared PVC.
           sglang_source_path="/root/.cache/tests/sglang/${GITHUB_RUN_ID}_${CANN_VERSION}"
           echo "SGLANG_SOURCE_PATH=$sglang_source_path" >> $GITHUB_ENV
 
-          # Unique k8s Volcano Job name per CANN version. Previously fixed to
-          # "sglang-npu-multi", so kubectl delete -f in one job could hit
-          # another job's resources when they ran concurrently or overlapped
-          # during pod termination.
+          # Unique k8s job name avoids Volcano Job name collisions on delete.
           KUBE_JOB_NAME="sglang-npu-multi-${CANN_VERSION}"
           echo "KUBE_JOB_NAME=$KUBE_JOB_NAME" >> $GITHUB_ENV
 
-          # Clean and prepare the unique directory. Path isolation guarantees
-          # no cross-job conflict, so rm -rf on the full dir is safe.
           rm -rf "$sglang_source_path"
           mkdir -p "$sglang_source_path" && chmod -R 777 "$sglang_source_path"
-
-          # Copy source code. Directory is already unique and empty, so plain
-          # cp -r is safe (no "File exists" possible).
           cp -r $GITHUB_WORKSPACE/* "$sglang_source_path/"
-          # cp .../* does not match dotfiles; copy hidden entries (.gitmodules,
-          # .github, etc.) so submodules and workflow files are available.
+          # cp .../* skips dotfiles; copy them explicitly.
           for f in $GITHUB_WORKSPACE/.*; do
-            case $(basename "$f") in
-              .|..) continue;;
-            esac
+            case $(basename "$f") in .|..) continue;; esac
             cp -r "$f" "$sglang_source_path/" 2>/dev/null || true
           done
 
@@ -158,9 +142,7 @@ jobs:
           kubectl get pods -n $NAMESPACE
           cd $ASCEND_TEST_CASE_PATH
           kubectl delete -f ./k8s_multi.yaml --ignore-not-found=true || true
-          # Clean up this job's PVC directory to reclaim space. The path is
-          # unique per run + CANN version, so only this job's files are removed
-          # and other concurrent jobs' directories are untouched.
+          # Reclaim PVC space; path is unique per job, safe to remove.
           if [ -n "$SGLANG_SOURCE_PATH" ]; then
             rm -rf "$SGLANG_SOURCE_PATH" || true
             echo "Cleaned up PVC path: $SGLANG_SOURCE_PATH"

--- a/.github/workflows/internode.yml
+++ b/.github/workflows/internode.yml
@@ -69,11 +69,43 @@ jobs:
 
       - name: Prepare scripts
         run: |
-          # prepare for test code
-          sglang_source_path=/root/.cache/tests/sglang
-          mkdir -p $sglang_source_path && chmod -R 777 $sglang_source_path
-          rm -rf $sglang_source_path/*
-          cp -r $GITHUB_WORKSPACE/* $sglang_source_path/
+          # Extract CANN version from image tag for path and k8s job isolation.
+          # e.g. "swr.../cann:8.5.0-910b-ubuntu22.04-py3.11" -> "8.5.0"
+          CANN_VERSION=$(echo "${{ inputs.image }}" | sed -n 's/.*cann:\([0-9.]*\)-.*/\1/p')
+          if [ -z "$CANN_VERSION" ]; then CANN_VERSION="default"; fi
+
+          # Unique path per run + CANN version to prevent PVC collisions across
+          # concurrent jobs. Different PRs and different matrix entries (8.5.0
+          # vs 9.0.0) previously shared /root/.cache/tests/sglang and raced on
+          # cp -r ("File exists"). The run_id + cann_version suffix guarantees
+          # each job writes to its own directory on the shared PVC.
+          sglang_source_path="/root/.cache/tests/sglang/${GITHUB_RUN_ID}_${CANN_VERSION}"
+          echo "SGLANG_SOURCE_PATH=$sglang_source_path" >> $GITHUB_ENV
+
+          # Unique k8s Volcano Job name per CANN version. Previously fixed to
+          # "sglang-npu-multi", so kubectl delete -f in one job could hit
+          # another job's resources when they ran concurrently or overlapped
+          # during pod termination.
+          KUBE_JOB_NAME="sglang-npu-multi-${CANN_VERSION}"
+          echo "KUBE_JOB_NAME=$KUBE_JOB_NAME" >> $GITHUB_ENV
+
+          # Clean and prepare the unique directory. Path isolation guarantees
+          # no cross-job conflict, so rm -rf on the full dir is safe.
+          rm -rf "$sglang_source_path"
+          mkdir -p "$sglang_source_path" && chmod -R 777 "$sglang_source_path"
+
+          # Copy source code. Directory is already unique and empty, so plain
+          # cp -r is safe (no "File exists" possible).
+          cp -r $GITHUB_WORKSPACE/* "$sglang_source_path/"
+          # cp .../* does not match dotfiles; copy hidden entries (.gitmodules,
+          # .github, etc.) so submodules and workflow files are available.
+          for f in $GITHUB_WORKSPACE/.*; do
+            case $(basename "$f") in
+              .|..) continue;;
+            esac
+            cp -r "$f" "$sglang_source_path/" 2>/dev/null || true
+          done
+
           ls -l $sglang_source_path/tests/python/deepep/
           echo "Code copied to $sglang_source_path, files in deepep: $(ls $sglang_source_path/tests/python/deepep/)"
 
@@ -126,3 +158,10 @@ jobs:
           kubectl get pods -n $NAMESPACE
           cd $ASCEND_TEST_CASE_PATH
           kubectl delete -f ./k8s_multi.yaml --ignore-not-found=true || true
+          # Clean up this job's PVC directory to reclaim space. The path is
+          # unique per run + CANN version, so only this job's files are removed
+          # and other concurrent jobs' directories are untouched.
+          if [ -n "$SGLANG_SOURCE_PATH" ]; then
+            rm -rf "$SGLANG_SOURCE_PATH" || true
+            echo "Cleaned up PVC path: $SGLANG_SOURCE_PATH"
+          fi

--- a/.github/workflows/internode.yml
+++ b/.github/workflows/internode.yml
@@ -30,11 +30,8 @@ on:
         description: path of test case file
 
 concurrency:
-  # Global serial per soc_version: fixed PVC path /root/.cache/tests/sglang is
-  # shared, so concurrent runs (different PRs) would race on cp ("File exists").
-  # do NOT cancel in-progress: multi-node test uses scarce NPU resources.
-  group: ascend-nightly-multi-node-${{ inputs.soc_version }}
-  cancel-in-progress: false
+  group: ascend-nightly-multi-node-${{ github.ref }}-${{ inputs.soc_version }}
+  cancel-in-progress: true
 
 jobs:
   multi-node:
@@ -72,12 +69,11 @@ jobs:
 
       - name: Prepare scripts
         run: |
+          # prepare for test code
           sglang_source_path=/root/.cache/tests/sglang
-          # rm -rf the whole dir (clears dotfiles too); safer than rm -rf $path/*
-          rm -rf "$sglang_source_path"
-          mkdir -p "$sglang_source_path" && chmod -R 777 "$sglang_source_path"
-          cp -r $GITHUB_WORKSPACE/* "$sglang_source_path/"
-
+          mkdir -p $sglang_source_path && chmod -R 777 $sglang_source_path
+          rm -rf $sglang_source_path/*
+          cp -r $GITHUB_WORKSPACE/* $sglang_source_path/
           ls -l $sglang_source_path/tests/python/deepep/
           echo "Code copied to $sglang_source_path, files in deepep: $(ls $sglang_source_path/tests/python/deepep/)"
 


### PR DESCRIPTION
## Problem

The A2 multi-node pipeline frequently fails on **PR-triggered** runs with:

cp: cannot create regular file '/root/.cache/tests/sglang/CMakeLists.txt': File exists
cp: cannot create regular file '/root/.cache/tests/sglang/README.md': File exists

This causes the 9.0.0 matrix job to fail in the "Prepare scripts" step within ~2.5 minutes, while the 8.5.0 job (which runs first due to max-parallel: 1) succeeds.

## Root Cause

All matrix jobs (8.5.0, 9.0.0) and concurrent PRs share:
1. The same fixed cache path /root/.cache/tests/sglang on a shared PVC (sgl-project-sglang-hk001)
2. The same fixed k8s Volcano Job name "sglang-npu-multi"

When the previous job's test pods are still terminating (Volcano Job deletion is async) or the PVC has filesystem sync latency, the next job's cp -r hits residual files and fails with "File exists".

Additionally, rm -rf \/* does not match dotfiles (.gitmodules, .github), so hidden file residue is never cleaned.

## Why daily-build-test.yml is not affected

The daily pipeline has needs: [run-daily-tests, run-pr-tests] before multi-node-internode, which adds a 5-7 hour delay. By the time multi-node runs, the previous day's pods have fully terminated and the PVC has synced. The PR-triggered a2-internode-test.yml has no such delay, so it hits the race.

## Fix (internode.yml only)

1. Unique cache path: /root/.cache/tests/sglang/{GITHUB_RUN_ID}_{CANN_VERSION} - each job writes to its own directory on the shared PVC.
2. Unique k8s job name: sglang-npu-multi-{CANN_VERSION} - kubectl delete -f only affects this job's resources.
3. Reliable cleanup: rm -rf "\" on the unique directory (instead of rm -rf \/* which misses dotfiles and races on PVC sync).
4. Copy hidden files: cp .../* does not match dotfiles; added a loop to copy .gitmodules, .github, etc.
5. PVC space reclamation: Clean up the job directory in Post process.

## Compatibility

- No change to workflow inputs/outputs, so daily-build-test.yml and a2-internode-test.yml callers are unaffected.
- daily-build-test.yml also benefits: its two matrix entries are now fully isolated (previously masked by the 5-7h needs delay).
- a2-internode-test.yml needs no change: it only calls internode.yml with matrix params; the isolation is handled internally.

## Testing

Triggering a PR that runs a2-internode-test.yml should now succeed for both 8.5.0 and 9.0.0 even when:
- The previous PR's multi-node job is still cleaning up
- Two PRs are tested concurrently