### PR TITLE
[refactor] use init_moe_routing instead of npu_moe_token_permute

### DIFF
--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -882,6 +882,16 @@ jobs:
         env:
           HCCL_BUFFSIZE: 2048
         run: python3 $GITHUB_WORKSPACE/tests/python/deepep/test_dispatch_ffn_combine.py
+      - name: Run test alltoall mode for both normal and low_latency
+        if: matrix.cann_version == '9.0.0'
+        timeout-minutes: 10
+        env:
+          DEEP_MOE_MODE: alltoall
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type int8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type int8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type bf16
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type bf16
 
   test-build-deepep-a2:
     needs: get-changed-files

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -83,9 +83,12 @@ class Buffer:
         )
 
         # set strategy by env
-        deep_mode = os.getenv("DEEP_USE_MODE", "default").lower()
+        deep_mode = os.getenv("DEEP_USE_MODE")
 
-        normal_strategy, low_latency_strategy = StrategyMap.get_strategy(deep_mode)
+        if deep_mode is not None:
+            normal_strategy, low_latency_strategy = StrategyMap.get_strategy(
+                deep_mode.lower()
+            )
 
         # Initialize normal mode strategy
         self._init_normal_strategy(normal_strategy)

--- a/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
@@ -473,7 +473,7 @@ class AllToAllLowLatencyCommStrategy(LowLatencyEPCommStrategy):
         return ["low_latency"]
 
     def low_latency_dispatch(
-        buffer,
+        self,
         x,
         topk_idx,
         num_max_dispatch_tokens_per_rank,
@@ -488,10 +488,10 @@ class AllToAllLowLatencyCommStrategy(LowLatencyEPCommStrategy):
         topk_weights: Optional[torch.Tensor] = None,
         quant_mode: Optional[str] = None,
     ):
-        group = buffer.group
-        group_size = buffer.group_size
+        group = self.group
+        group_size = self.group_size
         num_local_experts = num_experts // group_size
-        ep_rank = buffer.rank
+        ep_rank = self.rank
         device = x.device
         hidden = x.size(1)
         aligned_num_tokens = num_max_dispatch_tokens_per_rank
@@ -576,7 +576,7 @@ class AllToAllLowLatencyCommStrategy(LowLatencyEPCommStrategy):
         )
 
     def low_latency_combine(
-        buffer,
+        self,
         x,
         topk_idx,
         topk_weights,
@@ -594,7 +594,7 @@ class AllToAllLowLatencyCommStrategy(LowLatencyEPCommStrategy):
         group_size = handle[5]
 
         device = x.device
-        group = buffer.group
+        group = self.group
 
         x_reordered = x.reshape(num_local_experts, group_size, expert_capacity, hidden)
         x_reordered = x_reordered.permute(1, 0, 2, 3).contiguous()
@@ -620,8 +620,8 @@ class AllToAllLowLatencyCommStrategy(LowLatencyEPCommStrategy):
         topk_weights_padding = torch.empty(
             expert_capacity,
             topk_weights.size(1),
-            dtype=x.dtype,
-            device=x.device,
+            dtype=topk_weights.dtype,
+            device=topk_weights.device,
         )
         topk_weights_padding[:num_tokens].copy_(topk_weights)
         output = torch_npu.npu_moe_finalize_routing(

--- a/python/deep_ep/deep_ep/strategies/normal_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/normal_strategy.py
@@ -520,6 +520,7 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
             "output_splits": output_splits,
             "num_global_tokens_per_local_expert": num_global_tokens_per_local_expert,
             "global_tokens_indices": global_tokens_indices,
+            "num_experts": num_experts,
         }
 
         num_tokens_per_rank = num_local_tokens_per_expert.reshape(
@@ -573,38 +574,43 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
             "num_global_tokens_per_local_expert"
         ]
         global_tokens_indices = layout["global_tokens_indices"]
+        num_experts = layout["num_experts"]
+        topk_idx_int = topk_idx.to(torch.int32)
 
+        # Determine quant type from quant_mode
+        VALID_QUANT_MODES = {
+            "bf16",
+            "int8",
+        }
         if quant_mode is None:
-            quant_mode = (
-                "int8"
-                if os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT") == "1"
-                else "bf16"
-            )
+            quant_mode = "bf16"
         if quant_mode not in VALID_QUANT_MODES:
-            raise ValueError(
-                f"Invalid quant_mode: {quant_mode}. Valid options: {VALID_QUANT_MODES}"
-            )
-        if quant_mode not in ("bf16", "int8"):
             raise NotImplementedError(
                 f"quant_mode '{quant_mode}' is not supported by the alltoall strategy. "
                 f"Only 'bf16' and 'int8' are supported; use the default strategy for "
                 f"FP8/FP4 modes."
             )
-        input_quant = quant_mode == "int8"
-
         hidden_shape = x.shape
-        x = x.view(-1, hidden_shape[-1])
 
-        permutated_tokens, reversed_local_mapping = torch_npu.npu_moe_token_permute(
-            tokens=x,
-            indices=topk_idx,
-            num_out_tokens=topk_idx.numel(),
+        use_quant = 1 if quant_mode == "int8" else -1
+        is_quant_env = os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT")
+        if is_quant_env is not None and quant_mode is None:
+            use_quant = 1 if is_quant_env == "1" else -1
+
+        (permutated_tokens, reversed_local_mapping, _, dynamic_scale) = (
+            torch_npu.npu_moe_init_routing_v2(
+                x,
+                topk_idx_int,
+                quant_mode=use_quant,
+                expert_num=num_experts,
+                expert_tokens_num_type=1,
+                expert_tokens_num_flag=True,
+                row_idx_type=0,
+                active_expert_range=[0, num_experts],
+            )
         )
 
-        if input_quant:
-            permutated_tokens, dynamic_scale = torch_npu.npu_dynamic_quant(
-                permutated_tokens
-            )
+        if use_quant == 1:
             _, dynamic_scale_after_all2all, scale_handle = self._async_all_to_all(
                 dynamic_scale, output_splits, input_splits, self.group
             )
@@ -621,14 +627,39 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
         permutated_tokens.untyped_storage().resize_(0)
 
         if num_local_experts > 1:
-            if input_quant:
-                dynamic_scale_after_all2all, _ = torch_npu.npu_moe_token_permute(
-                    dynamic_scale_after_all2all.unsqueeze(-1), global_tokens_indices
+            global_tokens_indices = global_tokens_indices.reshape(
+                global_tokens_indices.size(0), 1
+            )
+            if use_quant == 1:
+                dynamic_scale_after_all2all = dynamic_scale_after_all2all.reshape(
+                    dynamic_scale_after_all2all.size(0), 1
                 )
-                dynamic_scale_after_all2all = dynamic_scale_after_all2all.squeeze(-1)
-
-            dispatch_out, reversed_global_mapping = torch_npu.npu_moe_token_permute(
-                global_input_tokens, global_tokens_indices
+                (dynamic_scale_after_routing, reversed_global_mapping, _, _) = (
+                    torch_npu.npu_moe_init_routing_v2(
+                        dynamic_scale_after_all2all,
+                        global_tokens_indices,
+                        quant_mode=-1,
+                        expert_num=num_local_experts,
+                        expert_tokens_num_type=1,
+                        expert_tokens_num_flag=True,
+                        row_idx_type=0,
+                        active_expert_range=[0, num_local_experts],
+                    )
+                )
+                dynamic_scale_after_routing = dynamic_scale_after_routing.reshape(
+                    dynamic_scale_after_routing.size(0)
+                )
+            (dispatch_out, reversed_global_mapping, _, _) = (
+                torch_npu.npu_moe_init_routing_v2(
+                    global_input_tokens,
+                    global_tokens_indices,
+                    quant_mode=-1,
+                    expert_num=num_local_experts,
+                    expert_tokens_num_type=1,
+                    expert_tokens_num_flag=True,
+                    row_idx_type=0,
+                    active_expert_range=[0, num_local_experts],
+                )
             )
         else:
             dispatch_out = global_input_tokens
@@ -648,9 +679,10 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
             "hidden_shape_before_permute": x.shape,
             "num_local_experts": num_local_experts,
         }
-
         recv_x = (
-            (dispatch_out, dynamic_scale_after_all2all) if input_quant else dispatch_out
+            (dispatch_out, dynamic_scale_after_routing)
+            if use_quant == 1
+            else dispatch_out
         )
 
         return (
@@ -690,7 +722,16 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
             and num_local_experts > 1
             and reversed_global_mapping is not None
         ):
-            x = torch_npu.npu_moe_token_unpermute(x, reversed_global_mapping)
+            x = torch_npu.npu_moe_finalize_routing(
+                expanded_permuted_rows=x,
+                skip1=None,
+                skip2=None,
+                bias=None,
+                scales=None,
+                expanded_src_to_dst_row=reversed_global_mapping.to(torch.int32),
+                export_for_source_row=None,
+                drop_pad_mode=2,
+            )
 
         _, local_tokens, a2a_handle = self._async_all_to_all(
             x,
@@ -701,11 +742,15 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
         a2a_handle.wait()
         x.untyped_storage().resize_(0)
 
-        output = torch_npu.npu_moe_token_unpermute(
-            permuted_tokens=local_tokens,
-            sorted_indices=reversed_local_mapping.to(torch.int32),
-            probs=topk_weights,
-            restore_shape=hidden_shape_before_permute,
+        output = torch_npu.npu_moe_finalize_routing(
+            expanded_permuted_rows=local_tokens,
+            skip1=None,
+            skip2=None,
+            bias=None,
+            scales=topk_weights,
+            expanded_src_to_dst_row=reversed_local_mapping.to(torch.int32),
+            export_for_source_row=None,
+            drop_pad_mode=2,
         )
         output = output.view(hidden_shape)
 

--- a/tests/python/deepep/test_ll_alltoall.py
+++ b/tests/python/deepep/test_ll_alltoall.py
@@ -1,0 +1,400 @@
+import argparse
+import os
+import random
+import time
+from functools import partial
+
+import torch
+import torch.distributed as dist
+import torch_npu
+from deep_ep import Buffer
+from utils import (
+    bench,
+    bench_kineto,
+    calc_diff,
+    calculate_avg_stats,
+    hash_tensor,
+    init_dist,
+    per_token_cast_back,
+)
+
+
+def test(
+    aligned_num_tokens: int,  # 对齐后的最大token数
+    num_tokens: int,  # 当前rank的实际token数，有效token数
+    hidden: int,
+    num_experts: int,
+    num_topk: int,
+    rank: int,
+    num_ranks: int,
+    group: dist.ProcessGroup,
+    buffer: Buffer,
+    seed: int = 0,
+    quant_type: str = "no",
+    local_rank: int = 0,
+):
+    torch.manual_seed(seed + rank)
+    random.seed(seed + rank)
+
+    assert num_experts % num_ranks == 0
+    num_local_experts = num_experts // num_ranks
+
+    rank_offset = 128
+    assert (
+        num_ranks - rank_offset < 257
+    ), "Too many ranks (exceeding test precision limit)"
+
+    x = torch.ones((num_tokens, hidden), dtype=torch.bfloat16, device="npu") * (
+        rank - rank_offset
+    )
+    x[:, -128:] = torch.arange(num_tokens, device="npu").to(torch.bfloat16).view(-1, 1)
+    x_pure_rand = torch.randn((num_tokens, hidden), dtype=torch.bfloat16, device="npu")
+    scores = (
+        torch.randn((num_tokens, num_experts), dtype=torch.float32, device="npu").abs()
+        + 1
+    )
+    topk_idx = torch.topk(scores, num_topk, dim=-1, largest=True, sorted=True)[1]
+
+    topk_weights = torch.randn(
+        (num_tokens, num_topk), dtype=torch.float32, device="npu"
+    ).abs()
+
+    # Check dispatch correctness
+    do_check = True
+    return_recv_hook = False
+    hash_value, num_times = 0, 0
+
+    cumulative_local_expert_recv_stats = torch.zeros(
+        (num_local_experts,), dtype=torch.int, device="npu"
+    )
+
+    if quant_type == "int8":
+        quant_configs = [(True, False, False)]
+    else:  # no quant
+        quant_configs = [(False, False, False)]
+
+    for dispatch_use_fp8, dispatch_use_ue8m0, dispatch_use_mxfp4 in quant_configs:
+        for current_x in filter(lambda elem: elem is not None, (x_pure_rand,)):
+            if local_rank == 0:
+                print(
+                    f'[testing] Running with {quant_type=}, data={"rand" if current_x is x_pure_rand else "uniform"} ...',
+                    flush=True,
+                )
+
+            packed_recv_x, packed_recv_count, handle, event, hook = (
+                buffer.low_latency_dispatch(
+                    current_x,
+                    topk_idx,
+                    aligned_num_tokens,
+                    num_experts,
+                    use_fp8=dispatch_use_fp8,
+                    round_scale=False,
+                    use_ue8m0=dispatch_use_ue8m0,
+                    use_mxfp4=dispatch_use_mxfp4,
+                    cumulative_local_expert_recv_stats=cumulative_local_expert_recv_stats,
+                    async_finish=not return_recv_hook,
+                    return_recv_hook=return_recv_hook,
+                    topk_weights=topk_weights,
+                )
+            )
+            simulated_gemm_x = (
+                per_token_cast_back(*packed_recv_x)
+                if dispatch_use_fp8
+                else packed_recv_x
+            )
+
+            padding_size = aligned_num_tokens - num_tokens
+            if padding_size > 0:
+                padding_tensor = torch.full(
+                    (padding_size, num_topk),
+                    fill_value=-1,
+                    dtype=topk_idx.dtype,
+                    device="npu",
+                )
+                topk_idx_padded = torch.cat([topk_idx, padding_tensor], dim=0)
+            else:
+                topk_idx_padded = topk_idx
+
+            all_topk_idx = torch.empty(
+                (num_ranks, aligned_num_tokens, num_topk),
+                dtype=topk_idx.dtype,
+                device="npu",
+            )
+            dist.all_gather_into_tensor(all_topk_idx, topk_idx_padded, group=group)
+
+        # Check combine correctness
+        src_info = handle[0]
+        layout_range = handle[1]
+        num_max_dispatch_tokens_per_rank = handle[2]
+        hidden = handle[3]
+        packed_recv_count = handle[5]
+        expand_scales = handle[6]
+
+        out = torch.empty(
+            (aligned_num_tokens, hidden), dtype=torch.bfloat16, device="npu"
+        )
+        combined_x, event, hook = buffer.low_latency_combine(
+            simulated_gemm_x,
+            topk_idx,
+            topk_weights,
+            handle,
+            async_finish=not return_recv_hook,
+            zero_copy=False,
+            return_recv_hook=return_recv_hook,
+            out=out,
+        )
+
+        if do_check:
+            ref_x = x_pure_rand if current_x is x_pure_rand else x
+            diff = calc_diff(
+                ref_x
+                * topk_weights.masked_fill(topk_idx == -1, 0).sum(dim=1).view(-1, 1),
+                combined_x,
+            )
+            assert torch.isnan(combined_x).sum().item() == 0
+            golden = ref_x * topk_weights.masked_fill(topk_idx == -1, 0).sum(
+                dim=1
+            ).view(-1, 1)
+            eps = 1e-8
+            golden_nozero = torch.where(golden == 0, eps, golden)
+            max_diff = torch.max(torch.abs(combined_x - golden) / golden_nozero).item()
+            avg_diff = torch.mean(torch.abs(combined_x - golden) / golden_nozero).item()
+            print(
+                f"rank {rank} PASSED [{quant_type=}] avg_diff={avg_diff:.5f}, max_diff={max_diff:.5f}, cosine_diff={diff:.5f}"
+            )
+            if dispatch_use_mxfp4:
+                assert diff < 1e-2, f"Error: {diff=}"
+            elif dispatch_use_ue8m0:
+                assert diff < 1e-3, f"Error: {diff=}"
+            elif dispatch_use_fp8:
+                assert diff < 1e-4, f"Error: {diff=}"
+            else:
+                assert diff < 1e-5, f"Error: {diff=}"
+            hash_value ^= hash_tensor(combined_x)
+            if local_rank == 0:
+                print(" passed", flush=True)
+    if local_rank == 0:
+        print("", flush=True)
+
+    # noinspection PyShadowingNames
+    def test_func(zero_copy: bool, return_recv_hook: bool):
+        recv_x, recv_count, handle, event, hook = buffer.low_latency_dispatch(
+            current_x,
+            topk_idx,
+            aligned_num_tokens,
+            num_experts,
+            cumulative_local_expert_recv_stats=cumulative_local_expert_recv_stats,
+            use_fp8=dispatch_use_fp8,
+            use_ue8m0=dispatch_use_ue8m0,
+            use_mxfp4=dispatch_use_mxfp4,
+            async_finish=False,
+            return_recv_hook=return_recv_hook,
+            topk_weights=topk_weights,
+        )
+        simulated_gemm_x_local = (
+            per_token_cast_back(*recv_x) if dispatch_use_fp8 else recv_x
+        )
+        combined_x, event, hook = buffer.low_latency_combine(
+            simulated_gemm_x_local,
+            topk_idx,
+            topk_weights,
+            handle,
+            zero_copy=zero_copy,
+            return_recv_hook=return_recv_hook,
+        )
+
+    # Calculate bandwidth based on quant_type
+    def calculate_dispatch_bytes(num_tokens, hidden, quant_type):
+        BLOCK_SIZE = 32
+        num_values = num_tokens * hidden
+        if quant_type == "int8":
+            data_bytes = num_values * 1
+            scale_bytes = num_tokens * 2
+            return data_bytes + scale_bytes
+        else:
+            return num_values * 2
+
+    num_bf16_bytes = hidden * 2
+    num_dispatch_comm_bytes, num_combine_comm_bytes = 0, 0
+    for i in range(num_tokens):
+        num_selections = (topk_idx[i] != -1).sum().item()
+        num_dispatch_comm_bytes += calculate_dispatch_bytes(
+            num_selections, hidden, quant_type
+        )
+        num_combine_comm_bytes += num_bf16_bytes * num_selections
+
+    # Dispatch + combine testing
+    avg_t, min_t, max_t = bench(
+        partial(test_func, zero_copy=False, return_recv_hook=False)
+    )
+    print(f"[test] finish.")
+    # return
+
+    # tuning dispatch
+    dispatch_args = {
+        "x": current_x,
+        "topk_idx": topk_idx,
+        "num_max_dispatch_tokens_per_rank": aligned_num_tokens,
+        "num_experts": num_experts,
+        "cumulative_local_expert_recv_stats": cumulative_local_expert_recv_stats,
+        "use_fp8": dispatch_use_fp8,
+        "use_ue8m0": dispatch_use_ue8m0,
+        "use_mxfp4": dispatch_use_mxfp4,
+        "topk_weights": topk_weights,
+    }
+    # dispatch_t = bench(lambda: buffer.low_latency_dispatch(**dispatch_args))[0]
+    dispatch_alltoall_t = bench_kineto(
+        lambda: buffer.low_latency_dispatch(**dispatch_args),
+        kernel_names=("MoeInitRoutingV3", "hcom_alltoallv_"),
+        barrier_comm_profiling=True,
+        suppress_kineto_output=True,
+        num_kernels_per_period=2 if return_recv_hook else 1,
+        trace_path=None,
+    )
+    dispatch_t = sum(dispatch_alltoall_t)
+
+    # tuning combine
+    recv_x, _, handle, _, _ = buffer.low_latency_dispatch(**dispatch_args)
+    simulated_gemm_x_local = (
+        per_token_cast_back(*recv_x) if dispatch_use_fp8 else recv_x
+    )
+    combine_args = {
+        "x": simulated_gemm_x_local,
+        "topk_idx": topk_idx,
+        "topk_weights": topk_weights,
+        "handle": handle,
+    }
+    # combine_t = bench(lambda: buffer.low_latency_combine(**combine_args))[0]
+    combine_alltoall_t = bench_kineto(
+        lambda: buffer.low_latency_combine(**combine_args),
+        kernel_names=("hcom_alltoallv_", "MoeFinalizeRoutingV2"),
+        barrier_comm_profiling=True,
+        suppress_kineto_output=True,
+        num_kernels_per_period=2 if return_recv_hook else 1,
+        trace_path=None,
+    )
+    combine_t = sum(combine_alltoall_t)
+
+    print(
+        f"[rank {rank}] Dispatch bandwidth: {num_dispatch_comm_bytes / 1e9 / dispatch_t:.2f} GB/s, avg_t={dispatch_t * 1e6:.2f} us | "
+        f"Combine bandwidth: {num_combine_comm_bytes / 1e9 / combine_t:.2f} GB/s, avg_t={combine_t * 1e6:.2f} us",
+        flush=True,
+    )
+    calculate_avg_stats(
+        dispatch_t=dispatch_t,
+        num_dispatch_comm_bytes=num_dispatch_comm_bytes,
+        combine_t=combine_t,
+        num_combine_comm_bytes=num_combine_comm_bytes,
+        rank=rank,
+        num_ranks=num_ranks,
+        root_rank=0,
+    )
+
+    return hash_value
+
+
+def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
+    rank, num_ranks, group = init_dist(local_rank, num_local_ranks)
+    shared_expert_rank_num = int(os.getenv("MOE_SHARED_EXPERT_RANK_NUM", 0))
+    base_num_tokens, hidden = args.num_tokens, args.hidden
+    num_topk, num_experts = args.num_topk, args.num_experts
+    use_experts = num_experts if shared_expert_rank_num == 0 else (num_experts - 1)
+    use_ranks = num_ranks - shared_expert_rank_num
+
+    enable_dynamic_tokens = args.enable_dynamic_tokens
+
+    if enable_dynamic_tokens:
+        fluctuation_percentage = 0.1
+        min_fluctuation = 2
+
+        if base_num_tokens < 10:
+            fluctuation = random.randint(-min_fluctuation, min_fluctuation)
+            num_tokens = base_num_tokens + fluctuation
+        else:
+            fluctuation = random.uniform(
+                1 - fluctuation_percentage, 1 + fluctuation_percentage
+            )
+            num_tokens = int(base_num_tokens * fluctuation)
+
+        raw_num_tokens = max(num_tokens, 1)
+    else:
+        raw_num_tokens = base_num_tokens
+
+    local_tokens_tensor = torch.tensor(
+        [raw_num_tokens], dtype=torch.int32, device="npu"
+    )
+    dist.all_reduce(local_tokens_tensor, op=dist.ReduceOp.MAX)
+    aligned_num_tokens = local_tokens_tensor.item()
+
+    print(
+        f"[rank {rank}] raw_num_tokens: {raw_num_tokens}, aligned_num_tokens: {aligned_num_tokens}"
+    )
+
+    num_rdma_bytes = Buffer.get_low_latency_rdma_size_hint(
+        aligned_num_tokens, hidden, num_ranks, num_experts
+    )
+    buffer = Buffer(
+        group,
+        num_rdma_bytes=num_rdma_bytes,
+        low_latency_mode=True,
+        num_qps_per_rank=use_experts // use_ranks if use_ranks > 0 else 1,
+        low_latency_strategy="alltoall",
+    )
+
+    test(
+        aligned_num_tokens,
+        raw_num_tokens,
+        hidden,
+        use_experts,
+        num_topk,
+        rank,
+        use_ranks,
+        group,
+        buffer,
+        seed=1,
+        quant_type=args.quant_type,
+        local_rank=local_rank,
+    )
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Test intranode EP kernels")
+    parser.add_argument(
+        "--num-processes",
+        type=int,
+        default=16,
+        help="Number of processes to spawn (default: 16)",
+    )
+    parser.add_argument(
+        "--num-tokens", type=int, default=256, help="Number of tokens (default: 256)"
+    )
+    parser.add_argument(
+        "--hidden", type=int, default=7168, help="Hidden dimension size (default: 7168)"
+    )
+    parser.add_argument(
+        "--num-topk", type=int, default=8, help="Number of top-k experts (default: 8)"
+    )
+    parser.add_argument(
+        "--num-experts", type=int, default=256, help="Number of experts (default: 256)"
+    )
+    parser.add_argument(
+        "--enable-dynamic-tokens",
+        action="store_true",
+        help="Enable dynamic and inconsistent num_tokens across different ranks",
+    )
+    parser.add_argument(
+        "--quant-type",
+        dest="quant_type",
+        type=str,
+        default="bf16",
+        choices=["bf16", "int8"],
+        help="Quantization type for dispatch: bf16, int8 (per-token)",
+    )
+    args = parser.parse_args()
+
+    num_processes = args.num_processes
+    torch.multiprocessing.spawn(
+        test_loop, args=(num_processes, args), nprocs=num_processes
+    )

--- a/tests/python/deepep/test_low_latency.py
+++ b/tests/python/deepep/test_low_latency.py
@@ -338,9 +338,9 @@ def test(
     for return_recv_hook in (False,):
         enable_neg_one = int(os.getenv("MOE_ENABLE_TOPK_NEG_ONE", 0))
         dist.barrier()
-        enable_topk_neg_one = os.getenv("MOE_ENABLE_TOPK_NEG_ONE", "").lower()
+        is_layout = os.getenv("DEEP_USE_MODE", "").lower()
 
-        if enable_topk_neg_one == "ops":
+        if is_layout == "ops":
             dispatch_name = "MoeDistributeDispatchV2"
             combine_name = "MoeDistributeCombineV2"
         else:

--- a/tests/python/deepep/test_normal_alltoall.py
+++ b/tests/python/deepep/test_normal_alltoall.py
@@ -1,0 +1,422 @@
+import argparse
+import os
+import random
+import time
+from typing import Optional
+
+# noinspection PyUnresolvedReferences
+import deep_ep
+import numpy as np
+import torch
+import torch.distributed as dist
+import torch_npu
+from utils import (
+    bench,
+    calc_diff,
+    diagnose_matrix,
+    init_dist,
+    inplace_unique,
+    per_token_cast_back,
+)
+
+# 设置环境变量
+env = os.environ.copy()
+os.environ["DEEP_USE_MODE"] = "alltoall"
+
+
+# noinspection PyShadowingNames
+def test_main(
+    args: argparse.Namespace,
+    num_local_ranks: int,
+    local_rank: int,
+    num_ranks: int,
+    rank: int,
+    buffer: deep_ep.Buffer,
+    group: dist.ProcessGroup,
+):
+    # Settings
+    base_num_tokens, hidden = args.num_tokens, args.hidden
+    num_topk, num_experts = args.num_topk, args.num_experts
+    enable_dynamic_tokens = args.enable_dynamic_tokens
+    quant_type = args.quant_type  # bf16, int8
+
+    num_servers = num_ranks // num_local_ranks
+    expert_token_nums_type = int(os.getenv("MOE_EXPERT_TOKEN_NUMS_TYPE", 1))
+
+    if enable_dynamic_tokens:
+        fluctuation_percentage = 0.1
+        min_fluctuation = 2
+
+        if base_num_tokens < 10:
+            fluctuation = random.randint(-min_fluctuation, min_fluctuation)
+            num_tokens = base_num_tokens + fluctuation
+        else:
+            fluctuation = random.uniform(
+                1 - fluctuation_percentage, 1 + fluctuation_percentage
+            )
+            num_tokens = int(base_num_tokens * fluctuation)
+
+        # Ensure num_tokens is at least 1
+        num_tokens = max(num_tokens, 1)
+    else:
+        num_tokens = base_num_tokens
+
+    assert num_experts % num_ranks == 0
+    if local_rank == 0:
+        print(
+            f"[config] num_tokens={num_tokens}, hidden={hidden}, num_topk={num_topk}, active_ranks={args.active_ranks}",
+            flush=True,
+        )
+
+    experts_per_rank = num_experts // num_ranks
+
+    if args.active_ranks:
+        # Only assign tokens to the specified ranks
+        try:
+            active_ranks = [
+                int(r.strip()) for r in args.active_ranks.split(",") if r.strip()
+            ]
+        except ValueError:
+            raise ValueError(
+                f"Invalid value in --active-ranks: {args.active_ranks}. "
+                f"Must be a comma-separated list of integers, e.g., '0,1,3'."
+            )
+
+        # Validate range
+        if any(r < 0 or r >= num_ranks for r in active_ranks):
+            raise ValueError(
+                f"Invalid rank in --active-ranks: {active_ranks}. "
+                f"Ranks must be in range [0, {num_ranks-1}]."
+            )
+
+        if not active_ranks:
+            raise ValueError(
+                "Parsed --active-ranks is empty. Provide at least one valid rank."
+            )
+
+        valid_experts = torch.cat(
+            [
+                torch.arange(
+                    r * experts_per_rank, (r + 1) * experts_per_rank, device="npu"
+                )
+                for r in active_ranks
+            ]
+        )
+        # Randomly sample experts from active ranks only
+        topk_idx = valid_experts[
+            torch.randint(0, len(valid_experts), (num_tokens, num_topk), device="npu")
+        ]
+    else:
+        # Default: random over all experts (original behavior)
+        scores = (
+            torch.randn(
+                (num_tokens, num_experts), dtype=torch.float32, device="npu"
+            ).abs()
+            + 1
+        )
+        topk_idx = torch.zeros((num_tokens, num_topk), dtype=torch.int64, device="npu")
+        for t in range(num_tokens):
+            start = (t * num_topk) % num_experts
+            for k in range(num_topk):
+                topk_idx[t, k] = (start + k) % num_experts
+    topk_weights = (
+        torch.ones((num_tokens, num_topk), dtype=torch.float32, device="npu") * rank
+    )
+    rank_idx = topk_idx // experts_per_rank
+    rank_idx.masked_fill_(topk_idx == -1, -1)
+    inplace_unique(rank_idx, num_ranks)
+
+    # Expert meta
+    num_tokens_per_expert = torch.zeros((num_experts), dtype=torch.int, device="npu")
+    for expert_id in range(num_experts):
+        num_tokens_per_expert[expert_id] = (topk_idx == expert_id).sum()
+
+    gbl_num_tokens_per_expert = num_tokens_per_expert.clone()
+    dist.all_reduce(gbl_num_tokens_per_expert, op=dist.ReduceOp.SUM, group=group)
+
+    # Rank layout meta
+    num_tokens_per_rank = torch.empty((num_ranks,), dtype=torch.int, device="npu")
+    token_idx_in_rank = torch.full(
+        (num_ranks, num_tokens), -1, dtype=torch.long, device="npu"
+    )
+
+    for i in range(num_ranks):
+        token_sel = (rank_idx == i).max(dim=-1)[0]  # [num_tokens]
+        token_indices = torch.nonzero(token_sel, as_tuple=True)[0]  # [count]
+        count = token_indices.numel()
+        num_tokens_per_rank[i] = count
+        if count > 0:
+            token_idx_in_rank[i][token_indices] = torch.arange(count, device="npu")
+
+    token_idx_in_rank = token_idx_in_rank.T.contiguous().to(torch.int)
+    is_token_in_rank = (token_idx_in_rank >= 0).to(torch.bool)
+    gbl_num_tokens_per_rank = num_tokens_per_rank.clone()
+    dist.all_reduce(gbl_num_tokens_per_rank, group=group)
+
+    t = bench(lambda: buffer.get_dispatch_layout(topk_idx, num_experts))[0]
+    print(f"[layout] {rank=} Kernel performance: {t * 1000:.3f} ms", flush=True)
+    print("", flush=True)
+    dist.barrier()
+    time.sleep(1)
+
+    return_values = buffer.get_dispatch_layout(topk_idx, num_experts)
+    (
+        ref_num_tokens_per_rank,
+        _,
+        ref_num_tokens_per_expert,
+        ref_is_token_in_rank,
+        _,
+    ) = return_values
+    print(f"rank {rank} layout PASSED")
+
+    # Config
+    buffer_size = 256
+    config = deep_ep.Config(24, 8, buffer_size)
+
+    # Random data
+    x = torch.ones((num_tokens, hidden), dtype=torch.bfloat16, device="npu") * rank
+    x_pure_rand = torch.randn((num_tokens, hidden), dtype=torch.bfloat16, device="npu")
+    topk_weights = (
+        torch.ones((num_tokens, num_topk), dtype=torch.float32, device="npu") * rank
+    )
+    topk_weights_pure_rand = torch.randn(
+        (num_tokens, num_topk), dtype=torch.float32, device="npu"
+    )
+
+    # Test dispatch
+    for current_x in filter(lambda elem: elem is not None, (x, x_pure_rand)):
+        if local_rank == 0:
+            print(
+                f'[testing] Running with {"INT8" if isinstance(current_x, tuple) else "BF16"}, with top-k {num_topk} ...',
+                flush=True,
+            )
+        dispatch_args = {
+            "x": current_x,
+            "num_tokens_per_rank": ref_num_tokens_per_rank,
+            "is_token_in_rank": ref_is_token_in_rank,
+            "num_tokens_per_expert": ref_num_tokens_per_expert,
+            "config": config,
+            "topk_idx": topk_idx,
+            "topk_weights": (
+                topk_weights_pure_rand if current_x is x_pure_rand else topk_weights
+            ),
+            "quant_mode": quant_type,
+        }
+
+        (
+            recv_x,
+            recv_topk_idx,
+            recv_topk_weights,
+            recv_num_tokens_per_expert_list,
+            handle,
+            event,
+        ) = buffer.dispatch(**dispatch_args)
+        recv_x_original = (
+            recv_x[0].view(torch.uint8).clone().view(recv_x[0].dtype)
+            if isinstance(recv_x, tuple)
+            else recv_x.clone()
+        )
+        quant_scales = (
+            recv_x[1].view(torch.uint8).clone().view(recv_x[1].dtype)
+            if isinstance(recv_x, tuple)
+            else None
+        )
+        recv_x = per_token_cast_back(*recv_x) if isinstance(recv_x, tuple) else recv_x
+
+        # Checks
+        local_expert_token = gbl_num_tokens_per_expert.view(num_ranks, -1)[rank]
+        if expert_token_nums_type == 0:
+            local_expert_token_list = local_expert_token.cumsum(
+                dim=0
+            ).tolist()  # 计算前缀和并转为 list
+        else:
+            local_expert_token_list = local_expert_token.tolist()
+
+        assert (
+            local_expert_token_list == recv_num_tokens_per_expert_list
+        ), f"Assertion num_tokens_per_rank failed on rank {rank}: Expected {local_expert_token_list}, Actual {recv_num_tokens_per_expert_list}"
+
+        # Test combine
+        combine_args = {
+            "x": recv_x,
+            "handle": handle,
+            "config": config,
+            "async_finish": False,
+            "topk_weights": handle["topk_weights"],
+        }
+        combined_x, combined_topk_weights, event = buffer.combine(**combine_args)
+        check_x = combined_x.float()
+
+        ref_x = x_pure_rand if current_x is x_pure_rand else x
+        diff = calc_diff(
+            check_x,
+            ref_x
+            * handle["topk_weights"]
+            .masked_fill(topk_idx == -1, 0)
+            .sum(dim=1)
+            .view(-1, 1),
+        )
+        golden = ref_x * handle["topk_weights"].masked_fill(topk_idx == -1, 0).sum(
+            dim=1
+        ).view(-1, 1)
+        # translate all zeros to eps in golden
+        eps = 1e-8
+        golden_nozero = torch.where(golden == 0, eps, golden)
+        max_diff = torch.max(torch.abs(check_x - golden) / golden_nozero).item()
+
+        avg_diff = torch.mean(torch.abs(check_x - golden) / golden_nozero).item()
+        print(f"{rank=}, {avg_diff=:.5f}, {max_diff=:.5f}, cosine_diff={diff:.5f}")
+        assert diff < 5e-5, f"Assertion diff failed on {rank=}"
+
+        # For later tuning
+        dispatch_bf16_recv_bytes = recv_x.numel() * 2
+        combine_bf16_send_bytes = dispatch_bf16_recv_bytes
+
+        if local_rank == 0:
+            print(f"[test] passed, {dispatch_bf16_recv_bytes=}", flush=True)
+    if local_rank == 0:
+        print("", flush=True)
+
+    # Tune dispatch performance
+    def calculate_recv_bytes(dispatch_bf16_recv_bytes, quant_type):
+        hidden_dim = hidden
+        bs = dispatch_bf16_recv_bytes / 2 / hidden_dim
+        num_values = bs * hidden_dim
+
+        if quant_type == "bf16":
+            # No quantization, use original BF16 communication
+            recv_bytes = dispatch_bf16_recv_bytes
+        elif quant_type == "int8":
+            # INT8 per-token quantization:
+            # - Data: num_values * 1 byte (INT8)
+            # - Scale: x tokens * 2 bytes each (BF16)
+            data_bytes = num_values * 1
+            scale_bytes = bs * 2
+            recv_bytes = data_bytes + scale_bytes
+        else:
+            raise ValueError(f"Unsupported quant_type: {quant_type}")
+        return recv_bytes
+
+    config = deep_ep.Config(24, 8, buffer_size)
+    for current_x in filter(lambda elem: elem is not None, (x,)):
+        # Replace the original recv_bytes calculation with:
+        recv_bytes = calculate_recv_bytes(dispatch_bf16_recv_bytes, quant_type)
+
+        tune_args = {
+            "x": current_x,
+            "config": config,
+            "num_tokens_per_rank": ref_num_tokens_per_rank,
+            "is_token_in_rank": ref_is_token_in_rank,
+            "num_tokens_per_expert": ref_num_tokens_per_expert,
+            "topk_idx": topk_idx,
+            "topk_weights": topk_weights,
+            "quant_mode": quant_type,
+        }
+
+        t = bench(lambda: buffer.dispatch(**tune_args))[0]
+        if local_rank == 0:
+            print(
+                f"[tuning] Dispatch ({quant_type=}) {recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
+                flush=True,
+            )
+            print("", flush=True)
+
+    dispatch_args = {
+        "x": x,
+        "num_tokens_per_rank": ref_num_tokens_per_rank,
+        "is_token_in_rank": ref_is_token_in_rank,
+        "num_tokens_per_expert": ref_num_tokens_per_expert,
+        "config": config,
+        "topk_idx": topk_idx,
+        "topk_weights": topk_weights,
+        "quant_mode": quant_type,
+    }
+    recv_x, _, _, _, handle, _ = buffer.dispatch(**dispatch_args)
+    recv_x = per_token_cast_back(*recv_x) if isinstance(recv_x, tuple) else recv_x
+    # Tune combine performance
+    tune_args = {
+        "x": recv_x,
+        "handle": handle,
+        "config": config,
+        "async_finish": False,
+        "topk_weights": handle["topk_weights"],
+    }
+    t = bench(lambda: buffer.combine(**tune_args))[0]
+    if local_rank == 0:
+        print(
+            f"[tuning] Combine {combine_bf16_send_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
+            flush=True,
+        )
+        print("", flush=True)
+
+
+# noinspection PyUnboundLocalVariable,PyShadowingNames
+def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
+    rank, num_ranks, group = init_dist(local_rank, num_local_ranks)
+
+    print(f"[Rank {rank} | Local rank {local_rank}] Initializing buffer...", flush=True)
+    buffer = deep_ep.Buffer(
+        group,
+        int(2e9),
+        0,
+        low_latency_mode=False,
+        num_qps_per_rank=1,
+        normal_strategy="alltoall",
+        low_latency_strategy="alltoall",
+    )
+    print(f"[Rank {rank}] Buffer created OK.", flush=True)
+    torch.manual_seed(rank)
+
+    test_main(args, num_local_ranks, local_rank, num_ranks, rank, buffer, group)
+    if local_rank == 0:
+        print("", flush=True)
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Test intranode EP kernels")
+    parser.add_argument(
+        "--num-processes",
+        type=int,
+        default=16,
+        help="Number of processes to spawn (default: 16)",
+    )
+    parser.add_argument(
+        "--num-tokens", type=int, default=4096, help="Number of tokens (default: 4096)"
+    )
+    parser.add_argument(
+        "--hidden", type=int, default=7168, help="Hidden dimension size (default: 7168)"
+    )
+    parser.add_argument(
+        "--num-topk", type=int, default=8, help="Number of top-k experts (default: 8)"
+    )
+    parser.add_argument(
+        "--num-experts", type=int, default=256, help="Number of experts (default: 256)"
+    )
+    parser.add_argument(
+        "--active-ranks",
+        type=str,
+        default="",
+        help="Comma-separated list of ranks that will receive tokens. "
+        'Example: "0,1,3". If empty, all ranks may receive tokens.',
+    )
+    parser.add_argument(
+        "--enable-dynamic-tokens",
+        action="store_true",
+        help="Whether to enable dynamic tokens for testing",
+    )
+    parser.add_argument(
+        "--quant-type",
+        dest="quant_type",
+        type=str,
+        default="bf16",
+        help="quant type: bf16, int8",
+    )
+    args = parser.parse_args()
+
+    num_processes = args.num_processes
+    torch.multiprocessing.spawn(
+        test_loop, args=(num_processes, args), nprocs=num_processes
+    )

--- a/tests/python/deepep/utils.py
+++ b/tests/python/deepep/utils.py
@@ -302,7 +302,7 @@ def bench_kineto(
     # Return average kernel durations
     kernel_durations = []
     for kernel_name in kernel_names:
-        events = [event for event in profile_data if kernel_name == event["name"]]
+        events = [event for event in profile_data if kernel_name in event["name"]]
         assert len(events) > 0, f"Kernel '{kernel_name}' not found in trace"
         events = sorted(events, key=lambda event: event["ts"])
         durations = [event["dur"] / 1e6 for event in events]
@@ -407,37 +407,55 @@ def calculate_avg_stats(
     num_ranks,
     root_rank: 0,
 ):
-    # dispatch_t / combine_t: the unit is second
+    # 1. 创建本地统计张量
+    # 注意：确保 dtype 和 device 在所有进程中一致
     local_stats = torch.tensor(
         [
-            dispatch_t * 1e6,
-            num_dispatch_comm_bytes,
-            combine_t * 1e6,
-            num_combine_comm_bytes,
+            dispatch_t * 1e6,  # us
+            num_dispatch_comm_bytes,  # bytes
+            combine_t * 1e6,  # us
+            num_combine_comm_bytes,  # bytes
         ],
         dtype=torch.float64,
         device="npu",
     )
-    gather_stats = (
-        [torch.zeros_like(local_stats) for _ in range(num_ranks)]
-        if rank == root_rank
-        else None
-    )
-    dist.gather(local_stats, gather_list=gather_stats, dst=0)
+
+    # 2. 【修改点】为所有进程准备接收列表
+    # all_gather 要求所有进程都参与，且缓冲区形状必须一致
+    # 每个进程都创建一个大小为 num_ranks 的列表，每个元素形状与 local_stats 一致
+    gather_list = [torch.zeros_like(local_stats) for _ in range(num_ranks)]
+
+    # 3. 【修改点】使用 all_gather 替代 gather
+    # 此时，每个进程的 gather_list 都将包含所有 rank 的 local_stats
+    dist.all_gather(gather_list, local_stats)
+
+    # 4. 仅在 root_rank (通常是 0) 上进行统计和打印
+    # 其他进程虽然也执行了 all_gather，但不需要处理结果，节省计算资源
     if rank == root_rank:
-        stats_tensor = torch.stack(gather_stats)  # Shape [num_ranks, 4]
+        # 将列表堆叠成 [num_ranks, 4] 的张量
+        stats_tensor = (
+            torch.stack(gather_stats) if (gather_stats := gather_list) else None
+        )
+        # 注意：上面这行写法可能较新，为了兼容性，我们可以直接写：
+        stats_tensor = torch.stack(gather_list)  # Shape [num_ranks, 4]
+
         dispatch_latency = stats_tensor[:, 0]  # us
         dispatch_bytes = stats_tensor[:, 1]  # bytes
         combine_latency = stats_tensor[:, 2]  # us
         combine_bytes = stats_tensor[:, 3]  # bytes
 
+        # 计算平均值
         avg_dispatch_lat = torch.mean(dispatch_latency)
         avg_dispatch_bytes = torch.mean(dispatch_bytes)
         avg_combine_lat = torch.mean(combine_latency)
         avg_combine_bytes = torch.mean(combine_bytes)
 
+        # 计算带宽 (GB/s)
+        # 注意：如果 latency 为 0 会导致除以零错误，建议加一个极小值保护或断言
+        # 这里假设 latency > 0
         avg_dispatch_bw = avg_dispatch_bytes / avg_dispatch_lat * 1e-3  # GB/s
         avg_combine_bw = avg_combine_bytes / avg_combine_lat * 1e-3  # GB/s
+
         print(
             f"\n\nAverage Dispatch bandwidth: {avg_dispatch_bw:.2f} GB/s, avg_t={avg_dispatch_lat:.2f} us \n"
             f"Average Combine bandwidth: {avg_combine_bw:.2f} GB/s, avg_t={avg_combine_lat:.2f} us\n\n",


### PR DESCRIPTION
## Motivation

The original implementation cannot run properly in A5 9.1.0.  Fix #648 ,Fix #649 

## Modifications

Replace npu_moe_token_permute and npu_dynamic_quant used in the alltoall mode with npu_moe_init_routing_v2 so that the operator can adapt to the Ascend 910 AI Processor 9.1.0 scenario.

## Testing

export DEEP_USE_MODE=alltoall
export HCCL_OP_EXPANSION_MODE=AIV
python test_normal_alltoall.py --num-processes 8 --quant-type bf16
python test_normal_alltoall.py --num-processes 8 --quant-type int8

## Benchmarking and Profiling

after modify:
    [tuning] Dispatch (quant_type='no') 88.64 GB/s (HCCS), avg_t: 5299.96 us
    [tuning] Combine 111.95 GB/s (HCCS), avg_t: 4196.35 us
before modify:
    [tuning] Dispatch (quant_type='no') 88.85 GB/s (HCCS), avg_t: 5287.14 us
    [tuning] Combine 110.63 GB/s (HCCS), avg_t: 4246.31 us

## Checklist

- [ ] Format your code.
- [ ] Add unit tests.
- [ ] Update documentation.
- [ ] Provide accuracy and speed benchmark results.