### PR TITLE
[chore] dispatch_ffn_combine support DEEPEP_HCCL_BUFFSIZE

### DIFF
--- a/csrc/deepep/ops/op_host/dispatch_ffn_combine_tiling.cpp
+++ b/csrc/deepep/ops/op_host/dispatch_ffn_combine_tiling.cpp
@@ -26,8 +26,6 @@
 using namespace AscendC;
 using namespace ge;
 
-#define HCCL_BUFFSIZE "HCCL_BUFFSIZE"
-
 namespace {
 // 1. Constant definitions
 const char *K_INNER_DEBUG = "DispatchFFNCombine Tiling Debug";
@@ -54,10 +52,10 @@ namespace optiling {
 static uint64_t GetMaxWindowSize()
 {
     uint16_t defaultWindowSize = 200;
-    const char *hccl_buffsize_env = getenv(HCCL_BUFFSIZE);
-    if (hccl_buffsize_env != nullptr) {
+    const char *hcclBuffSize = getenv("DEEPEP_HCCL_BUFFSIZE") == nullptr ? "HCCL_BUFFSIZE" : "DEEPEP_HCCL_BUFFSIZE";
+    if (getenv(hcclBuffSize) != nullptr) {
         try {
-            std::string envStr(hccl_buffsize_env);
+            std::string envStr(getenv(hcclBuffSize));
             unsigned long val = std::stoul(envStr);
             if (val <= std::numeric_limits<uint16_t>::max()) {
                 defaultWindowSize = static_cast<uint16_t>(val);


### PR DESCRIPTION
## Motivation

The dispatch_ffn_combine supports the configuration of the DEEPEP_HCCL_BUFFSIZE environment variable. If this variable is configured, it will be used preferentially instead of HCCL_BUFFSIZE.

## Modifications

csrc/deepep/ops/op_host/dispatch_ffn_combine_tiling.cpp: Checking the DEEPEP_HCCL_BUFFSIZE environment variable.

## Testing

结合框架测试，框架运行成功
```bash
[2026-07-21 15:00:13 TP0 EP0] Prefill batch, #new-seq: 8, #new-token: 54400, #cached-token: 482304, token usage: 0.66, #running-req: 16, #queue-req: 2, #pending-token: 0, npu graph: False, input throughput (token/s): 2793.64
[2026-07-21 15:00:13 TP0 EP0] Decode batch, #running-req: 24, #token: 233600, token usage: 0.66, accept len: 3.05, accept rate: 0.68, npu graph: True, gen throughput (token/s): 239.06, #queue-req: 2
[2026-07-21 15:00:15] INFO:     127.0.0.1:43514 - "POST /generate HTTP/1.1" 200 OK
[2026-07-21 15:00:17 TP0 EP0] Decode batch, #running-req: 23, #token: 227968, token usage: 0.64, accept len: 2.63, accept rate: 0.54, npu graph: True, gen throughput (token/s): 631.96, #queue-req: 3
[2026-07-21 15:00:19] INFO:     127.0.0.1:50784 - "POST /generate HTTP/1.1" 200 OK
[2026-07-21 15:00:21 TP0 EP0] Decode batch, #running-req: 22, #token: 222720, token usage: 0.63, accept len: 2.83, accept rate: 0.61, npu graph: True, gen throughput (token/s): 648.87, #queue-req: 4
[2026-07-21 15:00:23] INFO:     127.0.0.1:50800 - "POST /generate HTTP/1.1" 200 OK
[2026-07-21 15:00:23] INFO:     127.0.0.1:50806 - "POST /generate HTTP/1.1" 200 OK
[2026-07-21 15:00:24] INFO:     127.0.0.1:50810 - "POST /generate HTTP/1.1" 200 OK
[2026-07-21 15:00:24] INFO:     127.0.0.1:50822 - "POST /generate HTTP/1.1" 200 OK
[2026-07-21 15:00:24 TP0 EP0] Decode batch, #running-req: 18, #token: 193664, token usage: 0.54, accept len: 2.82, accept rate: 0.61, npu graph: True, gen throughput (token/s): 669.08, #queue-req: 7
[2026-07-21 15:00:25] INFO:     127.0.0.1:50834 - "POST /generate HTTP/1.1" 200 OK
[2026-07-21 15:00:25] INFO:     127.0.0.1:60914 - "POST /generate HTTP/1.1" 200 OK
[2026-07-21 15:00:32 TP0 EP0] Prefill batch, #new-seq: 8, #new-token: 54400, #cached-token: 482304, token usage: 0.66, #running-req: 16, #queue-req: 2, #pending-token: 0, npu graph: False, input throughput (token/s): 2895.94
[2026-07-21 15:00:32] INFO:     127.0.0.1:60922 - "POST /generate HTTP/1.1" 200 OK
[2026-07-21 15:00:34 TP0 EP0] Decode batch, #running-req: 23, #token: 226944, token usage: 0.64, accept len: 2.59, accept rate: 0.53, npu graph: True, gen throughput (token/s): 220.23, #queue-req: 3
[2026-07-21 15:00:35] INFO:     127.0.0.1:60928 - "POST /generate HTTP/1.1" 200 OK
[2026-07-21 15:00:38] INFO:     127.0.0.1:42762 - "POST /generate HTTP/1.1" 200 OK
[2026-07-21 15:00:38] INFO:     127.0.0.1:42774 - "POST /generate HTTP/1.1" 200 OK
[2026-07-21 15:00:38 TP0 EP0] Decode batch, #running-req: 20, #token: 205824, token usage: 0.58, accept len: 2.81, accept rate: 0.60, npu graph: True, gen throughput (token/s): 642.30, #queue-req: 5
[2026-07-21 15:00:38] INFO:     127.0.0.1:42780 - "POST /generate HTTP/1.1" 200 OK
[2026-07-21 15:00:41 TP0 EP0] Decode batch, #running-req: 19, #token: 200064, token usage: 0.56, accept len: 2.85, accept rate: 0.62, npu graph: True, gen throughput (token/s): 746.55, #queue-req: 7
[2026-07-21 15:00:43] INFO:     127.0.0.1:42794 - "POST /generate HTTP/1.1" 200 OK
[2026-07-21 15:00:44] INFO:     127.0.0.1:42800 - "POST /generate HTTP/1.1" 200 OK
[2026-07-21 15:00:44] INFO:     127.0.0.1:42808 - "POST /generate HTTP/1.1" 200 OK
[2026-07-21 15:00:51 TP0 EP0] Prefill batch, #new-seq: 9, #new-token: 61056, #cached-token: 542592, token usage: 0.67, #running-req: 16, #queue-req: 1, #pending-token: 0, npu graph: False, input throughput (token/s): 3073.17
[2026-07-21 15:00:52 TP0 EP0] Decode batch, #running-req: 25, #token: 239872, token usage: 0.67, accept len: 2.82, accept rate: 0.61, npu graph: True, gen throughput (token/s): 203.23, #queue-req: 1
[2026-07-21 15:00:55] INFO:     127.0.0.1:57118 - "POST /generate HTTP/1.1" 200 OK
[2026-07-21 15:00:56 TP0 EP0] Decode batch, #running-req: 23, #token: 227072, token usage: 0.64, accept len: 2.49, accept rate: 0.50, npu graph: True, gen throughput (token/s): 568.18, #queue-req: 2
[2026-07-21 15:01:00 TP0 EP0] Decode batch, #running-req: 22, #token: 221696, token usage: 0.62, accept len: 2.78, accept rate: 0.59, npu graph: True, gen throughput (token/s): 641.89, #queue-req: 2
[2026-07-21 15:01:04 TP0 EP0] Decode batch, #running-req: 18, #token: 192640, token usage: 0.54, accept len: 2.88, accept rate: 0.63, npu graph: True, gen throughput (token/s): 646.28, #queue-req: 2
[2026-07-21 15:01:07 TP0 EP0] Prefill batch, #new-seq: 2, #new-token: 13568, #cached-token: 120576, token usage: 0.54, #running-req: 16, #queue-req: 0, #pending-token: 0, npu graph: False, input throughput (token/s): 894.61
[2026-07-21 15:01:08 TP0 EP0] Decode batch, #running-req: 18, #token: 192640, token usage: 0.54, accept len: 2.74, accept rate: 0.58, npu graph: True, gen throughput (token/s): 423.04, #queue-req: 0
[2026-07-21 15:01:11 TP0 EP0] Decode batch, #running-req: 18, #token: 194560, token usage: 0.55, accept len: 2.86, accept rate: 0.62, npu graph: True, gen throughput (token/s): 724.66, #queue-req: 0
[2026-07-21 15:01:14 TP0 EP0] Decode batch, #running-req: 15, #token: 172800, token usage: 0.49, accept len: 2.89, accept rate: 0.63, npu graph: True, gen throughput (token/s): 663.46, #queue-req: 0
[2026-07-21 15:01:20 TP0 EP0] Decode batch, #running-req: 11, #token: 142848, token usage: 0.40, accept len: 2.77, accept rate: 0.59, npu graph: True, gen throughput (token/s): 266.17, #queue-req: 0
[2026-07-21 15:01:22 TP0 EP0] Decode batch, #running-req: 10, #token: 128256, token usage: 0.36, accept len: 2.67, accept rate: 0.56, npu graph: True, gen throughput (token/s): 420.75, #queue-req: 0
[2026-07-21 15:01:25 TP0 EP0] Decode batch, #running-req: 7, #token: 113536, token usage: 0.32, accept len: 2.51, accept rate: 0.50, npu graph: True, gen throughput (token/s): 310.51, #queue-req: 0
[2026-07-21 15:01:27 TP0 EP0] Decode batch, #running-req: 4, #token: 90496, token usage: 0.25, accept len: 2.38, accept rate: 0.46, npu graph: True, gen throughput (token/s): 203.73, #queue-req: 0
[2026-07-21 15:01:29 TP0 EP0] Decode batch, #running-req: 4, #token: 91008, token usage: 0.26, accept len: 2.44, accept rate: 0.48, npu graph: True, gen throughput (token/s): 242.55, #queue-req: 0
[2026-07-21 15:01:31 TP0 EP0] Decode batch, #running-req: 2, #token: 75520, token usage: 0.21, accept len: 2.36, accept rate: 0.45, npu graph: True, gen throughput (token/s): 159.60, #queue-req: 0
[2026-07-21 15:01:32 TP0 EP0] Decode batch, #running-req: 1, #token: 67712, token usage: 0.19, accept len: 1.89, accept rate: 0.30, npu graph: True, gen throughput (token/s): 84.43, #queue-req: 0
[2026-07-21 15:01:35 TP0 EP0] Decode batch, #running-req: 1, #token: 67840, token usage: 0.19, accept len: 1.15, accept rate: 0.05, npu graph: True, gen throughput (token/s): 20.36, #queue-req: 0
[2026-07-21 15:01:37 TP0 EP0] Decode batch, #running-req: 1, #token: 67840, token usage: 0.19, accept len: 1.23, accept rate: 0.07, npu graph: True, gen throughput (token/s): 21.76, #queue-req: 0
[2026-07-21 15:01:39 TP0 EP0] Decode batch, #running-req: 1, #token: 67968, token usage: 0.19, accept len: 1.32, accept rate: 0.11, npu graph: True, gen throughput (token/s): 23.59, #queue-req: 0
[2026-07-21 15:01:41 TP0 EP0] Decode batch, #running-req: 1, #token: 67968, token usage: 0.19, accept len: 1.32, accept rate: 0.11, npu graph: True, gen throughput (token/s): 23.60, #queue-req: 0
[2026-07-21 15:01:44 TP0 EP0] Decode batch, #running-req: 1, #token: 67968, token usage: 0.19, accept len: 1.45, accept rate: 0.15, npu graph: True, gen throughput (token/s): 25.71, #queue-req: 0
[2026-07-21 15:01:46 TP0 EP0] Decode batch, #running-req: 1, #token: 68096, token usage: 0.19, accept len: 1.43, accept rate: 0.14, npu graph: True, gen throughput (token/s): 25.35, #queue-req: 0
[2026-07-21 15:01:48] INFO:     127.0.0.1:33610 - "GET /server_info HTTP/1.1" 200 OK
[2026-07-21 15:01:48] INFO:     127.0.0.1:33620 - "GET /server_info HTTP/1.1" 200 OK
```

## Benchmarking and Profiling

N/A

## Checklist

- [x] Format your code.
- [x] Add unit tests.
- [x] Update documentation.
- [x] Provide accuracy and speed benchmark results.