### PR TITLE
feat: kimi linear runnable

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/ascend_ub_manager.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/ascend_ub_manager.py
@@ -1,0 +1,576 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+# copied from https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/backends/_ascend/ub_manager.py
+
+"""
+Unified Buffer (UB) Manager for Ascend NPU.
+
+This module provides UB capacity detection and tiling strategy computation
+for running Triton kernels on Ascend NPU. It automatically calculates
+optimal block sizes based on UB capacity constraints to prevent UB overflow.
+"""
+
+import os
+import warnings
+
+import torch
+import triton
+
+# Ascend Triton launch limits (see triton_ascend/activations.py).
+ASCEND_MAX_GRID_DIM = 65535
+# Legacy fused kernel byte cap (65536 // fp16 element size).
+_FALLBACK_MAX_FUSED_BLOCK = 65536 // 2
+# Conservative UB fallback when runtime detection is unavailable (64 KiB).
+_FALLBACK_UB_CAPACITY_BITS = 65536 * 8
+
+
+def is_npu_available() -> bool:
+    """Detect Ascend NPU availability."""
+    if hasattr(torch, 'npu'):
+        try:
+            return torch.npu.is_available()
+        except Exception:
+            pass
+    try:
+        from transformers.utils import is_torch_npu_available
+
+        return is_torch_npu_available()
+    except ImportError:
+        return False
+
+
+def _fallback_ub_capacity(reason: str) -> int:
+    warnings.warn(
+        f"Using fallback UB capacity ({_FALLBACK_UB_CAPACITY_BITS // 8} bytes): {reason}",
+        stacklevel=3,
+    )
+    return _FALLBACK_UB_CAPACITY_BITS
+
+
+def _normalize_tiling_dims(tiling_dim: int | tuple[int, ...]) -> set:
+    """
+    Normalize tiling dimension specification to a set of dimension indices.
+
+    Args:
+        tiling_dim: Either an int (single dimension) or tuple of ints (multiple dimensions).
+
+    Returns:
+        Set of dimension indices that can be tiled.
+    """
+    if isinstance(tiling_dim, int):
+        return {tiling_dim}
+    elif isinstance(tiling_dim, tuple):
+        return set(tiling_dim)
+    else:
+        return set()
+
+
+def _default_strategy(
+    ub_capacity_bits: int,
+    safety_margin: float,
+    dtype_size: int,
+    memory_multiplier: float,
+    shapes: tuple[tuple[int, ...], ...],
+    tiling_dims: tuple[int | tuple[int, ...], ...],
+) -> tuple[int, ...]:
+    """
+    Default tiling strategy: calculate maximum safe block size based on UB capacity.
+
+    This is a unified strategy function that works for all kernels by abstracting
+    the memory calculation as: memory_multiplier * BLOCK_SIZE * unit_param * dtype_size * 8 bits
+
+    Args:
+        ub_capacity_bits: UB capacity in bits
+        safety_margin: Safety margin as a float (e.g., 0.80 for 80%)
+        dtype_size: Size of data type in bytes (e.g., 2 for float16, 4 for float32)
+        memory_multiplier: Memory multiplier for estimating peak memory usage
+        shapes: Tuple of full shapes. Each shape is a tuple of dimension sizes.
+            - For ROPE: ((n_q_head, hd), (n_kv_head, hd))
+            - For GEGLU: ((n_cols,),)
+        tiling_dims: Tuple specifying which dimensions can be tiled for each shape.
+            Each element can be:
+            - int: single dimension index (e.g., 0 for first dimension)
+            - tuple of ints: multiple dimensions that can be tiled together
+            - For ROPE: (0, 0) means first dimension of each shape can be tiled
+            - For GEGLU: (0,) means first dimension of the shape can be tiled
+            Length must match len(shapes).
+
+    Returns:
+        Tuple of maximum safe block sizes, one for each shape.
+        Each element is a power of 2.
+
+    Note:
+        For each shape, fixed dimensions (non-tiling) are multiplied together to get unit_param.
+        The final block size is computed in compute_default_tiling_strategy by taking
+        min(desired_block_size, max_safe_block_size) where desired_block_size = triton.next_power_of_2(original_dim).
+    """
+    if not shapes or not tiling_dims:
+        return ()
+
+    # Calculate max_safe_block_size for each tiling dimension
+    max_safe_sizes = []
+
+    for shape, tiling_dim in zip(shapes, tiling_dims):
+        # Normalize tiling_dim to a set of dimension indices
+        tiling_dim_set = _normalize_tiling_dims(tiling_dim)
+
+        # Validate tiling dimensions are within shape bounds
+        if not tiling_dim_set:
+            raise ValueError(
+                f"Invalid tiling_dim: {tiling_dim}. tiling_dim must be an int or a non-empty tuple of ints."
+            )
+        if any(dim_idx < 0 or dim_idx >= len(shape) for dim_idx in tiling_dim_set):
+            raise ValueError(
+                f"Invalid tiling_dim: {tiling_dim} for shape {shape}. "
+                f"All dimension indices must be in range [0, {len(shape)})."
+            )
+
+        # Calculate unit_param: product of fixed (non-tiling) dimensions
+        unit_param = 1.0
+        for dim_idx, dim_size in enumerate(shape):
+            if dim_idx not in tiling_dim_set:
+                if dim_size <= 0:
+                    # Invalid dimension size, use conservative default
+                    unit_param = 1.0
+                    break
+                unit_param *= float(dim_size)
+
+        # Ensure unit_param is at least 1.0
+        if unit_param <= 0:
+            unit_param = 1.0
+
+        # Calculate maximum safe block size based on UB capacity
+        # Memory: memory_multiplier * BLOCK_SIZE * unit_param * dtype_size * 8 bits
+        SAFE_UB_CAPACITY_BITS = int(ub_capacity_bits * safety_margin)
+
+        # Solve: memory_multiplier * BLOCK_SIZE * unit_param * dtype_size * 8 <= SAFE_UB_CAPACITY_BITS
+        # BLOCK_SIZE <= SAFE_UB_CAPACITY_BITS / (memory_multiplier * unit_param * dtype_size * 8)
+        max_block_size = int(SAFE_UB_CAPACITY_BITS // (memory_multiplier * unit_param * dtype_size * 8))
+        max_block_size = max(1, max_block_size)
+
+        # Find largest power of 2 <= max_block_size
+        # Use triton.next_power_of_2(max_block_size + 1) // 2 to get the largest power of 2 <= max_block_size
+        safe_block_size = triton.next_power_of_2(max_block_size + 1) // 2
+        max_safe_sizes.append(safe_block_size)
+
+    return tuple(max_safe_sizes)
+
+
+class UBManager:
+    """
+    Unified Buffer Manager for Ascend NPU.
+
+    Provides UB capacity detection and management for Ascend NPU devices.
+    The UB capacity is used by tiling strategy functions to calculate optimal block sizes.
+    """
+
+    def __init__(self, ub_capacity_bits: int | None = None):
+        """
+        Initialize UB Manager.
+
+        Args:
+            ub_capacity_bits: UB capacity in bits. If None, will be detected automatically.
+        """
+        self._npu_model = self._detect_npu_model()
+        self._ub_capacity_bits = ub_capacity_bits or self._detect_ub_capacity()
+
+    @property
+    def ub_capacity_bits(self) -> int:
+        """Get UB capacity in bits."""
+        return self._ub_capacity_bits
+
+    @property
+    def ub_capacity_bytes(self) -> int:
+        """Get UB capacity in bytes."""
+        return self._ub_capacity_bits // 8
+
+    @property
+    def npu_model(self) -> str:
+        """Get detected NPU model name."""
+        return self._npu_model
+
+    def _detect_npu_model(self) -> str:
+        """Detect NPU model from device properties."""
+        if not is_npu_available():
+            return "unknown"
+
+        try:
+            dev_props = torch.npu.get_device_properties(0)
+            # Try to get model name from device properties
+            return dev_props.name
+        except Exception:
+            pass
+
+        return "default"
+
+    def _detect_ub_capacity(self) -> int:
+        """
+        Detect UB capacity from environment variable or get_soc_spec.
+
+        Returns:
+            UB capacity in bits. Falls back to a conservative default with a warning
+            when detection fails.
+        """
+        # Check environment variable first (in bits)
+        env_capacity = os.getenv("ASCEND_UB_CAPACITY_BITS")
+        if env_capacity is not None:
+            try:
+                capacity_bits = int(env_capacity)
+                if capacity_bits > 0:
+                    return capacity_bits
+            except ValueError:
+                pass
+
+        # Try to get from get_soc_spec (returns bytes, convert to bits)
+        if is_npu_available():
+            try:
+                from tbe.common.platform import get_soc_spec, set_current_compile_soc_info
+
+                # Set current SOC info for get_soc_spec to work correctly
+                device = torch.npu
+                soc_info = device.get_device_name(device.current_device())
+                set_current_compile_soc_info(soc_info)
+
+                # Query UB size (get_soc_spec returns size in bytes)
+                ub_size_bytes = get_soc_spec("UB_SIZE")
+
+                if ub_size_bytes is None or ub_size_bytes <= 0:
+                    raise ValueError(f"Invalid UB_SIZE from get_soc_spec: {ub_size_bytes}")
+
+                # Convert bytes to bits
+                ub_capacity_bits = ub_size_bytes * 8
+                return ub_capacity_bits
+
+            except ImportError:
+                return _fallback_ub_capacity(
+                    "Cannot import tbe.common.platform.get_soc_spec. "
+                    "Source CANN set_env.sh or set ASCEND_UB_CAPACITY_BITS."
+                )
+            except Exception as e:
+                return _fallback_ub_capacity(
+                    f"Failed to detect UB capacity from get_soc_spec: {e}. "
+                    "Set ASCEND_UB_CAPACITY_BITS to override."
+                )
+
+        return _fallback_ub_capacity(
+            "NPU is not available. Set ASCEND_UB_CAPACITY_BITS to override."
+        )
+
+
+# Global singleton instance
+_ub_manager: UBManager | None = None
+
+
+def get_ub_manager() -> UBManager:
+    """Get global UB manager instance."""
+    global _ub_manager
+    if _ub_manager is None:
+        _ub_manager = UBManager()
+    return _ub_manager
+
+
+def compute_default_tiling_strategy(
+    safety_margin: float = 0.80,
+    dtype_size: int | None = None,
+    memory_multiplier: float | None = None,
+    shapes: tuple[tuple[int, ...], ...] | None = None,
+    tiling_dims: tuple[int | tuple[int, ...], ...] | None = None,
+) -> tuple[tuple[int, ...], ...] | None:
+    """
+    Compute tiling strategy using the default strategy function.
+
+    This function directly calls the default strategy and computes the final
+    tiling result. All kernels use the same unified strategy function, so
+    there's no need for kernel_name-based lookup.
+
+    Args:
+        safety_margin: Safety margin as a float (e.g., 0.80 for 80%). Default is 0.80.
+        dtype_size: Size of data type in bytes (e.g., 2 for float16, 4 for float32).
+            Must be provided. If None or <= 0, defaults to 4 (float32).
+        memory_multiplier: Memory multiplier for estimating peak memory usage.
+            - For GEGLU: typically 10.0 for backward, 4.0 for forward
+            - For ROPE: typically 3.0
+            If None, defaults to 10.0 (conservative estimate).
+        shapes: Tuple of full shapes. Each shape is a tuple of dimension sizes.
+            - For ROPE: ((n_q_head, hd), (n_kv_head, hd))
+            - For GEGLU: ((n_cols,),)
+            Can pass original shapes (will handle padding internally) or padded shapes.
+        tiling_dims: Tuple specifying which dimensions can be tiled for each shape.
+            Each element can be:
+            - int: single dimension index (e.g., 0 for first dimension)
+            - tuple of ints: multiple dimensions that can be tiled together
+            - For ROPE: (0, 0) means first dimension of each shape can be tiled
+            - For GEGLU: (0,) means first dimension of the shape can be tiled
+            Length must match len(shapes). Cannot be empty.
+
+    Returns:
+        Tuple of tiled shapes with same structure as input shapes.
+        Tiling dimensions are replaced with computed block sizes (power of 2),
+        while non-tiling dimensions are padded to next power of 2.
+        - For ROPE: ((block_size_q, pad_hd), (block_size_kv, pad_hd))
+        - For GEGLU: ((block_size,),)
+        Returns None if shapes or tiling_dims is None or empty.
+
+    Examples:
+        >>> # ROPE forward
+        >>> strategy = compute_default_tiling_strategy(
+        ...     safety_margin=0.90,
+        ...     dtype_size=4,
+        ...     memory_multiplier=3.0,
+        ...     shapes=((32, 128), (32, 128)),
+        ...     tiling_dims=(0, 0)
+        ... )
+        >>> # Returns: ((block_size_q, 128), (block_size_kv, 128))
+        >>> # GEGLU forward
+        >>> strategy = compute_default_tiling_strategy(
+        ...     safety_margin=0.80,
+        ...     dtype_size=2,
+        ...     memory_multiplier=7.0,
+        ...     shapes=((4096,),),
+        ...     tiling_dims=(0,)
+        ... )
+        >>> # Returns: ((block_size,),)
+    """
+    ub_manager = get_ub_manager()
+
+    if shapes is None or not shapes or tiling_dims is None or not tiling_dims:
+        return None
+
+    if len(shapes) != len(tiling_dims):
+        return None
+
+    if dtype_size is None or dtype_size <= 0:
+        dtype_size = 4  # Default to float32
+
+    if memory_multiplier is None or memory_multiplier <= 0:
+        memory_multiplier = 10.0  # Default conservative estimate
+
+    # Call strategy to get max_safe_block_size for each shape
+    max_supported = _default_strategy(
+        ub_manager.ub_capacity_bits,
+        safety_margin,
+        dtype_size,
+        memory_multiplier,
+        shapes,
+        tiling_dims,
+    )
+
+    if not max_supported or len(max_supported) != len(shapes):
+        return None
+
+    # Build result: same structure as shapes, with tiling dims replaced by computed block sizes
+    result = []
+    for shape, tiling_dim, max_safe in zip(shapes, tiling_dims, max_supported):
+        result_shape = list(shape)
+
+        # Normalize tiling_dim to a set of dimension indices
+        tiling_dim_set = _normalize_tiling_dims(tiling_dim)
+
+        # Validate tiling dimensions are within shape bounds
+        if not tiling_dim_set:
+            raise ValueError(
+                f"Invalid tiling_dim: {tiling_dim}. tiling_dim must be an int or a non-empty tuple of ints."
+            )
+        if any(dim_idx < 0 or dim_idx >= len(result_shape) for dim_idx in tiling_dim_set):
+            raise ValueError(
+                f"Invalid tiling_dim: {tiling_dim} for shape {shape}. "
+                f"All dimension indices must be in range [0, {len(result_shape)})."
+            )
+
+        # Replace tiling dimensions with computed block sizes
+        # For each tiling dimension, compute: min(desired, max_safe)
+        for dim_idx in tiling_dim_set:
+            original_dim = result_shape[dim_idx]
+            desired = triton.next_power_of_2(original_dim)
+            final_val = min(desired, max_safe)
+            final_val = max(1, final_val)  # Ensure at least 1
+            result_shape[dim_idx] = final_val
+
+        # Pad non-tiling dimensions to next power of 2
+        for dim_idx, dim_size in enumerate(result_shape):
+            if dim_idx not in tiling_dim_set:
+                result_shape[dim_idx] = triton.next_power_of_2(dim_size)
+
+        result.append(tuple(result_shape))
+
+    return tuple(result)
+
+
+def compute_ub_block_size(
+    dim_size: int,
+    memory_multiplier: float,
+    *,
+    safety_margin: float = 0.9,
+    dtype_size: int = 4,
+    fallback: int = 2048,
+    min_block: int = 1,
+    max_block: int | None = None,
+    desired: int | None = None,
+) -> int:
+    """Compute UB-safe block size for a single tilable dimension."""
+    if desired is None:
+        desired = triton.next_power_of_2(dim_size)
+
+    tile_shapes = compute_default_tiling_strategy(
+        safety_margin=safety_margin,
+        dtype_size=dtype_size,
+        memory_multiplier=memory_multiplier,
+        shapes=((dim_size,),),
+        tiling_dims=(0,),
+    )
+    block = min(desired, tile_shapes[0][0]) if tile_shapes else min(desired, fallback)
+    block = max(min_block, block)
+    if max_block is not None:
+        block = min(block, max_block)
+    return block
+
+
+def compute_vocab_block_size(
+    vocab_size: int,
+    num_rows: int,
+    memory_multiplier: float,
+    *,
+    safety_margin: float = 0.9,
+    max_block: int = 8192,
+    fallback: int = 2048,
+) -> int:
+    """UB-safe vocab tile size respecting Ascend grid dim0 limit."""
+    ub_block = compute_ub_block_size(
+        vocab_size,
+        memory_multiplier,
+        safety_margin=safety_margin,
+        fallback=fallback,
+    )
+    max_splits = max(1, ASCEND_MAX_GRID_DIM // max(num_rows, 1))
+    grid_min = triton.next_power_of_2((vocab_size + max_splits - 1) // max_splits)
+    return min(max(ub_block, grid_min), max_block)
+
+
+def compute_elementwise_block_size(
+    n_elements: int,
+    memory_multiplier: float = 2.5,
+    *,
+    safety_margin: float = 0.9,
+    min_block: int = 1024,
+    fallback: int | None = None,
+) -> int:
+    """UB-safe block size for elementwise kernels under grid limit."""
+    if fallback is None:
+        fallback = _FALLBACK_MAX_FUSED_BLOCK
+    ub_block = compute_ub_block_size(
+        n_elements,
+        memory_multiplier,
+        safety_margin=safety_margin,
+        fallback=fallback,
+    )
+    grid_min = max(
+        min_block,
+        triton.next_power_of_2((n_elements + ASCEND_MAX_GRID_DIM - 1) // ASCEND_MAX_GRID_DIM),
+    )
+    return min(ub_block, grid_min)
+
+
+def compute_activation_block_size(
+    total_elements: int,
+    is_backward: bool,
+    *,
+    max_grid: int = ASCEND_MAX_GRID_DIM,
+    max_core_dim: int = 65535,
+    safety_margin: float = 0.9,
+    max_block: int = 2048,
+    memory_multiplier: float | None = None,
+) -> int:
+    """UB-safe block size for flattened activation kernels."""
+    if memory_multiplier is None:
+        memory_multiplier = 6.0 if is_backward else 3.0
+    block = compute_ub_block_size(
+        total_elements,
+        memory_multiplier,
+        safety_margin=safety_margin,
+        fallback=2048,
+        min_block=256,
+        max_block=max_block,
+    )
+    block = min(block, max_core_dim // 8)
+    if triton.cdiv(total_elements, block) > max_grid:
+        block = triton.cdiv(total_elements, max_grid)
+        block = max(triton.next_power_of_2(block), 1)
+    return block
+
+
+def compute_row_tile_block_size(
+    row_dim: int,
+    fixed_dim: int,
+    memory_multiplier: float,
+    *,
+    tiling_row: bool = True,
+    safety_margin: float = 0.85,
+    dtype_size: int = 4,
+    fallback: int = 16,
+    min_block: int = 1,
+    max_block: int | None = None,
+) -> int:
+    """UB-safe tile along one axis of a 2D [row, col] kernel tile."""
+    if tiling_row:
+        shapes = ((row_dim, fixed_dim),)
+        tiling_dims = (0,)
+        desired = triton.next_power_of_2(row_dim)
+    else:
+        shapes = ((row_dim, fixed_dim),)
+        tiling_dims = (1,)
+        desired = triton.next_power_of_2(fixed_dim)
+
+    tile_shapes = compute_default_tiling_strategy(
+        safety_margin=safety_margin,
+        dtype_size=dtype_size,
+        memory_multiplier=memory_multiplier,
+        shapes=shapes,
+        tiling_dims=tiling_dims,
+    )
+    if tile_shapes:
+        block = tile_shapes[0][0] if tiling_row else tile_shapes[0][1]
+        block = min(desired, block)
+    else:
+        block = min(desired, fallback)
+    block = max(min_block, block)
+    if max_block is not None:
+        block = min(block, max_block)
+    return block
+
+
+def max_grid_axis_chunks(
+    axis_size: int,
+    other_grid_product: int,
+    *,
+    max_grid: int = ASCEND_MAX_GRID_DIM,
+) -> int:
+    """Max launch chunks along one grid axis while keeping the product <= max_grid."""
+    return max(1, max_grid // max(other_grid_product, 1))
+
+
+def compute_grid_limited_tile_size(
+    axis_size: int,
+    other_grid_product: int,
+    ub_safe_block: int,
+    *,
+    max_grid: int = ASCEND_MAX_GRID_DIM,
+    min_block: int = 1,
+) -> int:
+    """Pick a UB-safe tile size; host-side chunking handles grid overflow."""
+    return max(min_block, min(ub_safe_block, axis_size))
+
+
+def iter_axis_launch_chunks(
+    axis_size: int,
+    other_grid_product: int,
+    *,
+    max_grid: int = ASCEND_MAX_GRID_DIM,
+):
+    """Yield ``(offset, chunk_len)`` for host-side grid-axis tiling."""
+    max_chunks = max_grid_axis_chunks(axis_size, other_grid_product, max_grid=max_grid)
+    for offset in range(0, axis_size, max_chunks):
+        yield offset, min(max_chunks, axis_size - offset)

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda/__init__.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda/__init__.py
@@ -1,0 +1,7 @@
+# Ascend NPU KDA (Kimi Delta Attention) chunked-prefill kernels.
+# Vendored from flash-linear-attention (fla/ops/kda/backends/triton_ascend),
+# with fla.* imports rewritten to sgl_kernel_npu.fla.* and the intra kernel
+# wired to the NPU token-parallel helper.
+from sgl_kernel_npu.fla.kda.chunk_intra import chunk_kda_fwd_intra_npu
+
+__all__ = ["chunk_kda_fwd_intra_npu"]

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda/chunk_intra.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda/chunk_intra.py
@@ -1,0 +1,1037 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""KDA chunk intra kernels for triton-ascend on Ascend NPU."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from sgl_kernel_npu.fla.kda.wy_fast import recompute_w_u_fwd_kda_npu as _recompute_w_u_fwd_npu
+from sgl_kernel_npu.fla.kda.chunk_intra_token_parallel import chunk_kda_fwd_intra_token_parallel_npu as chunk_kda_fwd_intra_token_parallel
+from sgl_kernel_npu.fla.utils import prepare_chunk_indices
+from sgl_kernel_npu.fla.utils import exp2
+from sgl_kernel_npu.fla.utils import input_guard
+from sgl_kernel_npu.fla.ascend_ub_manager import (
+    ASCEND_MAX_GRID_DIM,
+    compute_row_tile_block_size,
+    max_grid_axis_chunks,
+)
+
+_BC = 16
+_NUM_WARPS_SUB = 2
+_NUM_WARPS_INTER = 2
+_SUB_CHUNK_MEM_MULT = 6.0
+_INTER_MEM_MULT = 14.0
+_SAFETY_MARGIN = 0.80
+_FALLBACK_BK = 16
+_MAX_INTER_BK = 64
+# limit programs per launch to stay within Ascend AICore task time.
+_KDA_LAUNCH_BLOCK_BUDGET = 4096
+
+
+def _get_sub_chunk_bk(K: int) -> int:
+    return compute_row_tile_block_size(
+        _BC,
+        K,
+        _SUB_CHUNK_MEM_MULT,
+        tiling_row=False,
+        safety_margin=_SAFETY_MARGIN,
+        fallback=_FALLBACK_BK,
+        min_block=16,
+        max_block=triton.next_power_of_2(K),
+    )
+
+
+def _get_inter_bk(K: int) -> int:
+    return compute_row_tile_block_size(
+        _BC,
+        K,
+        _INTER_MEM_MULT,
+        tiling_row=False,
+        safety_margin=_SAFETY_MARGIN,
+        fallback=_FALLBACK_BK,
+        min_block=16,
+        max_block=min(_MAX_INTER_BK, triton.next_power_of_2(K)),
+    )
+
+
+def _recompute_w_u_fwd(*args, **kwargs):
+    return _recompute_w_u_fwd_npu(*args, **kwargs)
+
+
+def _launch_sub_chunk_kernel(
+    kernel,
+    *,
+    nt: int,
+    nc: int,
+    bh_total: int,
+    kernel_kwargs: dict,
+) -> None:
+    budget = _KDA_LAUNCH_BLOCK_BUDGET
+    chunk_indices = kernel_kwargs.get('chunk_indices')
+    cu_seqlens = kernel_kwargs.get('cu_seqlens')
+    nt_step = nt if nt * nc * bh_total <= budget else max(1, budget // max(nc * bh_total, 1))
+    for nt_off in range(0, nt, nt_step):
+        nt_len = min(nt_step, nt - nt_off)
+        if cu_seqlens is not None and chunk_indices is not None:
+            kernel_kwargs['chunk_indices'] = chunk_indices[nt_off:nt_off + nt_len]
+            kernel_kwargs['NT_OFFSET'] = 0
+        else:
+            kernel_kwargs['NT_OFFSET'] = nt_off
+        nc_budget = max(1, budget // max(nt_len * bh_total, 1))
+        max_nc = min(
+            nc_budget,
+            max_grid_axis_chunks(nc, nt_len * bh_total, max_grid=ASCEND_MAX_GRID_DIM),
+        )
+        for nc_off in range(0, nc, max_nc):
+            nc_len = min(max_nc, nc - nc_off)
+            kernel_kwargs['NC_OFFSET'] = nc_off
+            bh_budget = max(1, budget // max(nt_len * nc_len, 1))
+            max_bh = min(
+                bh_budget,
+                max_grid_axis_chunks(bh_total, nt_len * nc_len, max_grid=ASCEND_MAX_GRID_DIM),
+            )
+            for bh_off in range(0, bh_total, max_bh):
+                bh_len = min(max_bh, bh_total - bh_off)
+                kernel_kwargs['BH_OFFSET'] = bh_off
+                kernel[(nt_len, nc_len, bh_len)](num_warps=_NUM_WARPS_SUB, **kernel_kwargs)
+
+
+def _launch_inter_kernel(
+    kernel,
+    *,
+    nt: int,
+    bh_total: int,
+    kernel_kwargs: dict,
+) -> None:
+    budget = _KDA_LAUNCH_BLOCK_BUDGET
+    chunk_indices = kernel_kwargs.get('chunk_indices')
+    cu_seqlens = kernel_kwargs.get('cu_seqlens')
+    nt_step = nt if nt * bh_total <= budget else max(1, min(nt, budget // max(bh_total, 1)))
+    for nt_off in range(0, nt, nt_step):
+        nt_len = min(nt_step, nt - nt_off)
+        if cu_seqlens is not None and chunk_indices is not None:
+            kernel_kwargs['chunk_indices'] = chunk_indices[nt_off:nt_off + nt_len]
+            kernel_kwargs['NT_OFFSET'] = 0
+        else:
+            kernel_kwargs['NT_OFFSET'] = nt_off
+        bh_budget = max(1, budget // max(nt_len, 1))
+        max_bh = min(
+            bh_budget,
+            max_grid_axis_chunks(bh_total, nt_len, max_grid=ASCEND_MAX_GRID_DIM),
+        )
+        for bh_off in range(0, bh_total, max_bh):
+            bh_len = min(max_bh, bh_total - bh_off)
+            kernel_kwargs['BH_OFFSET'] = bh_off
+            kernel[(nt_len, bh_len)](num_warps=_NUM_WARPS_INTER, **kernel_kwargs)
+
+
+@triton.jit(do_not_specialize=['T', 'NT_OFFSET', 'NC_OFFSET', 'BH_OFFSET'])
+def chunk_kda_fwd_kernel_diag_solve_npu(
+    Akkd,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    HV: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    NT_OFFSET,
+    NC_OFFSET,
+    BH_OFFSET,
+):
+    """Per-subchunk lower-triangular forward substitution into Akkd.
+
+    Run before inter_solve so the fused inter kernel only merges off-diagonal
+    blocks, keeping scalar BC loops off the large (NT, BH) grid.
+    """
+    i_t = tl.program_id(0) + NT_OFFSET
+    i_i = tl.program_id(1) + NC_OFFSET
+    i_bh = tl.program_id(2) + BH_OFFSET
+    i_b, i_hv = i_bh // HV, i_bh % HV
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    i_ti = i_t * BT + i_i * BC
+    if i_ti >= T:
+        return
+
+    Akkd = Akkd + (bos * HV + i_hv) * BC
+    o_i = tl.arange(0, BC)
+    m_A = o_i[:, None] > o_i[None, :]
+    m_I = o_i[:, None] == o_i[None, :]
+
+    p_Akk = tl.make_block_ptr(Akkd, (T, BC), (HV * BC, 1), (i_ti, 0), (BC, BC), (1, 0))
+    b_Akk = tl.load(p_Akk, boundary_check=(0, 1)).to(tl.float32)
+    b_Ai = -tl.where(m_A, b_Akk, 0)
+    for i in range(2, min(BC, T - i_ti)):
+        b_a = -tl.load(Akkd + (i_ti + i) * HV * BC + o_i)
+        b_a = tl.where(o_i < i, b_a, 0.)
+        b_a += tl.sum(b_a[:, None] * b_Ai, 0)
+        b_Ai = tl.where((o_i == i)[:, None], b_a, b_Ai)
+    b_Ai += m_I
+    tl.store(p_Akk, b_Ai.to(Akkd.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.jit(do_not_specialize=['T', 'NT_OFFSET', 'NC_OFFSET', 'BH_OFFSET'])
+def chunk_kda_fwd_kernel_intra_sub_chunk_npu(
+    q,
+    k,
+    g,
+    beta,
+    Aqk,
+    Akk,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    NT_OFFSET,
+    NC_OFFSET,
+    BH_OFFSET,
+):
+    i_t = tl.program_id(0) + NT_OFFSET
+    i_i = tl.program_id(1) + NC_OFFSET
+    i_bh = tl.program_id(2) + BH_OFFSET
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    i_ti = i_t * BT + i_i * BC
+    if i_ti >= T:
+        return
+
+    o_c = i_ti + tl.arange(0, BC)
+    m_c = o_c < T
+
+    q = q + (bos * H + i_h) * K
+    k = k + (bos * H + i_h) * K
+    g = g + (bos * HV + i_hv) * K
+    beta = beta + bos * HV + i_hv
+    Aqk = Aqk + (bos * HV + i_hv) * BT
+    Akk = Akk + (bos * HV + i_hv) * BC
+
+    p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0))
+    p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_ti, 0), (BC, BK), (1, 0))
+    p_g = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_ti, 0), (BC, BK), (1, 0))
+
+    p_beta = tl.make_block_ptr(beta, (T,), (HV,), (i_ti,), (BC,), (0,))
+
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_beta = tl.load(p_beta, boundary_check=(0,))
+
+    p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * HV * K + tl.arange(0, BK)
+    b_gn = tl.load(p_gn, mask=tl.arange(0, BK) < K, other=0.0)
+    b_gn = b_gn[None, :]
+
+    b_gm = (b_g - b_gn).to(tl.float32)
+
+    b_gq = tl.where(m_c[:, None], exp2(b_gm), 0.)
+    b_gk = tl.where(m_c[:, None], exp2(-b_gm), 0.)
+
+    b_kgt = tl.trans(b_k * b_gk)
+
+    b_Aqk = tl.dot(b_q * b_gq, b_kgt, allow_tf32=False) * scale
+    b_Akk = tl.dot(b_k * b_gq, b_kgt, allow_tf32=False) * b_beta[:, None]
+
+    o_i = tl.arange(0, BC)
+    m_Aqk = o_i[:, None] >= o_i[None, :]
+    m_Akk = o_i[:, None] > o_i[None, :]
+
+    b_Aqk = tl.where(m_Aqk, b_Aqk, 0.0)
+    b_Akk = tl.where(m_Akk, b_Akk, 0.0)
+
+    p_Aqk = tl.make_block_ptr(Aqk, (T, BT), (HV * BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
+    p_Akk = tl.make_block_ptr(Akk, (T, BC), (HV * BC, 1), (i_ti, 0), (BC, BC), (1, 0))
+    tl.store(p_Aqk, b_Aqk.to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk, b_Akk.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.jit(do_not_specialize=['T', 'NT_OFFSET', 'BH_OFFSET'])
+def chunk_kda_fwd_kernel_inter_solve_fused_npu(
+    q,
+    k,
+    g,
+    beta,
+    Aqk,
+    Akkd,
+    Akk,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    NC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    NT_OFFSET,
+    BH_OFFSET,
+):
+    # Diagonal Akkd blocks are inverted by diag_solve before this kernel.
+    i_t = tl.program_id(0) + NT_OFFSET
+    i_bh = tl.program_id(1) + BH_OFFSET
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
+
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT >= T:
+        return
+
+    i_tc0 = i_t * BT
+    i_tc1 = i_t * BT + BC
+    i_tc2 = i_t * BT + 2 * BC
+    i_tc3 = i_t * BT + 3 * BC
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    g += (bos * HV + i_hv) * K
+    Aqk += (bos * HV + i_hv) * BT
+    Akk += (bos * HV + i_hv) * BT
+    Akkd += (bos * HV + i_hv) * BC
+
+    o_i = tl.arange(0, BC)
+    m_tc1 = (i_tc1 + o_i) < T
+    m_tc2 = (i_tc2 + o_i) < T
+    m_tc3 = (i_tc3 + o_i) < T
+
+    b_Aqk10 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk10 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    b_Aqk20 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk20 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk21 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk21 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    b_Aqk30 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk30 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk31 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk31 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Aqk32 = tl.zeros([BC, BC], dtype=tl.float32)
+    b_Akk32 = tl.zeros([BC, BC], dtype=tl.float32)
+
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+
+        p_k0 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+        p_g0 = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_tc0, i_k * BK), (BC, BK), (1, 0))
+        b_k0 = tl.load(p_k0, boundary_check=(0, 1)).to(tl.float32)
+        b_g0 = tl.load(p_g0, boundary_check=(0, 1)).to(tl.float32)
+
+        # Ascend cannot compile dynamic `if i_tc* < T` around dots (scf.if shape mismatch);
+        # block_ptr uses boundary_check, and bare g loads mask out-of-range rows.
+        p_q1 = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+        p_k1 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+        p_g1 = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_tc1, i_k * BK), (BC, BK), (1, 0))
+        b_q1 = tl.load(p_q1, boundary_check=(0, 1)).to(tl.float32)
+        b_k1 = tl.load(p_k1, boundary_check=(0, 1)).to(tl.float32)
+        b_g1 = tl.load(p_g1, boundary_check=(0, 1)).to(tl.float32)
+        b_gn1 = tl.load(g + i_tc1 * HV * K + o_k, mask=m_k & (i_tc1 < T), other=0).to(tl.float32)
+        b_gqn = tl.where(m_tc1[:, None], exp2(b_g1 - b_gn1[None, :]), 0)
+        b_kgt = tl.trans(b_k0 * exp2(b_gn1[None, :] - b_g0))
+        b_Aqk10 += tl.dot(b_q1 * b_gqn, b_kgt, allow_tf32=False)
+        b_Akk10 += tl.dot(b_k1 * b_gqn, b_kgt, allow_tf32=False)
+
+        if NC >= 3:
+            p_q2 = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+            p_k2 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+            p_g2 = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_tc2, i_k * BK), (BC, BK), (1, 0))
+            b_q2 = tl.load(p_q2, boundary_check=(0, 1)).to(tl.float32)
+            b_k2 = tl.load(p_k2, boundary_check=(0, 1)).to(tl.float32)
+            b_g2 = tl.load(p_g2, boundary_check=(0, 1)).to(tl.float32)
+            b_gn2 = tl.load(g + i_tc2 * HV * K + o_k, mask=m_k & (i_tc2 < T), other=0).to(tl.float32)
+            b_gqn2 = tl.where(m_tc2[:, None], exp2(b_g2 - b_gn2[None, :]), 0)
+            b_qg2 = b_q2 * b_gqn2
+            b_kg2 = b_k2 * b_gqn2
+            b_kgt = tl.trans(b_k0 * exp2(b_gn2[None, :] - b_g0))
+            b_Aqk20 += tl.dot(b_qg2, b_kgt, allow_tf32=False)
+            b_Akk20 += tl.dot(b_kg2, b_kgt, allow_tf32=False)
+            b_kgt = tl.trans(b_k1 * exp2(b_gn2[None, :] - b_g1))
+            b_Aqk21 += tl.dot(b_qg2, b_kgt, allow_tf32=False)
+            b_Akk21 += tl.dot(b_kg2, b_kgt, allow_tf32=False)
+
+            if NC >= 4:
+                p_q3 = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+                p_k3 = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+                p_g3 = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_tc3, i_k * BK), (BC, BK), (1, 0))
+                b_q3 = tl.load(p_q3, boundary_check=(0, 1)).to(tl.float32)
+                b_k3 = tl.load(p_k3, boundary_check=(0, 1)).to(tl.float32)
+                b_g3 = tl.load(p_g3, boundary_check=(0, 1)).to(tl.float32)
+                b_gn3 = tl.load(g + i_tc3 * HV * K + o_k, mask=m_k & (i_tc3 < T), other=0).to(tl.float32)
+                b_gqn3 = tl.where(m_tc3[:, None], exp2(b_g3 - b_gn3[None, :]), 0)
+                b_qg3 = b_q3 * b_gqn3
+                b_kg3 = b_k3 * b_gqn3
+                b_kgt = tl.trans(b_k0 * exp2(b_gn3[None, :] - b_g0))
+                b_Aqk30 += tl.dot(b_qg3, b_kgt, allow_tf32=False)
+                b_Akk30 += tl.dot(b_kg3, b_kgt, allow_tf32=False)
+                b_kgt = tl.trans(b_k1 * exp2(b_gn3[None, :] - b_g1))
+                b_Aqk31 += tl.dot(b_qg3, b_kgt, allow_tf32=False)
+                b_Akk31 += tl.dot(b_kg3, b_kgt, allow_tf32=False)
+                b_kgt = tl.trans(b_k2 * exp2(b_gn3[None, :] - b_g2))
+                b_Aqk32 += tl.dot(b_qg3, b_kgt, allow_tf32=False)
+                b_Akk32 += tl.dot(b_kg3, b_kgt, allow_tf32=False)
+
+    p_Aqk10 = tl.make_block_ptr(Aqk, (T, BT), (HV * BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
+    tl.store(p_Aqk10, (b_Aqk10 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+
+    p_b1 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc1,), (BC,), (0,))
+    b_b1 = tl.load(p_b1, boundary_check=(0,)).to(tl.float32)
+    b_Akk10 = b_Akk10 * b_b1[:, None]
+    if NC >= 3:
+        p_Aqk20 = tl.make_block_ptr(Aqk, (T, BT), (HV * BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
+        p_Aqk21 = tl.make_block_ptr(Aqk, (T, BT), (HV * BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
+        tl.store(p_Aqk20, (b_Aqk20 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Aqk21, (b_Aqk21 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+
+        p_b2 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc2,), (BC,), (0,))
+        b_b2 = tl.load(p_b2, boundary_check=(0,)).to(tl.float32)
+        b_Akk20 = b_Akk20 * b_b2[:, None]
+        b_Akk21 = b_Akk21 * b_b2[:, None]
+    if NC >= 4:
+        p_Aqk30 = tl.make_block_ptr(Aqk, (T, BT), (HV * BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
+        p_Aqk31 = tl.make_block_ptr(Aqk, (T, BT), (HV * BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
+        p_Aqk32 = tl.make_block_ptr(Aqk, (T, BT), (HV * BT, 1), (i_tc3, 2 * BC), (BC, BC), (1, 0))
+        tl.store(p_Aqk30, (b_Aqk30 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Aqk31, (b_Aqk31 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Aqk32, (b_Aqk32 * scale).to(Aqk.dtype.element_ty), boundary_check=(0, 1))
+
+        p_b3 = tl.make_block_ptr(beta + bos * HV + i_hv, (T,), (HV,), (i_tc3,), (BC,), (0,))
+        b_b3 = tl.load(p_b3, boundary_check=(0,)).to(tl.float32)
+        b_Akk30 = b_Akk30 * b_b3[:, None]
+        b_Akk31 = b_Akk31 * b_b3[:, None]
+        b_Akk32 = b_Akk32 * b_b3[:, None]
+
+    p_Akk00 = tl.make_block_ptr(Akkd, (T, BC), (HV * BC, 1), (i_tc0, 0), (BC, BC), (1, 0))
+    p_Akk11 = tl.make_block_ptr(Akkd, (T, BC), (HV * BC, 1), (i_tc1, 0), (BC, BC), (1, 0))
+    b_Ai00 = tl.load(p_Akk00, boundary_check=(0, 1)).to(tl.float32)
+    b_Ai11 = tl.load(p_Akk11, boundary_check=(0, 1)).to(tl.float32)
+    if NC >= 3:
+        p_Akk22 = tl.make_block_ptr(Akkd, (T, BC), (HV * BC, 1), (i_tc2, 0), (BC, BC), (1, 0))
+        b_Ai22 = tl.load(p_Akk22, boundary_check=(0, 1)).to(tl.float32)
+    if NC >= 4:
+        p_Akk33 = tl.make_block_ptr(Akkd, (T, BC), (HV * BC, 1), (i_tc3, 0), (BC, BC), (1, 0))
+        b_Ai33 = tl.load(p_Akk33, boundary_check=(0, 1)).to(tl.float32)
+
+    b_Ai10 = -tl.dot(
+        tl.dot(b_Ai11, b_Akk10, allow_tf32=False),
+        b_Ai00,
+        allow_tf32=False,
+    )
+
+    if NC >= 3:
+        b_Ai21 = -tl.dot(
+            tl.dot(b_Ai22, b_Akk21, allow_tf32=False),
+            b_Ai11,
+            allow_tf32=False,
+        )
+        b_Ai20 = -tl.dot(
+            b_Ai22,
+            tl.dot(b_Akk20, b_Ai00, allow_tf32=False) +
+            tl.dot(b_Akk21, b_Ai10, allow_tf32=False),
+            allow_tf32=False,
+        )
+    if NC >= 4:
+        b_Ai32 = -tl.dot(
+            tl.dot(b_Ai33, b_Akk32, allow_tf32=False),
+            b_Ai22,
+            allow_tf32=False,
+        )
+        b_Ai31 = -tl.dot(
+            b_Ai33,
+            tl.dot(b_Akk31, b_Ai11, allow_tf32=False) +
+            tl.dot(b_Akk32, b_Ai21, allow_tf32=False),
+            allow_tf32=False,
+        )
+        b_Ai30 = -tl.dot(
+            b_Ai33,
+            tl.dot(b_Akk30, b_Ai00, allow_tf32=False) +
+            tl.dot(b_Akk31, b_Ai10, allow_tf32=False) +
+            tl.dot(b_Akk32, b_Ai20, allow_tf32=False),
+            allow_tf32=False,
+        )
+
+    p_Akk00 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc0, 0), (BC, BC), (1, 0))
+    p_Akk10 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc1, 0), (BC, BC), (1, 0))
+    p_Akk11 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc1, BC), (BC, BC), (1, 0))
+
+    tl.store(p_Akk00, b_Ai00.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk10, b_Ai10.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Akk11, b_Ai11.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    if NC >= 3:
+        p_Akk20 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc2, 0), (BC, BC), (1, 0))
+        p_Akk21 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc2, BC), (BC, BC), (1, 0))
+        p_Akk22 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc2, 2 * BC), (BC, BC), (1, 0))
+        tl.store(p_Akk20, b_Ai20.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk21, b_Ai21.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk22, b_Ai22.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+    if NC >= 4:
+        p_Akk30 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc3, 0), (BC, BC), (1, 0))
+        p_Akk31 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc3, BC), (BC, BC), (1, 0))
+        p_Akk32 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc3, 2 * BC), (BC, BC), (1, 0))
+        p_Akk33 = tl.make_block_ptr(Akk, (T, BT), (HV * BT, 1), (i_tc3, 3 * BC), (BC, BC), (1, 0))
+        tl.store(p_Akk30, b_Ai30.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk31, b_Ai31.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk32, b_Ai32.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+        tl.store(p_Akk33, b_Ai33.to(Akk.dtype.element_ty), boundary_check=(0, 1))
+
+
+@input_guard
+def chunk_kda_fwd_intra_npu(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gk: torch.Tensor | None = None,
+    beta: torch.Tensor | None = None,
+    scale: float | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+    safe_gate: bool = False,
+    disable_recompute: bool = False,
+):
+    B, T, H, K, HV = *k.shape, gk.shape[2]
+    BT = chunk_size
+    if BT not in (32, 64):
+        raise ValueError(f"KDA intra chunk kernel only supports chunk_size 32 or 64, got {BT}.")
+    BC = _BC
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NC = triton.cdiv(BT, BC)
+    is_varlen = cu_seqlens is not None
+
+    Aqk = torch.zeros(B, T, HV, BT, device=k.device, dtype=k.dtype)
+    Akk = torch.zeros(B, T, HV, BT, device=k.device, dtype=k.dtype)
+    Akkd = torch.zeros(B, T, HV, BC, device=k.device, dtype=torch.float32)
+
+    if safe_gate:
+        sub_bk = _get_sub_chunk_bk(K)
+        _launch_sub_chunk_kernel(
+            chunk_kda_fwd_kernel_intra_sub_chunk_npu,
+            nt=NT,
+            nc=NC,
+            bh_total=B * HV,
+            kernel_kwargs=dict(
+                q=q,
+                k=k,
+                g=gk,
+                beta=beta,
+                Aqk=Aqk,
+                Akk=Akkd,
+                scale=scale,
+                cu_seqlens=cu_seqlens,
+                chunk_indices=chunk_indices,
+                T=T,
+                H=H,
+                HV=HV,
+                K=K,
+                BT=BT,
+                BC=BC,
+                BK=sub_bk,
+                IS_VARLEN=is_varlen,
+                NT_OFFSET=0,
+                NC_OFFSET=0,
+                BH_OFFSET=0,
+            ),
+        )
+    else:
+        Aqk, Akkd = chunk_kda_fwd_intra_token_parallel(
+            q=q,
+            k=k,
+            gk=gk,
+            beta=beta,
+            Aqk=Aqk,
+            Akk=Akkd,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            chunk_size=BT,
+            sub_chunk_size=BC,
+        )
+
+    # Invert diagonal Akkd blocks first; inter then only merges off-diagonals.
+    _launch_sub_chunk_kernel(
+        chunk_kda_fwd_kernel_diag_solve_npu,
+        nt=NT,
+        nc=NC,
+        bh_total=B * HV,
+        kernel_kwargs=dict(
+            Akkd=Akkd,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            T=T,
+            HV=HV,
+            BT=BT,
+            BC=BC,
+            IS_VARLEN=is_varlen,
+            NT_OFFSET=0,
+            NC_OFFSET=0,
+            BH_OFFSET=0,
+        ),
+    )
+
+    inter_bk = _get_inter_bk(K)
+    _launch_inter_kernel(
+        chunk_kda_fwd_kernel_inter_solve_fused_npu,
+        nt=NT,
+        bh_total=B * HV,
+        kernel_kwargs=dict(
+            q=q,
+            k=k,
+            g=gk,
+            beta=beta,
+            Aqk=Aqk,
+            Akkd=Akkd,
+            Akk=Akk,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            T=T,
+            H=H,
+            HV=HV,
+            K=K,
+            BT=BT,
+            BC=BC,
+            NC=NC,
+            BK=inter_bk,
+            IS_VARLEN=is_varlen,
+            NT_OFFSET=0,
+            BH_OFFSET=0,
+        ),
+    )
+    w, u, qg, kg = _recompute_w_u_fwd(
+        k=k,
+        v=v,
+        beta=beta,
+        A=Akk,
+        q=q if disable_recompute else None,
+        gk=gk,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    return w, u, qg, kg, Aqk, Akk
+
+
+_NUM_WARPS_BWD = 2
+# Vectorized diagonal path keeps BC×BK tiles live; keep BK small for Ascend UB.
+_BWD_INTRA_MEM_MULT = 18.0
+_FALLBACK_BK = 16
+_MAX_BK = 16
+# limit programs per launch to stay within Ascend AICore task time.
+_KDA_BWD_INTRA_LAUNCH_BLOCK_BUDGET = 4096
+
+
+def _get_bwd_intra_bk(K: int) -> int:
+    return compute_row_tile_block_size(
+        _BC,
+        K,
+        _BWD_INTRA_MEM_MULT,
+        tiling_row=False,
+        safety_margin=_SAFETY_MARGIN,
+        fallback=_FALLBACK_BK,
+        min_block=16,
+        max_block=min(_MAX_BK, triton.next_power_of_2(K)),
+    )
+
+
+def _launch_bwd_intra_kernel(
+    kernel,
+    *,
+    nk_nc: int,
+    nt: int,
+    bh_total: int,
+    kernel_kwargs: dict,
+) -> None:
+    # limit programs per launch to stay within Ascend AICore task time.
+    budget = _KDA_BWD_INTRA_LAUNCH_BLOCK_BUDGET
+    chunk_indices = kernel_kwargs.get('chunk_indices')
+    cu_seqlens = kernel_kwargs.get('cu_seqlens')
+    nk_step = nk_nc if nk_nc * nt * bh_total <= budget else max(1, budget // max(nt * bh_total, 1))
+    for nknc_off in range(0, nk_nc, nk_step):
+        nknc_len = min(nk_step, nk_nc - nknc_off)
+        kernel_kwargs['NKNC_OFFSET'] = nknc_off
+        nt_budget = max(1, budget // max(nknc_len * bh_total, 1))
+        max_nt = min(
+            nt_budget,
+            max_grid_axis_chunks(nt, nknc_len * bh_total, max_grid=ASCEND_MAX_GRID_DIM),
+        )
+        for nt_off in range(0, nt, max_nt):
+            nt_len = min(max_nt, nt - nt_off)
+            if cu_seqlens is not None and chunk_indices is not None:
+                kernel_kwargs['chunk_indices'] = chunk_indices[nt_off:nt_off + nt_len]
+                kernel_kwargs['NT_OFFSET'] = 0
+            else:
+                kernel_kwargs['NT_OFFSET'] = nt_off
+            bh_budget = max(1, budget // max(nknc_len * nt_len, 1))
+            max_bh = min(
+                bh_budget,
+                max_grid_axis_chunks(bh_total, nknc_len * nt_len, max_grid=ASCEND_MAX_GRID_DIM),
+            )
+            for bh_off in range(0, bh_total, max_bh):
+                bh_len = min(max_bh, bh_total - bh_off)
+                kernel_kwargs['BH_OFFSET'] = bh_off
+                kernel[(nknc_len, nt_len, bh_len)](num_warps=_NUM_WARPS_BWD, **kernel_kwargs)
+
+
+@triton.jit(do_not_specialize=['B', 'T', 'NKNC_OFFSET', 'NT_OFFSET', 'BH_OFFSET'])
+def chunk_kda_bwd_kernel_intra_npu(
+    q,
+    k,
+    g,
+    beta,
+    dAqk,
+    dAkk,
+    dq,
+    dq2,
+    dk,
+    dk2,
+    dg,
+    dg2,
+    db,
+    cu_seqlens,
+    chunk_indices,
+    B,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    NC: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    SAFE_GATE: tl.constexpr,
+    NKNC_OFFSET,
+    NT_OFFSET,
+    BH_OFFSET,
+):
+    i_kc = tl.program_id(0) + NKNC_OFFSET
+    i_t = tl.program_id(1) + NT_OFFSET
+    i_bh = tl.program_id(2) + BH_OFFSET
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
+    i_k, i_i = i_kc // NC, i_kc % NC
+
+    all = B * T
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+    else:
+        bos, eos = i_b * T, i_b * T + T
+    T = eos - bos
+
+    i_ti = i_t * BT + i_i * BC
+    if i_ti >= T:
+        return
+
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_k = o_k < K
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    g += (bos * HV + i_hv) * K
+    beta += bos * HV + i_hv
+
+    dAqk += (bos * HV + i_hv) * BT
+    dAkk += (bos * HV + i_hv) * BT
+    dq += (bos * HV + i_hv) * K
+    dq2 += (bos * HV + i_hv) * K
+    dk += (bos * HV + i_hv) * K
+    dk2 += (bos * HV + i_hv) * K
+    dg += (bos * HV + i_hv) * K
+    dg2 += (bos * HV + i_hv) * K
+    db += (i_k * all + bos) * HV + i_hv
+
+    p_g = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+
+    p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_ti,), (BC,), (0,))
+    b_b = tl.load(p_b, boundary_check=(0,))
+
+    b_dq2 = tl.zeros([BC, BK], dtype=tl.float32)
+    b_dk2 = tl.zeros([BC, BK], dtype=tl.float32)
+    if i_i > 0:
+        p_gn = g + i_ti * HV * K + o_k
+        b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
+        for i_j in range(0, i_i):
+            p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
+            p_gk = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
+            p_dAqk = tl.make_block_ptr(dAqk, (T, BT), (HV * BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
+            p_dAkk = tl.make_block_ptr(dAkk, (T, BT), (HV * BT, 1), (i_ti, i_j * BC), (BC, BC), (1, 0))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_gk = tl.load(p_gk, boundary_check=(0, 1))
+            b_kg = b_k * exp2(b_gn - b_gk)
+            b_dAqk = tl.load(p_dAqk, boundary_check=(0, 1))
+            b_dAkk = tl.load(p_dAkk, boundary_check=(0, 1))
+            b_dq2 += tl.dot(b_dAqk, b_kg, allow_tf32=False)
+            b_dk2 += tl.dot(b_dAkk, b_kg, allow_tf32=False)
+        b_gqn = exp2(b_g - b_gn)
+        b_dq2 *= b_gqn
+        b_dk2 *= b_gqn
+
+    o_i = tl.arange(0, BC)
+    m_dA = (i_ti + o_i) < T
+    o_dA = (i_ti + o_i) * HV * BT + i_i * BC
+    p_kj = k + i_ti * H * K + o_k
+    p_gkj = g + i_ti * HV * K + o_k
+
+    p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_k = tl.load(p_k, boundary_check=(0, 1))
+
+    if SAFE_GATE:
+        # Midpoint-offset vectorized path (bounded under lower_bound=-5).
+        p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * HV * K + o_k
+        b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
+
+        p_dAqk = tl.make_block_ptr(dAqk, (T, BT), (HV * BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
+        p_dAkk = tl.make_block_ptr(dAkk, (T, BT), (HV * BT, 1), (i_ti, i_i * BC), (BC, BC), (1, 0))
+        b_dAqk_diag_qk = tl.load(p_dAqk, boundary_check=(0, 1)).to(tl.float32)
+        b_dAkk_diag_qk = tl.load(p_dAkk, boundary_check=(0, 1)).to(tl.float32)
+
+        m_i_diag_qk = (o_i[:, None] >= o_i[None, :]) & ((i_ti + o_i[:, None]) < T) & ((i_ti + o_i[None, :]) < T)
+        m_j_diag_qk = (i_ti + o_i[:, None]) < T
+
+        b_dAqk_diag_qk = tl.where(m_i_diag_qk, b_dAqk_diag_qk, 0.)
+        b_dAkk_diag_qk = tl.where(m_i_diag_qk, b_dAkk_diag_qk, 0.)
+        b_g_diag_qk = tl.where(m_j_diag_qk, b_g - b_gn, 0.)
+        exp_b_g_diag_qk = tl.where(m_j_diag_qk, exp2(b_g_diag_qk), 0.)
+        exp_neg_b_g_diag_qk = tl.where(m_j_diag_qk, exp2(-b_g_diag_qk), 0.)
+
+        b_k_exp_diag_qk = b_k * exp_neg_b_g_diag_qk
+        b_dq2 += tl.dot(b_dAqk_diag_qk, b_k_exp_diag_qk, allow_tf32=False) * exp_b_g_diag_qk
+        b_dk2 += tl.dot(b_dAkk_diag_qk, b_k_exp_diag_qk, allow_tf32=False) * exp_b_g_diag_qk
+    else:
+        # Pairwise scalar path required for unbounded non-safe gates (avoids Inf/NaN).
+        for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
+            b_dAqk = tl.load(dAqk + o_dA + j, mask=m_dA, other=0)
+            b_dAkk = tl.load(dAkk + o_dA + j, mask=m_dA, other=0)
+            b_kj = tl.load(p_kj, mask=m_k, other=0).to(tl.float32)
+            b_gkj = tl.load(p_gkj, mask=m_k, other=0).to(tl.float32)
+            m_i = o_i[:, None] >= j
+            b_gqk = exp2(b_g - b_gkj[None, :])
+            b_dq2 += tl.where(m_i, b_dAqk[:, None] * b_kj[None, :] * b_gqk, 0.)
+            b_dk2 += tl.where(m_i, b_dAkk[:, None] * b_kj[None, :] * b_gqk, 0.)
+
+            p_kj += H * K
+            p_gkj += HV * K
+
+    b_db = tl.sum(b_dk2 * b_k, 1)
+    b_dk2 *= b_b[:, None]
+
+    p_dq = tl.make_block_ptr(dq, (T, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_dq2 = tl.make_block_ptr(dq2, (T, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_db = tl.make_block_ptr(db, (T,), (HV,), (i_ti,), (BC,), (0,))
+
+    b_dg2 = b_q * b_dq2
+    b_dq2 = b_dq2 + tl.load(p_dq, boundary_check=(0, 1))
+    tl.store(p_dq2, b_dq2.to(p_dq2.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_db, b_db.to(p_db.dtype.element_ty), boundary_check=(0,))
+
+    # synchronize before the second half of the kernel that reuses the same tiles.
+    tl.debug_barrier()
+    b_dkt = tl.zeros([BC, BK], dtype=tl.float32)
+
+    NC = min(NC, tl.cdiv(T - i_t * BT, BC))
+    if i_i < NC - 1:
+        p_gn = g + (min(i_ti + BC, T) - 1) * HV * K + o_k
+        b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
+        for i_j in range(i_i + 1, NC):
+            p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
+            p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
+            p_gk = tl.make_block_ptr(g, (T, K), (HV * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0))
+            p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_t * BT + i_j * BC,), (BC,), (0,))
+            p_dAqk = tl.make_block_ptr(dAqk, (BT, T), (1, HV * BT), (i_i * BC, i_t * BT + i_j * BC), (BC, BC), (0, 1))
+            p_dAkk = tl.make_block_ptr(dAkk, (BT, T), (1, HV * BT), (i_i * BC, i_t * BT + i_j * BC), (BC, BC), (0, 1))
+            b_b = tl.load(p_b, boundary_check=(0,))
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_kb = tl.load(p_k, boundary_check=(0, 1)) * b_b[:, None]
+            b_gk = tl.load(p_gk, boundary_check=(0, 1)).to(tl.float32)
+            b_dAqk = tl.load(p_dAqk, boundary_check=(0, 1))
+            b_dAkk = tl.load(p_dAkk, boundary_check=(0, 1))
+
+            o_j = i_t * BT + i_j * BC + o_i
+            m_j = o_j < T
+            b_gkn = exp2(b_gk - b_gn)
+            b_qg = b_q * tl.where(m_j[:, None], b_gkn, 0)
+            b_kbg = b_kb * tl.where(m_j[:, None], b_gkn, 0)
+            b_dkt += tl.dot(b_dAqk, b_qg, allow_tf32=False)
+            b_dkt += tl.dot(b_dAkk, b_kbg, allow_tf32=False)
+        b_dkt *= exp2(b_gn - b_g)
+
+    o_dA = i_ti * HV * BT + i_i * BC + o_i
+    p_qj = q + i_ti * H * K + o_k
+    p_kj = k + i_ti * H * K + o_k
+    p_gkj = g + i_ti * HV * K + o_k
+    p_bj = beta + i_ti * HV
+
+    if SAFE_GATE:
+        p_gn = g + (i_ti + min(BC // 2, T - i_ti - 1)) * HV * K + o_k
+        b_gn = tl.load(p_gn, mask=m_k, other=0).to(tl.float32)[None, :]
+        p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_ti,), (BC,), (0,))
+        b_b = tl.load(p_b, boundary_check=(0,))
+
+        p_dAqk = tl.make_block_ptr(dAqk, (BT, T), (1, HV * BT), (i_i * BC, i_ti), (BC, BC), (0, 1))
+        p_dAkk = tl.make_block_ptr(dAkk, (BT, T), (1, HV * BT), (i_i * BC, i_ti), (BC, BC), (0, 1))
+        b_dAqk_diag_kk = tl.load(p_dAqk, boundary_check=(0, 1)).to(tl.float32)
+        b_dAkk_diag_kk = tl.load(p_dAkk, boundary_check=(0, 1)).to(tl.float32)
+
+        m_i_diag_kk = (o_i[:, None] <= o_i[None, :]) & ((i_ti + o_i[:, None]) < T) & ((i_ti + o_i[None, :]) < T)
+        m_j_diag_kk = (i_ti + o_i[:, None]) < T
+
+        b_dAqk_diag_kk = tl.where(m_i_diag_kk, b_dAqk_diag_kk, 0.)
+        b_dAkk_diag_kk = tl.where(m_i_diag_kk, b_dAkk_diag_kk, 0.)
+        b_g_diag_kk = tl.where(m_j_diag_kk, b_g - b_gn, 0.)
+        exp_b_g_diag_kk = tl.where(m_j_diag_kk, exp2(b_g_diag_kk), 0.)
+        exp_neg_b_g_diag_kk = tl.where(m_j_diag_kk, exp2(-b_g_diag_kk), 0.)
+
+        b_q_exp = b_q * exp_b_g_diag_kk
+        b_kb_exp = b_k * b_b[:, None] * exp_b_g_diag_kk
+
+        b_dkt += tl.dot(b_dAqk_diag_kk, b_q_exp, allow_tf32=False) * exp_neg_b_g_diag_kk
+        b_dkt += tl.dot(b_dAkk_diag_kk, b_kb_exp, allow_tf32=False) * exp_neg_b_g_diag_kk
+    else:
+        for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
+            b_dAqk = tl.load(dAqk + o_dA + j * HV * BT)
+            b_dAkk = tl.load(dAkk + o_dA + j * HV * BT)
+            b_qj = tl.load(p_qj, mask=m_k, other=0).to(tl.float32)
+            b_kbj = tl.load(p_kj, mask=m_k, other=0).to(tl.float32) * tl.load(p_bj)
+            b_gkj = tl.load(p_gkj, mask=m_k, other=0).to(tl.float32)
+            m_i = o_i[:, None] <= j
+            b_gkq = exp2(b_gkj[None, :] - b_g)
+            b_dkt += tl.where(m_i, b_dAqk[:, None] * b_qj[None, :] * b_gkq, 0.)
+            b_dkt += tl.where(m_i, b_dAkk[:, None] * b_kbj[None, :] * b_gkq, 0.)
+
+            p_qj += H * K
+            p_kj += H * K
+            p_gkj += HV * K
+            p_bj += HV
+
+    p_dk = tl.make_block_ptr(dk, (T, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_dk2 = tl.make_block_ptr(dk2, (T, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_dg = tl.make_block_ptr(dg, (T, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+    p_dg2 = tl.make_block_ptr(dg2, (T, K), (HV * K, 1), (i_ti, i_k * BK), (BC, BK), (1, 0))
+
+    b_dg2 += (b_dk2 - b_dkt) * b_k + tl.load(p_dg, boundary_check=(0, 1))
+    b_dk2 += tl.load(p_dk, boundary_check=(0, 1))
+    b_dk2 += b_dkt
+
+    tl.store(p_dk2, b_dk2.to(p_dk2.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dg2, b_dg2.to(p_dg2.dtype.element_ty), boundary_check=(0, 1))
+
+
+@input_guard
+def chunk_kda_bwd_intra_npu(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    dAqk: torch.Tensor,
+    dAkk: torch.Tensor,
+    dq: torch.Tensor,
+    dk: torch.Tensor,
+    db: torch.Tensor,
+    dg: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    safe_gate: bool = False,
+):
+    B, T, H, K, HV = *k.shape, g.shape[2]
+    BT = chunk_size
+    BC = min(_BC, BT)
+    BK = _get_bwd_intra_bk(K)
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NC = triton.cdiv(BT, BC)
+    NK = triton.cdiv(K, BK)
+    is_varlen = cu_seqlens is not None
+
+    dq2 = torch.empty_like(dq)
+    dk2 = torch.empty_like(dk)
+    db2 = beta.new_empty(NK, *beta.shape, dtype=torch.float)
+    dg2 = torch.empty_like(dg, dtype=torch.float)
+
+    _launch_bwd_intra_kernel(
+        chunk_kda_bwd_kernel_intra_npu,
+        nk_nc=NK * NC,
+        nt=NT,
+        bh_total=B * HV,
+        kernel_kwargs=dict(
+            q=q,
+            k=k,
+            g=g,
+            beta=beta,
+            dAqk=dAqk,
+            dAkk=dAkk,
+            dq=dq,
+            dq2=dq2,
+            dk=dk,
+            dk2=dk2,
+            dg=dg,
+            dg2=dg2,
+            db=db2,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            B=B,
+            T=T,
+            H=H,
+            HV=HV,
+            K=K,
+            BT=BT,
+            BC=BC,
+            BK=BK,
+            NC=NC,
+            IS_VARLEN=is_varlen,
+            SAFE_GATE=safe_gate,
+            NKNC_OFFSET=0,
+            NT_OFFSET=0,
+            BH_OFFSET=0,
+        ),
+    )
+    dq = dq2
+    dk = dk2
+    db = db2.sum(0).add_(db)
+    dg = dg2
+
+    return dq, dk, db, dg

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda/chunk_intra.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda/chunk_intra.py
@@ -524,6 +524,8 @@ def chunk_kda_fwd_intra_npu(
     chunk_indices: torch.LongTensor | None = None,
     safe_gate: bool = False,
     disable_recompute: bool = False,
+    fuse_diagonal: bool = False, # not used, for sglang compatibility
+    fuse_recompute: bool = False, # not used, for sglang compatibility
 ):
     B, T, H, K, HV = *k.shape, gk.shape[2]
     BT = chunk_size

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda/chunk_intra_token_parallel.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda/chunk_intra_token_parallel.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""KDA chunk intra token-parallel kernels for triton-ascend on Ascend NPU."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from sgl_kernel_npu.fla.utils import exp2
+from sgl_kernel_npu.fla.utils import input_guard
+from sgl_kernel_npu.fla.ascend_ub_manager import (
+    ASCEND_MAX_GRID_DIM,
+    max_grid_axis_chunks,
+)
+
+_BH = 4
+_NUM_WARPS = 2
+
+
+def _launch_token_parallel_kernel(
+    kernel,
+    *,
+    tg_total: int,
+    hv_total: int,
+    kernel_kwargs: dict,
+) -> None:
+    hg_total = triton.cdiv(hv_total, _BH)
+    max_tg = max_grid_axis_chunks(tg_total, hg_total, max_grid=ASCEND_MAX_GRID_DIM)
+    for tg_off in range(0, tg_total, max_tg):
+        tg_len = min(max_tg, tg_total - tg_off)
+        kernel_kwargs['TG_OFFSET'] = tg_off
+        max_hg = max_grid_axis_chunks(hg_total, tg_len, max_grid=ASCEND_MAX_GRID_DIM)
+        for hg_off in range(0, hg_total, max_hg):
+            hg_len = min(max_hg, hg_total - hg_off)
+            kernel_kwargs['HG_OFFSET'] = hg_off
+            kernel[(tg_len, hg_len)](num_warps=_NUM_WARPS, **kernel_kwargs)
+
+
+@triton.heuristics({
+    'IS_VARLEN': lambda args: args['cu_seqlens'] is not None,
+})
+@triton.jit(do_not_specialize=['T', 'N'])
+def chunk_kda_fwd_kernel_intra_token_parallel_npu(
+    q,
+    k,
+    g,
+    beta,
+    Aqk,
+    Akk,
+    scale,
+    cu_seqlens,
+    N,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BH: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    TG_OFFSET: tl.constexpr,
+    HG_OFFSET: tl.constexpr,
+):
+    i_tg = tl.program_id(0) + TG_OFFSET
+    i_hg = tl.program_id(1) + HG_OFFSET
+
+    if IS_VARLEN:
+        i_n = 0
+        left, right = 0, N
+
+        for _ in range(20):
+            if left < right:
+                mid = (left + right) // 2
+                if i_tg < tl.load(cu_seqlens + mid + 1).to(tl.int32):
+                    right = mid
+                else:
+                    left = mid + 1
+        i_n = left
+
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        i_t = i_tg - bos
+    else:
+        bos = (i_tg // T) * T
+        i_t = i_tg % T
+
+    if i_t >= T:
+        return
+
+    i_c = i_t // BT
+    i_s = (i_t % BT) // BC
+    i_tc = i_c * BT
+    i_ts = i_tc + i_s * BC
+
+    G: tl.constexpr = HV // H
+
+    q += bos * H * K
+    k += bos * H * K
+    g += bos * HV * K
+    Aqk += bos * HV * BT
+    Akk += bos * HV * BC
+    beta += bos * HV
+
+    BK: tl.constexpr = triton.next_power_of_2(K)
+    o_hv = i_hg * BH + tl.arange(0, BH)
+    o_h = o_hv // G
+    o_k = tl.arange(0, BK)
+    m_hv = o_hv < HV
+    m_k = o_k < K
+    m_hk = m_hv[:, None] & m_k[None, :]
+
+    p_qk = o_h[:, None] * K + o_k[None, :]
+    b_q = tl.load(q + i_t * H * K + p_qk, mask=m_hk, other=0).to(tl.float32)
+    b_k = tl.load(k + i_t * H * K + p_qk, mask=m_hk, other=0).to(tl.float32)
+
+    p_g = tl.make_block_ptr(g + i_t * HV * K, (HV, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
+    p_beta = tl.make_block_ptr(beta + i_t * HV, (HV,), (1,), (i_hg * BH,), (BH,), (0,))
+    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+    b_k = b_k * tl.load(p_beta, boundary_check=(0,)).to(tl.float32)[:, None]
+
+    for j in range(i_ts, min(i_t + 1, min(T, i_ts + BC))):
+        b_kj = tl.load(k + j * H * K + p_qk, mask=m_hk, other=0).to(tl.float32)
+        p_gj = tl.make_block_ptr(g + j * HV * K, (HV, K), (K, 1), (i_hg * BH, 0), (BH, BK), (1, 0))
+        b_gj = tl.load(p_gj, boundary_check=(0, 1)).to(tl.float32)
+
+        b_kgj = tl.where(m_k[None, :], b_kj * exp2(b_g - b_gj), 0.0)
+        b_Aqk = tl.sum(b_q * b_kgj, axis=1) * scale
+        b_Akk = tl.sum(b_k * b_kgj, axis=1) * tl.where(j < i_t, 1.0, 0.0)
+
+        tl.store(Aqk + i_t * HV * BT + o_hv * BT + j % BT, b_Aqk.to(Aqk.dtype.element_ty), mask=m_hv)
+        tl.store(Akk + i_t * HV * BC + o_hv * BC + j - i_ts, b_Akk.to(Akk.dtype.element_ty), mask=m_hv)
+
+
+@input_guard
+def chunk_kda_fwd_intra_token_parallel_npu(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    gk: torch.Tensor,
+    beta: torch.Tensor,
+    Aqk: torch.Tensor,
+    Akk: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    sub_chunk_size: int = 16,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Token-parallel NPU implementation: each token gets its own thread block.
+    Supports both fixed-length and variable-length sequences (GVA: HV >= H).
+
+    Writes directly to Aqk and Akk tensors (in-place).
+    """
+    B, T, H, K, HV = *q.shape, gk.shape[2]
+    N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
+    BT = chunk_size
+    BC = sub_chunk_size
+
+    _launch_token_parallel_kernel(
+        chunk_kda_fwd_kernel_intra_token_parallel_npu,
+        tg_total=B * T,
+        hv_total=HV,
+        kernel_kwargs=dict(
+            q=q,
+            k=k,
+            g=gk,
+            beta=beta,
+            Aqk=Aqk,
+            Akk=Akk,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            N=N,
+            T=T,
+            H=H,
+            HV=HV,
+            K=K,
+            BT=BT,
+            BC=BC,
+            BH=_BH,
+            TG_OFFSET=0,
+            HG_OFFSET=0,
+        ),
+    )
+    return Aqk, Akk

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda/chunk_intra_token_parallel.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda/chunk_intra_token_parallel.py
@@ -61,6 +61,7 @@ def chunk_kda_fwd_kernel_intra_token_parallel_npu(
     H: tl.constexpr,
     HV: tl.constexpr,
     K: tl.constexpr,
+    BK: tl.constexpr,
     BT: tl.constexpr,
     BC: tl.constexpr,
     BH: tl.constexpr,
@@ -108,7 +109,6 @@ def chunk_kda_fwd_kernel_intra_token_parallel_npu(
     Akk += bos * HV * BC
     beta += bos * HV
 
-    BK: tl.constexpr = triton.next_power_of_2(K)
     o_hv = i_hg * BH + tl.arange(0, BH)
     o_h = o_hv // G
     o_k = tl.arange(0, BK)
@@ -161,6 +161,7 @@ def chunk_kda_fwd_intra_token_parallel_npu(
     N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
     BT = chunk_size
     BC = sub_chunk_size
+    BK = triton.next_power_of_2(K)
 
     _launch_token_parallel_kernel(
         chunk_kda_fwd_kernel_intra_token_parallel_npu,
@@ -180,6 +181,7 @@ def chunk_kda_fwd_intra_token_parallel_npu(
             H=H,
             HV=HV,
             K=K,
+            BK=BK,
             BT=BT,
             BC=BC,
             BH=_BH,

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda/wy_fast.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda/wy_fast.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""KDA WY-representation kernels adapted for triton-ascend on Ascend NPU."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from sgl_kernel_npu.fla.utils import prepare_chunk_indices
+from sgl_kernel_npu.fla.utils import exp2
+from sgl_kernel_npu.fla.utils import input_guard
+from sgl_kernel_npu.fla.ascend_ub_manager import (
+    ASCEND_MAX_GRID_DIM,
+    compute_row_tile_block_size,
+    max_grid_axis_chunks,
+)
+
+_NUM_WARPS = 2
+# recompute_w_u_fwd: b_A[BT,BT], b_vb[BT,BV], b_kb[BT,BK]
+_RECOMPUTE_FWD_MEM_MULT = 6.0
+_SAFETY_MARGIN = 0.75
+_FALLBACK_TILE = 8
+_MAX_TILE_FWD = 64
+
+
+def _get_fwd_tiles(BT: int, K: int, V: int) -> tuple[int, int]:
+    BK = compute_row_tile_block_size(
+        BT, K, _RECOMPUTE_FWD_MEM_MULT,
+        tiling_row=False,
+        safety_margin=_SAFETY_MARGIN,
+        fallback=_FALLBACK_TILE,
+        min_block=8,
+        max_block=min(_MAX_TILE_FWD, triton.next_power_of_2(K)),
+    )
+    BV = compute_row_tile_block_size(
+        BT, V, _RECOMPUTE_FWD_MEM_MULT,
+        tiling_row=False,
+        safety_margin=_SAFETY_MARGIN,
+        fallback=_FALLBACK_TILE,
+        min_block=8,
+        max_block=min(_MAX_TILE_FWD, triton.next_power_of_2(V)),
+    )
+    return BK, BV
+
+
+def _launch_wy_kernel(kernel, *, NT: int, bh_total: int, kernel_kwargs: dict) -> None:
+    max_nt = max_grid_axis_chunks(NT, bh_total, max_grid=ASCEND_MAX_GRID_DIM)
+    chunk_indices = kernel_kwargs.get('chunk_indices')
+    cu_seqlens = kernel_kwargs.get('cu_seqlens')
+    for nt_off in range(0, NT, max_nt):
+        nt_len = min(max_nt, NT - nt_off)
+        if cu_seqlens is not None and chunk_indices is not None:
+            kernel_kwargs['chunk_indices'] = chunk_indices[nt_off:nt_off + nt_len]
+            kernel_kwargs['NT_OFFSET'] = 0
+        else:
+            kernel_kwargs['NT_OFFSET'] = nt_off
+        max_bh = max_grid_axis_chunks(bh_total, nt_len, max_grid=ASCEND_MAX_GRID_DIM)
+        for bh_off in range(0, bh_total, max_bh):
+            bh_len = min(max_bh, bh_total - bh_off)
+            kernel_kwargs['BH_OFFSET'] = bh_off
+            kernel[(nt_len, bh_len)](num_warps=_NUM_WARPS, **kernel_kwargs)
+
+
+@triton.jit(do_not_specialize=['T'])
+def recompute_w_u_fwd_kda_kernel_npu(
+    q,
+    k,
+    qg,
+    kg,
+    v,
+    beta,
+    w,
+    u,
+    A,
+    gk,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    STORE_QG: tl.constexpr,
+    STORE_KG: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    NT_OFFSET: tl.constexpr,
+    BH_OFFSET: tl.constexpr,
+):
+    i_t = tl.program_id(0) + NT_OFFSET
+    i_bh = tl.program_id(1) + BH_OFFSET
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    k += (bos * H + i_h) * K
+    v += (bos * HV + i_hv) * V
+    u += (bos * HV + i_hv) * V
+    w += (bos * HV + i_hv) * K
+    gk += (bos * HV + i_hv) * K
+    beta += bos * HV + i_hv
+    A += (bos * HV + i_hv) * BT
+    kg += (bos * HV + i_hv) * K
+    if STORE_QG:
+        q += (bos * H + i_h) * K
+        qg += (bos * HV + i_hv) * K
+
+    p_b = tl.make_block_ptr(beta, (T,), (HV,), (i_t * BT,), (BT,), (0,))
+    b_b = tl.load(p_b, boundary_check=(0,))
+
+    p_A = tl.make_block_ptr(A, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    b_A = tl.load(p_A, boundary_check=(0, 1)).to(tl.float32)
+
+    for i_v in range(tl.cdiv(V, BV)):
+        p_v = tl.make_block_ptr(v, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        p_u = tl.make_block_ptr(u, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+        b_v = tl.load(p_v, boundary_check=(0, 1)).to(tl.float32)
+        b_vb = b_v * b_b[:, None]
+        b_u = tl.dot(b_A, b_vb, allow_tf32=False)
+        tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
+
+    b_A = tl.load(p_A, boundary_check=(0, 1)).to(tl.float32)
+    last_idx = min(i_t * BT + BT, T) - 1
+    for i_k in range(tl.cdiv(K, BK)):
+        p_w = tl.make_block_ptr(w, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        p_k = tl.make_block_ptr(k, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_kb = b_k * b_b[:, None]
+
+        p_gk = tl.make_block_ptr(gk, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+        b_gk = tl.load(p_gk, boundary_check=(0, 1)).to(tl.float32)
+        b_kb = b_kb * exp2(b_gk)
+
+        if STORE_QG:
+            p_q = tl.make_block_ptr(q, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            p_qg = tl.make_block_ptr(qg, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_qg = b_q * exp2(b_gk)
+            tl.store(p_qg, b_qg.to(p_qg.dtype.element_ty), boundary_check=(0, 1))
+
+        if STORE_KG:
+            o_k = i_k * BK + tl.arange(0, BK)
+            m_k = o_k < K
+            b_gn = tl.load(gk + last_idx * HV * K + o_k, mask=m_k, other=0.).to(tl.float32)
+            b_kg = b_k * tl.where((i_t * BT + tl.arange(0, BT) < T)[:, None], exp2(b_gn[None, :] - b_gk), 0)
+            p_kg = tl.make_block_ptr(kg, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0))
+            tl.store(p_kg, b_kg.to(p_kg.dtype.element_ty), boundary_check=(0, 1))
+
+        b_w = tl.dot(b_A, b_kb.to(tl.float32), allow_tf32=False)
+        tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+
+
+@input_guard
+def recompute_w_u_fwd_kda_npu(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    gk: torch.Tensor,
+    q: torch.Tensor | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    HV = v.shape[2]
+    BT = A.shape[-1]
+    BK, BV = _get_fwd_tiles(BT, K, V)
+    store_qg = q is not None
+    is_varlen = cu_seqlens is not None
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    w = torch.zeros(B, T, HV, K, device=k.device, dtype=k.dtype)
+    u = torch.zeros_like(v)
+    qg = torch.zeros(B, T, HV, K, device=k.device, dtype=k.dtype) if store_qg else None
+    kg = torch.zeros(B, T, HV, K, device=k.device, dtype=k.dtype)
+
+    _launch_wy_kernel(
+        recompute_w_u_fwd_kda_kernel_npu,
+        NT=NT,
+        bh_total=B * HV,
+        kernel_kwargs=dict(
+            q=q,
+            k=k,
+            qg=qg,
+            kg=kg,
+            v=v,
+            beta=beta,
+            w=w,
+            u=u,
+            A=A,
+            gk=gk,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            T=T,
+            H=H,
+            HV=HV,
+            K=K,
+            V=V,
+            BT=BT,
+            BK=BK,
+            BV=BV,
+            STORE_QG=store_qg,
+            STORE_KG=True,
+            IS_VARLEN=is_varlen,
+        ),
+    )
+    return w, u, qg, kg

--- a/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d.py
@@ -1368,13 +1368,18 @@ def causal_conv1d_update_npu(
 
     if cache_seqlens is None and num_accepted_tokens is None:
         conv_state_update = conv_state[conv_state_indices]
-        out, conv_state[conv_state_indices] = torch_causal_conv1d_update_npu(
+        out, new_conv_state = torch_causal_conv1d_update_npu(
             x,
             conv_state_update,
             weight,
             bias=bias,
             activation=activation,
         )
+        # The update is computed in `weight.dtype` (float32 for the KDA conv
+        # weights), but the conv cache is stored in its own dtype (bf16 by
+        # default). NPU `aclnnIndexPut` requires the assigned value to match the
+        # destination dtype, so cast the write-back to the cache dtype.
+        conv_state[conv_state_indices] = new_conv_state.to(conv_state.dtype)
     else:
         _causal_conv1d_update_kernel[grid](
             # Pointers to matrices


### PR DESCRIPTION
Currently kimi-linear in sglang runs the default Triton kernels optimized for cuda and other platforms, which don't work at all for some kernels (e.g. the chunked prefill). Ascend specific kernels were recently added to FLA in [1047](https://github.com/fla-org/flash-linear-attention/pull/1047). 

This PR combined with [PR 32075](https://github.com/sgl-project/sglang/pull/32075) in upstream sglang, adds support for kimi-linear (by enabling the chunked prefill).