### PR TITLE
[refactor] disable pertoken_fp8_e5m2 on low latency

### DIFF
--- a/csrc/deepep/deep_ep.cpp
+++ b/csrc/deepep/deep_ep.cpp
@@ -26,13 +26,6 @@ constexpr uint32_t MAX_ROUNDS = 256;
 constexpr uint32_t MIN_TOKENS_PER_ROUND = 32;
 constexpr uint32_t MAX_TOKENS_PER_ROUND = 8192;
 constexpr uint32_t MAX_TOTAL_TOKENS = 131072;
-#ifdef __DAV_C310__
-constexpr const char *PERTOKEN_FP8_E5M2_UNSUPPORTED_MESSAGE =
-    "pertoken_fp8_e5m2 is not supported yet, please use pertoken_fp8_e4m3 instead.";
-#else
-constexpr const char *PERTOKEN_FP8_E5M2_UNSUPPORTED_MESSAGE =
-    "pertoken_fp8_e5m2 is not supported on this device, please use int8 or bf16 instead.";
-#endif
 
 Buffer::Buffer(int64_t rank, int64_t num_ranks, int64_t num_nvl_bytes, int64_t num_rdma_bytes, bool low_latency_mode,
                std::string moe_all_to_all_group_name)
@@ -311,10 +304,7 @@ Buffer::intranode_dispatch(const at::Tensor &x, const std::optional<at::Tensor> 
     int num_recv_tokens = (trt == 0) ? 1 : trt;
     is_mxfp8_quant = use_quant && (quant_type == "mx_fp8_e4m3" || quant_type == "mx_fp8_e5m2");
     bool is_mxfp4_quant = use_quant && (quant_type == "mx_fp4_e2m1");
-    // Reject E5M2 explicitly; simply removing it from the per-token check would misclassify it as INT8 below.
-    if (use_quant && quant_type == "pertoken_fp8_e5m2") {
-        EP_HOST_ASSERT_S(false, PERTOKEN_FP8_E5M2_UNSUPPORTED_MESSAGE);
-    }
+
     bool is_pertoken_fp8_quant = use_quant && quant_type == "pertoken_fp8_e4m3";
     int64_t quant_mode =
         use_quant
@@ -341,9 +331,6 @@ Buffer::intranode_dispatch(const at::Tensor &x, const std::optional<at::Tensor> 
         dynamic_scales_out =
             torch::empty({num_recv_tokens * hidden / MX_BLOCK_SIZE}, at::dtype(at::kFloat8_e8m0fnu).device(x.device()));
     } else if (quant_mode == PER_TOKEN_FP8_SCALES) {
-        if (quant_type == "pertoken_fp8_e5m2") {
-            EP_HOST_ASSERT_S(false, PERTOKEN_FP8_E5M2_UNSUPPORTED_MESSAGE);
-        }
         expandx_out = torch::empty({num_recv_tokens, hidden}, at::dtype(at::kFloat8_e4m3fn).device(x.device()));
         dynamic_scales_out = torch::empty({num_recv_tokens}, at::dtype(at::kFloat).device(x.device()));
     } else if (quant_mode == MXFP4_SCALES) {
@@ -869,14 +856,11 @@ Buffer::low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
     const bool is_mxfp4_quant = quant_mode_name == "mx_fp4_e2m1";
     const bool is_pertoken_fp8_quant = quant_mode_name == "pertoken_fp8_e4m3";
 
-    if (quant_mode_name == "pertoken_fp8_e5m2") {
-        EP_HOST_ASSERT_S(false, PERTOKEN_FP8_E5M2_UNSUPPORTED_MESSAGE);
-    }
 #ifndef __DAV_C310__
     const bool is_a5_only_quant = is_mxfp8_quant || is_mxfp4_quant || is_pertoken_fp8_quant;
     if (is_a5_only_quant) {
         EP_HOST_ASSERT_S(false, quant_mode_name,
-                         " is not supported on this device (requires A5/C310), please use int8 or bf16 instead.");
+                         " is not supported on this device, please use int8 or bf16 instead.");
     }
 #endif
 

--- a/csrc/deepep/deep_ep.cpp
+++ b/csrc/deepep/deep_ep.cpp
@@ -304,7 +304,6 @@ Buffer::intranode_dispatch(const at::Tensor &x, const std::optional<at::Tensor> 
     int num_recv_tokens = (trt == 0) ? 1 : trt;
     is_mxfp8_quant = use_quant && (quant_type == "mx_fp8_e4m3" || quant_type == "mx_fp8_e5m2");
     bool is_mxfp4_quant = use_quant && (quant_type == "mx_fp4_e2m1");
-
     bool is_pertoken_fp8_quant = use_quant && quant_type == "pertoken_fp8_e4m3";
     int64_t quant_mode =
         use_quant
@@ -850,7 +849,6 @@ Buffer::low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
         num_max_tokens = global_bs * std::min(num_topk, num_local_experts);
     }
     auto max_size = std::max(num_tokens * num_topk, num_max_tokens * 128);
-
     const bool is_mxfp8_quant = quant_mode_name == "mx_fp8_e4m3" || quant_mode_name == "mx_fp8_e5m2";
     const bool is_mxfp4_quant = quant_mode_name == "mx_fp4_e2m1";
     const bool is_pertoken_fp8_quant = quant_mode_name == "pertoken_fp8_e4m3";
@@ -915,7 +913,6 @@ Buffer::low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
     at::Tensor scales;
     at::Tensor active_mask;
     int enable_neg_one = get_value_from_env("MOE_ENABLE_TOPK_NEG_ONE", 0);
-
     int64_t tp_size = 1;
     int64_t tp_rank = 0;
     int64_t expert_shard_type = 0;

--- a/csrc/deepep/deep_ep.cpp
+++ b/csrc/deepep/deep_ep.cpp
@@ -315,8 +315,7 @@ Buffer::intranode_dispatch(const at::Tensor &x, const std::optional<at::Tensor> 
 #ifndef __DAV_C310__
     const bool is_a5_only_quant = is_mxfp8_quant || is_mxfp4_quant || is_pertoken_fp8_quant;
     if (is_a5_only_quant) {
-        EP_HOST_ASSERT_S(false, quant_type,
-                         " is not supported on this device (requires A5/C310), please use int8 or bf16 instead.");
+        EP_HOST_ASSERT_S(false, quant_type, " is not supported on this device, please use int8 or bf16 instead.");
     }
 #endif
     at::Tensor expandx_out;
@@ -859,8 +858,7 @@ Buffer::low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
 #ifndef __DAV_C310__
     const bool is_a5_only_quant = is_mxfp8_quant || is_mxfp4_quant || is_pertoken_fp8_quant;
     if (is_a5_only_quant) {
-        EP_HOST_ASSERT_S(false, quant_mode_name,
-                         " is not supported on this device, please use int8 or bf16 instead.");
+        EP_HOST_ASSERT_S(false, quant_mode_name, " is not supported on this device, please use int8 or bf16 instead.");
     }
 #endif
 

--- a/csrc/deepep/deep_ep.cpp
+++ b/csrc/deepep/deep_ep.cpp
@@ -26,6 +26,13 @@ constexpr uint32_t MAX_ROUNDS = 256;
 constexpr uint32_t MIN_TOKENS_PER_ROUND = 32;
 constexpr uint32_t MAX_TOKENS_PER_ROUND = 8192;
 constexpr uint32_t MAX_TOTAL_TOKENS = 131072;
+#ifdef __DAV_C310__
+constexpr const char *PERTOKEN_FP8_E5M2_UNSUPPORTED_MESSAGE =
+    "pertoken_fp8_e5m2 is not supported yet, please use pertoken_fp8_e4m3 instead.";
+#else
+constexpr const char *PERTOKEN_FP8_E5M2_UNSUPPORTED_MESSAGE =
+    "pertoken_fp8_e5m2 is not supported on this device, please use int8 or bf16 instead.";
+#endif
 
 Buffer::Buffer(int64_t rank, int64_t num_ranks, int64_t num_nvl_bytes, int64_t num_rdma_bytes, bool low_latency_mode,
                std::string moe_all_to_all_group_name)
@@ -304,13 +311,24 @@ Buffer::intranode_dispatch(const at::Tensor &x, const std::optional<at::Tensor> 
     int num_recv_tokens = (trt == 0) ? 1 : trt;
     is_mxfp8_quant = use_quant && (quant_type == "mx_fp8_e4m3" || quant_type == "mx_fp8_e5m2");
     bool is_mxfp4_quant = use_quant && (quant_type == "mx_fp4_e2m1");
-    bool is_pertoken_fp8_quant = use_quant && (quant_type == "pertoken_fp8_e4m3" || quant_type == "pertoken_fp8_e5m2");
+    // Reject E5M2 explicitly; simply removing it from the per-token check would misclassify it as INT8 below.
+    if (use_quant && quant_type == "pertoken_fp8_e5m2") {
+        EP_HOST_ASSERT_S(false, PERTOKEN_FP8_E5M2_UNSUPPORTED_MESSAGE);
+    }
+    bool is_pertoken_fp8_quant = use_quant && quant_type == "pertoken_fp8_e4m3";
     int64_t quant_mode =
         use_quant
             ? (is_mxfp8_quant
                    ? MXFP8_SCALES
                    : (is_mxfp4_quant ? MXFP4_SCALES : (is_pertoken_fp8_quant ? PER_TOKEN_FP8_SCALES : DYNAMIC_SCALES)))
             : NO_SCALES;
+#ifndef __DAV_C310__
+    const bool is_a5_only_quant = is_mxfp8_quant || is_mxfp4_quant || is_pertoken_fp8_quant;
+    if (is_a5_only_quant) {
+        EP_HOST_ASSERT_S(false, quant_type,
+                         " is not supported on this device (requires A5/C310), please use int8 or bf16 instead.");
+    }
+#endif
     at::Tensor expandx_out;
     at::Tensor dynamic_scales_out;
 #ifdef __DAV_C310__
@@ -323,8 +341,9 @@ Buffer::intranode_dispatch(const at::Tensor &x, const std::optional<at::Tensor> 
         dynamic_scales_out =
             torch::empty({num_recv_tokens * hidden / MX_BLOCK_SIZE}, at::dtype(at::kFloat8_e8m0fnu).device(x.device()));
     } else if (quant_mode == PER_TOKEN_FP8_SCALES) {
-        EP_HOST_ASSERT_S(quant_type != "pertoken_fp8_e5m2",
-                         "pertoken_fp8_e5m2 is not supported yet, please use pertoken_fp8_e4m3 instead");
+        if (quant_type == "pertoken_fp8_e5m2") {
+            EP_HOST_ASSERT_S(false, PERTOKEN_FP8_E5M2_UNSUPPORTED_MESSAGE);
+        }
         expandx_out = torch::empty({num_recv_tokens, hidden}, at::dtype(at::kFloat8_e4m3fn).device(x.device()));
         dynamic_scales_out = torch::empty({num_recv_tokens}, at::dtype(at::kFloat).device(x.device()));
     } else if (quant_mode == MXFP4_SCALES) {
@@ -846,20 +865,35 @@ Buffer::low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
     }
     auto max_size = std::max(num_tokens * num_topk, num_max_tokens * 128);
 
+    const bool is_mxfp8_quant = quant_mode_name == "mx_fp8_e4m3" || quant_mode_name == "mx_fp8_e5m2";
+    const bool is_mxfp4_quant = quant_mode_name == "mx_fp4_e2m1";
+    const bool is_pertoken_fp8_quant = quant_mode_name == "pertoken_fp8_e4m3";
+
+    if (quant_mode_name == "pertoken_fp8_e5m2") {
+        EP_HOST_ASSERT_S(false, PERTOKEN_FP8_E5M2_UNSUPPORTED_MESSAGE);
+    }
+#ifndef __DAV_C310__
+    const bool is_a5_only_quant = is_mxfp8_quant || is_mxfp4_quant || is_pertoken_fp8_quant;
+    if (is_a5_only_quant) {
+        EP_HOST_ASSERT_S(false, quant_mode_name,
+                         " is not supported on this device (requires A5/C310), please use int8 or bf16 instead.");
+    }
+#endif
+
     int64_t quant_mode = NO_SCALES;
     if (quant_mode_name == "int8") {
         quant_mode = DYNAMIC_SCALES;
-    } else if (quant_mode_name == "mx_fp8_e4m3" || quant_mode_name == "mx_fp8_e5m2") {
-        quant_mode = MXFP8_SCALES;
-    } else if (quant_mode_name == "mx_fp4_e2m1") {
-        quant_mode = MXFP4_SCALES;
-    } else if (quant_mode_name == "pertoken_fp8_e4m3" || quant_mode_name == "pertoken_fp8_e5m2") {
+    }
 #ifdef __DAV_C310__
+    else if (is_mxfp8_quant) {
+        quant_mode = MXFP8_SCALES;
+    } else if (is_mxfp4_quant) {
+        quant_mode = MXFP4_SCALES;
+    } else if (is_pertoken_fp8_quant) {
         quant_mode = PER_TOKEN_FP8_SCALES;
-#else
-        EP_HOST_ASSERT(false);
+    }
 #endif
-    } else {
+    else {
         EP_HOST_ASSERT(quant_mode_name == "none");
     }
     // Allocate packed tensors
@@ -874,9 +908,7 @@ Buffer::low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
     }
 #ifdef __DAV_C310__
     else if (quant_mode == PER_TOKEN_FP8_SCALES) {  // per-token fp8_e4m3
-        packed_recv_x = quant_mode_name == "pertoken_fp8_e5m2"
-                            ? at::empty({num_max_tokens, hidden}, at::dtype(at::kFloat8_e5m2).device(device))
-                            : at::empty({num_max_tokens, hidden}, at::dtype(at::kFloat8_e4m3fn).device(device));
+        packed_recv_x = at::empty({num_max_tokens, hidden}, at::dtype(at::kFloat8_e4m3fn).device(device));
         packed_recv_x_scales = at::empty({num_max_tokens}, at::dtype(at::kFloat).device(device));
     } else if (quant_mode == 3) {  // MXFP8
         packed_recv_x = quant_mode_name == "mx_fp8_e5m2"

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -684,7 +684,7 @@ class Buffer:
             use_ue8m0: deprecated for the default low-latency strategy and ignored when selecting its quantization mode.
             use_mxfp4: deprecated for the default low-latency strategy and ignored when selecting its quantization mode.
             quant_mode: quantization mode used by the default low-latency strategy. Supported values are `None`,
-                `int8`, `mx_fp8_e4m3`, `mx_fp8_e5m2`, `pertoken_fp8_e4m3`, `pertoken_fp8_e5m2`, and `mx_fp4_e2m1`.
+                `int8`, `mx_fp8_e4m3`, `mx_fp8_e5m2`, `pertoken_fp8_e4m3` and `mx_fp4_e2m1`.
             async_finish: the current stream will not wait for the communication kernels to be finished if set.
             return_recv_hook: return a receiving hook if set. If set, the kernel will just do the RDMA request issues,
                 but **without actually receiving the data**. You must call the received hook to make sure the data's arrival.

--- a/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
@@ -62,7 +62,6 @@ class DefaultLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             "mx_fp8_e4m3",
             "mx_fp8_e5m2",
             "pertoken_fp8_e4m3",
-            "pertoken_fp8_e5m2",
             "mx_fp4_e2m1",
         }
         if quant_mode not in valid_quant_modes:

--- a/python/deep_ep/deep_ep/strategies/normal_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/normal_strategy.py
@@ -163,7 +163,6 @@ class DefaultNormalCommStrategy(NormalEPCommStrategy):
             "mx_fp8_e4m3",
             "mx_fp8_e5m2",
             "pertoken_fp8_e4m3",
-            "pertoken_fp8_e5m2",
             "mx_fp4_e2m1",
         }
         if quant_mode is None:

--- a/tests/python/deepep/test_intranode.py
+++ b/tests/python/deepep/test_intranode.py
@@ -623,7 +623,7 @@ if __name__ == "__main__":
         dest="quant_type",
         type=str,
         default="bf16",
-        help="quant type: bf16, int8, mx_fp8_e4m3, mx_fp8_e5m2, pertoken_fp8_e4m3, pertoken_fp8_e5m2, mx_fp4_e2m1",
+        help="quant type: bf16, int8, mx_fp8_e4m3, mx_fp8_e5m2, pertoken_fp8_e4m3, mx_fp4_e2m1",
     )
     args = parser.parse_args()
 

--- a/tests/python/deepep/test_low_latency.py
+++ b/tests/python/deepep/test_low_latency.py
@@ -84,7 +84,6 @@ def test(
     elif quant_type in (
         "int8",
         "pertoken_fp8_e4m3",
-        "pertoken_fp8_e5m2",
         "mx_fp4_e2m1",
     ):
         fp8_configs = [(True, False)]
@@ -119,7 +118,6 @@ def test(
                         "mx_fp8_e4m3": "mx_fp8_e4m3",
                         "mx_fp8_e5m2": "mx_fp8_e5m2",
                         "pertoken_fp8_e4m3": "pertoken_fp8_e4m3",
-                        "pertoken_fp8_e5m2": "pertoken_fp8_e5m2",
                         "mx_fp4_e2m1": "mx_fp4_e2m1",
                     }[quant_type],
                 )
@@ -301,7 +299,6 @@ def test(
                 "mx_fp8_e4m3": "mx_fp8_e4m3",
                 "mx_fp8_e5m2": "mx_fp8_e5m2",
                 "pertoken_fp8_e4m3": "pertoken_fp8_e4m3",
-                "pertoken_fp8_e5m2": "pertoken_fp8_e5m2",
                 "mx_fp4_e2m1": "mx_fp4_e2m1",
             }[quant_type],
         )
@@ -549,7 +546,6 @@ if __name__ == "__main__":
             "mx_fp8_e4m3",
             "mx_fp8_e5m2",
             "pertoken_fp8_e4m3",
-            "pertoken_fp8_e5m2",
             "mx_fp4_e2m1",
         ],
         help="Quantization type for dispatch",


### PR DESCRIPTION
## Motivation

- Current DeepEP low latency should not support pertoken_fp8_e5m2 on A5. This PR aims to disable pertoken_fp8_e5m2 quant mode.  
- fixed issue: https://github.com/sgl-project/sgl-kernel-npu/issues/613

## Modification

1. README.md: removed pertoken_fp8_e5m2 from the documented Scalar FP8 support
2. README_CN.md: removed remove pertoken_fp8_e5m2 from the documented Scalar FP8 support
3. csrc/deepep/deep_ep.cpp — rejects per-token E5M2 before invoking the operator.
4. python/deep_ep/deep_ep/buffer.py — removes E5M2 from the documented supported modes.
5. tests/python/deepep/test_low_latency.py — removes E5M2 from normal test choices.

## Testing

- python3 tests/python/deepep/test_low_latency.py --num-processes 8 --num-tokens 1 --hidden 1024 --num-topk 1 --num-experts 64  --quant-type pertoken_fp8_e5m2
- python3 tests/python/deepep/test_low_latency.py --num-processes 8 --num-tokens 1 --hidden 1024 --num-topk 1 --num-experts 64  --quant-type pertoken_fp8_e4m3

## Benchmarking and Profiling

- test_low_latency.py: error: argument --quant-type: invalid choice: 'pertoken_fp8_e5m2' (choose from 'no', 'int8', 'mx_fp8_e4m3', 'mx_fp8_e5m2', 'pertoken_fp8_e4m3', 'mx_fp4_e4m1'})
- Average Dispatch bandwidth: 0.07 GB/s, avg_t=15.54 us
- Average Combine bandwidth: 0.32 GB/s, avg_t=6.34 us
- This is a small change. No performance impact

## Checklist

- [x] Format your code.
- [x] Add unit tests.
- [x] Update documentation.  
- [x] Provide accuracy and speed  
