### PR TITLE
fix(build): skip attentions build for DeepEP targets

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,9 +6,6 @@ BUILD_DEEPEP_MODULE="ON"
 BUILD_DEEPEP_OPS="ON"
 BUILD_KERNELS_MODULE="ON"
 BUILD_MEMORY_SAVER_MODULE="ON"
-
-ONLY_BUILD_DEEPEP_ADAPTER_MODULE="OFF"
-ONLY_BUILD_DEEPEP_KERNELs_MODULE="OFF"
 ONLY_BUILD_MEMORY_SAVER_MODULE="OFF"
 
 DEBUG_MODE="OFF"
@@ -19,27 +16,18 @@ while getopts ":a:hd" opt; do
             BUILD_DEEPEP_MODULE="OFF"
             BUILD_KERNELS_MODULE="OFF"
             BUILD_MEMORY_SAVER_MODULE="OFF"
+            BUILD_ATTENTIONS_MODULE="OFF"
             case "$OPTARG" in
                 deepep )
-                    BUILD_ATTENTIONS_MODULE="OFF"
                     BUILD_DEEPEP_MODULE="ON"
                     BUILD_DEEPEP_OPS="ON"
                     ;;
                 deepep2 )
-                    BUILD_ATTENTIONS_MODULE="OFF"
                     BUILD_DEEPEP_MODULE="ON"
                     BUILD_DEEPEP_OPS="OFF"
                     ;;
                 kernels )
                     BUILD_KERNELS_MODULE="ON"
-                    ;;
-                deepep-adapter )
-                    BUILD_DEEPEP_MODULE="ON"
-                    ONLY_BUILD_DEEPEP_ADAPTER_MODULE="ON"
-                    ;;
-                deepep-kernels )
-                    BUILD_DEEPEP_MODULE="ON"
-                    ONLY_BUILD_DEEPEP_KERNELs_MODULE="ON"
                     ;;
                 memory-saver )
                     BUILD_MEMORY_SAVER_MODULE="ON"
@@ -47,7 +35,7 @@ while getopts ":a:hd" opt; do
                     ;;
                 * )
                     echo "Error: Invalid Value"
-                    echo "Allowed value: deepep|kernels|deepep-adapter|deepep-kernels|memory-saver"
+                    echo "Allowed value: deepep|deepep2|kernels|memory-saver"
                     exit 1
                     ;;
             esac
@@ -60,9 +48,8 @@ while getopts ":a:hd" opt; do
             echo "Use './build.sh -a <target>' to build specific parts of the project."
             echo "    <target> can be:"
             echo "    deepep            Only build deep_ep."
+            echo "    deepep2           Only build deep_ep for A2."
             echo "    kernels           Only build sgl_kernel_npu."
-            echo "    deepep-adapter    Only build deepep adapter layer and use old build of deepep kernels."
-            echo "    deepep-kernels    Only build deepep kernels and use old build of deepep adapter layer."
             echo "    memory-saver      Only build torch_memory_saver (under contrib)."
             exit 1
             ;;
@@ -153,7 +140,6 @@ COMPILE_OPTIONS=""
 
 function build_kernels()
 {
-    if [[ "$ONLY_BUILD_DEEPEP_KERNELs_MODULE" == "ON" ]]; then return 0; fi
     if [[ "$ONLY_BUILD_MEMORY_SAVER_MODULE" == "ON" ]]; then return 0; fi
 
     CMAKE_DIR=""
@@ -183,7 +169,6 @@ function build_kernels()
 
 function build_deepep_kernels()
 {
-    if [[ "$ONLY_BUILD_DEEPEP_ADAPTER_MODULE" == "ON" ]]; then return 0; fi
     if [[ "$BUILD_DEEPEP_MODULE" != "ON" ]]; then return 0; fi
 
     if [[ "$BUILD_DEEPEP_OPS" == "ON" ]]; then
@@ -302,16 +287,15 @@ function main()
     create_deepep_cmake
     build_kernels
     build_deepep_kernels
-    build_attentions_kernels
+    if [[ "$BUILD_ATTENTIONS_MODULE" == "ON" ]]; then
+        build_attentions_kernels
+    fi
     if pip3 show wheel;then
         echo "wheel has been installed"
     else
         pip3 install wheel==0.45.1
     fi
     build_memory_saver
-    if [[ "$BUILD_ATTENTIONS_MODULE" == "ON" ]]; then
-        build_attentions_kernels
-    fi
     if [[ "$BUILD_DEEPEP_MODULE" == "ON" ]]; then
         make_deepep_package
     fi

--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,8 @@ readonly OUTPUT_DIR="${PROJECT_ROOT}/output"
 readonly BUILD_DIR="${PROJECT_ROOT}/build"
 readonly DEFAULT_ASCEND_ROOT="/usr/local/Ascend/ascend-toolkit"
 
+export VERSION="${VERSION:-1.0.0}"
+
 BUILD_TARGET="all"
 REQUESTED_SOC_VERSION=""
 SOC_VERSION=""

--- a/build.sh
+++ b/build.sh
@@ -162,7 +162,7 @@ function detect_deepep_soc_version()
         return
     fi
 
-    die "Cannot determine whether the device is A3+ or A5 from npu-smi output."
+    die "Cannot determine the device type (A2/A3/A5) from npu-smi output."
 }
 
 function configure_soc_version()

--- a/build.sh
+++ b/build.sh
@@ -274,7 +274,6 @@ function make_sgl_kernel_npu_package()
 
 function build_attentions_kernels()
 {
-    if [[ "$BUILD_ATTENTIONS_MODULE" != "ON" ]]; then return 0; fi
     CUSTOM_OPP_DIR="${CURRENT_DIR}/python/attentions/attentions"
     KERNEL_DIR="csrc/attentions/build"
 
@@ -310,6 +309,9 @@ function main()
         pip3 install wheel==0.45.1
     fi
     build_memory_saver
+    if [[ "$BUILD_ATTENTIONS_MODULE" == "ON" ]]; then
+        build_attentions_kernels
+    fi
     if [[ "$BUILD_DEEPEP_MODULE" == "ON" ]]; then
         make_deepep_package
     fi

--- a/build.sh
+++ b/build.sh
@@ -34,21 +34,21 @@ function print_help()
 {
     cat <<'EOF'
 Usage:
-    ./build.sh                                  Build all modules for A3+.
-    ./build.sh -a deepep [SOC_VERSION]          Build deep_ep; auto-detect A2, A3+, or A5.
+    ./build.sh                                  Build all modules for A3.
+    ./build.sh -a deepep [SOC_VERSION]          Build deep_ep; auto-detect A2, A3, or A5.
     ./build.sh -a deepep2 [SOC_VERSION]         Build deep_ep for A2 (compatible alias).
     ./build.sh -a kernels [SOC_VERSION]         Build sgl_kernel_npu.
     ./build.sh -a memory-saver                  Build torch_memory_saver.
 
 Targets:
-    deepep         Build deep_ep and auto-select ops (A3+/A5) or ops2 (A2).
+    deepep         Build deep_ep and auto-select ops (A3/A5) or ops2 (A2).
     deepep2        Build deep_ep with ops2 for A2 (compatible alias).
     kernels        Build sgl_kernel_npu only.
     memory-saver   Build torch_memory_saver only.
 
 Chip mapping:
     A2   : ./build.sh -a deepep               # Auto-detected as Ascend910B1/ops2
-    A3+  : ./build.sh -a deepep               # Auto-detected as Ascend910_9382
+    A3  : ./build.sh -a deepep               # Auto-detected as Ascend910_9382
     A5   : ./build.sh -a deepep               # Auto-detected as Ascend950
 
 Compatible commands:
@@ -128,7 +128,7 @@ function detect_deepep_soc_version()
 {
     local board_info=""
 
-    # Build containers may not expose an NPU. Preserve the existing A3+ default
+    # Build containers may not expose an NPU. Preserve the existing A3 default
     # in that case; callers can still provide Ascend950 explicitly.
     if ! command -v npu-smi >/dev/null 2>&1; then
         SOC_VERSION="Ascend910_9382"
@@ -158,7 +158,7 @@ function detect_deepep_soc_version()
     if printf '%s\n' "$board_info" |
         grep -Eiq '^[[:space:]]*Chip Name[[:space:]]*:[[:space:]]*Ascend910'; then
         SOC_VERSION="Ascend910_9382"
-        echo "Detected A3+: DeepEP SOC_VERSION=$SOC_VERSION"
+        echo "Detected A3: DeepEP SOC_VERSION=$SOC_VERSION"
         return
     fi
 
@@ -190,7 +190,7 @@ function configure_soc_version()
                     DEEPEP_VARIANT="deepep"
                     ;;
                 * )
-                    die "Target 'deepep' supports only Ascend910B1 (A2), Ascend910_9382 (A3+), or Ascend950 (A5)."
+                    die "Target 'deepep' supports only Ascend910B1 (A2), Ascend910_9382 (A3), or Ascend950 (A5)."
                     ;;
             esac
             CMAKE_SOC_VERSION="Ascend910_9382"
@@ -354,7 +354,7 @@ function prepare_deepep_build()
 # - BUILD_KERNELS_MODULE=ON: the sgl_kernel_npu host library and AscendC kernels
 #
 # Ascend950 is a DeepEP build alias, but it is not accepted by AscendC's
-# host_config.cmake. Keep the top-level CMake SOC on the supported A3+ value;
+# host_config.cmake. Keep the top-level CMake SOC on the supported A3 value;
 # A5 host differences are enabled separately through DEEPEP_IS_A5_BUILD.
 function build_cmake_modules()
 {
@@ -489,6 +489,7 @@ function main()
     setup_ascend_environment
     mkdir -p "$OUTPUT_DIR"
     echo "Output directory: $OUTPUT_DIR"
+    echo "CANN path: $ASCEND_HOME_PATH"
 
     # Build native components first. All module selection is controlled here.
     if [[ "$BUILD_DEEPEP_MODULE" == "ON" ]]; then

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,7 @@ readonly DEFAULT_ASCEND_ROOT="/usr/local/Ascend/ascend-toolkit"
 BUILD_TARGET="all"
 REQUESTED_SOC_VERSION=""
 SOC_VERSION=""
+CMAKE_SOC_VERSION="Ascend910_9382"
 DEEPEP_VARIANT="deepep"
 DEEPEP_IS_A5_BUILD="OFF"
 
@@ -130,7 +131,8 @@ function configure_soc_version()
 
     echo "Build target: $BUILD_TARGET"
     echo "DeepEP variant: $DEEPEP_VARIANT"
-    echo "SOC_VERSION: $SOC_VERSION"
+    echo "DeepEP SOC_VERSION: $SOC_VERSION"
+    echo "CMake SOC_VERSION: $CMAKE_SOC_VERSION"
 }
 
 function resolve_ascend_home()
@@ -254,13 +256,17 @@ function prepare_deepep_build()
 # The top-level CMake project builds two independently controlled components:
 # - BUILD_DEEPEP_MODULE=ON: the DeepEP host/pybind adapter (deep_ep_cpp)
 # - BUILD_KERNELS_MODULE=ON: the sgl_kernel_npu host library and AscendC kernels
+#
+# Ascend950 is a DeepEP build alias, but it is not accepted by AscendC's
+# host_config.cmake. Keep the top-level CMake SOC on the supported A3+ value;
+# A5 host differences are enabled separately through DEEPEP_IS_A5_BUILD.
 function build_cmake_modules()
 {
     local cmake_args=(
         "-DCMAKE_INSTALL_PREFIX=$OUTPUT_DIR"
         "-DASCEND_HOME_PATH=$ASCEND_HOME_PATH"
         "-DASCEND_INCLUDE_DIR=$ASCEND_INCLUDE_DIR"
-        "-DSOC_VERSION=$SOC_VERSION"
+        "-DSOC_VERSION=$CMAKE_SOC_VERSION"
         "-DDEEPEP_IS_A5_BUILD=$DEEPEP_IS_A5_BUILD"
         "-DBUILD_DEEPEP_MODULE=$BUILD_DEEPEP_MODULE"
         "-DBUILD_KERNELS_MODULE=$BUILD_KERNELS_MODULE"

--- a/build.sh
+++ b/build.sh
@@ -35,21 +35,25 @@ function print_help()
     cat <<'EOF'
 Usage:
     ./build.sh                                  Build all modules for A3+.
-    ./build.sh -a deepep [SOC_VERSION]          Build deep_ep for A3+ or A5.
-    ./build.sh -a deepep2 [SOC_VERSION]         Build deep_ep for A2.
+    ./build.sh -a deepep [SOC_VERSION]          Build deep_ep; auto-detect A2, A3+, or A5.
+    ./build.sh -a deepep2 [SOC_VERSION]         Build deep_ep for A2 (compatible alias).
     ./build.sh -a kernels [SOC_VERSION]         Build sgl_kernel_npu.
     ./build.sh -a memory-saver                  Build torch_memory_saver.
 
 Targets:
-    deepep         Build deep_ep with ops (A3+ by default; use Ascend950 for A5).
-    deepep2        Build deep_ep with ops2 (A2 by default).
+    deepep         Build deep_ep and auto-select ops (A3+/A5) or ops2 (A2).
+    deepep2        Build deep_ep with ops2 for A2 (compatible alias).
     kernels        Build sgl_kernel_npu only.
     memory-saver   Build torch_memory_saver only.
 
 Chip mapping:
-    A2   : ./build.sh -a deepep2              # Ascend910B1
-    A3+  : ./build.sh -a deepep               # Ascend910_9382
-    A5   : ./build.sh -a deepep Ascend950
+    A2   : ./build.sh -a deepep               # Auto-detected as Ascend910B1/ops2
+    A3+  : ./build.sh -a deepep               # Auto-detected as Ascend910_9382
+    A5   : ./build.sh -a deepep               # Auto-detected as Ascend950
+
+Compatible commands:
+    ./build.sh -a deepep2                     # Explicit A2 build
+    ./build.sh -a deepep Ascend950            # Explicit A5 build
 
 Options:
     -d             Enable debug logging.
@@ -120,6 +124,47 @@ function configure_build_target()
     esac
 }
 
+function detect_deepep_soc_version()
+{
+    local board_info=""
+
+    # Build containers may not expose an NPU. Preserve the existing A3+ default
+    # in that case; callers can still provide Ascend950 explicitly.
+    if ! command -v npu-smi >/dev/null 2>&1; then
+        SOC_VERSION="Ascend910_9382"
+        echo "Cannot find npu-smi; defaulting DeepEP SOC_VERSION to $SOC_VERSION"
+        return
+    fi
+
+    # A5 supports the device-level query and reports Chip Name as Ascend950*.
+    board_info="$(npu-smi info -t board -i 0 2>/dev/null || true)"
+    if printf '%s\n' "$board_info" |
+        grep -Eiq '^[[:space:]]*Chip Name[[:space:]]*:[[:space:]]*Ascend950'; then
+        SOC_VERSION="Ascend950"
+        echo "Detected A5: DeepEP SOC_VERSION=$SOC_VERSION"
+        return
+    fi
+
+    # A2 and A3 require a chip ID. Check A2 first because it reports 910B*,
+    # while A3 reports Ascend910.
+    board_info="$(npu-smi info -t board -i 0 -c 0 2>/dev/null || true)"
+    if printf '%s\n' "$board_info" |
+        grep -Eiq '^[[:space:]]*Chip Name[[:space:]]*:[[:space:]]*910B'; then
+        SOC_VERSION="Ascend910B1"
+        echo "Detected A2: DeepEP SOC_VERSION=$SOC_VERSION"
+        return
+    fi
+
+    if printf '%s\n' "$board_info" |
+        grep -Eiq '^[[:space:]]*Chip Name[[:space:]]*:[[:space:]]*Ascend910'; then
+        SOC_VERSION="Ascend910_9382"
+        echo "Detected A3+: DeepEP SOC_VERSION=$SOC_VERSION"
+        return
+    fi
+
+    die "Cannot determine whether the device is A3+ or A5 from npu-smi output."
+}
+
 function configure_soc_version()
 {
     case "$BUILD_TARGET" in
@@ -131,10 +176,23 @@ function configure_soc_version()
             CMAKE_SOC_VERSION="Ascend910_9382"
             ;;
         deepep )
-            SOC_VERSION="${REQUESTED_SOC_VERSION:-Ascend910_9382}"
-            if [[ "$SOC_VERSION" != "Ascend910_9382" && "$SOC_VERSION" != "Ascend950" ]]; then
-                die "Target 'deepep' supports only Ascend910_9382 (A3+) or Ascend950 (A5)."
+            if [[ -n "$REQUESTED_SOC_VERSION" ]]; then
+                SOC_VERSION="$REQUESTED_SOC_VERSION"
+            else
+                detect_deepep_soc_version
             fi
+
+            case "$SOC_VERSION" in
+                Ascend910B1 )
+                    DEEPEP_VARIANT="deepep2"
+                    ;;
+                Ascend910_9382 | Ascend950 )
+                    DEEPEP_VARIANT="deepep"
+                    ;;
+                * )
+                    die "Target 'deepep' supports only Ascend910B1 (A2), Ascend910_9382 (A3+), or Ascend950 (A5)."
+                    ;;
+            esac
             CMAKE_SOC_VERSION="Ascend910_9382"
             ;;
         deepep2 )

--- a/build.sh
+++ b/build.sh
@@ -32,8 +32,11 @@ function print_help()
 {
     cat <<'EOF'
 Usage:
-    ./build.sh                              Build all modules for A3+.
-    ./build.sh -a <target> [SOC_VERSION]    Build one target.
+    ./build.sh                                  Build all modules for A3+.
+    ./build.sh -a deepep [SOC_VERSION]          Build deep_ep for A3+ or A5.
+    ./build.sh -a deepep2 [SOC_VERSION]         Build deep_ep for A2.
+    ./build.sh -a kernels [SOC_VERSION]         Build sgl_kernel_npu.
+    ./build.sh -a memory-saver                  Build torch_memory_saver.
 
 Targets:
     deepep         Build deep_ep with ops (A3+ by default; use Ascend950 for A5).
@@ -117,22 +120,55 @@ function configure_build_target()
 
 function configure_soc_version()
 {
-    if [[ -n "$REQUESTED_SOC_VERSION" ]]; then
-        SOC_VERSION="$REQUESTED_SOC_VERSION"
-    elif [[ "$DEEPEP_VARIANT" == "deepep2" ]]; then
-        SOC_VERSION="Ascend910B1"
-    else
-        SOC_VERSION="Ascend910_9382"
-    fi
+    case "$BUILD_TARGET" in
+        all )
+            if [[ -n "$REQUESTED_SOC_VERSION" ]]; then
+                die "The default full build does not accept SOC_VERSION; use a specific -a target."
+            fi
+            SOC_VERSION="Ascend910_9382"
+            CMAKE_SOC_VERSION="Ascend910_9382"
+            ;;
+        deepep )
+            SOC_VERSION="${REQUESTED_SOC_VERSION:-Ascend910_9382}"
+            if [[ "$SOC_VERSION" != "Ascend910_9382" && "$SOC_VERSION" != "Ascend950" ]]; then
+                die "Target 'deepep' supports only Ascend910_9382 (A3+) or Ascend950 (A5)."
+            fi
+            CMAKE_SOC_VERSION="Ascend910_9382"
+            ;;
+        deepep2 )
+            SOC_VERSION="${REQUESTED_SOC_VERSION:-Ascend910B1}"
+            if [[ "$SOC_VERSION" != "Ascend910B1" ]]; then
+                die "Target 'deepep2' supports only Ascend910B1 (A2)."
+            fi
+            CMAKE_SOC_VERSION="Ascend910_9382"
+            ;;
+        kernels )
+            SOC_VERSION="${REQUESTED_SOC_VERSION:-Ascend910_9382}"
+            if [[ "$SOC_VERSION" == "Ascend950" ]]; then
+                die "Target 'kernels' requires an AscendC-supported SoC name instead of the DeepEP alias Ascend950."
+            fi
+            CMAKE_SOC_VERSION="$SOC_VERSION"
+            ;;
+        memory-saver )
+            if [[ -n "$REQUESTED_SOC_VERSION" ]]; then
+                die "Target 'memory-saver' does not accept SOC_VERSION."
+            fi
+            SOC_VERSION=""
+            ;;
+    esac
 
     if [[ "$SOC_VERSION" == "Ascend950" ]]; then
         DEEPEP_IS_A5_BUILD="ON"
     fi
 
     echo "Build target: $BUILD_TARGET"
-    echo "DeepEP variant: $DEEPEP_VARIANT"
-    echo "DeepEP SOC_VERSION: $SOC_VERSION"
-    echo "CMake SOC_VERSION: $CMAKE_SOC_VERSION"
+    if [[ "$BUILD_DEEPEP_MODULE" == "ON" ]]; then
+        echo "DeepEP variant: $DEEPEP_VARIANT"
+        echo "DeepEP SOC_VERSION: $SOC_VERSION"
+    fi
+    if [[ "$BUILD_DEEPEP_MODULE" == "ON" || "$BUILD_KERNELS_MODULE" == "ON" ]]; then
+        echo "CMake SOC_VERSION: $CMAKE_SOC_VERSION"
+    fi
 }
 
 function resolve_ascend_home()

--- a/build.sh
+++ b/build.sh
@@ -1,301 +1,410 @@
 #!/bin/bash
 set -e
 
-BUILD_ATTENTIONS_MODULE="ON"
-BUILD_DEEPEP_MODULE="ON"
-BUILD_DEEPEP_OPS="ON"
-BUILD_KERNELS_MODULE="ON"
-BUILD_MEMORY_SAVER_MODULE="ON"
-ONLY_BUILD_MEMORY_SAVER_MODULE="OFF"
+readonly PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly OUTPUT_DIR="${PROJECT_ROOT}/output"
+readonly BUILD_DIR="${PROJECT_ROOT}/build"
+readonly DEFAULT_ASCEND_ROOT="/usr/local/Ascend/ascend-toolkit"
+
+BUILD_TARGET="all"
+REQUESTED_SOC_VERSION=""
+SOC_VERSION=""
+DEEPEP_VARIANT="deepep"
+DEEPEP_IS_A5_BUILD="OFF"
+
+BUILD_ATTENTIONS_MODULE="OFF"
+BUILD_DEEPEP_MODULE="OFF"
+BUILD_KERNELS_MODULE="OFF"
+BUILD_MEMORY_SAVER_MODULE="OFF"
 
 DEBUG_MODE="OFF"
+ASC_CMAKE_DIR=""
+ASCEND_INCLUDE_DIR=""
 
-while getopts ":a:hd" opt; do
-    case ${opt} in
-        a )
-            BUILD_DEEPEP_MODULE="OFF"
-            BUILD_KERNELS_MODULE="OFF"
-            BUILD_MEMORY_SAVER_MODULE="OFF"
-            BUILD_ATTENTIONS_MODULE="OFF"
-            case "$OPTARG" in
-                deepep )
-                    BUILD_DEEPEP_MODULE="ON"
-                    BUILD_DEEPEP_OPS="ON"
-                    ;;
-                deepep2 )
-                    BUILD_DEEPEP_MODULE="ON"
-                    BUILD_DEEPEP_OPS="OFF"
-                    ;;
-                kernels )
-                    BUILD_KERNELS_MODULE="ON"
-                    ;;
-                memory-saver )
-                    BUILD_MEMORY_SAVER_MODULE="ON"
-                    ONLY_BUILD_MEMORY_SAVER_MODULE="ON"
-                    ;;
-                * )
-                    echo "Error: Invalid Value"
-                    echo "Allowed value: deepep|deepep2|kernels|memory-saver"
-                    exit 1
-                    ;;
-            esac
+function die()
+{
+    echo "Error: $*" 1>&2
+    exit 1
+}
+
+function print_help()
+{
+    cat <<'EOF'
+Usage:
+    ./build.sh                              Build all modules for A3+.
+    ./build.sh -a <target> [SOC_VERSION]    Build one target.
+
+Targets:
+    deepep         Build deep_ep with ops (A3+ by default; use Ascend950 for A5).
+    deepep2        Build deep_ep with ops2 (A2 by default).
+    kernels        Build sgl_kernel_npu only.
+    memory-saver   Build torch_memory_saver only.
+
+Chip mapping:
+    A2   : ./build.sh -a deepep2              # Ascend910B1
+    A3+  : ./build.sh -a deepep               # Ascend910_9382
+    A5   : ./build.sh -a deepep Ascend950
+
+Options:
+    -d             Enable debug logging.
+    -h             Show this help.
+EOF
+}
+
+function parse_arguments()
+{
+    local opt
+    OPTIND=1
+
+    while getopts ":a:hd" opt; do
+        case "$opt" in
+            a )
+                BUILD_TARGET="$OPTARG"
+                ;;
+            d )
+                DEBUG_MODE="ON"
+                ;;
+            h )
+                print_help
+                exit 0
+                ;;
+            \? )
+                die "Unknown flag: -$OPTARG. Run './build.sh -h' for more information."
+                ;;
+            : )
+                die "-$OPTARG requires a value. Run './build.sh -h' for more information."
+                ;;
+        esac
+    done
+
+    shift $((OPTIND - 1))
+    if [[ "$#" -gt 1 ]]; then
+        die "Expected at most one SOC_VERSION argument."
+    fi
+    REQUESTED_SOC_VERSION="${1:-}"
+}
+
+function configure_build_target()
+{
+    case "$BUILD_TARGET" in
+        all )
+            BUILD_ATTENTIONS_MODULE="ON"
+            BUILD_DEEPEP_MODULE="ON"
+            BUILD_KERNELS_MODULE="ON"
+            BUILD_MEMORY_SAVER_MODULE="ON"
+            DEEPEP_VARIANT="deepep"
             ;;
-        d )
-            DEBUG_MODE="ON"
+        deepep )
+            BUILD_DEEPEP_MODULE="ON"
+            DEEPEP_VARIANT="deepep"
             ;;
-        h )
-            echo "Use './build.sh' build all modules."
-            echo "Use './build.sh -a <target>' to build specific parts of the project."
-            echo "    <target> can be:"
-            echo "    deepep            Only build deep_ep."
-            echo "    deepep2           Only build deep_ep for A2."
-            echo "    kernels           Only build sgl_kernel_npu."
-            echo "    memory-saver      Only build torch_memory_saver (under contrib)."
-            exit 1
+        deepep2 )
+            BUILD_DEEPEP_MODULE="ON"
+            DEEPEP_VARIANT="deepep2"
             ;;
-        \? )
-            echo "Error: unknown flag: -$OPTARG" 1>&2
-            echo "Run './build.sh -h' for more information."
-            exit 1
+        kernels )
+            BUILD_KERNELS_MODULE="ON"
             ;;
-        : )
-            echo "Error: -$OPTARG requires a value" 1>&2
-            echo "Run './build.sh -h' for more information."
-            exit 1
+        memory-saver )
+            BUILD_MEMORY_SAVER_MODULE="ON"
+            ;;
+        * )
+            die "Invalid target '$BUILD_TARGET'. Allowed values: deepep|deepep2|kernels|memory-saver"
             ;;
     esac
-done
+}
 
-shift $((OPTIND -1))
-
-
-export DEBUG_MODE=$DEBUG_MODE
-
-# Chip mapping:
-# - deepep  → A3+ (Ascend910_9382)
-# - deepep2 → A2  (Ascend910B1)
-
-if [[ "$BUILD_DEEPEP_OPS" == "ON" ]]; then
-    SOC_VERSION="${1:-Ascend910_9382}"
-else
-    SOC_VERSION="${1:-Ascend910B1}"
-fi
-
-echo "Use SOC_VERSION: $SOC_VERSION"
-
-echo "=== Fixing ASCConfig for CANN 8.3 / A2 ==="
-
-# Prioritize using the ASCEND_HOME_PATH environment variable
-# If empty or points to latest, automatically select the actual installation version
-if [ -z "$ASCEND_HOME_PATH" ] || [[ "$ASCEND_HOME_PATH" == *"/latest" ]]; then
-    REAL_ASCEND_PATH=$(ls -d /usr/local/Ascend/ascend-toolkit/* \
-        | grep -v latest \
-        | sort -V \
-        | tail -1)
-
-    if [ -n "$REAL_ASCEND_PATH" ]; then
-        export ASCEND_HOME_PATH="$REAL_ASCEND_PATH"
+function configure_soc_version()
+{
+    if [[ -n "$REQUESTED_SOC_VERSION" ]]; then
+        SOC_VERSION="$REQUESTED_SOC_VERSION"
+    elif [[ "$DEEPEP_VARIANT" == "deepep2" ]]; then
+        SOC_VERSION="Ascend910B1"
     else
-        echo "Error: Cannot find Ascend toolkit installation"
-        exit 1
+        SOC_VERSION="Ascend910_9382"
     fi
-fi
 
-echo "using ASCEND_HOME_PATH: $ASCEND_HOME_PATH"
+    if [[ "$SOC_VERSION" == "Ascend950" ]]; then
+        DEEPEP_IS_A5_BUILD="ON"
+    fi
 
-# 主动查找并设置 ASCConfig.cmake 路径
-ASC_CONFIG_CMAKE=$(find "$ASCEND_HOME_PATH" -name "ASCConfig.cmake" -type f 2>/dev/null | head -n1)
-if [ -n "$ASC_CONFIG_CMAKE" ]; then
-    ASC_CMAKE_DIR=$(dirname "$ASC_CONFIG_CMAKE")
-    echo "Found ASCConfig.cmake at: $ASC_CONFIG_CMAKE"
-    export CMAKE_PREFIX_PATH="$ASC_CMAKE_DIR:$CMAKE_PREFIX_PATH"
-    export ASC_DIR="$ASC_CMAKE_DIR"
-    echo "Set CMAKE_PREFIX_PATH and ASC_DIR successfully"
-else
-    echo "Warning: Cannot find ASCConfig.cmake"
-fi
-
-# Get Current CANN Toolkit Installation Path
-if [ -n "$ASCEND_HOME_PATH" ]; then
-    _CANN_TOOLKIT_INSTALL_PATH="$ASCEND_HOME_PATH"
-else
-    _CANN_TOOLKIT_INSTALL_PATH=$(cat /etc/Ascend/ascend_cann_install.info | grep "Toolkit_InstallPath" | awk -F'=' '{print $2}')
-fi
-source ${_CANN_TOOLKIT_INSTALL_PATH}/set_env.sh
-echo -e "\e[1;32mDetected CANN Toolkit Installation Path: ${_CANN_TOOLKIT_INSTALL_PATH}\e[0m"
-echo -e "\e[1;33mDouble Checking Environment Variables:\e[0m"
-echo -e "\e[1;32mASCEND_HOME_PATH: ${ASCEND_HOME_PATH}\e[0m"
-echo -e "\e[1;32mASCEND_TOOLKIT_HOME: ${ASCEND_TOOLKIT_HOME}\e[0m"
-
-ASCEND_INCLUDE_DIR=${ASCEND_TOOLKIT_HOME}/$(arch)-linux/include
-CURRENT_DIR=$(pwd)
-PROJECT_ROOT=$(dirname "$CURRENT_DIR")
-VERSION="1.0.0"
-OUTPUT_DIR=$CURRENT_DIR/output
-mkdir -p $OUTPUT_DIR
-echo "outpath: ${OUTPUT_DIR}"
-
-COMPILE_OPTIONS=""
-
-
-function build_kernels()
-{
-    if [[ "$ONLY_BUILD_MEMORY_SAVER_MODULE" == "ON" ]]; then return 0; fi
-
-    CMAKE_DIR=""
-    BUILD_DIR="build"
-
-    cd "$CMAKE_DIR" || exit
-
-    rm -rf $BUILD_DIR
-    mkdir -p $BUILD_DIR
-
-    cmake $COMPILE_OPTIONS \
-    -DCMAKE_INSTALL_PREFIX="$OUTPUT_DIR" \
-    -DASCEND_HOME_PATH=$ASCEND_HOME_PATH \
-    -DASCEND_INCLUDE_DIR=$ASCEND_INCLUDE_DIR \
-    -DCMAKE_PREFIX_PATH="$ASC_CMAKE_DIR" \
-    -DASC_DIR="$ASC_CMAKE_DIR" \
-    -DSOC_VERSION=Ascend910_9382 \
-    -DDEEPEP_IS_A5_BUILD=$([[ "$SOC_VERSION" == "Ascend950" ]] && echo "ON" || echo "OFF") \
-    -DBUILD_DEEPEP_MODULE=$BUILD_DEEPEP_MODULE \
-    -DBUILD_KERNELS_MODULE=$BUILD_KERNELS_MODULE \
-    -B "$BUILD_DIR" \
-    -S .
-
-    cmake --build "$BUILD_DIR" --target install -j 16
-    cd -
+    echo "Build target: $BUILD_TARGET"
+    echo "DeepEP variant: $DEEPEP_VARIANT"
+    echo "SOC_VERSION: $SOC_VERSION"
 }
 
-function build_deepep_kernels()
+function resolve_ascend_home()
 {
-    if [[ "$BUILD_DEEPEP_MODULE" != "ON" ]]; then return 0; fi
+    local configured_path="${ASCEND_HOME_PATH:-}"
+    local candidate=""
+    local path=""
 
-    if [[ "$BUILD_DEEPEP_OPS" == "ON" ]]; then
-        KERNEL_DIR="csrc/deepep/ops"
+    if [[ -f "$configured_path" && "$(basename "$configured_path")" == "set_env.sh" ]]; then
+        configured_path="$(dirname "$configured_path")"
+    fi
+
+    if [[ -n "$configured_path" && "$(basename "$configured_path")" == "latest" ]]; then
+        candidate="$(readlink -f "$configured_path" 2>/dev/null || true)"
+        if [[ -n "$candidate" ]]; then
+            configured_path="$candidate"
+        fi
+    fi
+
+    if [[ -n "$configured_path" && -d "$configured_path" && -f "$configured_path/set_env.sh" ]]; then
+        candidate="$configured_path"
     else
-        KERNEL_DIR="csrc/deepep/ops2"
+        if [[ -n "$configured_path" ]]; then
+            echo "Warning: Ignoring invalid ASCEND_HOME_PATH: $configured_path"
+        fi
+
+        candidate=""
+        while IFS= read -r path; do
+            if [[ -f "$path/set_env.sh" ]]; then
+                candidate="$path"
+            fi
+        done < <(find "$DEFAULT_ASCEND_ROOT" \
+            -mindepth 1 \
+            -maxdepth 1 \
+            -type d \
+            ! -name latest \
+            -print 2>/dev/null | sort -V)
+
+        if [[ -z "$candidate" && -d "$DEFAULT_ASCEND_ROOT/latest" ]]; then
+            path="$(readlink -f "$DEFAULT_ASCEND_ROOT/latest" 2>/dev/null || true)"
+            if [[ -n "$path" && -f "$path/set_env.sh" ]]; then
+                candidate="$path"
+            fi
+        fi
+
+        if [[ -z "$candidate" && -f "$DEFAULT_ASCEND_ROOT/set_env.sh" ]]; then
+            candidate="$DEFAULT_ASCEND_ROOT"
+        fi
     fi
-    CUSTOM_OPP_DIR="${CURRENT_DIR}/python/deep_ep/deep_ep"
 
-    cd "$KERNEL_DIR" || exit
+    if [[ -z "$candidate" ]]; then
+        die "Cannot find an Ascend toolkit directory containing set_env.sh"
+    fi
 
-    chmod +x build.sh
-    ./build.sh
+    export ASCEND_HOME_PATH="$candidate"
+}
 
-    custom_opp_file=$(find ./build_out -maxdepth 1 -type f -name "custom_opp*.run")
-    if [ -z "$custom_opp_file" ]; then
-        echo "can not find run package"
-        exit 1
+function setup_ascend_environment()
+{
+    local resolved_ascend_home=""
+    local asc_config_cmake=""
+
+    resolve_ascend_home
+    resolved_ascend_home="$ASCEND_HOME_PATH"
+
+    # CANN's environment script may rewrite ASCEND_HOME_PATH to "latest".
+    # Keep the resolved installation directory as the source of truth.
+    source "$resolved_ascend_home/set_env.sh"
+    export ASCEND_HOME_PATH="$resolved_ascend_home"
+    export ASCEND_TOOLKIT_HOME="${ASCEND_TOOLKIT_HOME:-$resolved_ascend_home}"
+
+    asc_config_cmake="$(find "$ASCEND_HOME_PATH" \
+        -name "ASCConfig.cmake" \
+        -type f \
+        -print \
+        -quit 2>/dev/null)"
+    if [[ -n "$asc_config_cmake" ]]; then
+        ASC_CMAKE_DIR="$(dirname "$asc_config_cmake")"
+        export CMAKE_PREFIX_PATH="$ASC_CMAKE_DIR${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
+        export ASC_DIR="$ASC_CMAKE_DIR"
+        echo "Found ASCConfig.cmake at: $asc_config_cmake"
     else
-        echo "find run package: $custom_opp_file"
-        chmod +x "$custom_opp_file"
+        echo "Warning: Cannot find ASCConfig.cmake under $ASCEND_HOME_PATH"
     fi
-    rm -rf "$CUSTOM_OPP_DIR"/vendors
-    ./build_out/custom_opp_*.run --install-path=$CUSTOM_OPP_DIR
-    cd -
+
+    ASCEND_INCLUDE_DIR="${ASCEND_TOOLKIT_HOME}/$(arch)-linux/include"
+
+    echo "ASCEND_HOME_PATH: $ASCEND_HOME_PATH"
+    echo "ASCEND_TOOLKIT_HOME: $ASCEND_TOOLKIT_HOME"
+    echo "ASCEND_INCLUDE_DIR: $ASCEND_INCLUDE_DIR"
 }
 
-function build_memory_saver()
+function ensure_wheel_package()
 {
-    if [[ "$BUILD_MEMORY_SAVER_MODULE" != "ON" ]]; then return 0; fi
-    echo "[memory_saver] Building torch_memory_saver via setup.py"
-    cd contrib/torch_memory_saver/python || exit
-    rm -rf "$CURRENT_DIR"/contrib/torch_memory_saver/python/build
-    rm -rf "$CURRENT_DIR"/contrib/torch_memory_saver/python/dist
-    python3 setup.py clean --all
-    python3 setup.py bdist_wheel
-    mv -v "$CURRENT_DIR"/contrib/torch_memory_saver/python/dist/torch_memory_saver*.whl "${OUTPUT_DIR}/"
-    rm -rf "$CURRENT_DIR"/contrib/torch_memory_saver/python/dist
-    cd -
-}
-
-function create_deepep_cmake()
-{
-    if [[ "$BUILD_DEEPEP_MODULE" != "ON" ]]; then return 0; fi
-
-    cd csrc || exit
-    chmod +x deepep_cmake_build.sh
-    chmod +x deepep/build.sh
-    chmod +x deepep/compile_ascend_proj.sh
-    echo "${FUNCNAME[0]}:./deepep_cmake_build.sh all $SOC_VERSION"
-    ./deepep_cmake_build.sh all $SOC_VERSION
-
-    if [[ "$BUILD_DEEPEP_OPS" == "ON" ]]; then
-        echo "./deepep/compile_ascend_proj.sh ./deepep $SOC_VERSION deepep"
-        bash ./deepep/compile_ascend_proj.sh ./deepep $SOC_VERSION deepep
-    else
-        echo "./deepep/compile_ascend_proj.sh ./deepep $SOC_VERSION deepep2"
-        bash ./deepep/compile_ascend_proj.sh ./deepep $SOC_VERSION deepep2
-    fi
-    cd -
-}
-
-function make_deepep_package()
-{
-    cd python/deep_ep || exit
-
-    cp -v ${OUTPUT_DIR}/lib/* "$CURRENT_DIR"/python/deep_ep/deep_ep/
-    rm -rf "$CURRENT_DIR"/python/deep_ep/build
-    python3 setup.py clean --all
-    python3 setup.py bdist_wheel
-    mv -v "$CURRENT_DIR"/python/deep_ep/dist/deep_ep*.whl ${OUTPUT_DIR}/
-    rm -rf "$CURRENT_DIR"/python/deep_ep/dist
-    cd -
-}
-
-function make_sgl_kernel_npu_package()
-{
-    cd python/sgl_kernel_npu || exit
-
-    rm -rf "$CURRENT_DIR"/python/sgl_kernel_npu/dist
-    cp -v "${CURRENT_DIR}/config.ini" "${CURRENT_DIR}/python/sgl_kernel_npu/sgl_kernel_npu/"
-    python3 setup.py clean --all
-    python3 setup.py bdist_wheel
-    mv -v "$CURRENT_DIR"/python/sgl_kernel_npu/dist/sgl_kernel_npu*.whl ${OUTPUT_DIR}/
-    rm -rf "$CURRENT_DIR"/python/sgl_kernel_npu/dist
-    cd -
-}
-
-function build_attentions_kernels()
-{
-    CUSTOM_OPP_DIR="${CURRENT_DIR}/python/attentions/attentions"
-    KERNEL_DIR="csrc/attentions/build"
-
-    cd "$KERNEL_DIR" || exit
-
-    echo "run build attentions library"
-
-    chmod +x build.sh
-    ./build.sh
-    cd -
-}
-
-function make_attentions_package() {
-    cd python/attentions || exit
-
-    rm -rf "$CURRENT_DIR"/python/attentions/dist
-    python3 setup.py clean --all
-    python3 setup.py bdist_wheel
-    mv -v "$CURRENT_DIR"/python/attentions/dist/attentions*.whl ${OUTPUT_DIR}/
-    rm -rf "$CURRENT_DIR"/python/attentions/dist
-    cd -
-}
-
-function main()
-{
-    create_deepep_cmake
-    build_kernels
-    build_deepep_kernels
-    if [[ "$BUILD_ATTENTIONS_MODULE" == "ON" ]]; then
-        build_attentions_kernels
-    fi
-    if pip3 show wheel;then
+    if pip3 show wheel >/dev/null 2>&1; then
         echo "wheel has been installed"
     else
         pip3 install wheel==0.45.1
     fi
-    build_memory_saver
+}
+
+function prepare_deepep_build()
+{
+    (
+        cd "$PROJECT_ROOT/csrc"
+        chmod +x deepep_cmake_build.sh
+        chmod +x deepep/build.sh
+        chmod +x deepep/compile_ascend_proj.sh
+
+        echo "./deepep_cmake_build.sh all $SOC_VERSION"
+        ./deepep_cmake_build.sh all "$SOC_VERSION"
+
+        echo "./deepep/compile_ascend_proj.sh ./deepep $SOC_VERSION $DEEPEP_VARIANT"
+        bash ./deepep/compile_ascend_proj.sh \
+            ./deepep \
+            "$SOC_VERSION" \
+            "$DEEPEP_VARIANT"
+    )
+}
+
+# The top-level CMake project builds two independently controlled components:
+# - BUILD_DEEPEP_MODULE=ON: the DeepEP host/pybind adapter (deep_ep_cpp)
+# - BUILD_KERNELS_MODULE=ON: the sgl_kernel_npu host library and AscendC kernels
+function build_cmake_modules()
+{
+    local cmake_args=(
+        "-DCMAKE_INSTALL_PREFIX=$OUTPUT_DIR"
+        "-DASCEND_HOME_PATH=$ASCEND_HOME_PATH"
+        "-DASCEND_INCLUDE_DIR=$ASCEND_INCLUDE_DIR"
+        "-DSOC_VERSION=$SOC_VERSION"
+        "-DDEEPEP_IS_A5_BUILD=$DEEPEP_IS_A5_BUILD"
+        "-DBUILD_DEEPEP_MODULE=$BUILD_DEEPEP_MODULE"
+        "-DBUILD_KERNELS_MODULE=$BUILD_KERNELS_MODULE"
+    )
+
+    if [[ -n "$ASC_CMAKE_DIR" ]]; then
+        cmake_args+=(
+            "-DCMAKE_PREFIX_PATH=$ASC_CMAKE_DIR"
+            "-DASC_DIR=$ASC_CMAKE_DIR"
+        )
+    fi
+
+    rm -rf "$BUILD_DIR"
+    mkdir -p "$BUILD_DIR"
+
+    cmake "${cmake_args[@]}" \
+        -B "$BUILD_DIR" \
+        -S "$PROJECT_ROOT"
+    cmake --build "$BUILD_DIR" --target install -j 16
+}
+
+function build_deepep_kernels()
+{
+    local kernel_dir=""
+    local custom_opp_dir="${PROJECT_ROOT}/python/deep_ep/deep_ep"
+    local custom_opp_file=""
+
+    if [[ "$DEEPEP_VARIANT" == "deepep2" ]]; then
+        kernel_dir="${PROJECT_ROOT}/csrc/deepep/ops2"
+    else
+        kernel_dir="${PROJECT_ROOT}/csrc/deepep/ops"
+    fi
+
+    (
+        cd "$kernel_dir"
+        chmod +x build.sh
+        ./build.sh
+
+        custom_opp_file="$(find ./build_out \
+            -maxdepth 1 \
+            -type f \
+            -name "custom_opp*.run" \
+            -print \
+            -quit)"
+        if [[ -z "$custom_opp_file" ]]; then
+            die "Cannot find custom_opp*.run under $kernel_dir/build_out"
+        fi
+
+        echo "Found run package: $custom_opp_file"
+        chmod +x "$custom_opp_file"
+        rm -rf "$custom_opp_dir/vendors"
+        "$custom_opp_file" --install-path="$custom_opp_dir"
+    )
+}
+
+function build_attentions_kernels()
+{
+    (
+        cd "$PROJECT_ROOT/csrc/attentions/build"
+        echo "Building attentions kernels"
+        chmod +x build.sh
+        ./build.sh
+    )
+}
+
+function make_deepep_package()
+{
+    (
+        cd "$PROJECT_ROOT/python/deep_ep"
+        cp -v "$OUTPUT_DIR"/lib/* "$PROJECT_ROOT/python/deep_ep/deep_ep/"
+        rm -rf build dist
+        python3 setup.py clean --all
+        python3 setup.py bdist_wheel
+        mv -v dist/deep_ep*.whl "$OUTPUT_DIR/"
+        rm -rf dist
+    )
+}
+
+function make_sgl_kernel_npu_package()
+{
+    (
+        cd "$PROJECT_ROOT/python/sgl_kernel_npu"
+        rm -rf dist
+        cp -v "$PROJECT_ROOT/config.ini" sgl_kernel_npu/
+        python3 setup.py clean --all
+        python3 setup.py bdist_wheel
+        mv -v dist/sgl_kernel_npu*.whl "$OUTPUT_DIR/"
+        rm -rf dist
+    )
+}
+
+function make_attentions_package()
+{
+    (
+        cd "$PROJECT_ROOT/python/attentions"
+        rm -rf dist
+        python3 setup.py clean --all
+        python3 setup.py bdist_wheel
+        mv -v dist/attentions*.whl "$OUTPUT_DIR/"
+        rm -rf dist
+    )
+}
+
+function build_memory_saver_package()
+{
+    (
+        cd "$PROJECT_ROOT/contrib/torch_memory_saver/python"
+        echo "Building torch_memory_saver"
+        rm -rf build dist
+        python3 setup.py clean --all
+        python3 setup.py bdist_wheel
+        mv -v dist/torch_memory_saver*.whl "$OUTPUT_DIR/"
+        rm -rf dist
+    )
+}
+
+function main()
+{
+    parse_arguments "$@"
+    configure_build_target
+    configure_soc_version
+    export DEBUG_MODE
+
+    setup_ascend_environment
+    mkdir -p "$OUTPUT_DIR"
+    echo "Output directory: $OUTPUT_DIR"
+
+    # Build native components first. All module selection is controlled here.
+    if [[ "$BUILD_DEEPEP_MODULE" == "ON" ]]; then
+        prepare_deepep_build
+    fi
+    if [[ "$BUILD_DEEPEP_MODULE" == "ON" || "$BUILD_KERNELS_MODULE" == "ON" ]]; then
+        build_cmake_modules
+    fi
+    if [[ "$BUILD_DEEPEP_MODULE" == "ON" ]]; then
+        build_deepep_kernels
+    fi
+    if [[ "$BUILD_ATTENTIONS_MODULE" == "ON" ]]; then
+        build_attentions_kernels
+    fi
+
+    ensure_wheel_package
+
+    # Package only the modules selected above.
     if [[ "$BUILD_DEEPEP_MODULE" == "ON" ]]; then
         make_deepep_package
     fi
@@ -305,8 +414,11 @@ function main()
     if [[ "$BUILD_ATTENTIONS_MODULE" == "ON" ]]; then
         make_attentions_package
     fi
-
-
+    if [[ "$BUILD_MEMORY_SAVER_MODULE" == "ON" ]]; then
+        build_memory_saver_package
+    fi
 }
 
-main
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/build.sh
+++ b/build.sh
@@ -275,7 +275,6 @@ function make_sgl_kernel_npu_package()
 function build_attentions_kernels()
 {
     if [[ "$BUILD_ATTENTIONS_MODULE" != "ON" ]]; then return 0; fi
-
     CUSTOM_OPP_DIR="${CURRENT_DIR}/python/attentions/attentions"
     KERNEL_DIR="csrc/attentions/build"
 

--- a/build.sh
+++ b/build.sh
@@ -21,10 +21,12 @@ while getopts ":a:hd" opt; do
             BUILD_MEMORY_SAVER_MODULE="OFF"
             case "$OPTARG" in
                 deepep )
+                    BUILD_ATTENTIONS_MODULE="OFF"
                     BUILD_DEEPEP_MODULE="ON"
                     BUILD_DEEPEP_OPS="ON"
                     ;;
                 deepep2 )
+                    BUILD_ATTENTIONS_MODULE="OFF"
                     BUILD_DEEPEP_MODULE="ON"
                     BUILD_DEEPEP_OPS="OFF"
                     ;;
@@ -272,6 +274,8 @@ function make_sgl_kernel_npu_package()
 
 function build_attentions_kernels()
 {
+    if [[ "$BUILD_ATTENTIONS_MODULE" != "ON" ]]; then return 0; fi
+
     CUSTOM_OPP_DIR="${CURRENT_DIR}/python/attentions/attentions"
     KERNEL_DIR="csrc/attentions/build"
 

--- a/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
@@ -342,9 +342,9 @@ static bool CheckTensorDataType(const gert::TilingContext *context, const char *
             return false);
     } else if (quantMode == PER_TOKEN_FP8_SCALES) {
         OP_TILING_CHECK(
-            expandXDtype != ge::DT_FLOAT8_E4M3FN,
+            expandXDtype != ge::DT_FLOAT8_E4M3FN && expandXDtype != ge::DT_FLOAT8_E5M2,
             OP_LOGE(nodeName,
-                    "expandX dataType is invalid for per-token FP8 quant, dataType should be fp8e4m3, "
+                    "expandX dataType is invalid for per-token FP8 quant, dataType should be fp8e4m3 or fp8e5m2, "
                     "but is %s",
                     geDataTypeMap.at(expandXDesc->GetDataType()).c_str()),
             return false);

--- a/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
@@ -342,9 +342,9 @@ static bool CheckTensorDataType(const gert::TilingContext *context, const char *
             return false);
     } else if (quantMode == PER_TOKEN_FP8_SCALES) {
         OP_TILING_CHECK(
-            expandXDtype != ge::DT_FLOAT8_E4M3FN && expandXDtype != ge::DT_FLOAT8_E5M2,
+            expandXDtype != ge::DT_FLOAT8_E4M3FN,
             OP_LOGE(nodeName,
-                    "expandX dataType is invalid for per-token FP8 quant, dataType should be fp8e4m3 or fp8e5m2, "
+                    "expandX dataType is invalid for per-token FP8 quant, dataType should be fp8e4m3, "
                     "but is %s",
                     geDataTypeMap.at(expandXDesc->GetDataType()).c_str()),
             return false);

--- a/python/deep_ep/README.md
+++ b/python/deep_ep/README.md
@@ -48,21 +48,26 @@ DeepEP-Ascend supports A2, A3 and A5 and needs to generate packages separately o
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
 ```
 
-2. Build the project
-- **A5**
-    ```bash
-    bash build.sh -a deepep Ascend950
-    ```
-- **A3**
-    ```bash
-    bash build.sh -a deepep
-    ```
-- **A2**
-    ```bash
-    bash build.sh -a deepep2
-    ```
+2. Build DeepEP only
 
-> **Tip**: Add `-d` flag to enable debug logging (e.g., `bash build.sh -a deepep -d`).
+The `deepep` target builds only DeepEP, skips unrelated modules such as the attention kernels, and automatically detects
+whether the current platform is A2, A3, or A5:
+
+```bash
+bash build.sh -a deepep
+```
+
+The following explicit commands remain available when automatic detection is not desired:
+
+- **A5**: `bash build.sh -a deepep Ascend950`
+- **A3**: `bash build.sh -a deepep Ascend910_9382`
+- **A2**: `bash build.sh -a deepep Ascend910B1`
+- **A2 compatibility alias**: `bash build.sh -a deepep2`
+
+> **Note**: Running `bash build.sh` without `-a` performs a full A3+ build, including DeepEP, attention kernels,
+> SGLang kernels, and torch-memory-saver.
+>
+> **Tip**: Add the `-d` flag to enable debug logging (e.g., `bash build.sh -a deepep -d`).
 
 #### Installation
 
@@ -320,20 +325,24 @@ DeepEP-Ascend 支持 A2、A3 和 A5，需要在各平台上分别生成包。
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
 ```
 
-2、构建项目
-- **A5**
-    ```bash
-    bash build.sh -a deepep Ascend950
-    ```
-- **A3**
-    ```bash
-    bash build.sh -a deepep
-    ```
-- **A2**
-    ```bash
-    bash build.sh -a deepep2
-    ```
+2、仅构建 DeepEP
 
+`deepep` target 仅构建 DeepEP，跳过 attentions 等无关模块，并自动识别当前平台是 A2、A3 还是 A5：
+
+```bash
+bash build.sh -a deepep
+```
+
+不使用自动识别时，仍可使用以下显式命令：
+
+- **A5**：`bash build.sh -a deepep Ascend950`
+- **A3**：`bash build.sh -a deepep Ascend910_9382`
+- **A2**：`bash build.sh -a deepep Ascend910B1`
+- **A2 兼容命令**：`bash build.sh -a deepep2`
+
+> **说明**：不带 `-a` 运行 `bash build.sh` 时，将执行面向 A3+ 的全量构建，包括 DeepEP、attention kernels、
+> SGLang kernels 和 torch-memory-saver。
+>
 > **提示**：可加 `-d` 参数启用 DEBUG 日志（如 `bash build.sh -a deepep -d`）。
 
 #### 安装

--- a/python/deep_ep/README.md
+++ b/python/deep_ep/README.md
@@ -50,8 +50,7 @@ source /usr/local/Ascend/ascend-toolkit/set_env.sh
 
 2. Build DeepEP only
 
-The `deepep` target builds only DeepEP, skips unrelated modules such as the attention kernels, and automatically detects
-whether the current platform is A2, A3, or A5:
+The `deepep` target builds only DeepEP, skips unrelated modules such as the attention kernels, and automatically detects whether the current platform is A2, A3, or A5:
 
 ```bash
 bash build.sh -a deepep
@@ -60,12 +59,10 @@ bash build.sh -a deepep
 The following explicit commands remain available when automatic detection is not desired:
 
 - **A5**: `bash build.sh -a deepep Ascend950`
-- **A3**: `bash build.sh -a deepep Ascend910_9382`
-- **A2**: `bash build.sh -a deepep Ascend910B1`
-- **A2 compatibility alias**: `bash build.sh -a deepep2`
+- **A3**: `bash build.sh -a deepep`
+- **A2**: `bash build.sh -a deepep2`
 
-> **Note**: Running `bash build.sh` without `-a` performs a full A3+ build, including DeepEP, attention kernels,
-> SGLang kernels, and torch-memory-saver.
+> **Note**: Running `bash build.sh` without `-a` performs a full A3+ build, including DeepEP, attention kernels, SGLang kernels, and torch-memory-saver.
 >
 > **Tip**: Add the `-d` flag to enable debug logging (e.g., `bash build.sh -a deepep -d`).
 

--- a/python/deep_ep/README.md
+++ b/python/deep_ep/README.md
@@ -62,7 +62,7 @@ The following explicit commands remain available when automatic detection is not
 - **A3**: `bash build.sh -a deepep`
 - **A2**: `bash build.sh -a deepep2`
 
-> **Note**: Running `bash build.sh` without `-a` performs a full A3+ build, including DeepEP, attention kernels, SGLang kernels, and torch-memory-saver.
+> **Note**: Running `bash build.sh` without `-a` performs a full A3 build, including DeepEP, attention kernels, SGLang kernels, and torch-memory-saver.
 >
 > **Tip**: Add the `-d` flag to enable debug logging (e.g., `bash build.sh -a deepep -d`).
 
@@ -337,7 +337,7 @@ bash build.sh -a deepep
 - **A2**：`bash build.sh -a deepep Ascend910B1`
 - **A2 兼容命令**：`bash build.sh -a deepep2`
 
-> **说明**：不带 `-a` 运行 `bash build.sh` 时，将执行面向 A3+ 的全量构建，包括 DeepEP、attention kernels、
+> **说明**：不带 `-a` 运行 `bash build.sh` 时，将执行面向 A3 的全量构建，包括 DeepEP、attention kernels、
 > SGLang kernels 和 torch-memory-saver。
 >
 > **提示**：可加 `-d` 参数启用 DEBUG 日志（如 `bash build.sh -a deepep -d`）。


### PR DESCRIPTION
## Motivation

1. The current build.sh compiles deepep and attentions kernels at the same time and attentions kernels have problems, which impact the creation of deep_ep*.whl. This PR aims to decouple the compilation of deepep and attentions kernels. 
2. Fixed issue: https://github.com/sgl-project/sgl-kernel-npu/issues/625

## Modification

- Refactored the top-level `build.sh` to centralize build target selection and module orchestration.
- Added a DeepEP-only build flow (`build.sh -a deepep`) that skips attention kernel compilation and does not generate an `attentions*.whl` package.
- Added automatic SoC detection for A2, A3, and A5 while retaining explicit SoC arguments and the `deepep2` compatibility alias for A2.
- Preserved the default full-build mode and the standalone `kernels` and `memory-saver` targets.
- Removed the unused `deepep-adapter` and `deepep-kernels` targets.
- Improved Ascend toolkit discovery, path handling, argument validation, and device-detection error messages.
- Updated `python/deep_ep/README.md` to document the new build behavior and commands.

## Testing

- Compile deep_ep at A2, A3 and A5 and make sure attentions*.whl is not created.

## Benchmarking and Profiling

- This is a small change. No impact on performance

## Checklist

- [x] Format your code
- [x] Add unit tests
- [x] Update documentation
- [x] Provide accuracy and speed benchmark results    