### PR TITLE
[docs] update readme for all deepep

### DIFF
--- a/python/deep_ep/README.md
+++ b/python/deep_ep/README.md
@@ -27,7 +27,7 @@ DeepEP-Ascend uses a **strategy-based architecture** that allows flexible select
 
 ### Software and Hardware
 
-Supported Hardware Models: Atlas A2, A3 (support CANN 8.5 and CANN 9.0), and Atlas A5 (only supports CANN 9.0).
+Supported Hardware Models: Atlas A2, A3 (support CANN 8.5 and CANN 9.0), and Atlas A5 (supports CANN 9.0).
 
 Platform: aarch64/x86
 
@@ -243,7 +243,7 @@ For detailed A2 usage, see [A2_DEEPEP](doc/A2_DEEPEP.md).
 
 #### A5
 
-- Only supports CANN 9.0.
+- Supports CANN 9.0.
 - Build with: `bash build.sh -a deepep Ascend950`.
 - Supports scalar FP8 per-token quantization (`quant_mode="pertoken_fp8_e4m3"`) and MXFP8 per-block quantization in normal dispatch.
 
@@ -298,7 +298,7 @@ DeepEP-Ascend 采用**策略式架构**，通过环境变量灵活选择通信�
 
 ### 软硬件配套说明
 
-硬件型号支持：Atlas A2、A3 系列产品能适配 CANN 8.5 和 CANN 9.0，Atlas A5 只能适配 CANN 9.0。
+硬件型号支持：Atlas A2、A3 系列产品能适配 CANN 8.5 和 CANN 9.0，Atlas A5 适配 CANN 9.0。
 
 平台：aarch64/x86
 
@@ -496,7 +496,7 @@ low_latency_dispatch 量化模式（通过 `quant_mode` 参数指定；`use_fp8`
 
 #### A5
 
-- 仅支持 CANN 9.0。
+- 适配 CANN 9.0。
 - 构建命令：`bash build.sh -a deepep Ascend950`。
 
 ### 测试

--- a/python/deep_ep/README.md
+++ b/python/deep_ep/README.md
@@ -20,8 +20,8 @@ English | [中文](#中文)
 
 **DeepEP-Ascend** is the Ascend NPU implementation of [DeepEP](https://github.com/deepseek-ai/DeepEP), providing highly optimized Expert Parallelism (EP) communication kernels for Mixture-of-Experts (MoE) models on Ascend hardware. It supports two communication modes:
 
-- **Normal Mode**: High-throughput dispatch and combine operations for training and prefill phases.
-- **Low-Latency Mode**: Optimized for production inference with small batch sizes, achieving sub-150us latency.
+- **Normal Mode**: High-throughput MoE dispatch and combine kernels for training and prefill phases.
+- **Low-Latency Mode**: Low-latency MoE dispatch and combine kernels for inference decode.
 
 DeepEP-Ascend uses a **strategy-based architecture** that allows flexible selection of communication implementations via environment variables, supporting various hardware topologies (A2, A3, A5) and communication backends (HCCS, RDMA, AlltoAll).
 
@@ -140,11 +140,11 @@ For detailed API documentation, see:
 
 #### Normal Mode (Prefill / Training)
 
-High-throughput dispatch and combine for training and prefill phases:
+High-throughput MoE dispatch and combine kernels for training and prefill phases:
 - **A3**: Pure HCCS intranode communication, full-mesh HCCS internode communication. No hierarchical implementation needed.
 - **A2 Intranode**: Pure HCCS communication, supports up to `bs=8000` for normal dispatch/combine.
 - **A2 Internode**: Hierarchical (HCCS intranode + RDMA internode) or non-hierarchical (pure RDMA) implementation. Supports up to `bs=4096`.
-- **A5**: Supports scalar FP8 per-token quantization and MXFP8 per-block quantization (A5 only).
+- **A5**: Supports scalar FP8 per-token quantization, MXFP8 per-block quantization, and MXFP4 per-block quantization (A5 only).
 
 #### Quantization Modes in Normal Dispatch
 
@@ -176,28 +176,29 @@ buffer.dispatch(x=data, quant_mode="mx_fp4_e2m1", ...)
 
 #### Low-Latency Mode (Decode)
 
-Optimized for inference with small batch sizes (128 tokens/batch):
+Low-latency MoE dispatch and combine kernels for inference decode:
 - **A3**: Supports `default`, `ops`, and `alltoall` strategies. `ops` strategy supports `comm_alg` options: `hierarchy`, `fullmesh_v1`, `fullmesh_v2`, `ccu`.
 - **A5**: Supports `default` and `ops` strategies with scalar FP8 per-token quantization (`quant_mode="pertoken_fp8_e4m3"`) and MXFP8 per-block quantization (`quant_mode="mx_fp8_e4m3"`).
 - **A2 Intranode**: Supports up to `bs=512` for low_latency dispatch/combine.
 - **A2 Internode**: Hierarchical (HCCS + RDMA) or non-hierarchical (pure RDMA) implementation. Supports up to `bs=512`.
 
-Quantization modes in `low_latency_dispatch` (via `quant_mode` parameter; `use_fp8`/`use_ue8m0`/`use_mxfp4` are deprecated):
-- **BF16**: `quant_mode=None` — no quantization, bfloat16 communication.
-- **INT8**: `quant_mode="int8"` — per-token INT8 with `float32` scales. INT8 payload on all platforms (A2/A3/A5). Available on all strategies (default/ops/alltoall) and platforms.
+Quantization modes in `low_latency_dispatch`. The `quant_mode` string parameter is only effective on the `default` strategy; `ops` and `alltoall` strategies use legacy `use_fp8`/`use_ue8m0`/`use_mxfp4` booleans:
+- **BF16**: `quant_mode=None` (default strategy) or `use_fp8=False` (ops/alltoall) — no quantization, bfloat16 communication.
+- **INT8**: `quant_mode="int8"` (default) or `use_fp8=True` (ops/alltoall) — per-token INT8 with `float32` scales. INT8 payload on all platforms (A2/A3/A5). Available on all strategies.
 - **Scalar FP8 per-token**: `quant_mode="pertoken_fp8_e4m3"` — per-token FP8 dynamic quantization with `float32` scales. **A5 only**; `default` strategy only.
-- **MXFP8 per-block**: `quant_mode="mx_fp8_e4m3"` or `"mx_fp8_e5m2"` — per-block quantization, `float8_e4m3fn`/`float8_e5m2` data + `float8_e8m0fnu` scales. **A5 only**; `default` strategy supports both e4m3 and e5m2; `ops` strategy supports e4m3 only (via legacy `use_ue8m0=True`); `alltoall` not supported.
-- **MXFP4 per-block**: `quant_mode="mx_fp4_e2m1"` — per-block quantization, `float4_e2m1fn_x2` data + `float8_e8m0fnu` scales. **A5 only**; only supported on `default` strategy.
+- **MXFP8 per-block**: `quant_mode="mx_fp8_e4m3"` or `"mx_fp8_e5m2"` (default) or `use_ue8m0=True` (ops, e4m3 only) — per-block quantization, `float8_e4m3fn`/`float8_e5m2` data + `float8_e8m0fnu` scales. **A5 only**; `default` supports both e4m3/e5m2; `ops` supports e4m3 only; `alltoall` not supported.
+- **MXFP4 per-block**: `quant_mode="mx_fp4_e2m1"` — per-block quantization, `float4_e2m1fn_x2` data + `float8_e8m0fnu` scales. **A5 only**; `default` strategy only.
 
 ### Fused MoE
 
 The `fused_deep_moe` API fuses dispatch + expert FFN computation + combine into a single operator call, significantly reducing communication overhead and end-to-end latency.
 
 Two fuse modes are available via the `FuseMode` enum:
-- `FuseMode.FUSED_DEEP_MOE` (default): Full fusion of dispatch + FFN + combine.
-- `FuseMode.DISPATCH_FFN_COMBINE`: Dispatch + FFN + combine with separate dispatch handling.
+- `FuseMode.FUSED_DEEP_MOE` (default): Full fusion of dispatch + FFN + combine via staged CamMoe communication with cross-core barriers.
+- `FuseMode.DISPATCH_FFN_COMBINE`: Integrated routing + FFN + combine with embedded HCCL communication, no cross-core barriers.
 
 Quantization modes (`quant_mode`):
+- `0`: No quantization (BF16 weights)
 - `1`: INT8 quantization (default)
 - FP8 will be supported in A5 release.
 
@@ -208,11 +209,17 @@ See [Fused Deep MoE API](doc/FUSED_DEEP_MOE.md) for details.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DEEP_USE_MODE` | `default` | Normal mode strategy and Low-latency mode strategy: `default`, `ops`, or `alltoall`. |
-| `DEEP_NORMAL_MODE_USE_INT8_QUANT` | `0` | **Removed.** INT8 quantization is now specified via `quant_mode="int8"` parameter in `dispatch()`. MXFP8/MXFP4 per-block quantization (A5 only, intranode only) is triggered by passing a tuple `(data_tensor, scale_tensor)` as `x`; see [Normal Mode quantization](#normal-mode-prefill--training) for supported dtypes. |
-| `SGLANG_DEEPEP_BF16_DISPATCH` | `0` | Disable quantization in low_latency_dispatch (BF16 dispatch). Set to `1` to disable; only effective in decode phase. |
+| `DEEP_NORMAL_MODE_USE_INT8_QUANT` | `0` | **Deprecated for `default` strategy.** INT8 quantization is now specified via `quant_mode="int8"` parameter in `dispatch()`. For `alltoall` strategy, this env var is still the only way to enable INT8. MXFP8/MXFP4 per-block quantization (A5 only, intranode only) is specified via `quant_mode` parameter (e.g., `quant_mode="mx_fp8_e4m3"`); see [Normal Mode quantization](#normal-mode-prefill--training) for supported values. |
+| `SGLANG_DEEPEP_BF16_DISPATCH` | `0` | Disable quantization in `low_latency_dispatch` (BF16 dispatch). Set to `1` to disable; only effective in decode phase. **Configured by SGLang framework**, not read by deep_ep directly. |
 | `MOE_EXPERT_TOKEN_NUMS_TYPE` | `1` | Dispatch return type for `num_recv_tokens_per_expert_list`: `1` = per-expert token count, `0` = prefix sum. |
 | `MOE_SHARED_EXPERT_RANK_NUM` | `0` | Number of shared expert ranks (used by ops strategy). |
-| `HCCL_BUFFSIZE` | `200` (MB) | HCCL buffer size in MB. **Must be set** when using DeepEP on A2. |
+| `MOE_ENABLE_TOPK_NEG_ONE` | `0` | Set to `1` to enable `-1` indices in `topk_idx` (token not dispatched to any expert). Used by low-latency dispatch. |
+| `MOE_ENABLE_CCU` | `0` | Set to `1` to use `comm_alg="ccu"` in default low-latency strategy. |
+| `HCCL_BUFFSIZE` | `200` (MB) | HCCL buffer size in MB. **Must be set** when using DeepEP on A2. Minimum required size (non-layered): `(bs × ep_world_size × min(num_local_experts, topk) × hidden × 2B + 2MB) × 2`. For layered (dual-node): `num_experts × bs × (hidden × 2B + 4 × topk × 4B) + 4MB + 800MB`. A5 subtracts 1MB state zone from the configured value. |
+| `DEEPEP_HCCL_BUFFSIZE` | — | Reserved. Takes priority over `HCCL_BUFFSIZE` if set. DeepEP reads this for preliminary validation only; actual HCCL buffer must be configured by the framework (e.g., SGLang). |
+| `DEEPEP_NORMAL_LONG_SEQ_ROUND` | `1` | "Ant moving home" feature: number of dispatch rounds per rank. Range [1, 256]. Must be set together with `DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS`. |
+| `DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS` | `8192` | "Ant moving home" feature: tokens per round per rank. Range [32, 8192]. Product with `ROUND` must be ≤ 131072. |
+| `DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ` | `0` | Set to `1` to enable "ant moving home" in the combine phase. |
 | `HCCL_INTRA_PCIE_ENABLE` | `0` | Set to `1` for A2 dual-node hierarchical communication. |
 | `HCCL_INTRA_ROCE_ENABLE` | `1` | Set to `0` for A2 dual-node hierarchical communication. |
 | `HCCL_OP_EXPANSION_MODE` | — | **Must be disabled** on A2 when using DeepEP (remove or unset this variable). |
@@ -245,16 +252,16 @@ For detailed A2 usage, see [A2_DEEPEP](doc/A2_DEEPEP.md).
 
 - Supports CANN 9.0.
 - Build with: `bash build.sh -a deepep Ascend950`.
-- Supports scalar FP8 per-token quantization (`quant_mode="pertoken_fp8_e4m3"`) and MXFP8 per-block quantization in normal dispatch.
+- Supports scalar FP8 per-token quantization (`quant_mode="pertoken_fp8_e4m3"`), MXFP8 per-block quantization, and MXFP4 per-block quantization in normal dispatch.
 
 ### Test
 
 Execute DeepEP-related test scripts:
 
 ```bash
-python3 tests/python/deepep/test_fused_deep_moe.py
 python3 tests/python/deepep/test_intranode.py
 python3 tests/python/deepep/test_low_latency.py
+python3 tests/python/deepep/test_fused_deep_moe.py
 
 # A2 single-node tests
 python3 tests/python/deepep/test_intranode.py --num-processes=8
@@ -291,8 +298,8 @@ ln -s deep_ep/deep_ep_cpp*.so
 
 **DeepEP-Ascend** 是 [DeepEP](https://github.com/deepseek-ai/DeepEP) 的 Ascend NPU 实现，为 MoE（混合专家）模型提供高度优化的专家并行（EP）通信内核。它支持两种通信模式：
 
-- **Normal 模式**：高吞吐的 dispatch 和 combine 操作，适用于训练和 Prefill 阶段。
-- **Low-Latency 模式**：针对小 batch 生产推理优化，延迟低于 150us。
+- **Normal 模式**：面向训练和 Prefill 阶段的高吞吐 MoE dispatch/combine 通信内核。
+- **Low-Latency 模式**：面向推理 Decode 阶段的低时延 MoE dispatch/combine 通信内核。
 
 DeepEP-Ascend 采用**策略式架构**，通过环境变量灵活选择通信实现方式，支持多种硬件拓扑（A2、A3、A5）和通信后端（HCCS、RDMA、AlltoAll）。
 
@@ -412,10 +419,11 @@ DeepEP-Ascend 采用**策略式架构**，通信实现被抽象为可互换的�
 
 #### Normal 模式（Prefill / 训练）
 
-高吞吐的 dispatch 和 combine，适用于训练和 Prefill 阶段：
+面向训练和 Prefill 阶段的高吞吐 MoE dispatch/combine 通信内核：
 - **A3**：纯 HCCS 节点内通信，全互联 HCCS 节点间通信。无需分层实现。
 - **A2 单机**：纯 HCCS 通信，normal dispatch/combine 最大支持 `bs=8000`。
 - **A2 双机**：分层（节点内 HCCS + 节点间 RDMA）或不分层（纯 RDMA）实现。最大支持 `bs=4096`。
+- **A5**：支持 scalar FP8 per-token 量化、MXFP8 per-block 量化和 MXFP4 per-block 量化（仅 A5）。
 
 normal_dispatch 量化模式（通过 `quant_mode` 参数指定）：
 
@@ -429,17 +437,17 @@ normal_dispatch 量化模式（通过 `quant_mode` 参数指定）：
 
 #### Low-Latency 模式（Decode）
 
-针对小 batch 推理优化（128 tokens/batch）：
+面向推理 Decode 阶段的低时延 MoE dispatch/combine 通信内核：
 - **A3**：支持 `default`、`ops`、`alltoall` 策略。`ops` 策略支持 `comm_alg` 选项：`hierarchy`、`fullmesh_v1`、`fullmesh_v2`、`ccu`。
 - **A5**：支持 `default` 和 `ops` 策略，支持 scalar FP8 per-token 量化（`quant_mode="pertoken_fp8_e4m3"`）和 MXFP8 per-block 量化（`quant_mode="mx_fp8_e4m3"`）。
 - **A2 单机**：low_latency dispatch/combine 最大支持 `bs=512`。
 - **A2 双机**：分层（HCCS + RDMA）或不分层（纯 RDMA）实现。最大支持 `bs=512`。
 
-low_latency_dispatch 量化模式（通过 `quant_mode` 参数指定；`use_fp8`/`use_ue8m0`/`use_mxfp4` 已弃用）：
-- **BF16**：`quant_mode=None` — 不量化，bfloat16 通信。
-- **INT8**：`quant_mode="int8"` — per-token INT8 + `float32` 缩放因子。全平台（A2/A3/A5）均为 INT8 载荷。全策略（default/ops/alltoall）全平台支持。
+low_latency_dispatch 量化模式。`quant_mode` 字符串参数仅对 `default` 策略生效；`ops` 和 `alltoall` 策略使用旧参数 `use_fp8`/`use_ue8m0`/`use_mxfp4`：
+- **BF16**：`quant_mode=None`（default）或 `use_fp8=False`（ops/alltoall）— 不量化，bfloat16 通信。
+- **INT8**：`quant_mode="int8"`（default）或 `use_fp8=True`（ops/alltoall）— per-token INT8 + `float32` 缩放因子。全平台（A2/A3/A5）均为 INT8 载荷。全策略支持。
 - **Scalar FP8 per-token**：`quant_mode="pertoken_fp8_e4m3"` — per-token FP8 动态量化 + `float32` 缩放因子。**仅 A5**；仅 `default` 策略支持。
-- **MXFP8 per-block**：`quant_mode="mx_fp8_e4m3"` 或 `"mx_fp8_e5m2"` — per-block 量化，`float8_e4m3fn`/`float8_e5m2` 数据 + `float8_e8m0fnu` 缩放因子。**仅 A5**；`default` 策略支持 e4m3 和 e5m2；`ops` 策略仅支持 e4m3（通过旧 API `use_ue8m0=True`）；`alltoall` 不支持。
+- **MXFP8 per-block**：`quant_mode="mx_fp8_e4m3"` 或 `"mx_fp8_e5m2"`（default）或 `use_ue8m0=True`（ops，仅 e4m3）— per-block 量化，`float8_e4m3fn`/`float8_e5m2` 数据 + `float8_e8m0fnu` 缩放因子。**仅 A5**；`default` 支持 e4m3/e5m2；`ops` 仅 e4m3；`alltoall` 不支持。
 - **MXFP4 per-block**：`quant_mode="mx_fp4_e2m1"` — per-block 量化，`float4_e2m1fn_x2` 数据 + `float8_e8m0fnu` 缩放因子。**仅 A5**；仅 `default` 策略支持。
 
 ### 融合 MoE
@@ -447,10 +455,11 @@ low_latency_dispatch 量化模式（通过 `quant_mode` 参数指定；`use_fp8`
 `fused_deep_moe` API 将 dispatch + 专家 FFN 计算 + combine 融合为单次算子调用，显著降低通信开销和端到端延迟。
 
 通过 `FuseMode` 枚举提供两种融合模式：
-- `FuseMode.FUSED_DEEP_MOE`（默认）：dispatch + FFN + combine 完整融合。
-- `FuseMode.DISPATCH_FFN_COMBINE`：dispatch + FFN + combine，dispatch 分离处理。
+- `FuseMode.FUSED_DEEP_MOE`（默认）：dispatch + FFN + combine 完整融合，通信阶段（dispatch/combine）使用 CamMoe，与 GMM 阶段间通过跨核 barrier 串联。
+- `FuseMode.DISPATCH_FFN_COMBINE`：集成路由 + FFN + combine，HCCL 通信内嵌于 GMM kernel 中，无跨核 barrier。
 
 量化模式（`quant_mode`）：
+- `0`：无量化（BF16 权重）
 - `1`：INT8 量化（默认）
 - FP8 将在 A5 版本中支持。
 
@@ -461,11 +470,17 @@ low_latency_dispatch 量化模式（通过 `quant_mode` 参数指定；`use_fp8`
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
 | `DEEP_USE_MODE` | `default` | Normal 模式策略 and Low-latency 模式策略：`default`、`ops` 或 `alltoall`。 |
-| `DEEP_NORMAL_MODE_USE_INT8_QUANT` | `0` | **已移除。** INT8 量化现通过 `dispatch()` 的 `quant_mode="int8"` 参数指定。MXFP8/MXFP4 per-block 量化（仅 A5，仅 intranode）通过 `quant_mode` 参数指定，支持的 dtype 见 [Normal 模式量化](#normal-模式prefill--训练)。 |
-| `SGLANG_DEEPEP_BF16_DISPATCH` | `0` | 在 low_latency_dispatch 中关闭量化（BF16 dispatch）。设为 `1` 关闭量化；仅在 Decode 阶段生效。 |
+| `DEEP_NORMAL_MODE_USE_INT8_QUANT` | `0` | **对 `default` 策略已弃用。** INT8 量化现通过 `dispatch()` 的 `quant_mode="int8"` 参数指定。对于 `alltoall` 策略，此环境变量仍是启用 INT8 的唯一方式。MXFP8/MXFP4 per-block 量化（仅 A5，仅 intranode）通过 `quant_mode` 参数指定（如 `quant_mode="mx_fp8_e4m3"`），支持的值见 [Normal 模式量化](#normal-模式prefill--训练)。 |
+| `SGLANG_DEEPEP_BF16_DISPATCH` | `0` | 在 `low_latency_dispatch` 中关闭量化（BF16 dispatch）。设为 `1` 关闭量化；仅在 Decode 阶段生效。**由 SGLang 框架配置**，deep_ep 不直接读取。 |
 | `MOE_EXPERT_TOKEN_NUMS_TYPE` | `1` | dispatch 返回的 `num_recv_tokens_per_expert_list` 类型：`1` = 各专家 token 数，`0` = 前缀和。 |
 | `MOE_SHARED_EXPERT_RANK_NUM` | `0` | 共享专家 rank 数（ops 策略使用）。 |
-| `HCCL_BUFFSIZE` | `200`（MB） | HCCL 缓冲区大小（MB）。A2 使用 DeepEP 时**必须设置**。 |
+| `MOE_ENABLE_TOPK_NEG_ONE` | `0` | 设为 `1` 启用 `topk_idx` 中 `-1` 值（token 不分发到任何专家）。low-latency dispatch 使用。 |
+| `MOE_ENABLE_CCU` | `0` | 设为 `1` 时 default low-latency 策略使用 `comm_alg="ccu"`。 |
+| `HCCL_BUFFSIZE` | `200`（MB） | HCCL 缓冲区大小（MB）。A2 使用 DeepEP 时**必须设置**。非分层最小需求：`(bs × ep_world_size × min(num_local_experts, topk) × hidden × 2B + 2MB) × 2`；分层（双机）：`num_experts × bs × (hidden × 2B + 4 × topk × 4B) + 4MB + 800MB`。A5 从配置值中扣除 1MB 状态区。 |
+| `DEEPEP_HCCL_BUFFSIZE` | — | 预留字段，优先级高于 `HCCL_BUFFSIZE`。DeepEP 仅用于初步校验，实际 HCCL 缓冲需由框架（如 SGLang）配置。 |
+| `DEEPEP_NORMAL_LONG_SEQ_ROUND` | `1` | 蚂蚁搬家特性：每 rank 发送轮数。范围 [1, 256]。需与 `DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS` 同时设置。 |
+| `DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS` | `8192` | 蚂蚁搬家特性：每轮每 rank 发送 token 数。范围 [32, 8192]。与 `ROUND` 的乘积需 ≤ 131072。 |
+| `DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ` | `0` | 设为 `1` 在 combine 阶段启用蚂蚁搬家。 |
 | `HCCL_INTRA_PCIE_ENABLE` | `0` | A2 双机分层通信时设为 `1`。 |
 | `HCCL_INTRA_ROCE_ENABLE` | `1` | A2 双机分层通信时设为 `0`。 |
 | `HCCL_OP_EXPANSION_MODE` | — | A2 使用 DeepEP 时**必须禁用**（移除或取消设置此变量）。 |
@@ -485,7 +500,7 @@ low_latency_dispatch 量化模式（通过 `quant_mode` 参数指定；`use_fp8`
 #### A2 双机
 
 - 适用条件：P/D 节点 ranks > 8（跨节点通信）。
-- **Normal 模式不支持量化**（`DEEP_NORMAL_MODE_USE_INT8_QUANT=0`）。
+- **Normal 模式不支持量化**（A2 双机使用 BF16 `quant_mode`）。
 - **必须设置** `HCCL_INTRA_PCIE_ENABLE=1` 和 `HCCL_INTRA_ROCE_ENABLE=0` 启用分层通信。
 - **性能上限**：normal 最大 `bs=4096`，low_latency 最大 `bs=512`。
 
@@ -498,15 +513,16 @@ low_latency_dispatch 量化模式（通过 `quant_mode` 参数指定；`use_fp8`
 
 - 适配 CANN 9.0。
 - 构建命令：`bash build.sh -a deepep Ascend950`。
+- 支持 scalar FP8 per-token 量化（`quant_mode="pertoken_fp8_e4m3"`）、MXFP8 per-block 量化和 MXFP4 per-block 量化（normal dispatch）。
 
 ### 测试
 
 执行 DeepEP 相关测试脚本：
 
 ```bash
-python3 tests/python/deepep/test_fused_deep_moe.py
 python3 tests/python/deepep/test_intranode.py
 python3 tests/python/deepep/test_low_latency.py
+python3 tests/python/deepep/test_fused_deep_moe.py
 
 # A2 单机测试
 python3 tests/python/deepep/test_intranode.py --num-processes=8

--- a/python/deep_ep/doc/A2_DEEPEP.md
+++ b/python/deep_ep/doc/A2_DEEPEP.md
@@ -1,13 +1,13 @@
-# A2 DeepEP Guide
+# A2 DeepEP Configuration Guide
 
 <div align="center">
 
-[![Platform](https://img.shields.io/badge/Platform-A2%20only-red)]()
+[![Platform](https://img.shields.io/badge/Platform-A2%20%7C%20A3%20%7C%20A5-green)]()
 
 </div>
 
-> [!IMPORTANT]
-> **A2 only.** This document applies exclusively to Atlas A2 series.
+> [!NOTE]
+> DeepEP supports A2, A3, and A5 platforms. This document covers **A2-specific** configuration (single/dual node setup, HCCL tuning, environment variables).
 
 English | [中文](#中文)
 
@@ -65,7 +65,32 @@ Framework configuration (SGLang):
 | D node (Decode) | `--deepep-mode` | `low_latency` |
 | Mixed PD node | `--deepep-mode` | `auto` |
 
-**Note**: DeepEP A2 only supports HCCL communication domain. When DeepEP is enabled, `HCCL_BUFFSIZE` **must** be set, otherwise dispatch & combine operators will fail:
+**Note**: DeepEP A2 only supports HCCL communication domain. When DeepEP is enabled, `HCCL_BUFFSIZE` **must** be set, otherwise dispatch & combine operators will fail. The minimum required size depends on the communication mode:
+
+- **Non-layered (single-node)**: `(bs × ep_world_size × min(num_local_experts, topk) × hidden × 2B + 2MB) × 2`
+- **Layered (dual-node)**: `num_experts × bs × (hidden × 2B + 4 × topk × 4B) + 4MB + 800MB`
+
+Where `bs` = max tokens per rank, `hidden` = hidden size, `topk` = num top-k experts, `num_local_experts` = `num_experts / ep_world_size`. A5 subtracts 1MB state zone from the configured value.
+
+**"Ant moving home" (long sequence) feature**: When the input sequence length exceeds 8192, enable this feature in both dispatch and combine phases:
+
+```bash
+# Enable long sequence dispatch (rounds × tokens_per_round = total sequence length)
+export DEEPEP_NORMAL_LONG_SEQ_ROUND=1          # default 1, range [1, 256]
+export DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS=8192  # default 8192, range [32, 8192]
+export DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ=1  # enable in combine phase
+```
+
+HCCL_BUFFSIZE formula with long sequence enabled:
+```
+HCCL_BUFFSIZE >= 2 × (102MB + 4MB + PER_ROUND_TOKENS × (hidden_size × 3) × topk) + PADDING_BUFFSIZE
+```
+HCCL_BUFFSIZE formula without long sequence:
+```
+HCCL_BUFFSIZE >= 2 × (102MB + 4MB + TOTAL_SEQ_LEN × (hidden_size × 3) × topk) + PADDING_BUFFSIZE
+```
+Where `PADDING_BUFFSIZE` is recommended to be 20 or larger.
+
 ```bash
 # Adjust size based on your model scenario
 export HCCL_BUFFSIZE=1024
@@ -155,7 +180,9 @@ bash run_test_internode.sh
 
 ### 软硬件配套说明
 
-硬件型号支持：Atlas A2 系列产品
+DeepEP 支持 A2、A3、A5 平台。本节为 A2 专属配置说明。
+
+硬件型号：Atlas A2 系列
 平台：aarch64/x86
 配套软件
 - 驾动 Ascend HDK ≥ 25.3.RC1、CANN ≥ 8.5.0
@@ -203,7 +230,32 @@ DeepEp 向上层提供以下核心接口：
 | D 节点（Decode） | `--deepep-mode` | `low_latency` |
 | 混部节点（PD） | `--deepep-mode` | `auto` |
 
-**注意**：当前deepep A2仅支持HCCL通信域通信，开启deepep后，必须设置的`HCCL_BUFFSIZE`大小，否则dispatch&combine算子会报错。
+**注意**：当前deepep A2仅支持HCCL通信域通信，开启deepep后，必须设置的`HCCL_BUFFSIZE`大小，否则dispatch&combine算子会报错。最小需求取决于通信模式：
+
+- **非分层（单机）**：`(bs × ep_world_size × min(num_local_experts, topk) × hidden × 2B + 2MB) × 2`
+- **分层（双机）**：`num_experts × bs × (hidden × 2B + 4 × topk × 4B) + 4MB + 800MB`
+
+其中 `bs` = 每 rank 最大 token 数，`hidden` = 隐藏层大小，`topk` = top-k 专家数，`num_local_experts` = `num_experts / ep_world_size`。A5 从配置值中扣除 1MB 状态区。
+
+**蚂蚁搬家（长序列）特性**：当输入序列长度超过 8192 时，建议在 dispatch 和 combine 阶段均开启蚂蚁搬家功能：
+
+```bash
+# 启用长序列 dispatch（轮数 × 每轮 token 数 = 总序列长度）
+export DEEPEP_NORMAL_LONG_SEQ_ROUND=1          # 默认 1，范围 [1, 256]
+export DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS=8192  # 默认 8192，范围 [32, 8192]
+export DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ=1  # 在 combine 阶段启用
+```
+
+启用蚂蚁搬家时 HCCL_BUFFSIZE 计算公式：
+```
+HCCL_BUFFSIZE >= 2 × (102MB + 4MB + PER_ROUND_TOKENS × (hidden_size × 3) × topk) + PADDING_BUFFSIZE
+```
+未启用蚂蚁搬家时：
+```
+HCCL_BUFFSIZE >= 2 × (102MB + 4MB + TOTAL_SEQ_LEN × (hidden_size × 3) × topk) + PADDING_BUFFSIZE
+```
+其中 `PADDING_BUFFSIZE` 建议设置为 20 或更大的值。
+
 ```bash
 # 根据实际模型场景灵活调整大小
 export HCCL_BUFFSIZE=1024

--- a/python/deep_ep/doc/FUSED_DEEP_MOE.md
+++ b/python/deep_ep/doc/FUSED_DEEP_MOE.md
@@ -27,8 +27,8 @@ Two fuse modes are available via the `FuseMode` enum:
 
 | FuseMode | Value | CANN Operator | Description |
 |----------|-------|---------------|-------------|
-| `FuseMode.FUSED_DEEP_MOE` | `1` | `aclnnFusedDeepMoe` | Full fusion: InitRouting + AllToAll + GMM1 + DequantSwigluQuant + GMM2 + Dequant + Unpermute/Combine in a single AscendC kernel. |
-| `FuseMode.DISPATCH_FFN_COMBINE` | `2` | `aclnnDispatchFFNCombine` | Separate dispatch handling: InitRouting + AllToAll dispatch + GMM1 + DequantSwigluQuant + GMM2 + Dequant + Combine in a single AscendC kernel, using a different internal fusion strategy. |
+| `FuseMode.FUSED_DEEP_MOE` | `1` | `aclnnFusedDeepMoe` | Full fusion: InitRouting + AllToAll + GMM1 + DequantSwigluQuant + GMM2 + Dequant + Unpermute/Combine in a single AscendC kernel. Communication stages (dispatch/combine) use CamMoe with cross-core barriers between GMM stages. |
+| `FuseMode.DISPATCH_FFN_COMBINE` | `2` | `aclnnDispatchFFNCombine` | Integrated routing (`MoeInitRoutingQuantV2`) + AllToAll + GMM1 + DequantSwigluQuant + GMM2 + Dequant + Combine in a single AscendC kernel. HCCL communication is embedded into the GMM kernel via shared memory, without cross-core barriers between stages. |
 
 > [!NOTE]
 > `FuseMode` is **not** exported from the package's top-level `__init__.py`. Import it explicitly:
@@ -39,14 +39,13 @@ Two fuse modes are available via the `FuseMode` enum:
 
 #### Key Differences Between Fuse Modes
 
-| Aspect | `FUSED_DEEP_MOE` | `DISPATCH_FFN_COMBINE` |
-|--------|-------------------|------------------------|
-| **Weight scale dtype** | `float32` (auto-converted to `float` internally) | `int64` (float32 values reinterpreted as int64 bit patterns; **not auto-converted** — caller must perform the conversion manually) |
-| **Weight layout (GMM1)** | Permuted via tile-N permutation (`reshape_fusion_gmm_weight` in test code) | Standard NZ format, no additional permutation needed |
-| **`num_max_dispatch_tokens_per_rank`** semantics | Max tokens to dispatch per rank | Max tokens received in dispatch (i.e., `max_bs × num_ranks × topk`) |
-| **Second return value** | `ep_recv_count`, shape `[num_local_experts × num_ranks]` | `expert_token_nums`, shape `[num_local_experts]` (per-rank only) |
-| **Shared expert support** | Supported | **Not supported** |
-| **BF16 weight support** | Available | **Not available** — only INT8 weights are supported currently |
+| Aspect | `FUSED_DEEP_MOE` (mode=1) | `DISPATCH_FFN_COMBINE` (mode=2) |
+|--------|---------------------------|---------------------------------|
+| **Weight scale dtype** | `float32` (`DT_FLOAT`, auto-converted internally) | `int64` (`DT_INT64`, float32 values reinterpreted as int64 bit patterns — **not auto-converted**, caller must perform conversion manually) |
+| **Weight layout (GMM1)** | Tile-N permuted (`reshape_fusion_gmm_weight` in test code) | Standard NZ format, no additional permutation needed |
+| **Shared expert** | Full support (`shared_expert_num`, `shared_expert_rank_num` attrs + host logic + kernel branch) | **Not supported** (no shared expert attrs or logic) |
+| **Second return value** | `ep_recv_count`, shape `[num_local_experts × num_ranks]` (per-rank breakdown) | `expert_token_nums`, shape `[num_local_experts]` (local rank only) |
+| **EP world size** | `num_experts` must be divisible by `(num_ranks - shared_expert_rank_num)`; `moeExpertNumPerRank ≤ aivNum/2` | No explicit EP world size constraint; `num_local_experts = num_experts / num_ranks` (simple division) |
 
 ### Python API
 
@@ -84,10 +83,21 @@ def fused_deep_moe(
 
 ### Constraints
 
-- **bs** (batch size): range **[0, 256]**.
+#### For `fuse_mode=FUSED_DEEP_MOE` (mode=1)
+
+- **bs** (batch size): range **[1, 256]**.
 - **hidden**: range **[512, 7168]**, must be divisible by **32**.
+- **gmm1_hidden**: range **[1024, 6144]**.
 - **num_topk** (topk): range **(0, 12]** — the kernel tiling enforces `topk ≤ 12`.
 - **num_experts**: range **(0, 512]** — the kernel tiling enforces `moeExpertNum ≤ 512`. `num_experts` must be divisible by `(num_ranks - shared_expert_rank_num)`.
+- **global_bs**: must be divisible by `ep_rank_size` (auto-derived from `bs × ep_rank_size` if set to 0).
+
+#### For `fuse_mode=DISPATCH_FFN_COMBINE` (mode=2)
+
+- No explicit range checks for `bs`, `hidden`, `topk`, or `num_experts` in the current tiling implementation. Only basic attribute validation (rank ID, group name) and HCCL buffer size check are performed.
+- **HCCL_BUFFSIZE**: minimum required size = `M × topK × K × sizeof(int8_t) × 3 + 10MB`, where `M` = bs, `K` = hidden, `topK` = num_topk.
+- **BF16 weight**: not supported — only INT8 quantized weights are available.
+- **Shared expert**: not supported.
 
 ### Return Values
 
@@ -123,8 +133,8 @@ def fused_deep_moe(
 
 | FuseMode | 值 | CANN 算子 | 说明 |
 |----------|---|-----------|------|
-| `FuseMode.FUSED_DEEP_MOE` | `1` | `aclnnFusedDeepMoe` | 完整融合：InitRouting + AllToAll + GMM1 + DequantSwigluQuant + GMM2 + Dequant + Unpermute/Combine 在单个 AscendC kernel 中完成。 |
-| `FuseMode.DISPATCH_FFN_COMBINE` | `2` | `aclnnDispatchFFNCombine` | 分离 dispatch 处理：InitRouting + AllToAll 分发 + GMM1 + DequantSwigluQuant + GMM2 + Dequant + Combine 在单个 AscendC kernel 中完成，采用不同的内部融合策略。 |
+| `FuseMode.FUSED_DEEP_MOE` | `1` | `aclnnFusedDeepMoe` | 完整融合：InitRouting + AllToAll + GMM1 + DequantSwigluQuant + GMM2 + Dequant + Unpermute/Combine 在单个 AscendC kernel 中完成。通信阶段（dispatch/combine）使用 CamMoe，与 GMM 阶段间通过跨核 barrier 串联。 |
+| `FuseMode.DISPATCH_FFN_COMBINE` | `2` | `aclnnDispatchFFNCombine` | 集成路由（`MoeInitRoutingQuantV2`）+ AllToAll + GMM1 + DequantSwigluQuant + GMM2 + Dequant + Combine 在单个 AscendC kernel 中完成。HCCL 通信内嵌于 GMM kernel（共享内存），无跨核 barrier。 |
 
 > [!NOTE]
 > `FuseMode` **未**从包顶层 `__init__.py` 导出，需显式导入：
@@ -135,13 +145,13 @@ def fused_deep_moe(
 
 #### 两种融合模式的关键差异
 
-| 方面 | `FUSED_DEEP_MOE` | `DISPATCH_FFN_COMBINE` |
-|------|-------------------|------------------------|
-| **权重 scale 数据类型** | `float32`（内部自动转换为 `float`） | `int64`（float32 scale 值重新解释为 int64 位模式；**不会自动转换** — 调用者需手动执行转换） |
-| **GMM1 权重布局** | 经 tile-N 重排（参考实现 `reshape_fusion_gmm_weight` 在测试代码中） | 标准 NZ 格式，无需额外重排 |
-| **`num_max_dispatch_tokens_per_rank`** 语义 | 每个 rank 最多分发的 token 数 | dispatch 中最多接收的 token 数（即 `max_bs × num_ranks × topk`） |
-| **第二返回值** | `ep_recv_count`，形状 `[num_local_experts × num_ranks]` | `expert_token_nums`，形状 `[num_local_experts]`（仅本 rank） |
-| **共享专家支持** | 支持 | **不支持** |
+| 方面 | `FUSED_DEEP_MOE`（mode=1） | `DISPATCH_FFN_COMBINE`（mode=2） |
+|------|---------------------------|---------------------------------|
+| **权重 scale 数据类型** | `float32`（`DT_FLOAT`，内部自动转换） | `int64`（`DT_INT64`，float32 值重新解释为 int64 位模式 — **不自动转换**，调用者需手动转换） |
+| **GMM1 权重布局** | 经 tile-N 重排（参考 `reshape_fusion_gmm_weight`） | 标准 NZ 格式，无需额外重排 |
+| **共享专家** | 完整支持（`shared_expert_num`/`shared_expert_rank_num` attr + host 逻辑 + kernel 分支） | **不支持**（无共享专家 attr 或逻辑） |
+| **第二返回值** | `ep_recv_count`，形状 `[num_local_experts × num_ranks]`（按 rank 分解） | `expert_token_nums`，形状 `[num_local_experts]`（仅本 rank） |
+| **EP world size** | `num_experts` 必须能被 `(num_ranks - shared_expert_rank_num)` 整除；`moeExpertNumPerRank ≤ aivNum/2` | 无显式 EP world size 约束；`num_local_experts = num_experts / num_ranks`（简单整除） |
 
 ### Python API
 
@@ -179,10 +189,21 @@ def fused_deep_moe(
 
 ### 约束说明
 
+#### `fuse_mode=FUSED_DEEP_MOE`（mode=1）
+
 - **bs**（batch size）：取值范围 **[1, 256]**。
 - **hidden**：取值范围 **[512, 7168]**，且必须能被 **32** 整除。
+- **gmm1_hidden**：取值范围 **[1024, 6144]**。
 - **num_topk**（topk）：取值范围 **(0, 12]** — kernel tiling 强制 `topk ≤ 12`。
 - **num_experts**：取值范围 **(0, 512]** — kernel tiling 强制 `moeExpertNum ≤ 512`。`num_experts` 必须能被 `(num_ranks - shared_expert_rank_num)` 整除。
+- **global_bs**：必须能被 `ep_rank_size` 整除（设为 0 时自动取 `bs × ep_rank_size`）。
+
+#### `fuse_mode=DISPATCH_FFN_COMBINE`（mode=2）
+
+- 当前 tiling 实现中**无** `bs`、`hidden`、`topk`、`num_experts` 的显式范围校验，仅有基本属性校验（rank ID、group 名）和 HCCL 缓冲区大小校验。
+- **HCCL_BUFFSIZE**：最小需求 = `M × topK × K × sizeof(int8_t) × 3 + 10MB`，其中 `M` = bs，`K` = hidden，`topK` = num_topk。
+- **BF16 权重**：不支持 — 仅支持 INT8 量化权重。
+- **共享专家**：不支持。
 
 ### 返回值
 

--- a/python/deep_ep/doc/GET_DISPATCH_LAYOUT_API.md
+++ b/python/deep_ep/doc/GET_DISPATCH_LAYOUT_API.md
@@ -1,18 +1,140 @@
-**文件**：`buffer.py`
+# get_dispatch_layout API
 
-**核心类**：`Buffer`
+<div align="center">
 
-**依赖**：`torch`, `deep_ep_cpp`
+[![Mode](https://img.shields.io/badge/Mode-Normal-blue)]()
+[![Platform](https://img.shields.io/badge/Platform-A2%20%7C%20A3%20%7C%20A5-green)]()
 
-**目的**：normal模式下dispatch和combine之前的数据预处理。
+English | [中文](#中文)
 
-# get_dispatch_layout
+</div>
 
-## 接口功能简述
+> **File**: `buffer.py`
+> **Core class**: `Buffer`
+> **Dependencies**: `torch`, `deep_ep_cpp`
+> **Purpose**: Data preprocessing before dispatch and combine in Normal mode.
 
-根据传入的`topk_idx`计算Normal模式下后续的Dispatch和Combine需要的参数的本地副本
+---
 
-## 接口定义
+## `get_dispatch_layout`
+
+### Description
+
+Computes the local copy of parameters needed by subsequent Dispatch and Combine operations in Normal mode, based on the input `topk_idx`.
+
+### Interface
+
+```python
+def get_dispatch_layout(
+        self,
+        topk_idx: torch.Tensor,
+        num_experts: int,
+        previous_event: Optional[EventOverlap] = None,
+        async_finish: bool = False,
+        allocate_on_comm_stream: bool = False,
+    ) -> Tuple[
+        torch.Tensor, Optional[torch.Tensor], torch.Tensor, torch.Tensor, EventOverlap
+    ]:
+```
+
+```cpp
+std::tuple<
+torch::Tensor,                      // num_tokens_per_rank
+std::optional[torch::Tensor](torch::Tensor),      // num_tokens_per_rdma_rank (reserved)
+torch::Tensor,                      // num_tokens_per_expert
+torch::Tensor,                      // is_token_in_rank
+std::optional<EventHandle>         // output_event (currently unused)
+>
+
+Buffer::get_dispatch_layout(
+const torch::Tensor& topk_idx,
+int num_experts,
+std::optional<EventHandle>& previous_event,
+bool async,
+bool allocate_on_comm_stream
+)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `topk_idx` | `torch::Tensor` (`int64`, `[num_tokens, num_topk]`) | Top-k expert indices per token (must be a contiguous 2D tensor). Second dimension range: [1, 16]. |
+| `num_experts` | `int` | Total number of experts. Range: [1, 512], must be divisible by `num_ranks`. |
+| `previous_event` | `std::optional<EventHandle>&` | Pre-event for async execution (currently unused, pass `std::nullopt`). |
+| `async` | `bool` | Whether to enable async mode (currently unused). |
+| `allocate_on_comm_stream` | `bool` | Whether to allocate memory on the communication stream (currently unused). |
+
+### Constraints
+
+- **num_tokens**: Batch sequence size, i.e., the number of input/output tokens on this rank. Reflected as the first dimension of `topk_idx`.
+    - A2 series internode: (0, 4096]; intranode: (0, 8192];
+    - A3 series: without "ant moving home": (0, 8192], with "ant moving home": (0, 32k];
+
+### Return Values
+
+| Return Value | Type | Description |
+|--------------|------|-------------|
+| `num_tokens_per_rank` | `torch::Tensor` (`int32`, `[num_ranks]`) | Number of tokens assigned to each rank. |
+| `num_tokens_per_rdma_rank` | `std::optional<torch::Tensor>` | Reserved field, currently always `std::nullopt`. |
+| `num_tokens_per_expert` | `torch::Tensor` (`int32`, `[num_experts]`) | Number of tokens received by each expert. |
+| `is_token_in_rank` | `torch::Tensor` (`bool`, `[num_tokens, num_ranks]`) | Indicates whether each token belongs to a given rank. |
+| `output_event` | `std::optional<EventHandle>` | Reserved field, currently `std::nullopt`. |
+
+### Internal Logic
+
+1. Copy `topk_idx` to each core's UB buffer; first pass computes partial parameters;
+2. Use DataCopy to move results to GM, aggregate data across cores via atomic add or address-partitioned transfer;
+3. Move partial GM results (e.g., prefix sums) back to UB; second pass computes remaining parameters;
+4. Move final result tensors back to GM.
+
+### Multi-Core Strategy
+
+- Partition the 0th dimension of `topk_idx` (i.e., token count) as evenly as possible across cores. If token count < core count, only the first `num_tokens` cores are used, achieving data parallelism.
+
+### Example Usage
+
+```cpp
+auto topk_idx = torch::randint(0, 256, {4096, 8}, torch::dtype(torch::kInt64).device(torch::kCUDA));
+int num_experts = 256;
+
+std::optional<EventHandle> dummy_event = std::nullopt;
+
+auto [tokens_per_rank, _, tokens_per_expert, token_in_rank, _] =
+    buffer.get_dispatch_layout(topk_idx, num_experts, dummy_event, false, false);
+```
+
+### Notes
+
+- `topk_idx` must be `int64` type and located on NPU;
+- Maximum supported `num_ranks` is 384;
+- `async`, `previous_event`, `allocate_on_comm_stream` parameters are currently unused;
+- RDMA, async communication, or event scheduling requires extending this interface;
+- If `num_experts` is not divisible by `num_ranks`, a logic error will occur;
+- All returned tensors are located on the same device as the input tensor by default;
+- The layout implementation differs between A3 and A2, but both compute the parameters needed for subsequent operations. The operator is configured to select based on the environment, but ensure the correct platform-specific operator is used.
+
+### Future Extensions
+
+- Implement `async` execution and pre-event dependencies (improve pipeline parallelism);
+- Complete `num_tokens_per_rdma_rank` output after RDMA rank support is implemented.
+
+---
+
+<a id="中文"></a>
+
+## 中文
+
+> **文件**：`buffer.py`
+> **核心类**：`Buffer`
+> **依赖**：`torch`, `deep_ep_cpp`
+> **目的**：normal 模式下 dispatch 和 combine 之前的数据预处理。
+
+### 接口功能简述
+
+根据传入的 `topk_idx` 计算 Normal 模式下后续的 Dispatch 和 Combine 需要的参数的本地副本。
+
+### 接口定义
 
 ```python
 def get_dispatch_layout(
@@ -43,57 +165,46 @@ std::optional<EventHandle>& previous_event,
 bool async,
 bool allocate_on_comm_stream
 )
-
 ```
 
----
+### 输入参数说明
 
-## 输入参数说明
-
-| 参数名                    | 类型                                                | 说明                                                       |
-| ------------------------- | --------------------------------------------------- | ---------------------------------------------------------- |
-| `topk_idx`                | `torch::Tensor` (`int64`, `[num_tokens, num_topk]`) | 每个 token 的 top-k expert 索引（必须是连续的二维张量）第二维大小取值范围[1, 16] |
-| `num_experts`             | `int`                                               | 系统中总的 expert 数量，取值范围[1, 512]，且能被 `num_ranks` 整除 |
-| `previous_event`          | `std::optional<EventHandle>&`                       | 异步执行用的前置事件（当前未使用，传入 `std::nullopt`）    |
-| `async`                   | `bool`                                              | 是否启用异步模式（当前未使用）                             |
-| `allocate_on_comm_stream` | `bool`                                              | 是否在通信流上分配内存（当前未使用）                       |
+| 参数名 | 类型 | 说明 |
+|--------|------|------|
+| `topk_idx` | `torch::Tensor` (`int64`, `[num_tokens, num_topk]`) | 每个 token 的 top-k expert 索引（必须是连续的二维张量），第二维大小取值范围 [1, 16] |
+| `num_experts` | `int` | 系统中总的 expert 数量，取值范围 [1, 512]，且能被 `num_ranks` 整除 |
+| `previous_event` | `std::optional<EventHandle>&` | 异步执行用的前置事件（当前未使用，传入 `std::nullopt`） |
+| `async` | `bool` | 是否启用异步模式（当前未使用） |
+| `allocate_on_comm_stream` | `bool` | 是否在通信流上分配内存（当前未使用） |
 
 ### 输入约束
 
-* num_tokens: 表示batch sequence size，即本卡输入输出的token数量，在输入中体现为topk_idx的第一维。
-  * A2系列双机取值范围：(0, 4096]；单机取值范围：(0, 8192]；
-  * A3系列取值范围，不开蚂蚁搬家：(0, 8192]，开蚂蚁搬家：(0, 32k]；
+- num_tokens: 表示 batch sequence size，即本卡输入输出的 token 数量，在输入中体现为 topk_idx 的第一维。
+    - A2 系列双机取值范围：(0, 4096]；单机取值范围：(0, 8192]；
+    - A3 系列取值范围，不开蚂蚁搬家：(0, 8192]，开蚂蚁搬家：(0, 32k]；
 
----
+### 返回值说明
 
-## 返回值说明
+| 返回值 | 类型 | 说明 |
+|--------|------|------|
+| `num_tokens_per_rank` | `torch::Tensor` (`int32`, `[num_ranks]`) | 每个 rank 中被分配的 token 数量 |
+| `num_tokens_per_rdma_rank` | `std::optional<torch::Tensor>` | 保留字段，当前始终为 `std::nullopt` |
+| `num_tokens_per_expert` | `torch::Tensor` (`int32`, `[num_experts]`) | 每个 expert 接收到的 token 数量 |
+| `is_token_in_rank` | `torch::Tensor` (`bool`, `[num_tokens, num_ranks]`) | 指示每个 token 是否属于某个 rank |
+| `output_event` | `std::optional<EventHandle>` | 保留字段，当前为 `std::nullopt` |
 
-| 返回值                     | 类型                                                | 说明                                |
-| -------------------------- | --------------------------------------------------- | ----------------------------------- |
-| `num_tokens_per_rank`      | `torch::Tensor` (`int32`, `[num_ranks]`)            | 每个 rank 中被分配的 token 数量     |
-| `num_tokens_per_rdma_rank` | `std::optional<torch::Tensor>`                      | 保留字段，当前始终为 `std::nullopt` |
-| `num_tokens_per_expert`    | `torch::Tensor` (`int32`, `[num_experts]`)          | 每个 expert 接收到的 token 数量     |
-| `is_token_in_rank`         | `torch::Tensor` (`bool`, `[num_tokens, num_ranks]`) | 指示每个 token 是否属于某个 rank    |
-| `output_event`             | `std::optional<EventHandle>`                        | 保留字段，当前为 `std::nullopt`     |
+### 内部逻辑简述
 
----
+1. 将 `topk_idx` 搬到每个核的 UB buffer 上，第一遍遍历计算需要的部分参数；
+2. 使用 DataCopy 将计算结果搬到 GM 上，利用原子加或者分地址传输的方法聚合各核的数据；
+3. 将部分计算完的 GM 数据（如前缀和等）搬回 UB，第二遍遍历计算剩下的参数；
+4. 计算出的结果 tensor 搬回 GM。
 
-## 内部逻辑简述
+### 多核策略
 
-1. 将`topk_idx`搬到每个核的UB buffer上，第一遍遍历计算需要的部分参数；
-2. 使用DataCopy将计算结果搬到GM上，利用原子加或者分地址传输的方法聚合各核的数据；
-3. 将部分计算完的GM数据(如前缀和等)搬回UB，第二遍遍历计算剩下的参数；
-4. 计算出的结果tensor搬回GM。
+- 直接将 `topk_idx` 的第 0 维，即 token 数目按照核数目进行尽可能平均的划分，如果 token 数小于核数，则只使用前 token 数目个核，以此来实现数据并行。
 
----
-
-## 多核策略
-
-- 直接将`topk_idx`的第0维，即token数目按照核数目进行尽可能平均的划分，如果token数小于核数，则只使用前token数目个核，以此来实现数据并行。
-
----
-
-## 示例用法
+### 示例用法
 
 ```cpp
 auto topk_idx = torch::randint(0, 256, {4096, 8}, torch::dtype(torch::kInt64).device(torch::kCUDA));
@@ -105,21 +216,17 @@ auto [tokens_per_rank, _, tokens_per_expert, token_in_rank, _] =
     buffer.get_dispatch_layout(topk_idx, num_experts, dummy_event, false, false);
 ```
 
----
-
-## 注意事项
+### 注意事项
 
 - `topk_idx` 必须是 `int64` 类型并位于 NPU 上；
-- 当前支持的运行卡数`num_ranks`最大值为384；
+- 当前支持的运行卡数 `num_ranks` 最大值为 384；
 - 当前实现不使用 `async`、`previous_event`、`allocate_on_comm_stream` 等参数；
 - 若需要使用 `RDMA`、`异步通信` 或 `事件调度`，需扩展本接口；
 - 若 `num_experts` 不能被 `num_ranks` 整除，会导致逻辑错误；
 - 返回的所有 tensor 默认与输入 tensor 位于相同设备上；
-- A3机器和A2机器上layout实现并不完全相同，但都是计算后续需要的参数，算子中配置了根据环境选择，但仍要确保使用对应机器的算子。
+- A3 机器和 A2 机器上 layout 实现并不完全相同，但都是计算后续需要的参数，算子中配置了根据环境选择，但仍要确保使用对应机器的算子。
 
----
-
-## 扩展建议
+### 扩展建议
 
 - 实现 `async` 执行和前置事件依赖（提高流水线并行度）；
 - RDMA rank 支持后完善 `num_tokens_per_rdma_rank` 输出。

--- a/python/deep_ep/doc/LOW_LATENCY_API.md
+++ b/python/deep_ep/doc/LOW_LATENCY_API.md
@@ -4,7 +4,6 @@
 
 [![Mode](https://img.shields.io/badge/Mode-Low--Latency-orange)]()
 [![Platform](https://img.shields.io/badge/Platform-A2%20%7C%20A3%20%7C%20A5-green)]()
-[![Quant](https://img.shields.io/badge/Quantization-INT8%20%7C%20MXFP8-yellow)]()
 
 English | [中文](#中文)
 
@@ -74,7 +73,7 @@ def low_latency_dispatch(
 - **hidden**: A2 series: `0 < hidden <= 7168` and `hidden % 32 == 0`.
 - **num_topk**: A2 series internode: `[2, 16]`; intranode: `(0, 16]`; A3 series: `(0, 16]`.
 - **num_experts**: `(0, 512]`.
-- **HCCL_BUFFSIZE**: Check before calling. Default 200 MB.
+- **HCCL_BUFFSIZE**: Check before calling. Default 200 MB. Minimum required size (non-layered): `(bs × ep_world_size × min(num_local_experts, topk) × hidden × 2B + 2MB) × 2`. For layered (A2 dual-node): `num_experts × bs × (hidden × 2B + 4 × topk × 4B) + 4MB + 800MB`. A5 subtracts 1MB state zone from the configured value.
 - **HCCL_INTRA_PCIE_ENABLE / HCCL_INTRA_ROCE_ENABLE**: A2 series internode: set `HCCL_INTRA_PCIE_ENABLE=1` and `HCCL_INTRA_ROCE_ENABLE=0`.
 
 ---
@@ -121,7 +120,7 @@ def low_latency_combine(
 ### Constraints
 
 - `low_latency_dispatch` and `low_latency_combine` must be used together.
-- **HCCL_BUFFSIZE**: Check before calling. Default 200 MB.
+- **HCCL_BUFFSIZE**: Check before calling. Default 200 MB. Minimum required size (non-layered): `(bs × ep_world_size × min(num_local_experts, topk) × hidden × 2B + 2MB) × 2`. For layered (A2 dual-node): `num_experts × bs × (hidden × 2B + 4 × topk × 4B) + 4MB + 800MB`. A5 subtracts 1MB state zone from the configured value.
 - **HCCL_INTRA_PCIE_ENABLE / HCCL_INTRA_ROCE_ENABLE**: A2 series internode: set `HCCL_INTRA_PCIE_ENABLE=1` and `HCCL_INTRA_ROCE_ENABLE=0`.
 
 ---
@@ -194,7 +193,7 @@ def low_latency_dispatch(
 - **hidden**：A2 算子实现要求 `0 < hidden <= 7168` 且 `hidden % 32 == 0`。
 - **num_topk**：A2 系列双机 `[2, 16]`；单机 `(0, 16]`；A3 系列 `(0, 16]`。
 - **num_experts**：`(0, 512]`。
-- **HCCL_BUFFSIZE**：调用接口前需检查，默认 200 MB。
+- **HCCL_BUFFSIZE**：调用接口前需检查，默认 200 MB。非分层最小需求：`(bs × ep_world_size × min(num_local_experts, topk) × hidden × 2B + 2MB) × 2`；分层（A2双机）：`num_experts × bs × (hidden × 2B + 4 × topk × 4B) + 4MB + 800MB`。A5 从配置值中扣除 1MB 状态区。
 - **HCCL_INTRA_PCIE_ENABLE / HCCL_INTRA_ROCE_ENABLE**：A2 系列双机场景需配置 `HCCL_INTRA_PCIE_ENABLE=1` 和 `HCCL_INTRA_ROCE_ENABLE=0`。
 
 ---
@@ -241,5 +240,5 @@ def low_latency_combine(
 ### 约束说明
 
 - `low_latency_dispatch` 和 `low_latency_combine` 必须配套使用。
-- **HCCL_BUFFSIZE**：调用接口前需检查，默认 200 MB。
+- **HCCL_BUFFSIZE**：调用接口前需检查，默认 200 MB。非分层最小需求：`(bs × ep_world_size × min(num_local_experts, topk) × hidden × 2B + 2MB) × 2`；分层（A2双机）：`num_experts × bs × (hidden × 2B + 4 × topk × 4B) + 4MB + 800MB`。A5 从配置值中扣除 1MB 状态区。
 - **HCCL_INTRA_PCIE_ENABLE / HCCL_INTRA_ROCE_ENABLE**：A2 系列双机场景需配置 `HCCL_INTRA_PCIE_ENABLE=1` 和 `HCCL_INTRA_ROCE_ENABLE=0`。

--- a/python/deep_ep/doc/NORMAL_API.md
+++ b/python/deep_ep/doc/NORMAL_API.md
@@ -4,7 +4,6 @@
 
 [![Mode](https://img.shields.io/badge/Mode-Normal-blue)]()
 [![Platform](https://img.shields.io/badge/Platform-A2%20%7C%20A3%20%7C%20A5-green)]()
-[![Quant](https://img.shields.io/badge/Quantization-INT8%20%7C%20MXFP8%20%7C%20MXFP4-yellow)]()
 
 English | [中文](#中文)
 
@@ -101,7 +100,7 @@ dispatch(
     - num_topk: number of top‑k experts selected.
         - A2 series internode range: [2, 16]; intranode range: (0, 16];
         - A3 series range: (0, 16].
-- HCCL_BUFFSIZE: Check the HCCL_BUFFSIZE environment variable before calling the API. It represents the memory size (MB) occupied by a single communication domain, default 200MB.
+- HCCL_BUFFSIZE: Check the HCCL_BUFFSIZE environment variable before calling the API. It represents the memory size (MB) occupied by a single communication domain, default 200MB. Minimum required size (non-layered): `(bs × ep_world_size × min(num_local_experts, topk) × hidden × 2B + 2MB) × 2`. For layered (A2 dual-node): `num_experts × bs × (hidden × 2B + 4 × topk × 4B) + 4MB + 800MB`. A5 subtracts 1MB state zone from the configured value.
 - HCCL_INTRA_PCIE_ENABLE and HCCL_INTRA_ROCE_ENABLE:
     - A2 series internode scenario: set `HCCL_INTRA_PCIE_ENABLE=1` and `HCCL_INTRA_ROCE_ENABLE=0`;
 - Quantization: Setting `DEEP_NORMAL_MODE_USE_INT8_QUANT=1` quantizes `x` to INT8 and returns `(tensor, scales)`.
@@ -162,7 +161,7 @@ combine(
 ### Constraints
 
 - `dispatch` and `combine` must be used together.
-- HCCL_BUFFSIZE: Check the HCCL_BUFFSIZE environment variable before calling the API. It represents the memory size (MB) occupied by a single communication domain, default 200MB.
+- HCCL_BUFFSIZE: Check the HCCL_BUFFSIZE environment variable before calling the API. It represents the memory size (MB) occupied by a single communication domain, default 200MB. Minimum required size (non-layered): `(bs × ep_world_size × min(num_local_experts, topk) × hidden × 2B + 2MB) × 2`. For layered (A2 dual-node): `num_experts × bs × (hidden × 2B + 4 × topk × 4B) + 4MB + 800MB`. A5 subtracts 1MB state zone from the configured value.
 - HCCL_INTRA_PCIE_ENABLE and HCCL_INTRA_ROCE_ENABLE:
     - A2 series internode scenario: set `HCCL_INTRA_PCIE_ENABLE=1` and `HCCL_INTRA_ROCE_ENABLE=0`;
 
@@ -263,7 +262,7 @@ dispatch(
     - num_topk：表示选取topk个专家。
         - A2系列双机取值范围：[2, 16]；单机取值范围：(0, 16]；
         - A3系列取值范围：(0, 16]。
-- HCCL_BUFFSIZE: 调用接口前需检查HCCL_BUFFSIZE环境变量取值是否合理，该环境变量表示单个通信域占用内存大小，单位MB，不配置时默认为200MB。
+- HCCL_BUFFSIZE: 调用接口前需检查HCCL_BUFFSIZE环境变量取值是否合理，该环境变量表示单个通信域占用内存大小，单位MB，不配置时默认为200MB。非分层最小需求：`(bs × ep_world_size × min(num_local_experts, topk) × hidden × 2B + 2MB) × 2`；分层（A2双机）：`num_experts × bs × (hidden × 2B + 4 × topk × 4B) + 4MB + 800MB`。A5 从配置值中扣除 1MB 状态区。
 - HCCL_INTRA_PCIE_ENABLE和HCCL_INTRA_ROCE_ENABLE：
     - A2系列双机场景需要配置，`HCCL_INTRA_PCIE_ENABLE=1` 和 `HCCL_INTRA_ROCE_ENABLE=0`；
 - 量化：设置环境变量 `DEEP_NORMAL_MODE_USE_INT8_QUANT=1` 时，会把 `x` 量化为 `int8` 并返回 `(tensor, scales)`。
@@ -324,6 +323,6 @@ combine(
 ### 约束说明
 
 - `dispatch`和`combine`必须配套使用。
-- HCCL_BUFFSIZE: 调用接口前需检查HCCL_BUFFSIZE环境变量取值是否合理，该环境变量表示单个通信域占用内存大小，单位MB，不配置时默认为200MB。
+- HCCL_BUFFSIZE: 调用接口前需检查HCCL_BUFFSIZE环境变量取值是否合理，该环境变量表示单个通信域占用内存大小，单位MB，不配置时默认为200MB。非分层最小需求：`(bs × ep_world_size × min(num_local_experts, topk) × hidden × 2B + 2MB) × 2`；分层（A2双机）：`num_experts × bs × (hidden × 2B + 4 × topk × 4B) + 4MB + 800MB`。A5 从配置值中扣除 1MB 状态区。
 - HCCL_INTRA_PCIE_ENABLE和HCCL_INTRA_ROCE_ENABLE：
     - A2系列双机场景需要配置，`HCCL_INTRA_PCIE_ENABLE=1` 和 `HCCL_INTRA_ROCE_ENABLE=0`；


### PR DESCRIPTION
## Motivation

- The DeepEP documentation had several inconsistencies between code and docs, including incomplete environment variable coverage, misleading quantization strategy descriptions, and missing bilingual (EN/CN) structure in `GET_DISPATCH_LAYOUT_API.md`. This PR aligns all documentation with the actual codebase and ensures English/Chinese consistency across all files.
- fix issue: #622

## Modifications

- **`README.md`**:
  - Added 6 missing environment variables: `MOE_ENABLE_TOPK_NEG_ONE`, `MOE_ENABLE_CCU`, `DEEPEP_HCCL_BUFFSIZE`, `DEEPEP_NORMAL_LONG_SEQ_ROUND`, `DEEPEP_NORMAL_PER_ROUND_TOKENS`, `DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ`
  - Restored `SGLANG_DEEPEP_BF16_DISPATCH` with framework-side note
  - Clarified that `quant_mode` only takes effect under default strategy; `ops/alltoall` continue to use legacy `use_fp8`/`use_ue8m0` params (not deprecated for those strategies)
  - Updated `DEEP_NORMAL_MODE_USE_INT8_QUANT` from "Removed" to "Deprecated for default strategy" (still required for alltoall)
  - Added `quant_mode=0` (BF16) for `fused_deep_moe`; corrected fuse mode descriptions (CamMoe+barrier vs embedded HCCL)
  - Updated A5 to include MXFP4 support in prose; changed CANN from "only supports 9.0" to "supports CANN 9.0"
  - Fixed CN/EN mismatches: added missing A5 bullet in CN Normal Mode, added A5 quantization in CN platform notes, updated CN A2 dual-node env var reference
  - Reordered test commands for better logical flow

- **`doc/A2_DEEPEP.md`**:
  - Changed title from "A2 DeepEP Guide" to "A2 DeepEP Configuration Guide"
  - Updated badge from "A2 only" to "A2 | A3 | A5"
  - Added "ant moving home" (long sequence) env var documentation and HCCL_BUFFSIZE formulas (bilingual)

- **`doc/FUSED_DEEP_MOE.md`**:
  - Corrected fuse mode descriptions; removed misleading "separate dispatch handling"
  - Split constraints into mode=1 (with full range checks) and mode=2 (no explicit checks, with HCCL_BUFFSIZE formula)
  - Refined key differences table to 5 items
  - Added `gmm1_hidden` and `global_bs` constraints for mode=1

- **`doc/GET_DISPATCH_LAYOUT_API.md`**:
  - Restructured into bilingual format (English + Chinese) consistent with other doc files

- **`doc/LOW_LATENCY_API.md`**:
  - Removed Quantization badge (platform-dependent, avoids confusion)
  - Added HCCL_BUFFSIZE minimum formula

- **`doc/NORMAL_API.md`**:
  - Removed Quantization badge
  - Added HCCL_BUFFSIZE minimum formula

## Testing

- Built documentation site locally with no errors or warnings
- Verified all bilingual sections display correctly in both languages
- Confirmed all environment variable references are accurate and up-to-date with codebase
- Since this is a documentation-only change, no unit tests are required

## Benchmarking and Profiling

- This is a pure documentation update with no code changes; no performance impact

## Checklist

- [x] Format your code
- [x] Add unit tests (N/A - documentation only)
- [x] Update documentation
- [x] Provide accuracy and speed benchmark results (N/A - documentation only)
```