### PR TITLE
feat(hicache): add async Mamba state transfers

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -13,6 +13,7 @@ FILE(GLOB OP_SRCS
     ${PROJECT_OP_SRC_BASE}/batch_matmul_transpose/op_host/batch_matmul_transpose.cpp
     ${PROJECT_OP_SRC_BASE}/batch_matmul_transpose/op_host/tiling/tiling_data.cpp
     ${PROJECT_OP_SRC_BASE}/transfer_kv_dim_exchange/op_host/transfer_kv_dim_exchange.cpp
+    ${PROJECT_OP_SRC_BASE}/transfer_state_dim_exchange/op_host/transfer_state_dim_exchange.cpp
     ${PROJECT_OP_SRC_BASE}/lora/op_host/bgmv_expand.cpp
     ${PROJECT_OP_SRC_BASE}/lora/op_host/bgmv_shrink.cpp
     ${PROJECT_OP_SRC_BASE}/lora/op_host/sgmv_expand.cpp

--- a/csrc/pytorch_extensions.cpp
+++ b/csrc/pytorch_extensions.cpp
@@ -69,6 +69,11 @@ TORCH_LIBRARY_FRAGMENT(npu, m)
         "Tensor device_indices, Tensor host_indices, int page_size, int direct, int flags) -> ()");
 
     m.def(
+        "transfer_state_dim_exchange(Tensor[] device_states, Tensor[] host_states, "
+        "Tensor device_indices, Tensor host_indices, int direction, "
+        "int layer_begin, int layer_count, int flags) -> ()");
+
+    m.def(
         "bgmv_expand(Tensor! x, Tensor! weight, Tensor! indices, Tensor! y,"
         "            int slice_offset, int slice_size) -> Tensor");
 
@@ -170,6 +175,8 @@ TORCH_LIBRARY_IMPL(npu, PrivateUse1, m)
     m.impl("batch_matmul_transpose", TORCH_FN(sglang::npu_kernel::batch_matmul_transpose));
 
     m.impl("transfer_kv_dim_exchange", TORCH_FN(sglang::npu_kernel::transfer_kv_dim_exchange));
+
+    m.impl("transfer_state_dim_exchange", TORCH_FN(sglang::npu_kernel::transfer_state_dim_exchange));
 
     m.impl("bgmv_expand", TORCH_FN(sglang::npu_kernel::bgmv_expand));
 

--- a/csrc/pytorch_extensions.cpp
+++ b/csrc/pytorch_extensions.cpp
@@ -74,6 +74,14 @@ TORCH_LIBRARY_FRAGMENT(npu, m)
         "int layer_begin, int layer_count, int flags) -> ()");
 
     m.def(
+        "transfer_state_per_layer_direct_pf_lf(Tensor[] device_states, Tensor[] host_states, "
+        "Tensor device_indices, Tensor host_indices, int layer_id, int flags) -> ()");
+
+    m.def(
+        "transfer_state_all_layer_direct_lf_pf(Tensor[] device_states, Tensor[] host_states, "
+        "Tensor device_indices, Tensor host_indices, int flags) -> ()");
+
+    m.def(
         "bgmv_expand(Tensor! x, Tensor! weight, Tensor! indices, Tensor! y,"
         "            int slice_offset, int slice_size) -> Tensor");
 
@@ -177,6 +185,12 @@ TORCH_LIBRARY_IMPL(npu, PrivateUse1, m)
     m.impl("transfer_kv_dim_exchange", TORCH_FN(sglang::npu_kernel::transfer_kv_dim_exchange));
 
     m.impl("transfer_state_dim_exchange", TORCH_FN(sglang::npu_kernel::transfer_state_dim_exchange));
+
+    m.impl("transfer_state_per_layer_direct_pf_lf",
+           TORCH_FN(sglang::npu_kernel::transfer_state_per_layer_direct_pf_lf));
+
+    m.impl("transfer_state_all_layer_direct_lf_pf",
+           TORCH_FN(sglang::npu_kernel::transfer_state_all_layer_direct_lf_pf));
 
     m.impl("bgmv_expand", TORCH_FN(sglang::npu_kernel::bgmv_expand));
 

--- a/csrc/pytorch_extensions.cpp
+++ b/csrc/pytorch_extensions.cpp
@@ -74,8 +74,8 @@ TORCH_LIBRARY_FRAGMENT(npu, m)
         "int layer_begin, int layer_count, int flags) -> ()");
 
     m.def(
-        "transfer_state_per_layer_direct_pf_lf(Tensor[] device_states, Tensor[] host_states, "
-        "Tensor device_indices, Tensor host_indices, int layer_id, int flags) -> ()");
+        "transfer_state_per_layer_direct_pf_lf(Tensor src, Tensor dst, "
+        "Tensor src_indices, Tensor dst_indices, int layer_id, int flags) -> ()");
 
     m.def(
         "transfer_state_all_layer_direct_lf_pf(Tensor[] device_states, Tensor[] host_states, "

--- a/csrc/pytorch_extensions.cpp
+++ b/csrc/pytorch_extensions.cpp
@@ -69,11 +69,6 @@ TORCH_LIBRARY_FRAGMENT(npu, m)
         "Tensor device_indices, Tensor host_indices, int page_size, int direct, int flags) -> ()");
 
     m.def(
-        "transfer_state_dim_exchange(Tensor[] device_states, Tensor[] host_states, "
-        "Tensor device_indices, Tensor host_indices, int direction, "
-        "int layer_begin, int layer_count, int flags) -> ()");
-
-    m.def(
         "transfer_state_per_layer_direct_pf_lf(Tensor src, Tensor dst, "
         "Tensor src_indices, Tensor dst_indices, int layer_id, int flags) -> ()");
 
@@ -183,8 +178,6 @@ TORCH_LIBRARY_IMPL(npu, PrivateUse1, m)
     m.impl("batch_matmul_transpose", TORCH_FN(sglang::npu_kernel::batch_matmul_transpose));
 
     m.impl("transfer_kv_dim_exchange", TORCH_FN(sglang::npu_kernel::transfer_kv_dim_exchange));
-
-    m.impl("transfer_state_dim_exchange", TORCH_FN(sglang::npu_kernel::transfer_state_dim_exchange));
 
     m.impl("transfer_state_per_layer_direct_pf_lf",
            TORCH_FN(sglang::npu_kernel::transfer_state_per_layer_direct_pf_lf));

--- a/csrc/transfer_state_dim_exchange/op_host/transfer_state_dim_exchange.cpp
+++ b/csrc/transfer_state_dim_exchange/op_host/transfer_state_dim_exchange.cpp
@@ -23,11 +23,6 @@ namespace npu_kernel {
 
 constexpr int64_t STATE_TRANS_FLAG_2D = 1 << 1;
 
-enum class StateTransferDirection : int64_t {
-    H2D = 1,
-    D2H = 2,
-};
-
 namespace {
 
 struct StateComponentLayout {
@@ -50,11 +45,6 @@ struct ValidatedStateComponents {
 
 int64_t validate_dense_slot_payload(const at::Tensor &device, int64_t component)
 {
-    // NPU NEXTN stores the temporal state as a transpose of the two innermost
-    // dimensions.  The resulting Tensor is not logically contiguous, but every
-    // [layer, slot] payload is still one dense physical byte range.  HiCache
-    // treats the Host copy as opaque state bytes, so that layout is safe for a
-    // byte-exact D2H/H2D round trip.
     std::vector<std::pair<int64_t, int64_t>> payload_dims;
     int64_t slot_elements = 1;
     for (int64_t dim = 2; dim < device.dim(); ++dim) {
@@ -216,57 +206,8 @@ std::vector<std::pair<int64_t, int64_t>> build_contiguous_runs(const int64_t *de
     return runs;
 }
 
-void submit_h2d(const std::vector<StateComponentLayout> &components, const int64_t *device_indices,
-                const int64_t *host_indices, int64_t index_count, int64_t layer_begin, int64_t layer_count,
-                aclrtStream stream)
-{
-    const auto runs = build_contiguous_runs(device_indices, host_indices, index_count);
-    for (const auto &component : components) {
-        auto *device_base = static_cast<char *>(component.device.data_ptr());
-        auto *host_base = static_cast<char *>(component.host.data_ptr());
-        for (const auto layer : c10::irange(layer_begin, layer_begin + layer_count)) {
-            for (const auto &[run_begin, run_length] : runs) {
-                const auto device_slot = device_indices[run_begin];
-                const auto host_slot = host_indices[run_begin];
-                void *destination =
-                    device_base + layer * component.device_layer_pitch + device_slot * component.device_slot_pitch;
-                const void *source =
-                    host_base + host_slot * component.host_slot_pitch + layer * component.host_layer_pitch;
-                const auto result = aclrtMemcpy2dAsync(
-                    destination, component.device_slot_pitch, source, component.host_slot_pitch, component.slot_bytes,
-                    static_cast<size_t>(run_length), ACL_MEMCPY_HOST_TO_DEVICE, stream);
-                check_acl_copy(result, "H2D", component.slot_bytes, static_cast<size_t>(run_length));
-            }
-        }
-    }
-}
-
-void submit_d2h(const std::vector<StateComponentLayout> &components, const int64_t *device_indices,
-                const int64_t *host_indices, int64_t index_count, int64_t layer_begin, int64_t layer_count,
-                aclrtStream stream)
-{
-    for (const auto &component : components) {
-        auto *device_base = static_cast<char *>(component.device.data_ptr());
-        auto *host_base = static_cast<char *>(component.host.data_ptr());
-        for (const auto i : c10::irange(index_count)) {
-            const auto device_slot = device_indices[i];
-            const auto host_slot = host_indices[i];
-            const void *source = device_base + layer_begin * component.device_layer_pitch +
-                                 device_slot * component.device_slot_pitch;
-            void *destination =
-                host_base + host_slot * component.host_slot_pitch + layer_begin * component.host_layer_pitch;
-            const auto result = aclrtMemcpy2dAsync(
-                destination, component.host_layer_pitch, source, component.device_layer_pitch, component.slot_bytes,
-                static_cast<size_t>(layer_count), ACL_MEMCPY_DEVICE_TO_HOST, stream);
-            check_acl_copy(result, "D2H", component.slot_bytes, static_cast<size_t>(layer_count));
-        }
-    }
-}
-
-void submit_state_dim_exchange(at::TensorList device_states, at::TensorList host_states,
-                               const at::Tensor &device_indices, const at::Tensor &host_indices,
-                               StateTransferDirection direction, int64_t layer_begin, int64_t layer_count,
-                               int64_t flags)
+void submit_state_all_layer_d2h(at::TensorList device_states, at::TensorList host_states,
+                                const at::Tensor &device_indices, const at::Tensor &host_indices, int64_t flags)
 {
     TORCH_CHECK(device_states.size() != 0, "device_states must not be empty");
     TORCH_CHECK(device_states.size() == host_states.size(),
@@ -282,8 +223,11 @@ void submit_state_dim_exchange(at::TensorList device_states, at::TensorList host
     if (index_count == 0) {
         return;
     }
-    TORCH_CHECK(layer_begin >= 0, "layer_begin must be non-negative");
-    TORCH_CHECK(layer_count > 0, "layer_count must be positive");
+    TORCH_CHECK(device_states[0].dim() >= 2,
+                "device state must have layout [layers, device_slots, ...]");
+    const int64_t layer_begin = 0;
+    const int64_t layer_count = device_states[0].size(0);
+    TORCH_CHECK(layer_count > 0, "device state layer count must be positive");
     const auto *device_index_data = device_indices_cpu.data_ptr<int64_t>();
     const auto *host_index_data = host_indices_cpu.data_ptr<int64_t>();
 
@@ -291,13 +235,20 @@ void submit_state_dim_exchange(at::TensorList device_states, at::TensorList host
     validate_indices(device_index_data, host_index_data, index_count, components.device_slot_limit,
                      components.host_slot_limit);
 
-    const auto acl_stream = c10_npu::getCurrentNPUStream().stream();
-    if (direction == StateTransferDirection::H2D) {
-        submit_h2d(components.layouts, device_index_data, host_index_data, index_count, layer_begin, layer_count,
-                   acl_stream);
-    } else {
-        submit_d2h(components.layouts, device_index_data, host_index_data, index_count, layer_begin, layer_count,
-                   acl_stream);
+    const auto stream = c10_npu::getCurrentNPUStream().stream();
+    for (const auto &component : components.layouts) {
+        auto *device_base = static_cast<char *>(component.device.data_ptr());
+        auto *host_base = static_cast<char *>(component.host.data_ptr());
+        for (const auto i : c10::irange(index_count)) {
+            const auto device_slot = device_index_data[i];
+            const auto host_slot = host_index_data[i];
+            const void *source = device_base + device_slot * component.device_slot_pitch;
+            void *destination = host_base + host_slot * component.host_slot_pitch;
+            const auto result = aclrtMemcpy2dAsync(
+                destination, component.host_layer_pitch, source, component.device_layer_pitch, component.slot_bytes,
+                static_cast<size_t>(layer_count), ACL_MEMCPY_DEVICE_TO_HOST, stream);
+            check_acl_copy(result, "D2H", component.slot_bytes, static_cast<size_t>(layer_count));
+        }
     }
 }
 
@@ -369,25 +320,8 @@ void submit_state_per_layer_h2d(const at::Tensor &src, const at::Tensor &dst, co
     }
 }
 
-}  // namespace
-
-// Submit state-sidecar copies to the caller's current NPU stream.
-//
-// Device component layout: [layers, device_slots, *state_shape]
-// Host component layout:   [host_slots, layers, 1, *state_shape]
-HOST_API void transfer_state_dim_exchange(at::TensorList device_states, at::TensorList host_states,
-                                          const at::Tensor &device_indices, const at::Tensor &host_indices,
-                                          int64_t direction, int64_t layer_begin, int64_t layer_count, int64_t flags)
-{
-    TORCH_CHECK(direction == static_cast<int64_t>(StateTransferDirection::H2D) ||
-                    direction == static_cast<int64_t>(StateTransferDirection::D2H),
-                "direction must be 1 (H2D) or 2 (D2H)");
-    submit_state_dim_exchange(device_states, host_states, device_indices, host_indices,
-                              static_cast<StateTransferDirection>(direction), layer_begin, layer_count, flags);
 }
 
-// GPU-direct equivalent: load one layer from page-first Host state into the
-// layer-first Device state. The copy is enqueued on the caller's current stream.
 HOST_API void transfer_state_per_layer_direct_pf_lf(
     const at::Tensor &src, const at::Tensor &dst, const at::Tensor &src_indices,
     const at::Tensor &dst_indices, int64_t layer_id, int64_t flags)
@@ -395,16 +329,12 @@ HOST_API void transfer_state_per_layer_direct_pf_lf(
     submit_state_per_layer_h2d(src, dst, src_indices, dst_indices, layer_id, flags);
 }
 
-// GPU-direct equivalent: back up all layers from layer-first Device state into
-// page-first Host state. The copy is enqueued on the caller's current stream.
 HOST_API void transfer_state_all_layer_direct_lf_pf(
     at::TensorList device_states, at::TensorList host_states, const at::Tensor &device_indices,
     const at::Tensor &host_indices, int64_t flags)
 {
-    TORCH_CHECK(device_states.size() != 0, "device_states must not be empty");
-    submit_state_dim_exchange(device_states, host_states, device_indices, host_indices,
-                              StateTransferDirection::D2H, 0, device_states[0].size(0), flags);
+    submit_state_all_layer_d2h(device_states, host_states, device_indices, host_indices, flags);
 }
 
-}  // namespace npu_kernel
-}  // namespace sglang
+}
+}

--- a/csrc/transfer_state_dim_exchange/op_host/transfer_state_dim_exchange.cpp
+++ b/csrc/transfer_state_dim_exchange/op_host/transfer_state_dim_exchange.cpp
@@ -79,6 +79,30 @@ int64_t validate_dense_slot_payload(const at::Tensor &device, int64_t component)
     return slot_elements;
 }
 
+int64_t validate_dense_layer_payload(const at::Tensor &device_layer)
+{
+    std::vector<std::pair<int64_t, int64_t>> payload_dims;
+    int64_t slot_elements = 1;
+    for (int64_t dim = 1; dim < device_layer.dim(); ++dim) {
+        const int64_t size = device_layer.size(dim);
+        const int64_t stride = device_layer.stride(dim);
+        TORCH_CHECK(stride >= 0, "device layer state has a negative stride at dimension ", dim);
+        slot_elements *= size;
+        if (size > 1) {
+            payload_dims.emplace_back(stride, size);
+        }
+    }
+
+    std::sort(payload_dims.begin(), payload_dims.end());
+    int64_t expected_stride = 1;
+    for (const auto &[stride, size] : payload_dims) {
+        TORCH_CHECK(stride == expected_stride, "device layer state slot payload must be physically dense; got ",
+                    "payload stride ", stride, " while expecting ", expected_stride);
+        expected_stride *= size;
+    }
+    return slot_elements;
+}
+
 void check_acl_copy(aclError result, const char *direction, size_t width, size_t height)
 {
     TORCH_CHECK(result == ACL_SUCCESS, "aclrtMemcpy2dAsync failed for state ", direction, " transfer: error=",
@@ -277,6 +301,74 @@ void submit_state_dim_exchange(at::TensorList device_states, at::TensorList host
     }
 }
 
+void submit_state_per_layer_h2d(const at::Tensor &src, const at::Tensor &dst, const at::Tensor &src_indices,
+                                const at::Tensor &dst_indices, int64_t layer_id, int64_t flags)
+{
+    TORCH_CHECK(src_indices.numel() == dst_indices.numel(),
+                "source and destination indices must contain the same number of slots");
+    TORCH_CHECK((flags & STATE_TRANS_FLAG_2D) == STATE_TRANS_FLAG_2D,
+                "state direct transfer currently requires FAST2D (flags=2)");
+
+    const auto host_indices_cpu = src_indices.cpu().to(at::kLong).contiguous().reshape({-1});
+    const auto device_indices_cpu = dst_indices.cpu().to(at::kLong).contiguous().reshape({-1});
+    const int64_t index_count = host_indices_cpu.numel();
+    if (index_count == 0) {
+        return;
+    }
+
+    TORCH_CHECK(src.defined() && dst.defined(), "source and destination state tensors must be defined");
+    TORCH_CHECK(src.numel() != 0, "host state source must not be empty");
+    TORCH_CHECK(dst.numel() != 0, "device layer state destination must not be empty");
+    TORCH_CHECK(src.device().is_cpu(), "state source must be on CPU, got ", src.device());
+    TORCH_CHECK(src.is_pinned(), "state source must use pinned memory");
+    TORCH_CHECK(dst.device().type() == c10::DeviceType::PrivateUse1,
+                "state destination must be on NPU, got ", dst.device());
+    TORCH_CHECK(src.scalar_type() == dst.scalar_type(), "state source/destination dtypes differ: ",
+                src.scalar_type(), " vs ", dst.scalar_type());
+    TORCH_CHECK(dst.dim() >= 2, "device layer state must have layout [device_slots, ...]");
+    TORCH_CHECK(src.dim() == dst.dim() + 2,
+                "host state must have layout [host_slots, layers, 1, ...] for a Device layer view");
+    TORCH_CHECK(src.is_contiguous(), "host state source must be contiguous");
+    TORCH_CHECK(layer_id >= 0 && layer_id < src.size(1), "layer_id ", layer_id,
+                " is outside Host state layer count ", src.size(1));
+    TORCH_CHECK(src.size(2) == 1, "host state page dimension must be 1");
+    for (int64_t dim = 1; dim < dst.dim(); ++dim) {
+        TORCH_CHECK(dst.size(dim) == src.size(dim + 2),
+                    "state trailing shape mismatch at Device layer dimension ", dim);
+    }
+
+    const int64_t slot_elements = validate_dense_layer_payload(dst);
+    TORCH_CHECK(dst.stride(0) == slot_elements, "device layer state slot payload must be contiguous");
+    TORCH_CHECK(src.stride(1) == slot_elements, "host state layer payload must be contiguous");
+
+    const auto *host_index_data = host_indices_cpu.data_ptr<int64_t>();
+    const auto *device_index_data = device_indices_cpu.data_ptr<int64_t>();
+    validate_indices(device_index_data, host_index_data, index_count, dst.size(0), src.size(0));
+
+    const size_t slot_bytes = static_cast<size_t>(slot_elements) * dst.element_size();
+    const size_t device_slot_pitch = static_cast<size_t>(dst.stride(0)) * dst.element_size();
+    const size_t host_slot_pitch = static_cast<size_t>(src.stride(0)) * src.element_size();
+    const size_t host_layer_pitch = static_cast<size_t>(src.stride(1)) * src.element_size();
+    TORCH_CHECK(slot_bytes <= device_slot_pitch && slot_bytes <= host_slot_pitch && slot_bytes <= host_layer_pitch,
+                "invalid state pitch for per-layer H2D transfer");
+
+    auto *device_base = static_cast<char *>(dst.data_ptr());
+    auto *host_base = static_cast<char *>(src.data_ptr());
+    const auto runs = build_contiguous_runs(device_index_data, host_index_data, index_count);
+    const auto acl_stream = c10_npu::getCurrentNPUStream().stream();
+    for (const auto &[run_begin, run_length] : runs) {
+        const auto device_slot = device_index_data[run_begin];
+        const auto host_slot = host_index_data[run_begin];
+        void *destination = device_base + device_slot * device_slot_pitch;
+        const void *source =
+            host_base + host_slot * host_slot_pitch + static_cast<size_t>(layer_id) * host_layer_pitch;
+        const auto result = aclrtMemcpy2dAsync(
+            destination, device_slot_pitch, source, host_slot_pitch, slot_bytes, static_cast<size_t>(run_length),
+            ACL_MEMCPY_HOST_TO_DEVICE, acl_stream);
+        check_acl_copy(result, "H2D", slot_bytes, static_cast<size_t>(run_length));
+    }
+}
+
 }  // namespace
 
 // Submit state-sidecar copies to the caller's current NPU stream.
@@ -297,11 +389,10 @@ HOST_API void transfer_state_dim_exchange(at::TensorList device_states, at::Tens
 // GPU-direct equivalent: load one layer from page-first Host state into the
 // layer-first Device state. The copy is enqueued on the caller's current stream.
 HOST_API void transfer_state_per_layer_direct_pf_lf(
-    at::TensorList device_states, at::TensorList host_states, const at::Tensor &device_indices,
-    const at::Tensor &host_indices, int64_t layer_id, int64_t flags)
+    const at::Tensor &src, const at::Tensor &dst, const at::Tensor &src_indices,
+    const at::Tensor &dst_indices, int64_t layer_id, int64_t flags)
 {
-    submit_state_dim_exchange(device_states, host_states, device_indices, host_indices,
-                              StateTransferDirection::H2D, layer_id, 1, flags);
+    submit_state_per_layer_h2d(src, dst, src_indices, dst_indices, layer_id, flags);
 }
 
 // GPU-direct equivalent: back up all layers from layer-first Device state into

--- a/csrc/transfer_state_dim_exchange/op_host/transfer_state_dim_exchange.cpp
+++ b/csrc/transfer_state_dim_exchange/op_host/transfer_state_dim_exchange.cpp
@@ -1,0 +1,250 @@
+// Licensed under the BSD 3-Clause License  (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "acl/acl.h"
+#include "defines.h"
+#include "torch_helper.h"
+
+namespace sglang {
+namespace npu_kernel {
+
+constexpr int64_t STATE_TRANS_FLAG_2D = 1 << 1;
+
+enum class StateTransferDirection : int64_t {
+    H2D = 1,
+    D2H = 2,
+};
+
+namespace {
+
+struct StateComponentLayout {
+    at::Tensor device;
+    at::Tensor host;
+    int64_t device_slot_num;
+    int64_t host_slot_num;
+    size_t slot_bytes;
+    size_t device_layer_pitch;
+    size_t device_slot_pitch;
+    size_t host_slot_pitch;
+    size_t host_layer_pitch;
+};
+
+int64_t validate_dense_slot_payload(const at::Tensor &device, int64_t component)
+{
+    // NPU NEXTN stores the temporal state as a transpose of the two innermost
+    // dimensions.  The resulting Tensor is not logically contiguous, but every
+    // [layer, slot] payload is still one dense physical byte range.  HiCache
+    // treats the Host copy as opaque state bytes, so that layout is safe for a
+    // byte-exact D2H/H2D round trip.
+    std::vector<std::pair<int64_t, int64_t>> payload_dims;
+    int64_t slot_elements = 1;
+    for (int64_t dim = 2; dim < device.dim(); ++dim) {
+        const int64_t size = device.size(dim);
+        const int64_t stride = device.stride(dim);
+        TORCH_CHECK(size >= 0, "device state component ", component, " has a negative size at dimension ", dim);
+        TORCH_CHECK(stride >= 0, "device state component ", component,
+                    " has a negative stride at dimension ", dim);
+        slot_elements *= size;
+        if (size > 1) {
+            payload_dims.emplace_back(stride, size);
+        }
+    }
+
+    std::sort(payload_dims.begin(), payload_dims.end());
+    int64_t expected_stride = 1;
+    for (const auto &[stride, size] : payload_dims) {
+        TORCH_CHECK(stride == expected_stride, "device state component ", component,
+                    " slot payload must be physically dense; got payload stride ", stride,
+                    " while expecting ", expected_stride);
+        expected_stride *= size;
+    }
+    TORCH_CHECK(expected_stride == slot_elements, "device state component ", component,
+                " slot payload span does not match its element count");
+    return slot_elements;
+}
+
+void check_acl_copy(aclError result, const char *direction, size_t width, size_t height)
+{
+    TORCH_CHECK(result == ACL_SUCCESS, "aclrtMemcpy2dAsync failed for state ", direction, " transfer: error=",
+                static_cast<int64_t>(result), ", width=", width, ", height=", height);
+}
+
+StateComponentLayout validate_component(const at::Tensor &device, const at::Tensor &host, int64_t component,
+                                        int64_t layer_begin, int64_t layer_count)
+{
+    TORCH_CHECK(device.defined() && host.defined(), "state component ", component, " must be defined");
+    TORCH_CHECK(device.numel() != 0, "device state component ", component, " must not be empty");
+    TORCH_CHECK(host.numel() != 0, "host state component ", component, " must not be empty");
+    TORCH_CHECK(device.device().type() == c10::DeviceType::PrivateUse1, "device state component ", component,
+                " must be on NPU, got ", device.device());
+    TORCH_CHECK(host.device().is_cpu(), "host state component ", component, " must be on CPU, got ", host.device());
+    TORCH_CHECK(device.scalar_type() == host.scalar_type(), "state component ", component,
+                " has different device/host dtypes: ", device.scalar_type(), " vs ", host.scalar_type());
+    TORCH_CHECK(device.dim() >= 3, "device state component ", component,
+                " must have layout [layers, device_slots, ...], got ", device.dim(), " dimensions");
+    TORCH_CHECK(host.dim() == device.dim() + 1, "host state component ", component,
+                " must have layout [host_slots, layers, 1, ...]");
+    TORCH_CHECK(host.is_contiguous(), "host state component ", component, " must be contiguous");
+    TORCH_CHECK(device.size(0) == host.size(1), "state component ", component,
+                " has different device/host layer counts");
+    TORCH_CHECK(host.size(2) == 1, "host state component ", component, " page dimension must be 1");
+    for (int64_t dim = 2; dim < device.dim(); ++dim) {
+        TORCH_CHECK(device.size(dim) == host.size(dim + 1), "state component ", component,
+                    " trailing shape mismatch at device dimension ", dim);
+    }
+    TORCH_CHECK(layer_begin >= 0, "layer_begin must be non-negative");
+    TORCH_CHECK(layer_count > 0, "layer_count must be positive");
+    TORCH_CHECK(layer_begin + layer_count <= device.size(0), "requested layer range [", layer_begin, ", ",
+                layer_begin + layer_count, ") exceeds state component ", component, " layer count ", device.size(0));
+
+    const int64_t slot_elements = validate_dense_slot_payload(device, component);
+    TORCH_CHECK(device.stride(1) == slot_elements, "device state component ", component,
+                " slot payload must be contiguous");
+    TORCH_CHECK(device.stride(0) >= device.size(1) * device.stride(1), "device state component ", component,
+                " layer pitch overlaps adjacent slots");
+    TORCH_CHECK(host.stride(1) == slot_elements, "host state component ", component,
+                " layer payload must be contiguous");
+
+    const size_t slot_bytes = static_cast<size_t>(slot_elements) * device.element_size();
+    const size_t device_layer_pitch = static_cast<size_t>(device.stride(0)) * device.element_size();
+    const size_t device_slot_pitch = static_cast<size_t>(device.stride(1)) * device.element_size();
+    const size_t host_slot_pitch = static_cast<size_t>(host.stride(0)) * host.element_size();
+    const size_t host_layer_pitch = static_cast<size_t>(host.stride(1)) * host.element_size();
+    TORCH_CHECK(slot_bytes <= device_layer_pitch && slot_bytes <= device_slot_pitch &&
+                    slot_bytes <= host_slot_pitch && slot_bytes <= host_layer_pitch,
+                "invalid state component ", component, " pitch for aclrtMemcpy2dAsync");
+
+    return {
+        device,
+        host,
+        device.size(1),
+        host.size(0),
+        slot_bytes,
+        device_layer_pitch,
+        device_slot_pitch,
+        host_slot_pitch,
+        host_layer_pitch,
+    };
+}
+
+std::vector<std::pair<int64_t, int64_t>> build_contiguous_runs(const int64_t *device_indices,
+                                                                const int64_t *host_indices, int64_t count)
+{
+    std::vector<std::pair<int64_t, int64_t>> runs;
+    int64_t begin = 0;
+    while (begin < count) {
+        int64_t end = begin + 1;
+        while (end < count && device_indices[end] == device_indices[end - 1] + 1 &&
+               host_indices[end] == host_indices[end - 1] + 1) {
+            ++end;
+        }
+        runs.emplace_back(begin, end - begin);
+        begin = end;
+    }
+    return runs;
+}
+
+}  // namespace
+
+// Submit state-sidecar copies to the caller's current NPU stream.
+//
+// Device component layout: [layers, device_slots, *state_shape]
+// Host component layout:   [host_slots, layers, 1, *state_shape]
+HOST_API void transfer_state_dim_exchange(at::TensorList device_states, at::TensorList host_states,
+                                          const at::Tensor &device_indices, const at::Tensor &host_indices,
+                                          int64_t direction, int64_t layer_begin, int64_t layer_count, int64_t flags)
+{
+    TORCH_CHECK(device_states.size() != 0, "device_states must not be empty");
+    TORCH_CHECK(device_states.size() == host_states.size(),
+                "device_states and host_states must contain the same number of components");
+    TORCH_CHECK(device_indices.numel() == host_indices.numel(),
+                "device and host indices must contain the same number of slots");
+    TORCH_CHECK(direction == static_cast<int64_t>(StateTransferDirection::H2D) ||
+                    direction == static_cast<int64_t>(StateTransferDirection::D2H),
+                "direction must be 1 (H2D) or 2 (D2H)");
+    TORCH_CHECK((flags & STATE_TRANS_FLAG_2D) == STATE_TRANS_FLAG_2D,
+                "transfer_state_dim_exchange currently requires FAST2D (flags=2)");
+
+    const auto device_indices_cpu = device_indices.cpu().to(at::kLong).contiguous().reshape({-1});
+    const auto host_indices_cpu = host_indices.cpu().to(at::kLong).contiguous().reshape({-1});
+    const int64_t index_count = device_indices_cpu.numel();
+    if (index_count == 0) {
+        return;
+    }
+    const auto *device_index_data = device_indices_cpu.data_ptr<int64_t>();
+    const auto *host_index_data = host_indices_cpu.data_ptr<int64_t>();
+
+    std::vector<StateComponentLayout> components;
+    components.reserve(device_states.size());
+    for (const auto component : c10::irange(device_states.size())) {
+        components.emplace_back(validate_component(device_states[component], host_states[component], component,
+                                                   layer_begin, layer_count));
+    }
+
+    for (const auto i : c10::irange(index_count)) {
+        TORCH_CHECK(device_index_data[i] >= 0, "device index ", device_index_data[i], " must be non-negative");
+        TORCH_CHECK(host_index_data[i] >= 0, "host index ", host_index_data[i], " must be non-negative");
+        for (const auto &component : components) {
+            TORCH_CHECK(device_index_data[i] < component.device_slot_num, "device index ", device_index_data[i],
+                        " exceeds component slot count ", component.device_slot_num);
+            TORCH_CHECK(host_index_data[i] < component.host_slot_num, "host index ", host_index_data[i],
+                        " exceeds component slot count ", component.host_slot_num);
+        }
+    }
+
+    const auto acl_stream = c10_npu::getCurrentNPUStream().stream();
+    if (direction == static_cast<int64_t>(StateTransferDirection::H2D)) {
+        const auto runs = build_contiguous_runs(device_index_data, host_index_data, index_count);
+        for (const auto &component : components) {
+            auto *device_base = static_cast<char *>(component.device.data_ptr());
+            auto *host_base = static_cast<char *>(component.host.data_ptr());
+            for (const auto layer : c10::irange(layer_begin, layer_begin + layer_count)) {
+                for (const auto &[run_begin, run_length] : runs) {
+                    const auto device_slot = device_index_data[run_begin];
+                    const auto host_slot = host_index_data[run_begin];
+                    void *destination =
+                        device_base + layer * component.device_layer_pitch + device_slot * component.device_slot_pitch;
+                    const void *source =
+                        host_base + host_slot * component.host_slot_pitch + layer * component.host_layer_pitch;
+                    const auto result = aclrtMemcpy2dAsync(
+                        destination, component.device_slot_pitch, source, component.host_slot_pitch,
+                        component.slot_bytes, static_cast<size_t>(run_length), ACL_MEMCPY_HOST_TO_DEVICE, acl_stream);
+                    check_acl_copy(result, "H2D", component.slot_bytes, static_cast<size_t>(run_length));
+                }
+            }
+        }
+    } else {
+        for (const auto &component : components) {
+            auto *device_base = static_cast<char *>(component.device.data_ptr());
+            auto *host_base = static_cast<char *>(component.host.data_ptr());
+            for (const auto i : c10::irange(index_count)) {
+                const auto device_slot = device_index_data[i];
+                const auto host_slot = host_index_data[i];
+                const void *source = device_base + layer_begin * component.device_layer_pitch +
+                                     device_slot * component.device_slot_pitch;
+                void *destination =
+                    host_base + host_slot * component.host_slot_pitch + layer_begin * component.host_layer_pitch;
+                const auto result = aclrtMemcpy2dAsync(
+                    destination, component.host_layer_pitch, source, component.device_layer_pitch,
+                    component.slot_bytes, static_cast<size_t>(layer_count), ACL_MEMCPY_DEVICE_TO_HOST, acl_stream);
+                check_acl_copy(result, "D2H", component.slot_bytes, static_cast<size_t>(layer_count));
+            }
+        }
+    }
+}
+
+}  // namespace npu_kernel
+}  // namespace sglang

--- a/csrc/transfer_state_dim_exchange/op_host/transfer_state_dim_exchange.cpp
+++ b/csrc/transfer_state_dim_exchange/op_host/transfer_state_dim_exchange.cpp
@@ -50,8 +50,7 @@ int64_t validate_dense_slot_payload(const at::Tensor &device, int64_t component)
     for (int64_t dim = 2; dim < device.dim(); ++dim) {
         const int64_t size = device.size(dim);
         const int64_t stride = device.stride(dim);
-        TORCH_CHECK(stride >= 0, "device state component ", component,
-                    " has a negative stride at dimension ", dim);
+        TORCH_CHECK(stride >= 0, "device state component ", component, " has a negative stride at dimension ", dim);
         slot_elements *= size;
         if (size > 1) {
             payload_dims.emplace_back(stride, size);
@@ -62,8 +61,8 @@ int64_t validate_dense_slot_payload(const at::Tensor &device, int64_t component)
     int64_t expected_stride = 1;
     for (const auto &[stride, size] : payload_dims) {
         TORCH_CHECK(stride == expected_stride, "device state component ", component,
-                    " slot payload must be physically dense; got payload stride ", stride,
-                    " while expecting ", expected_stride);
+                    " slot payload must be physically dense; got payload stride ", stride, " while expecting ",
+                    expected_stride);
         expected_stride *= size;
     }
     return slot_elements;
@@ -95,8 +94,8 @@ int64_t validate_dense_layer_payload(const at::Tensor &device_layer)
 
 void check_acl_copy(aclError result, const char *direction, size_t width, size_t height)
 {
-    TORCH_CHECK(result == ACL_SUCCESS, "aclrtMemcpy2dAsync failed for state ", direction, " transfer: error=",
-                static_cast<int64_t>(result), ", width=", width, ", height=", height);
+    TORCH_CHECK(result == ACL_SUCCESS, "aclrtMemcpy2dAsync failed for state ", direction,
+                " transfer: error=", static_cast<int64_t>(result), ", width=", width, ", height=", height);
 }
 
 StateComponentLayout validate_component(const at::Tensor &device, const at::Tensor &host, int64_t component,
@@ -139,8 +138,8 @@ StateComponentLayout validate_component(const at::Tensor &device, const at::Tens
     const size_t device_slot_pitch = static_cast<size_t>(device.stride(1)) * device.element_size();
     const size_t host_slot_pitch = static_cast<size_t>(host.stride(0)) * host.element_size();
     const size_t host_layer_pitch = static_cast<size_t>(host.stride(1)) * host.element_size();
-    TORCH_CHECK(slot_bytes <= device_layer_pitch && slot_bytes <= device_slot_pitch &&
-                    slot_bytes <= host_slot_pitch && slot_bytes <= host_layer_pitch,
+    TORCH_CHECK(slot_bytes <= device_layer_pitch && slot_bytes <= device_slot_pitch && slot_bytes <= host_slot_pitch &&
+                    slot_bytes <= host_layer_pitch,
                 "invalid state component ", component, " pitch for aclrtMemcpy2dAsync");
 
     return {
@@ -162,8 +161,8 @@ ValidatedStateComponents validate_components(at::TensorList device_states, at::T
     std::vector<StateComponentLayout> layouts;
     layouts.reserve(device_states.size());
     for (const auto component : c10::irange(device_states.size())) {
-        layouts.emplace_back(validate_component(device_states[component], host_states[component], component,
-                                                layer_begin, layer_count));
+        layouts.emplace_back(
+            validate_component(device_states[component], host_states[component], component, layer_begin, layer_count));
     }
 
     int64_t device_slot_limit = layouts.front().device_slot_num;
@@ -183,13 +182,13 @@ void validate_indices(const int64_t *device_indices, const int64_t *host_indices
         TORCH_CHECK(host_indices[i] >= 0, "host index ", host_indices[i], " must be non-negative");
         TORCH_CHECK(device_indices[i] < device_slot_limit, "device index ", device_indices[i],
                     " exceeds component slot count ", device_slot_limit);
-        TORCH_CHECK(host_indices[i] < host_slot_limit, "host index ", host_indices[i],
-                    " exceeds component slot count ", host_slot_limit);
+        TORCH_CHECK(host_indices[i] < host_slot_limit, "host index ", host_indices[i], " exceeds component slot count ",
+                    host_slot_limit);
     }
 }
 
 std::vector<std::pair<int64_t, int64_t>> build_contiguous_runs(const int64_t *device_indices,
-                                                                const int64_t *host_indices, int64_t count)
+                                                               const int64_t *host_indices, int64_t count)
 {
     std::vector<std::pair<int64_t, int64_t>> runs;
     runs.reserve(count);
@@ -223,8 +222,7 @@ void submit_state_all_layer_d2h(at::TensorList device_states, at::TensorList hos
     if (index_count == 0) {
         return;
     }
-    TORCH_CHECK(device_states[0].dim() >= 2,
-                "device state must have layout [layers, device_slots, ...]");
+    TORCH_CHECK(device_states[0].dim() >= 2, "device state must have layout [layers, device_slots, ...]");
     const int64_t layer_begin = 0;
     const int64_t layer_count = device_states[0].size(0);
     TORCH_CHECK(layer_count > 0, "device state layer count must be positive");
@@ -244,9 +242,9 @@ void submit_state_all_layer_d2h(at::TensorList device_states, at::TensorList hos
             const auto host_slot = host_index_data[i];
             const void *source = device_base + device_slot * component.device_slot_pitch;
             void *destination = host_base + host_slot * component.host_slot_pitch;
-            const auto result = aclrtMemcpy2dAsync(
-                destination, component.host_layer_pitch, source, component.device_layer_pitch, component.slot_bytes,
-                static_cast<size_t>(layer_count), ACL_MEMCPY_DEVICE_TO_HOST, stream);
+            const auto result = aclrtMemcpy2dAsync(destination, component.host_layer_pitch, source,
+                                                   component.device_layer_pitch, component.slot_bytes,
+                                                   static_cast<size_t>(layer_count), ACL_MEMCPY_DEVICE_TO_HOST, stream);
             check_acl_copy(result, "D2H", component.slot_bytes, static_cast<size_t>(layer_count));
         }
     }
@@ -272,20 +270,20 @@ void submit_state_per_layer_h2d(const at::Tensor &src, const at::Tensor &dst, co
     TORCH_CHECK(dst.numel() != 0, "device layer state destination must not be empty");
     TORCH_CHECK(src.device().is_cpu(), "state source must be on CPU, got ", src.device());
     TORCH_CHECK(src.is_pinned(), "state source must use pinned memory");
-    TORCH_CHECK(dst.device().type() == c10::DeviceType::PrivateUse1,
-                "state destination must be on NPU, got ", dst.device());
-    TORCH_CHECK(src.scalar_type() == dst.scalar_type(), "state source/destination dtypes differ: ",
-                src.scalar_type(), " vs ", dst.scalar_type());
+    TORCH_CHECK(dst.device().type() == c10::DeviceType::PrivateUse1, "state destination must be on NPU, got ",
+                dst.device());
+    TORCH_CHECK(src.scalar_type() == dst.scalar_type(), "state source/destination dtypes differ: ", src.scalar_type(),
+                " vs ", dst.scalar_type());
     TORCH_CHECK(dst.dim() >= 2, "device layer state must have layout [device_slots, ...]");
     TORCH_CHECK(src.dim() == dst.dim() + 2,
                 "host state must have layout [host_slots, layers, 1, ...] for a Device layer view");
     TORCH_CHECK(src.is_contiguous(), "host state source must be contiguous");
-    TORCH_CHECK(layer_id >= 0 && layer_id < src.size(1), "layer_id ", layer_id,
-                " is outside Host state layer count ", src.size(1));
+    TORCH_CHECK(layer_id >= 0 && layer_id < src.size(1), "layer_id ", layer_id, " is outside Host state layer count ",
+                src.size(1));
     TORCH_CHECK(src.size(2) == 1, "host state page dimension must be 1");
     for (int64_t dim = 1; dim < dst.dim(); ++dim) {
-        TORCH_CHECK(dst.size(dim) == src.size(dim + 2),
-                    "state trailing shape mismatch at Device layer dimension ", dim);
+        TORCH_CHECK(dst.size(dim) == src.size(dim + 2), "state trailing shape mismatch at Device layer dimension ",
+                    dim);
     }
 
     const int64_t slot_elements = validate_dense_layer_payload(dst);
@@ -311,30 +309,28 @@ void submit_state_per_layer_h2d(const at::Tensor &src, const at::Tensor &dst, co
         const auto device_slot = device_index_data[run_begin];
         const auto host_slot = host_index_data[run_begin];
         void *destination = device_base + device_slot * device_slot_pitch;
-        const void *source =
-            host_base + host_slot * host_slot_pitch + static_cast<size_t>(layer_id) * host_layer_pitch;
-        const auto result = aclrtMemcpy2dAsync(
-            destination, device_slot_pitch, source, host_slot_pitch, slot_bytes, static_cast<size_t>(run_length),
-            ACL_MEMCPY_HOST_TO_DEVICE, acl_stream);
+        const void *source = host_base + host_slot * host_slot_pitch + static_cast<size_t>(layer_id) * host_layer_pitch;
+        const auto result = aclrtMemcpy2dAsync(destination, device_slot_pitch, source, host_slot_pitch, slot_bytes,
+                                               static_cast<size_t>(run_length), ACL_MEMCPY_HOST_TO_DEVICE, acl_stream);
         check_acl_copy(result, "H2D", slot_bytes, static_cast<size_t>(run_length));
     }
 }
 
-}
+}  // namespace
 
-HOST_API void transfer_state_per_layer_direct_pf_lf(
-    const at::Tensor &src, const at::Tensor &dst, const at::Tensor &src_indices,
-    const at::Tensor &dst_indices, int64_t layer_id, int64_t flags)
+HOST_API void transfer_state_per_layer_direct_pf_lf(const at::Tensor &src, const at::Tensor &dst,
+                                                    const at::Tensor &src_indices, const at::Tensor &dst_indices,
+                                                    int64_t layer_id, int64_t flags)
 {
     submit_state_per_layer_h2d(src, dst, src_indices, dst_indices, layer_id, flags);
 }
 
-HOST_API void transfer_state_all_layer_direct_lf_pf(
-    at::TensorList device_states, at::TensorList host_states, const at::Tensor &device_indices,
-    const at::Tensor &host_indices, int64_t flags)
+HOST_API void transfer_state_all_layer_direct_lf_pf(at::TensorList device_states, at::TensorList host_states,
+                                                    const at::Tensor &device_indices, const at::Tensor &host_indices,
+                                                    int64_t flags)
 {
     submit_state_all_layer_d2h(device_states, host_states, device_indices, host_indices, flags);
 }
 
-}
-}
+}  // namespace npu_kernel
+}  // namespace sglang

--- a/csrc/transfer_state_dim_exchange/op_host/transfer_state_dim_exchange.cpp
+++ b/csrc/transfer_state_dim_exchange/op_host/transfer_state_dim_exchange.cpp
@@ -42,6 +42,12 @@ struct StateComponentLayout {
     size_t host_layer_pitch;
 };
 
+struct ValidatedStateComponents {
+    std::vector<StateComponentLayout> layouts;
+    int64_t device_slot_limit;
+    int64_t host_slot_limit;
+};
+
 int64_t validate_dense_slot_payload(const at::Tensor &device, int64_t component)
 {
     // NPU NEXTN stores the temporal state as a transpose of the two innermost
@@ -54,7 +60,6 @@ int64_t validate_dense_slot_payload(const at::Tensor &device, int64_t component)
     for (int64_t dim = 2; dim < device.dim(); ++dim) {
         const int64_t size = device.size(dim);
         const int64_t stride = device.stride(dim);
-        TORCH_CHECK(size >= 0, "device state component ", component, " has a negative size at dimension ", dim);
         TORCH_CHECK(stride >= 0, "device state component ", component,
                     " has a negative stride at dimension ", dim);
         slot_elements *= size;
@@ -71,8 +76,6 @@ int64_t validate_dense_slot_payload(const at::Tensor &device, int64_t component)
                     " while expecting ", expected_stride);
         expected_stride *= size;
     }
-    TORCH_CHECK(expected_stride == slot_elements, "device state component ", component,
-                " slot payload span does not match its element count");
     return slot_elements;
 }
 
@@ -91,6 +94,7 @@ StateComponentLayout validate_component(const at::Tensor &device, const at::Tens
     TORCH_CHECK(device.device().type() == c10::DeviceType::PrivateUse1, "device state component ", component,
                 " must be on NPU, got ", device.device());
     TORCH_CHECK(host.device().is_cpu(), "host state component ", component, " must be on CPU, got ", host.device());
+    TORCH_CHECK(host.is_pinned(), "host state component ", component, " must use pinned memory");
     TORCH_CHECK(device.scalar_type() == host.scalar_type(), "state component ", component,
                 " has different device/host dtypes: ", device.scalar_type(), " vs ", host.scalar_type());
     TORCH_CHECK(device.dim() >= 3, "device state component ", component,
@@ -105,8 +109,6 @@ StateComponentLayout validate_component(const at::Tensor &device, const at::Tens
         TORCH_CHECK(device.size(dim) == host.size(dim + 1), "state component ", component,
                     " trailing shape mismatch at device dimension ", dim);
     }
-    TORCH_CHECK(layer_begin >= 0, "layer_begin must be non-negative");
-    TORCH_CHECK(layer_count > 0, "layer_count must be positive");
     TORCH_CHECK(layer_begin + layer_count <= device.size(0), "requested layer range [", layer_begin, ", ",
                 layer_begin + layer_count, ") exceeds state component ", component, " layer count ", device.size(0));
 
@@ -140,10 +142,43 @@ StateComponentLayout validate_component(const at::Tensor &device, const at::Tens
     };
 }
 
+ValidatedStateComponents validate_components(at::TensorList device_states, at::TensorList host_states,
+                                             int64_t layer_begin, int64_t layer_count)
+{
+    std::vector<StateComponentLayout> layouts;
+    layouts.reserve(device_states.size());
+    for (const auto component : c10::irange(device_states.size())) {
+        layouts.emplace_back(validate_component(device_states[component], host_states[component], component,
+                                                layer_begin, layer_count));
+    }
+
+    int64_t device_slot_limit = layouts.front().device_slot_num;
+    int64_t host_slot_limit = layouts.front().host_slot_num;
+    for (const auto &layout : layouts) {
+        device_slot_limit = std::min(device_slot_limit, layout.device_slot_num);
+        host_slot_limit = std::min(host_slot_limit, layout.host_slot_num);
+    }
+    return {std::move(layouts), device_slot_limit, host_slot_limit};
+}
+
+void validate_indices(const int64_t *device_indices, const int64_t *host_indices, int64_t count,
+                      int64_t device_slot_limit, int64_t host_slot_limit)
+{
+    for (const auto i : c10::irange(count)) {
+        TORCH_CHECK(device_indices[i] >= 0, "device index ", device_indices[i], " must be non-negative");
+        TORCH_CHECK(host_indices[i] >= 0, "host index ", host_indices[i], " must be non-negative");
+        TORCH_CHECK(device_indices[i] < device_slot_limit, "device index ", device_indices[i],
+                    " exceeds component slot count ", device_slot_limit);
+        TORCH_CHECK(host_indices[i] < host_slot_limit, "host index ", host_indices[i],
+                    " exceeds component slot count ", host_slot_limit);
+    }
+}
+
 std::vector<std::pair<int64_t, int64_t>> build_contiguous_runs(const int64_t *device_indices,
                                                                 const int64_t *host_indices, int64_t count)
 {
     std::vector<std::pair<int64_t, int64_t>> runs;
+    runs.reserve(count);
     int64_t begin = 0;
     while (begin < count) {
         int64_t end = begin + 1;
@@ -155,6 +190,53 @@ std::vector<std::pair<int64_t, int64_t>> build_contiguous_runs(const int64_t *de
         begin = end;
     }
     return runs;
+}
+
+void submit_h2d(const std::vector<StateComponentLayout> &components, const int64_t *device_indices,
+                const int64_t *host_indices, int64_t index_count, int64_t layer_begin, int64_t layer_count,
+                aclrtStream stream)
+{
+    const auto runs = build_contiguous_runs(device_indices, host_indices, index_count);
+    for (const auto &component : components) {
+        auto *device_base = static_cast<char *>(component.device.data_ptr());
+        auto *host_base = static_cast<char *>(component.host.data_ptr());
+        for (const auto layer : c10::irange(layer_begin, layer_begin + layer_count)) {
+            for (const auto &[run_begin, run_length] : runs) {
+                const auto device_slot = device_indices[run_begin];
+                const auto host_slot = host_indices[run_begin];
+                void *destination =
+                    device_base + layer * component.device_layer_pitch + device_slot * component.device_slot_pitch;
+                const void *source =
+                    host_base + host_slot * component.host_slot_pitch + layer * component.host_layer_pitch;
+                const auto result = aclrtMemcpy2dAsync(
+                    destination, component.device_slot_pitch, source, component.host_slot_pitch, component.slot_bytes,
+                    static_cast<size_t>(run_length), ACL_MEMCPY_HOST_TO_DEVICE, stream);
+                check_acl_copy(result, "H2D", component.slot_bytes, static_cast<size_t>(run_length));
+            }
+        }
+    }
+}
+
+void submit_d2h(const std::vector<StateComponentLayout> &components, const int64_t *device_indices,
+                const int64_t *host_indices, int64_t index_count, int64_t layer_begin, int64_t layer_count,
+                aclrtStream stream)
+{
+    for (const auto &component : components) {
+        auto *device_base = static_cast<char *>(component.device.data_ptr());
+        auto *host_base = static_cast<char *>(component.host.data_ptr());
+        for (const auto i : c10::irange(index_count)) {
+            const auto device_slot = device_indices[i];
+            const auto host_slot = host_indices[i];
+            const void *source = device_base + layer_begin * component.device_layer_pitch +
+                                 device_slot * component.device_slot_pitch;
+            void *destination =
+                host_base + host_slot * component.host_slot_pitch + layer_begin * component.host_layer_pitch;
+            const auto result = aclrtMemcpy2dAsync(
+                destination, component.host_layer_pitch, source, component.device_layer_pitch, component.slot_bytes,
+                static_cast<size_t>(layer_count), ACL_MEMCPY_DEVICE_TO_HOST, stream);
+            check_acl_copy(result, "D2H", component.slot_bytes, static_cast<size_t>(layer_count));
+        }
+    }
 }
 
 }  // namespace
@@ -184,65 +266,22 @@ HOST_API void transfer_state_dim_exchange(at::TensorList device_states, at::Tens
     if (index_count == 0) {
         return;
     }
+    TORCH_CHECK(layer_begin >= 0, "layer_begin must be non-negative");
+    TORCH_CHECK(layer_count > 0, "layer_count must be positive");
     const auto *device_index_data = device_indices_cpu.data_ptr<int64_t>();
     const auto *host_index_data = host_indices_cpu.data_ptr<int64_t>();
 
-    std::vector<StateComponentLayout> components;
-    components.reserve(device_states.size());
-    for (const auto component : c10::irange(device_states.size())) {
-        components.emplace_back(validate_component(device_states[component], host_states[component], component,
-                                                   layer_begin, layer_count));
-    }
-
-    for (const auto i : c10::irange(index_count)) {
-        TORCH_CHECK(device_index_data[i] >= 0, "device index ", device_index_data[i], " must be non-negative");
-        TORCH_CHECK(host_index_data[i] >= 0, "host index ", host_index_data[i], " must be non-negative");
-        for (const auto &component : components) {
-            TORCH_CHECK(device_index_data[i] < component.device_slot_num, "device index ", device_index_data[i],
-                        " exceeds component slot count ", component.device_slot_num);
-            TORCH_CHECK(host_index_data[i] < component.host_slot_num, "host index ", host_index_data[i],
-                        " exceeds component slot count ", component.host_slot_num);
-        }
-    }
+    auto components = validate_components(device_states, host_states, layer_begin, layer_count);
+    validate_indices(device_index_data, host_index_data, index_count, components.device_slot_limit,
+                     components.host_slot_limit);
 
     const auto acl_stream = c10_npu::getCurrentNPUStream().stream();
     if (direction == static_cast<int64_t>(StateTransferDirection::H2D)) {
-        const auto runs = build_contiguous_runs(device_index_data, host_index_data, index_count);
-        for (const auto &component : components) {
-            auto *device_base = static_cast<char *>(component.device.data_ptr());
-            auto *host_base = static_cast<char *>(component.host.data_ptr());
-            for (const auto layer : c10::irange(layer_begin, layer_begin + layer_count)) {
-                for (const auto &[run_begin, run_length] : runs) {
-                    const auto device_slot = device_index_data[run_begin];
-                    const auto host_slot = host_index_data[run_begin];
-                    void *destination =
-                        device_base + layer * component.device_layer_pitch + device_slot * component.device_slot_pitch;
-                    const void *source =
-                        host_base + host_slot * component.host_slot_pitch + layer * component.host_layer_pitch;
-                    const auto result = aclrtMemcpy2dAsync(
-                        destination, component.device_slot_pitch, source, component.host_slot_pitch,
-                        component.slot_bytes, static_cast<size_t>(run_length), ACL_MEMCPY_HOST_TO_DEVICE, acl_stream);
-                    check_acl_copy(result, "H2D", component.slot_bytes, static_cast<size_t>(run_length));
-                }
-            }
-        }
+        submit_h2d(components.layouts, device_index_data, host_index_data, index_count, layer_begin, layer_count,
+                   acl_stream);
     } else {
-        for (const auto &component : components) {
-            auto *device_base = static_cast<char *>(component.device.data_ptr());
-            auto *host_base = static_cast<char *>(component.host.data_ptr());
-            for (const auto i : c10::irange(index_count)) {
-                const auto device_slot = device_index_data[i];
-                const auto host_slot = host_index_data[i];
-                const void *source = device_base + layer_begin * component.device_layer_pitch +
-                                     device_slot * component.device_slot_pitch;
-                void *destination =
-                    host_base + host_slot * component.host_slot_pitch + layer_begin * component.host_layer_pitch;
-                const auto result = aclrtMemcpy2dAsync(
-                    destination, component.host_layer_pitch, source, component.device_layer_pitch,
-                    component.slot_bytes, static_cast<size_t>(layer_count), ACL_MEMCPY_DEVICE_TO_HOST, acl_stream);
-                check_acl_copy(result, "D2H", component.slot_bytes, static_cast<size_t>(layer_count));
-            }
-        }
+        submit_d2h(components.layouts, device_index_data, host_index_data, index_count, layer_begin, layer_count,
+                   acl_stream);
     }
 }
 

--- a/csrc/transfer_state_dim_exchange/op_host/transfer_state_dim_exchange.cpp
+++ b/csrc/transfer_state_dim_exchange/op_host/transfer_state_dim_exchange.cpp
@@ -239,26 +239,18 @@ void submit_d2h(const std::vector<StateComponentLayout> &components, const int64
     }
 }
 
-}  // namespace
-
-// Submit state-sidecar copies to the caller's current NPU stream.
-//
-// Device component layout: [layers, device_slots, *state_shape]
-// Host component layout:   [host_slots, layers, 1, *state_shape]
-HOST_API void transfer_state_dim_exchange(at::TensorList device_states, at::TensorList host_states,
-                                          const at::Tensor &device_indices, const at::Tensor &host_indices,
-                                          int64_t direction, int64_t layer_begin, int64_t layer_count, int64_t flags)
+void submit_state_dim_exchange(at::TensorList device_states, at::TensorList host_states,
+                               const at::Tensor &device_indices, const at::Tensor &host_indices,
+                               StateTransferDirection direction, int64_t layer_begin, int64_t layer_count,
+                               int64_t flags)
 {
     TORCH_CHECK(device_states.size() != 0, "device_states must not be empty");
     TORCH_CHECK(device_states.size() == host_states.size(),
                 "device_states and host_states must contain the same number of components");
     TORCH_CHECK(device_indices.numel() == host_indices.numel(),
                 "device and host indices must contain the same number of slots");
-    TORCH_CHECK(direction == static_cast<int64_t>(StateTransferDirection::H2D) ||
-                    direction == static_cast<int64_t>(StateTransferDirection::D2H),
-                "direction must be 1 (H2D) or 2 (D2H)");
     TORCH_CHECK((flags & STATE_TRANS_FLAG_2D) == STATE_TRANS_FLAG_2D,
-                "transfer_state_dim_exchange currently requires FAST2D (flags=2)");
+                "state direct transfer currently requires FAST2D (flags=2)");
 
     const auto device_indices_cpu = device_indices.cpu().to(at::kLong).contiguous().reshape({-1});
     const auto host_indices_cpu = host_indices.cpu().to(at::kLong).contiguous().reshape({-1});
@@ -276,13 +268,51 @@ HOST_API void transfer_state_dim_exchange(at::TensorList device_states, at::Tens
                      components.host_slot_limit);
 
     const auto acl_stream = c10_npu::getCurrentNPUStream().stream();
-    if (direction == static_cast<int64_t>(StateTransferDirection::H2D)) {
+    if (direction == StateTransferDirection::H2D) {
         submit_h2d(components.layouts, device_index_data, host_index_data, index_count, layer_begin, layer_count,
                    acl_stream);
     } else {
         submit_d2h(components.layouts, device_index_data, host_index_data, index_count, layer_begin, layer_count,
                    acl_stream);
     }
+}
+
+}  // namespace
+
+// Submit state-sidecar copies to the caller's current NPU stream.
+//
+// Device component layout: [layers, device_slots, *state_shape]
+// Host component layout:   [host_slots, layers, 1, *state_shape]
+HOST_API void transfer_state_dim_exchange(at::TensorList device_states, at::TensorList host_states,
+                                          const at::Tensor &device_indices, const at::Tensor &host_indices,
+                                          int64_t direction, int64_t layer_begin, int64_t layer_count, int64_t flags)
+{
+    TORCH_CHECK(direction == static_cast<int64_t>(StateTransferDirection::H2D) ||
+                    direction == static_cast<int64_t>(StateTransferDirection::D2H),
+                "direction must be 1 (H2D) or 2 (D2H)");
+    submit_state_dim_exchange(device_states, host_states, device_indices, host_indices,
+                              static_cast<StateTransferDirection>(direction), layer_begin, layer_count, flags);
+}
+
+// GPU-direct equivalent: load one layer from page-first Host state into the
+// layer-first Device state. The copy is enqueued on the caller's current stream.
+HOST_API void transfer_state_per_layer_direct_pf_lf(
+    at::TensorList device_states, at::TensorList host_states, const at::Tensor &device_indices,
+    const at::Tensor &host_indices, int64_t layer_id, int64_t flags)
+{
+    submit_state_dim_exchange(device_states, host_states, device_indices, host_indices,
+                              StateTransferDirection::H2D, layer_id, 1, flags);
+}
+
+// GPU-direct equivalent: back up all layers from layer-first Device state into
+// page-first Host state. The copy is enqueued on the caller's current stream.
+HOST_API void transfer_state_all_layer_direct_lf_pf(
+    at::TensorList device_states, at::TensorList host_states, const at::Tensor &device_indices,
+    const at::Tensor &host_indices, int64_t flags)
+{
+    TORCH_CHECK(device_states.size() != 0, "device_states must not be empty");
+    submit_state_dim_exchange(device_states, host_states, device_indices, host_indices,
+                              StateTransferDirection::D2H, 0, device_states[0].size(0), flags);
 }
 
 }  // namespace npu_kernel

--- a/include/sgl_kenel_npu_ops.h
+++ b/include/sgl_kenel_npu_ops.h
@@ -76,13 +76,6 @@ void transfer_kv_dim_exchange(at::Tensor &device_k, at::Tensor &host_k,
                               const at::Tensor &host_indices, int64_t page_size,
                               int64_t direction, int64_t flags);
 
-void transfer_state_dim_exchange(at::TensorList device_states,
-                                 at::TensorList host_states,
-                                 const at::Tensor &device_indices,
-                                 const at::Tensor &host_indices,
-                                 int64_t direction, int64_t layer_begin,
-                                 int64_t layer_count, int64_t flags);
-
 void transfer_state_per_layer_direct_pf_lf(
     const at::Tensor &src, const at::Tensor &dst,
     const at::Tensor &src_indices, const at::Tensor &dst_indices,

--- a/include/sgl_kenel_npu_ops.h
+++ b/include/sgl_kenel_npu_ops.h
@@ -76,6 +76,13 @@ void transfer_kv_dim_exchange(at::Tensor &device_k, at::Tensor &host_k,
                               const at::Tensor &host_indices, int64_t page_size,
                               int64_t direction, int64_t flags);
 
+void transfer_state_dim_exchange(at::TensorList device_states,
+                                 at::TensorList host_states,
+                                 const at::Tensor &device_indices,
+                                 const at::Tensor &host_indices,
+                                 int64_t direction, int64_t layer_begin,
+                                 int64_t layer_count, int64_t flags);
+
 at::Tensor bgmv_expand(at::Tensor &x, at::Tensor &weight, at::Tensor &indices,
                        at::Tensor &y, int64_t slice_offset, int64_t slice_size);
 

--- a/include/sgl_kenel_npu_ops.h
+++ b/include/sgl_kenel_npu_ops.h
@@ -76,15 +76,17 @@ void transfer_kv_dim_exchange(at::Tensor &device_k, at::Tensor &host_k,
                               const at::Tensor &host_indices, int64_t page_size,
                               int64_t direction, int64_t flags);
 
-void transfer_state_per_layer_direct_pf_lf(
-    const at::Tensor &src, const at::Tensor &dst,
-    const at::Tensor &src_indices, const at::Tensor &dst_indices,
-    int64_t layer_id, int64_t flags);
+void transfer_state_per_layer_direct_pf_lf(const at::Tensor &src,
+                                           const at::Tensor &dst,
+                                           const at::Tensor &src_indices,
+                                           const at::Tensor &dst_indices,
+                                           int64_t layer_id, int64_t flags);
 
-void transfer_state_all_layer_direct_lf_pf(
-    at::TensorList device_states, at::TensorList host_states,
-    const at::Tensor &device_indices, const at::Tensor &host_indices,
-    int64_t flags);
+void transfer_state_all_layer_direct_lf_pf(at::TensorList device_states,
+                                           at::TensorList host_states,
+                                           const at::Tensor &device_indices,
+                                           const at::Tensor &host_indices,
+                                           int64_t flags);
 
 at::Tensor bgmv_expand(at::Tensor &x, at::Tensor &weight, at::Tensor &indices,
                        at::Tensor &y, int64_t slice_offset, int64_t slice_size);

--- a/include/sgl_kenel_npu_ops.h
+++ b/include/sgl_kenel_npu_ops.h
@@ -84,8 +84,8 @@ void transfer_state_dim_exchange(at::TensorList device_states,
                                  int64_t layer_count, int64_t flags);
 
 void transfer_state_per_layer_direct_pf_lf(
-    at::TensorList device_states, at::TensorList host_states,
-    const at::Tensor &device_indices, const at::Tensor &host_indices,
+    const at::Tensor &src, const at::Tensor &dst,
+    const at::Tensor &src_indices, const at::Tensor &dst_indices,
     int64_t layer_id, int64_t flags);
 
 void transfer_state_all_layer_direct_lf_pf(

--- a/include/sgl_kenel_npu_ops.h
+++ b/include/sgl_kenel_npu_ops.h
@@ -83,6 +83,16 @@ void transfer_state_dim_exchange(at::TensorList device_states,
                                  int64_t direction, int64_t layer_begin,
                                  int64_t layer_count, int64_t flags);
 
+void transfer_state_per_layer_direct_pf_lf(
+    at::TensorList device_states, at::TensorList host_states,
+    const at::Tensor &device_indices, const at::Tensor &host_indices,
+    int64_t layer_id, int64_t flags);
+
+void transfer_state_all_layer_direct_lf_pf(
+    at::TensorList device_states, at::TensorList host_states,
+    const at::Tensor &device_indices, const at::Tensor &host_indices,
+    int64_t flags);
+
 at::Tensor bgmv_expand(at::Tensor &x, at::Tensor &weight, at::Tensor &indices,
                        at::Tensor &y, int64_t slice_offset, int64_t slice_size);
 

--- a/python/sgl_kernel_npu/sgl_kernel_npu/kvcacheio.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/kvcacheio.py
@@ -48,6 +48,51 @@ def transfer_state_dim_exchange(
     )
 
 
+def transfer_state_per_layer_direct_pf_lf(
+    device_states: Sequence[torch.Tensor],
+    host_states: Sequence[torch.Tensor],
+    device_indices: torch.Tensor,
+    host_indices: torch.Tensor,
+    layer_id: int,
+    flags: TransferFlag = TransferFlag.FAST2D,
+) -> None:
+    """Load one layer of page-first Host state into layer-first Device state.
+
+    This is the Ascend counterpart of the GPU per-layer direct PF->LF entry.
+    Callers normally pass one Mamba component (temporal or one conv state); the
+    operation is enqueued on the caller's current NPU stream.
+    """
+    torch.ops.npu.transfer_state_per_layer_direct_pf_lf(
+        list(device_states),
+        list(host_states),
+        device_indices,
+        host_indices,
+        layer_id,
+        flags.value,
+    )
+
+
+def transfer_state_all_layer_direct_lf_pf(
+    device_states: Sequence[torch.Tensor],
+    host_states: Sequence[torch.Tensor],
+    device_indices: torch.Tensor,
+    host_indices: torch.Tensor,
+    flags: TransferFlag = TransferFlag.FAST2D,
+) -> None:
+    """Back up every layer of one LF Device component into PF Host state.
+
+    This is the Ascend counterpart of the GPU all-layer direct LF->PF entry.
+    The operation is enqueued on the caller's current NPU stream.
+    """
+    torch.ops.npu.transfer_state_all_layer_direct_lf_pf(
+        list(device_states),
+        list(host_states),
+        device_indices,
+        host_indices,
+        flags.value,
+    )
+
+
 def transfer_kv_dim_exchange(
     device_indices: torch.Tensor,
     host_indices: torch.Tensor,

--- a/python/sgl_kernel_npu/sgl_kernel_npu/kvcacheio.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/kvcacheio.py
@@ -13,41 +13,6 @@ class TransferFlag(Enum):
     FAST2D = 2
 
 
-def transfer_state_dim_exchange(
-    device_states: Sequence[torch.Tensor],
-    host_states: Sequence[torch.Tensor],
-    device_indices: torch.Tensor,
-    host_indices: torch.Tensor,
-    direction: TransferDirection,
-    layer_begin: int,
-    layer_count: int,
-    flags: TransferFlag = TransferFlag.FAST2D,
-) -> None:
-    """Submit indexed state-sidecar copies to the current NPU stream.
-
-    Device components use ``[layers, device_slots, *state_shape]`` and host
-    components use ``[host_slots, layers, 1, *state_shape]``.  A device slot
-    payload may be a dense permutation (for example the NPU NEXTN temporal
-    transpose); the Host payload is an opaque byte-exact backup of that physical
-    layout.  The call only enqueues H2D/D2H work; completion is ordered by the
-    caller's stream/event.
-
-    Argument validation lives in the registered C++ operator so direct
-    ``torch.ops`` callers and this convenience wrapper share one safety
-    boundary.
-    """
-    torch.ops.npu.transfer_state_dim_exchange(
-        list(device_states),
-        list(host_states),
-        device_indices,
-        host_indices,
-        direction.value,
-        layer_begin,
-        layer_count,
-        flags.value,
-    )
-
-
 def transfer_state_per_layer_direct_pf_lf(
     src: torch.Tensor,
     dst: torch.Tensor,
@@ -56,13 +21,6 @@ def transfer_state_per_layer_direct_pf_lf(
     layer_id: int,
     flags: TransferFlag = TransferFlag.FAST2D,
 ) -> None:
-    """Load one layer of page-first Host state into layer-first Device state.
-
-    ``src`` is the complete page-first Host component and ``dst`` is the
-    current layer view of the layer-first Device component. This matches the
-    GPU per-layer direct PF->LF entry and is enqueued on the caller's current
-    NPU stream.
-    """
     torch.ops.npu.transfer_state_per_layer_direct_pf_lf(
         src,
         dst,
@@ -80,11 +38,6 @@ def transfer_state_all_layer_direct_lf_pf(
     host_indices: torch.Tensor,
     flags: TransferFlag = TransferFlag.FAST2D,
 ) -> None:
-    """Back up every layer of one LF Device component into PF Host state.
-
-    This is the Ascend counterpart of the GPU all-layer direct LF->PF entry.
-    The operation is enqueued on the caller's current NPU stream.
-    """
     torch.ops.npu.transfer_state_all_layer_direct_lf_pf(
         list(device_states),
         list(host_states),

--- a/python/sgl_kernel_npu/sgl_kernel_npu/kvcacheio.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/kvcacheio.py
@@ -49,24 +49,25 @@ def transfer_state_dim_exchange(
 
 
 def transfer_state_per_layer_direct_pf_lf(
-    device_states: Sequence[torch.Tensor],
-    host_states: Sequence[torch.Tensor],
-    device_indices: torch.Tensor,
-    host_indices: torch.Tensor,
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    src_indices: torch.Tensor,
+    dst_indices: torch.Tensor,
     layer_id: int,
     flags: TransferFlag = TransferFlag.FAST2D,
 ) -> None:
     """Load one layer of page-first Host state into layer-first Device state.
 
-    This is the Ascend counterpart of the GPU per-layer direct PF->LF entry.
-    Callers normally pass one Mamba component (temporal or one conv state); the
-    operation is enqueued on the caller's current NPU stream.
+    ``src`` is the complete page-first Host component and ``dst`` is the
+    current layer view of the layer-first Device component. This matches the
+    GPU per-layer direct PF->LF entry and is enqueued on the caller's current
+    NPU stream.
     """
     torch.ops.npu.transfer_state_per_layer_direct_pf_lf(
-        list(device_states),
-        list(host_states),
-        device_indices,
-        host_indices,
+        src,
+        dst,
+        src_indices,
+        dst_indices,
         layer_id,
         flags.value,
     )

--- a/python/sgl_kernel_npu/sgl_kernel_npu/kvcacheio.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/kvcacheio.py
@@ -31,22 +31,11 @@ def transfer_state_dim_exchange(
     transpose); the Host payload is an opaque byte-exact backup of that physical
     layout.  The call only enqueues H2D/D2H work; completion is ordered by the
     caller's stream/event.
+
+    Argument validation lives in the registered C++ operator so direct
+    ``torch.ops`` callers and this convenience wrapper share one safety
+    boundary.
     """
-    if not device_states:
-        raise ValueError("device_states must not be empty")
-    if len(device_states) != len(host_states):
-        raise ValueError(
-            "device_states and host_states must contain the same number of components"
-        )
-    for component, tensor in enumerate(host_states):
-        if tensor.device.type != "cpu":
-            raise ValueError(
-                f"host state component {component} must be on CPU, got {tensor.device}"
-            )
-        if not tensor.is_pinned():
-            raise ValueError(
-                f"host state component {component} must use pinned memory"
-            )
     torch.ops.npu.transfer_state_dim_exchange(
         list(device_states),
         list(host_states),

--- a/python/sgl_kernel_npu/sgl_kernel_npu/kvcacheio.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/kvcacheio.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional
+from typing import Optional, Sequence
 
 import torch
 
@@ -11,6 +11,52 @@ class TransferDirection(Enum):
 
 class TransferFlag(Enum):
     FAST2D = 2
+
+
+def transfer_state_dim_exchange(
+    device_states: Sequence[torch.Tensor],
+    host_states: Sequence[torch.Tensor],
+    device_indices: torch.Tensor,
+    host_indices: torch.Tensor,
+    direction: TransferDirection,
+    layer_begin: int,
+    layer_count: int,
+    flags: TransferFlag = TransferFlag.FAST2D,
+) -> None:
+    """Submit indexed state-sidecar copies to the current NPU stream.
+
+    Device components use ``[layers, device_slots, *state_shape]`` and host
+    components use ``[host_slots, layers, 1, *state_shape]``.  A device slot
+    payload may be a dense permutation (for example the NPU NEXTN temporal
+    transpose); the Host payload is an opaque byte-exact backup of that physical
+    layout.  The call only enqueues H2D/D2H work; completion is ordered by the
+    caller's stream/event.
+    """
+    if not device_states:
+        raise ValueError("device_states must not be empty")
+    if len(device_states) != len(host_states):
+        raise ValueError(
+            "device_states and host_states must contain the same number of components"
+        )
+    for component, tensor in enumerate(host_states):
+        if tensor.device.type != "cpu":
+            raise ValueError(
+                f"host state component {component} must be on CPU, got {tensor.device}"
+            )
+        if not tensor.is_pinned():
+            raise ValueError(
+                f"host state component {component} must use pinned memory"
+            )
+    torch.ops.npu.transfer_state_dim_exchange(
+        list(device_states),
+        list(host_states),
+        device_indices,
+        host_indices,
+        direction.value,
+        layer_begin,
+        layer_count,
+        flags.value,
+    )
 
 
 def transfer_kv_dim_exchange(

--- a/tests/python/sgl_kernel_npu/test_transfer_state_dim_exchange.py
+++ b/tests/python/sgl_kernel_npu/test_transfer_state_dim_exchange.py
@@ -204,10 +204,10 @@ class TestTransferStateDimExchange(unittest.TestCase):
         with torch.npu.stream(stream):
             for layer_id in range(NUM_LAYERS):
                 transfer_state_per_layer_direct_pf_lf(
-                    device_states=[device],
-                    host_states=[host],
-                    device_indices=device_indices,
-                    host_indices=host_indices,
+                    src=host,
+                    dst=device[layer_id],
+                    src_indices=host_indices,
+                    dst_indices=device_indices,
                     layer_id=layer_id,
                 )
             event.record(stream)
@@ -250,29 +250,25 @@ class TestTransferStateDimExchange(unittest.TestCase):
         stream = torch.npu.Stream()
         event = torch.npu.Event()
         with torch.npu.stream(stream):
-            transfer_state_dim_exchange(
+            transfer_state_all_layer_direct_lf_pf(
                 device_states=[temporal],
                 host_states=[host],
                 device_indices=device_indices,
                 host_indices=host_indices,
-                direction=TransferDirection.D2H,
-                layer_begin=0,
-                layer_count=NUM_LAYERS,
             )
             event.record(stream)
         event.synchronize()
 
         temporal[:, device_indices] = 0
         with torch.npu.stream(stream):
-            transfer_state_dim_exchange(
-                device_states=[temporal],
-                host_states=[host],
-                device_indices=device_indices,
-                host_indices=host_indices,
-                direction=TransferDirection.H2D,
-                layer_begin=0,
-                layer_count=NUM_LAYERS,
-            )
+            for layer_id in range(NUM_LAYERS):
+                transfer_state_per_layer_direct_pf_lf(
+                    src=host,
+                    dst=temporal[layer_id],
+                    src_indices=host_indices,
+                    dst_indices=device_indices,
+                    layer_id=layer_id,
+                )
             event.record(stream)
         event.synchronize()
 

--- a/tests/python/sgl_kernel_npu/test_transfer_state_dim_exchange.py
+++ b/tests/python/sgl_kernel_npu/test_transfer_state_dim_exchange.py
@@ -179,7 +179,7 @@ class TestTransferStateDimExchange(unittest.TestCase):
             )
 
     def test_reject_pageable_host_memory(self):
-        with self.assertRaisesRegex(ValueError, "pinned memory"):
+        with self.assertRaisesRegex(RuntimeError, "pinned memory"):
             transfer_state_dim_exchange(
                 device_states=self.device_states,
                 host_states=[

--- a/tests/python/sgl_kernel_npu/test_transfer_state_dim_exchange.py
+++ b/tests/python/sgl_kernel_npu/test_transfer_state_dim_exchange.py
@@ -3,7 +3,9 @@ import unittest
 import torch
 from sgl_kernel_npu.kvcacheio import (
     TransferDirection,
+    transfer_state_all_layer_direct_lf_pf,
     transfer_state_dim_exchange,
+    transfer_state_per_layer_direct_pf_lf,
 )
 
 
@@ -177,6 +179,41 @@ class TestTransferStateDimExchange(unittest.TestCase):
                 device[:, device_indices],
                 expected[component][:, device_indices],
             )
+
+    def test_round_trip_single_component_with_per_layer_h2d(self):
+        """Match MambaPoolHost's component-wise D2H/H2D call pattern."""
+        device = self.device_states[0]
+        host = self.host_states[0]
+        device_indices = torch.tensor([1, 4, 6], dtype=torch.int64)
+        host_indices = torch.tensor([2, 5, 7], dtype=torch.int64)
+        expected = device[:, device_indices].clone()
+        stream = torch.npu.Stream()
+        event = torch.npu.Event()
+
+        with torch.npu.stream(stream):
+            transfer_state_all_layer_direct_lf_pf(
+                device_states=[device],
+                host_states=[host],
+                device_indices=device_indices,
+                host_indices=host_indices,
+            )
+            event.record(stream)
+        event.synchronize()
+
+        device[:, device_indices] = 0
+        with torch.npu.stream(stream):
+            for layer_id in range(NUM_LAYERS):
+                transfer_state_per_layer_direct_pf_lf(
+                    device_states=[device],
+                    host_states=[host],
+                    device_indices=device_indices,
+                    host_indices=host_indices,
+                    layer_id=layer_id,
+                )
+            event.record(stream)
+        event.synchronize()
+
+        torch.testing.assert_close(device[:, device_indices], expected)
 
     def test_reject_pageable_host_memory(self):
         with self.assertRaisesRegex(RuntimeError, "pinned memory"):

--- a/tests/python/sgl_kernel_npu/test_transfer_state_dim_exchange.py
+++ b/tests/python/sgl_kernel_npu/test_transfer_state_dim_exchange.py
@@ -1,0 +1,279 @@
+import unittest
+
+import torch
+from sgl_kernel_npu.kvcacheio import (
+    TransferDirection,
+    transfer_state_dim_exchange,
+)
+
+
+NUM_LAYERS = 3
+DEVICE_SLOTS = 8
+HOST_SLOTS = 10
+
+
+class TestTransferStateDimExchange(unittest.TestCase):
+    def setUp(self):
+        torch.npu.set_device(0)
+        temporal = torch.arange(
+            NUM_LAYERS * DEVICE_SLOTS * 2 * 4,
+            dtype=torch.float32,
+            device="npu",
+        ).reshape(NUM_LAYERS, DEVICE_SLOTS, 2, 4)
+        conv = (
+            torch.arange(
+                NUM_LAYERS * DEVICE_SLOTS * 3,
+                dtype=torch.float16,
+                device="npu",
+            ).reshape(NUM_LAYERS, DEVICE_SLOTS, 3)
+            + 7
+        )
+        self.device_states = [temporal, conv]
+        self.host_states = [
+            torch.zeros(
+                (HOST_SLOTS, NUM_LAYERS, 1, 2, 4),
+                dtype=torch.float32,
+                pin_memory=True,
+            ),
+            torch.zeros(
+                (HOST_SLOTS, NUM_LAYERS, 1, 3),
+                dtype=torch.float16,
+                pin_memory=True,
+            ),
+        ]
+
+    def _submit(self, **kwargs):
+        stream = torch.npu.Stream()
+        event = torch.npu.Event()
+        with torch.npu.stream(stream):
+            transfer_state_dim_exchange(
+                device_states=self.device_states,
+                host_states=self.host_states,
+                **kwargs,
+            )
+            event.record(stream)
+        event.synchronize()
+
+    def test_d2h_all_layers_non_contiguous_indices(self):
+        device_indices = torch.tensor([1, 4, 6], dtype=torch.int64)
+        host_indices = torch.tensor([2, 5, 7], dtype=torch.int64)
+        expected = [
+            state[:, device_indices].transpose(0, 1).cpu()
+            for state in self.device_states
+        ]
+
+        self._submit(
+            device_indices=device_indices,
+            host_indices=host_indices,
+            direction=TransferDirection.D2H,
+            layer_begin=0,
+            layer_count=NUM_LAYERS,
+        )
+
+        for component, host in enumerate(self.host_states):
+            torch.testing.assert_close(
+                host[host_indices, :, 0],
+                expected[component],
+            )
+
+    def test_h2d_single_layer_duplicate_host_source(self):
+        layer = 1
+        host_indices = torch.tensor([3, 3, 4], dtype=torch.int64)
+        device_indices = torch.tensor([0, 2, 5], dtype=torch.int64)
+        for component, host in enumerate(self.host_states):
+            payload = torch.arange(
+                host[3, layer, 0].numel(),
+                dtype=host.dtype,
+            ).reshape_as(host[3, layer, 0])
+            host[3, layer, 0].copy_(payload + component * 10)
+            host[4, layer, 0].copy_(payload + component * 20)
+        for device in self.device_states:
+            device.zero_()
+
+        self._submit(
+            device_indices=device_indices,
+            host_indices=host_indices,
+            direction=TransferDirection.H2D,
+            layer_begin=layer,
+            layer_count=1,
+        )
+
+        for component, device in enumerate(self.device_states):
+            torch.testing.assert_close(
+                device[layer, 0].cpu(),
+                self.host_states[component][3, layer, 0],
+            )
+            torch.testing.assert_close(
+                device[layer, 2].cpu(),
+                self.host_states[component][3, layer, 0],
+            )
+            torch.testing.assert_close(
+                device[layer, 5].cpu(),
+                self.host_states[component][4, layer, 0],
+            )
+
+    def test_h2d_preserves_mapping_order(self):
+        layer = 2
+        host_indices = torch.tensor([7, 2, 5], dtype=torch.int64)
+        device_indices = torch.tensor([1, 6, 3], dtype=torch.int64)
+        for component, host in enumerate(self.host_states):
+            for offset, host_index in enumerate(host_indices.tolist()):
+                host[host_index, layer, 0].fill_(component * 100 + offset + 1)
+        for device in self.device_states:
+            device.zero_()
+
+        self._submit(
+            device_indices=device_indices,
+            host_indices=host_indices,
+            direction=TransferDirection.H2D,
+            layer_begin=layer,
+            layer_count=1,
+        )
+
+        for component, device in enumerate(self.device_states):
+            for offset, device_index in enumerate(device_indices.tolist()):
+                torch.testing.assert_close(
+                    device[layer, device_index].cpu(),
+                    torch.full_like(
+                        device[layer, device_index].cpu(),
+                        component * 100 + offset + 1,
+                    ),
+                )
+
+    def test_empty_indices_are_a_noop(self):
+        expected = [state.clone() for state in self.device_states]
+        self._submit(
+            device_indices=torch.empty(0, dtype=torch.int64),
+            host_indices=torch.empty(0, dtype=torch.int64),
+            direction=TransferDirection.H2D,
+            layer_begin=0,
+            layer_count=1,
+        )
+        for component, device in enumerate(self.device_states):
+            torch.testing.assert_close(device, expected[component])
+
+    def test_round_trip_contiguous_run(self):
+        device_indices = torch.tensor([2, 3, 4], dtype=torch.int64)
+        host_indices = torch.tensor([6, 7, 8], dtype=torch.int64)
+        expected = [state.clone() for state in self.device_states]
+        self._submit(
+            device_indices=device_indices,
+            host_indices=host_indices,
+            direction=TransferDirection.D2H,
+            layer_begin=0,
+            layer_count=NUM_LAYERS,
+        )
+        for device in self.device_states:
+            device[:, device_indices] = 0
+        self._submit(
+            device_indices=device_indices,
+            host_indices=host_indices,
+            direction=TransferDirection.H2D,
+            layer_begin=0,
+            layer_count=NUM_LAYERS,
+        )
+        for component, device in enumerate(self.device_states):
+            torch.testing.assert_close(
+                device[:, device_indices],
+                expected[component][:, device_indices],
+            )
+
+    def test_reject_pageable_host_memory(self):
+        with self.assertRaisesRegex(ValueError, "pinned memory"):
+            transfer_state_dim_exchange(
+                device_states=self.device_states,
+                host_states=[
+                    torch.empty_like(tensor, pin_memory=False)
+                    for tensor in self.host_states
+                ],
+                device_indices=torch.tensor([0]),
+                host_indices=torch.tensor([0]),
+                direction=TransferDirection.H2D,
+                layer_begin=0,
+                layer_count=1,
+            )
+
+    def test_round_trip_dense_permuted_payload(self):
+        temporal_base = torch.arange(
+            NUM_LAYERS * DEVICE_SLOTS * 2 * 4,
+            dtype=torch.float32,
+            device="npu",
+        ).reshape(NUM_LAYERS, DEVICE_SLOTS, 2, 4)
+        temporal = temporal_base.transpose(-1, -2)
+        self.assertFalse(temporal.is_contiguous())
+        host = torch.zeros(
+            (HOST_SLOTS, NUM_LAYERS, 1, 4, 2),
+            dtype=torch.float32,
+            pin_memory=True,
+        )
+        device_indices = torch.tensor([1, 4, 6], dtype=torch.int64)
+        host_indices = torch.tensor([2, 5, 7], dtype=torch.int64)
+        expected = temporal[:, device_indices].clone()
+
+        stream = torch.npu.Stream()
+        event = torch.npu.Event()
+        with torch.npu.stream(stream):
+            transfer_state_dim_exchange(
+                device_states=[temporal],
+                host_states=[host],
+                device_indices=device_indices,
+                host_indices=host_indices,
+                direction=TransferDirection.D2H,
+                layer_begin=0,
+                layer_count=NUM_LAYERS,
+            )
+            event.record(stream)
+        event.synchronize()
+
+        temporal[:, device_indices] = 0
+        with torch.npu.stream(stream):
+            transfer_state_dim_exchange(
+                device_states=[temporal],
+                host_states=[host],
+                device_indices=device_indices,
+                host_indices=host_indices,
+                direction=TransferDirection.H2D,
+                layer_begin=0,
+                layer_count=NUM_LAYERS,
+            )
+            event.record(stream)
+        event.synchronize()
+
+        torch.testing.assert_close(temporal[:, device_indices], expected)
+
+    def test_reject_non_dense_component(self):
+        non_dense = self.device_states[0][..., ::2]
+        host = torch.zeros(
+            (HOST_SLOTS, NUM_LAYERS, 1, 2, 2),
+            dtype=torch.float32,
+            pin_memory=True,
+        )
+        with self.assertRaisesRegex(RuntimeError, "physically dense"):
+            transfer_state_dim_exchange(
+                device_states=[
+                    non_dense,
+                    self.device_states[1],
+                ],
+                host_states=[host, self.host_states[1]],
+                device_indices=torch.tensor([0]),
+                host_indices=torch.tensor([0]),
+                direction=TransferDirection.H2D,
+                layer_begin=0,
+                layer_count=1,
+            )
+
+    def test_reject_out_of_range_index(self):
+        with self.assertRaisesRegex(RuntimeError, "exceeds component slot count"):
+            transfer_state_dim_exchange(
+                device_states=self.device_states,
+                host_states=self.host_states,
+                device_indices=torch.tensor([DEVICE_SLOTS]),
+                host_indices=torch.tensor([0]),
+                direction=TransferDirection.H2D,
+                layer_begin=0,
+                layer_count=1,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/sgl_kernel_npu/test_transfer_state_direct.py
+++ b/tests/python/sgl_kernel_npu/test_transfer_state_direct.py
@@ -2,9 +2,7 @@ import unittest
 
 import torch
 from sgl_kernel_npu.kvcacheio import (
-    TransferDirection,
     transfer_state_all_layer_direct_lf_pf,
-    transfer_state_dim_exchange,
     transfer_state_per_layer_direct_pf_lf,
 )
 
@@ -14,7 +12,7 @@ DEVICE_SLOTS = 8
 HOST_SLOTS = 10
 
 
-class TestTransferStateDimExchange(unittest.TestCase):
+class TestTransferStateDirect(unittest.TestCase):
     def setUp(self):
         torch.npu.set_device(0)
         temporal = torch.arange(
@@ -44,15 +42,32 @@ class TestTransferStateDimExchange(unittest.TestCase):
             ),
         ]
 
-    def _submit(self, **kwargs):
+    def _submit_d2h(self, device_indices, host_indices):
         stream = torch.npu.Stream()
         event = torch.npu.Event()
         with torch.npu.stream(stream):
-            transfer_state_dim_exchange(
+            transfer_state_all_layer_direct_lf_pf(
                 device_states=self.device_states,
                 host_states=self.host_states,
-                **kwargs,
+                device_indices=device_indices,
+                host_indices=host_indices,
             )
+            event.record(stream)
+        event.synchronize()
+
+    def _submit_h2d(self, device_indices, host_indices, layers):
+        stream = torch.npu.Stream()
+        event = torch.npu.Event()
+        with torch.npu.stream(stream):
+            for layer_id in layers:
+                for device, host in zip(self.device_states, self.host_states):
+                    transfer_state_per_layer_direct_pf_lf(
+                        src=host,
+                        dst=device[layer_id],
+                        src_indices=host_indices,
+                        dst_indices=device_indices,
+                        layer_id=layer_id,
+                    )
             event.record(stream)
         event.synchronize()
 
@@ -64,13 +79,7 @@ class TestTransferStateDimExchange(unittest.TestCase):
             for state in self.device_states
         ]
 
-        self._submit(
-            device_indices=device_indices,
-            host_indices=host_indices,
-            direction=TransferDirection.D2H,
-            layer_begin=0,
-            layer_count=NUM_LAYERS,
-        )
+        self._submit_d2h(device_indices, host_indices)
 
         for component, host in enumerate(self.host_states):
             torch.testing.assert_close(
@@ -92,13 +101,7 @@ class TestTransferStateDimExchange(unittest.TestCase):
         for device in self.device_states:
             device.zero_()
 
-        self._submit(
-            device_indices=device_indices,
-            host_indices=host_indices,
-            direction=TransferDirection.H2D,
-            layer_begin=layer,
-            layer_count=1,
-        )
+        self._submit_h2d(device_indices, host_indices, [layer])
 
         for component, device in enumerate(self.device_states):
             torch.testing.assert_close(
@@ -124,13 +127,7 @@ class TestTransferStateDimExchange(unittest.TestCase):
         for device in self.device_states:
             device.zero_()
 
-        self._submit(
-            device_indices=device_indices,
-            host_indices=host_indices,
-            direction=TransferDirection.H2D,
-            layer_begin=layer,
-            layer_count=1,
-        )
+        self._submit_h2d(device_indices, host_indices, [layer])
 
         for component, device in enumerate(self.device_states):
             for offset, device_index in enumerate(device_indices.tolist()):
@@ -144,12 +141,10 @@ class TestTransferStateDimExchange(unittest.TestCase):
 
     def test_empty_indices_are_a_noop(self):
         expected = [state.clone() for state in self.device_states]
-        self._submit(
-            device_indices=torch.empty(0, dtype=torch.int64),
-            host_indices=torch.empty(0, dtype=torch.int64),
-            direction=TransferDirection.H2D,
-            layer_begin=0,
-            layer_count=1,
+        self._submit_h2d(
+            torch.empty(0, dtype=torch.int64),
+            torch.empty(0, dtype=torch.int64),
+            [0],
         )
         for component, device in enumerate(self.device_states):
             torch.testing.assert_close(device, expected[component])
@@ -158,22 +153,10 @@ class TestTransferStateDimExchange(unittest.TestCase):
         device_indices = torch.tensor([2, 3, 4], dtype=torch.int64)
         host_indices = torch.tensor([6, 7, 8], dtype=torch.int64)
         expected = [state.clone() for state in self.device_states]
-        self._submit(
-            device_indices=device_indices,
-            host_indices=host_indices,
-            direction=TransferDirection.D2H,
-            layer_begin=0,
-            layer_count=NUM_LAYERS,
-        )
+        self._submit_d2h(device_indices, host_indices)
         for device in self.device_states:
             device[:, device_indices] = 0
-        self._submit(
-            device_indices=device_indices,
-            host_indices=host_indices,
-            direction=TransferDirection.H2D,
-            layer_begin=0,
-            layer_count=NUM_LAYERS,
-        )
+        self._submit_h2d(device_indices, host_indices, range(NUM_LAYERS))
         for component, device in enumerate(self.device_states):
             torch.testing.assert_close(
                 device[:, device_indices],
@@ -181,7 +164,6 @@ class TestTransferStateDimExchange(unittest.TestCase):
             )
 
     def test_round_trip_single_component_with_per_layer_h2d(self):
-        """Match MambaPoolHost's component-wise D2H/H2D call pattern."""
         device = self.device_states[0]
         host = self.host_states[0]
         device_indices = torch.tensor([1, 4, 6], dtype=torch.int64)
@@ -217,17 +199,12 @@ class TestTransferStateDimExchange(unittest.TestCase):
 
     def test_reject_pageable_host_memory(self):
         with self.assertRaisesRegex(RuntimeError, "pinned memory"):
-            transfer_state_dim_exchange(
-                device_states=self.device_states,
-                host_states=[
-                    torch.empty_like(tensor, pin_memory=False)
-                    for tensor in self.host_states
-                ],
-                device_indices=torch.tensor([0]),
-                host_indices=torch.tensor([0]),
-                direction=TransferDirection.H2D,
-                layer_begin=0,
-                layer_count=1,
+            transfer_state_per_layer_direct_pf_lf(
+                src=torch.empty_like(self.host_states[0], pin_memory=False),
+                dst=self.device_states[0][0],
+                src_indices=torch.tensor([0]),
+                dst_indices=torch.tensor([0]),
+                layer_id=0,
             )
 
     def test_round_trip_dense_permuted_payload(self):
@@ -282,29 +259,22 @@ class TestTransferStateDimExchange(unittest.TestCase):
             pin_memory=True,
         )
         with self.assertRaisesRegex(RuntimeError, "physically dense"):
-            transfer_state_dim_exchange(
-                device_states=[
-                    non_dense,
-                    self.device_states[1],
-                ],
-                host_states=[host, self.host_states[1]],
-                device_indices=torch.tensor([0]),
-                host_indices=torch.tensor([0]),
-                direction=TransferDirection.H2D,
-                layer_begin=0,
-                layer_count=1,
+            transfer_state_per_layer_direct_pf_lf(
+                src=host,
+                dst=non_dense[0],
+                src_indices=torch.tensor([0]),
+                dst_indices=torch.tensor([0]),
+                layer_id=0,
             )
 
     def test_reject_out_of_range_index(self):
         with self.assertRaisesRegex(RuntimeError, "exceeds component slot count"):
-            transfer_state_dim_exchange(
-                device_states=self.device_states,
-                host_states=self.host_states,
-                device_indices=torch.tensor([DEVICE_SLOTS]),
-                host_indices=torch.tensor([0]),
-                direction=TransferDirection.H2D,
-                layer_begin=0,
-                layer_count=1,
+            transfer_state_per_layer_direct_pf_lf(
+                src=self.host_states[0],
+                dst=self.device_states[0][0],
+                src_indices=torch.tensor([0]),
+                dst_indices=torch.tensor([DEVICE_SLOTS]),
+                layer_id=0,
             )
 
 

--- a/tests/python/sgl_kernel_npu/test_transfer_state_direct.py
+++ b/tests/python/sgl_kernel_npu/test_transfer_state_direct.py
@@ -6,7 +6,6 @@ from sgl_kernel_npu.kvcacheio import (
     transfer_state_per_layer_direct_pf_lf,
 )
 
-
 NUM_LAYERS = 3
 DEVICE_SLOTS = 8
 HOST_SLOTS = 10


### PR DESCRIPTION
## Motivation

SGLang HiCache needs to move Mamba state sidecars between NPU and pinned Host memory. The existing Torch fallback materializes the state layout before each D2H/H2D copy, adding device-side reads and writes and making submission effectively synchronous.

## Modifications

- Add two layout-aware Mamba state transfer APIs that match SGLang's existing copy structure:
  - `transfer_state_per_layer_direct_pf_lf` loads one layer from page-first Host state to the current layer Device view.
  - `transfer_state_all_layer_direct_lf_pf` backs up all layer-first Device states to page-first Host state.
- Use `aclrtMemcpy2dAsync` on the caller's current Ascend stream.
- Support indexed slots, contiguous-run batching, empty transfers, and dense physical permutations used by NEXTN Mamba states.
- Validate tensor devices, dtypes, layouts, pinned Host memory, and index ranges before submitting DMA.
- Add Python bindings and NPU unit coverage for the two public APIs.

The public surface intentionally contains only the two operations used by SGLang. Direction dispatch and layer-range parameters are not exposed as a separate generic API.

## Validation

Before the final API-only cleanup:

- Full kernels-only build passed on Ascend CANN 9.0.
- NPU state-transfer unit tests passed.
- Coverage included non-contiguous indices, duplicate Host sources, mapping order, empty transfers, round trips, dense transposed/NEXTN layouts, and validation failures.

After consolidating the public APIs:

- Python compilation passed.
- `git diff --check` passed.
- Tests now exercise the production D2H-all-layer and H2D-per-layer call pattern directly.
- A fresh NPU build and device test are still required because the public operator registration changed.

## Performance

Isolated completed-transfer measurements used 30 layers, BF16 temporal state `[16, 128, 128]`, conv state `[6, 4096]`, five warmups, and 20 measured iterations. Each slot is 16.41 MiB.

| Payload | Direction | Torch fallback | Native operator | Speedup |
| --- | --- | ---: | ---: | ---: |
| 16.41 MiB, 1 slot | D2H | 5.376 ms | 0.556 ms | 9.66x |
| 16.41 MiB, 1 slot | H2D | 66.692 ms | 1.799 ms | 37.08x |
| 32.81 MiB, 2 slots | D2H | 5.329 ms | 0.943 ms | 5.65x |
| 32.81 MiB, 2 slots | H2D | 169.047 ms | 1.906 ms | 88.69x |
| 65.63 MiB, 4 slots | D2H | 7.146 ms | 1.826 ms | 3.91x |
| 65.63 MiB, 4 slots | H2D | 273.673 ms | 1.985 ms | 137.84x |

These are isolated transfer measurements, not whole-model latency. They predate the final interface-only cleanup; the underlying ACL transfer implementation is unchanged.

A forced Host/L2 serving A/B used five alternating repeats, 16 prompts, 16K input tokens, 512 output tokens, concurrency 4, 16/16 pure Host hits, 261120 cached Host tokens, and zero Device hits in every run.

| Metric | Torch fallback | Native operator | Paired improvement |
| --- | ---: | ---: | ---: |
| Wall time | 29.868 s | 28.884 s | 3.30% |
| Mean TTFT | 669.44 ms | 589.07 ms | 11.95% |
| Mean TPOT | 12.796 ms | 12.342 ms | 3.56% |
| Mean E2E | 7208.36 ms | 6895.76 ms | 4.34% |
| Output throughput | 274.32 tok/s | 283.72 tok/s | 3.42% |

All five paired wall-time samples favored the native path. The smaller serving gain is expected because state transfer is only one part of long-context prefill and decode.

## Related SGLang Change

- https://github.com/sgl-project/sglang/pull/32500

## Checklist

- [x] Keep existing KV-cache transfer paths unchanged.
- [x] Preserve a Torch fallback in the SGLang integration.
- [x] Validate unsupported layouts before DMA submission.
- [x] Add unit coverage for both transfer directions.
- [ ] Rebuild and rerun the NPU tests after the final public-API cleanup.