### PR TITLE
A3 supports mega_moe activation by situ

### DIFF
--- a/log.txt
+++ b/log.txt
@@ -1,0 +1,33 @@
+Traceback (most recent call last):
+  File "/home/z30071866/sgl-kernel-npu/tests/python/deepep/test_fused_deep_moe_a3_w4a8_acc.py", line 1164, in <module>
+    torch.multiprocessing.spawn(
+  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch/multiprocessing/spawn.py", line 340, in spawn
+    return start_processes(fn, args, nprocs, join, daemon, start_method="spawn")
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch/multiprocessing/spawn.py", line 296, in start_processes
+    while not context.join():
+              ^^^^^^^^^^^^^^
+  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch/multiprocessing/spawn.py", line 211, in join
+    raise ProcessRaisedException(msg, error_index, failed_process.pid)
+torch.multiprocessing.spawn.ProcessRaisedException:
+
+-- Process 8 terminated with the following error:
+Traceback (most recent call last):
+  File "/usr/local/python3.11.15/lib/python3.11/site-packages/torch/multiprocessing/spawn.py", line 87, in _wrap
+    fn(i, *args)
+  File "/home/z30071866/sgl-kernel-npu/tests/python/deepep/test_fused_deep_moe_a3_w4a8_acc.py", line 1093, in test_loop
+    test_main(
+  File "/home/z30071866/sgl-kernel-npu/tests/python/deepep/test_fused_deep_moe_a3_w4a8_acc.py", line 1051, in test_main
+    launch_case(
+  File "/home/z30071866/sgl-kernel-npu/tests/python/deepep/test_fused_deep_moe_a3_w4a8_acc.py", line 895, in launch_case
+    fused_out, fused_counts = run_fused_reference(
+                              ^^^^^^^^^^^^^^^^^^^^
+  File "/home/z30071866/sgl-kernel-npu/tests/python/deepep/test_fused_deep_moe_a3_w4a8_acc.py", line 796, in run_fused_reference
+    out = buffer.fused_deep_moe(
+          ^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/local/python3.11.15/lib/python3.11/site-packages/deep_ep/buffer.py", line 966, in fused_deep_moe
+    output, expert_token_num = strategy.run(
+                               ^^^^^^^^^^^^^
+TypeError: MegaMoeFusedStrategy.run() missing 1 required keyword-only argument: 'quant_mode'
+
+[ERROR] 2026-07-30-09:08:01 (PID:126280, Device:-1, RankID:-1) ERR99999 UNKNOWN applicaiton exception

--- a/python/deep_ep/README.md
+++ b/python/deep_ep/README.md
@@ -191,15 +191,23 @@ Quantization modes in `low_latency_dispatch` (via `quant_mode` parameter; `use_f
 
 ### Fused MoE
 
-The `fused_deep_moe` API fuses dispatch + expert FFN computation + combine into a single operator call, significantly reducing communication overhead and end-to-end latency.
+The `fused_deep_moe` API now acts as a unified fused MoE entrypoint with two backends:
 
-Two fuse modes are available via the `FuseMode` enum:
-- `FuseMode.FUSED_DEEP_MOE` (default): Full fusion of dispatch + FFN + combine.
-- `FuseMode.DISPATCH_FFN_COMBINE`: Dispatch + FFN + combine with separate dispatch handling.
+- `backend="deep_ep"`: legacy fused kernels from `deep_ep_cpp`
+- `backend="mega_moe"`: `cann_ops_transformer.ops.mega_moe`
+- `backend="auto"`: keeps the existing A5 fused path and routes non-A5 or mega_moe-only features to `mega_moe`
 
-Quantization modes (`quant_mode`):
-- `1`: INT8 quantization (default)
-- FP8 will be supported in A5 release.
+Backend highlights:
+
+- `deep_ep` supports both `FuseMode.FUSED_DEEP_MOE` and `FuseMode.DISPATCH_FFN_COMBINE`
+- `mega_moe` supports only `FuseMode.FUSED_DEEP_MOE`
+- `activation="situ"` requires `backend="mega_moe"`
+- `linear_beta` is the public API name for the `situ` linear control; `activation_clamp` is no longer exposed at the DeepEP API layer
+- `l1_bias` / `l2_bias` are supported only on `mega_moe` for A8W4-INT compensation
+- `dispatch_quant_mode` and `dispatch_quant_out_dtype` are supported only on `mega_moe`
+
+For the `mega_moe` backend, the package `cann_ops_transformer` must be available. If it is
+missing, only calls that actually route to `mega_moe` fail; the legacy `deep_ep` path still works.
 
 See [Fused Deep MoE API](doc/FUSED_DEEP_MOE.md) for details.
 
@@ -444,15 +452,23 @@ low_latency_dispatch 量化模式（通过 `quant_mode` 参数指定；`use_fp8`
 
 ### 融合 MoE
 
-`fused_deep_moe` API 将 dispatch + 专家 FFN 计算 + combine 融合为单次算子调用，显著降低通信开销和端到端延迟。
+`fused_deep_moe` 现在是统一的融合 MoE 入口，内部支持两个后端：
 
-通过 `FuseMode` 枚举提供两种融合模式：
-- `FuseMode.FUSED_DEEP_MOE`（默认）：dispatch + FFN + combine 完整融合。
-- `FuseMode.DISPATCH_FFN_COMBINE`：dispatch + FFN + combine，dispatch 分离处理。
+- `backend="deep_ep"`：沿用 `deep_ep_cpp` 的旧 fused kernel
+- `backend="mega_moe"`：调用 `cann_ops_transformer.ops.mega_moe`
+- `backend="auto"`：保持 A5 现有 fused 路径不变，并在非 A5 或仅 mega_moe 支持的功能上自动切到 `mega_moe`
 
-量化模式（`quant_mode`）：
-- `1`：INT8 量化（默认）
-- FP8 将在 A5 版本中支持。
+后端差异要点：
+
+- `deep_ep` 同时支持 `FuseMode.FUSED_DEEP_MOE` 和 `FuseMode.DISPATCH_FFN_COMBINE`
+- `mega_moe` 只支持 `FuseMode.FUSED_DEEP_MOE`
+- `activation="situ"` 只能走 `mega_moe`
+- `linear_beta` 是对外的新参数名，用于 `situ` 激活；DeepEP API 层不再暴露 `activation_clamp`
+- `l1_bias` / `l2_bias` 仅在 `mega_moe` 的 A8W4-INT 补偿场景中支持
+- `dispatch_quant_mode` / `dispatch_quant_out_dtype` 仅 `mega_moe` 支持
+
+如果要使用 `mega_moe` 后端，需要安装或暴露 `cann_ops_transformer`。缺少该依赖时，
+只有实际路由到 `mega_moe` 的调用会报错，旧的 `deep_ep` 路径不受影响。
 
 详见 [融合 Deep MoE API](doc/FUSED_DEEP_MOE.md)。
 

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -1,6 +1,6 @@
 import os
 from enum import IntEnum
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 import deep_ep_cpp
 import torch
@@ -12,22 +12,11 @@ from .ep_strategy import (
     LowLatencyStrategy,
     NormalStrategy,
     StrategyMap,
+    get_fused_strategy,
     get_low_latency_strategy,
     get_normal_strategy,
 )
 from .utils import EventOverlap, log_parameters
-
-try:
-    from cann_ops_transformer.ops import (
-        get_symm_buffer_for_mega_moe as _get_symm_buffer_for_mega_moe,
-    )
-    from cann_ops_transformer.ops import mega_moe as _mega_moe
-
-    _MEGA_MOE_IMPORT_ERROR = None
-except ImportError as exc:
-    _get_symm_buffer_for_mega_moe = None
-    _mega_moe = None
-    _MEGA_MOE_IMPORT_ERROR = exc
 
 
 class FuseMode(IntEnum):
@@ -41,6 +30,7 @@ TensorOrTensors = Union[torch.Tensor, List[torch.Tensor]]
 class Buffer:
 
     num_sms: int = 20
+    FuseMode = FuseMode
 
     def __init__(
         self,
@@ -107,7 +97,7 @@ class Buffer:
 
         # Initialize low latency mode strategy
         self._init_low_latency_strategy(low_latency_strategy)
-        self._mega_moe_symm_buffer_cache: Dict[tuple, object] = {}
+        self._init_fused_strategies()
 
     def _init_normal_strategy(self, strategy: Union[str, NormalStrategy]):
         """Initialize normal mode communication strategy"""
@@ -138,17 +128,16 @@ class Buffer:
 
         self.low_latency_strategy = strategy_cls(**init_kwargs)
 
-    def _destroy_mega_moe_symm_buffers(self) -> None:
-        for sym_buffer in self._mega_moe_symm_buffer_cache.values():
-            try:
-                sym_buffer.destroy()
-            except Exception:
-                pass
-        self._mega_moe_symm_buffer_cache.clear()
+    def _init_fused_strategies(self):
+        self._fused_strategies = {
+            "deep_ep": get_fused_strategy("deep_ep")(),
+            "mega_moe": get_fused_strategy("mega_moe")(),
+        }
 
     def __del__(self):
         try:
-            self._destroy_mega_moe_symm_buffers()
+            for strategy in getattr(self, "_fused_strategies", {}).values():
+                strategy.destroy()
         except Exception:
             pass
 
@@ -809,44 +798,6 @@ class Buffer:
             out=out,
         )
 
-    def _require_mega_moe_ops(self) -> Tuple[Callable, Callable]:
-        if _get_symm_buffer_for_mega_moe is None or _mega_moe is None:
-            raise ImportError(
-                "The mega_moe backend requires the optional dependency "
-                "`cann_ops_transformer`. Install or expose `cann_ops_transformer.ops` "
-                'before calling `Buffer.fused_deep_moe(..., backend="mega_moe")`.'
-            ) from _MEGA_MOE_IMPORT_ERROR
-        return _get_symm_buffer_for_mega_moe, _mega_moe
-
-    @staticmethod
-    def _normalize_expert_param(
-        param: Optional[TensorOrTensors],
-        name: str,
-        expected_num_local_experts: int,
-    ) -> Optional[List[torch.Tensor]]:
-        if param is None:
-            return None
-        if isinstance(param, list):
-            if len(param) != expected_num_local_experts:
-                raise ValueError(
-                    f"`{name}` must contain exactly {expected_num_local_experts} "
-                    f"local expert tensors, but got {len(param)}."
-                )
-            return param
-        if not isinstance(param, torch.Tensor):
-            raise TypeError(
-                f"`{name}` must be a Tensor, a list[Tensor], or None, "
-                f"but got {type(param)}."
-            )
-        if param.dim() == 0:
-            raise ValueError(f"`{name}` must not be a scalar tensor.")
-        if param.size(0) != expected_num_local_experts:
-            raise ValueError(
-                f"`{name}` must have leading dimension {expected_num_local_experts} "
-                f"for local experts, but got shape {tuple(param.shape)}."
-            )
-        return [param[i] for i in range(expected_num_local_experts)]
-
     @staticmethod
     def _is_zero_like_linear_beta(linear_beta: Optional[float]) -> bool:
         return linear_beta is None or linear_beta == 0
@@ -864,154 +815,6 @@ class Buffer:
         if activation_clamp < 0:
             raise ValueError("`activation_clamp` must be None or >= 0.")
         return activation_clamp
-
-    @staticmethod
-    def _infer_mega_moe_quant_config(
-        l1_weights_sf: Optional[List[torch.Tensor]],
-        l2_weights_sf: Optional[List[torch.Tensor]],
-        l1_bias: Optional[List[torch.Tensor]],
-        l2_bias: Optional[List[torch.Tensor]],
-        dispatch_quant_mode: Optional[int],
-        dispatch_quant_out_dtype: Optional[torch.dtype],
-    ) -> Tuple[int, Optional[torch.dtype]]:
-        has_scales = l1_weights_sf is not None or l2_weights_sf is not None
-        has_bias = l1_bias is not None or l2_bias is not None
-        if has_scales and (l1_weights_sf is None or l2_weights_sf is None):
-            raise ValueError(
-                "`gmm1_permuted_weight_scale` and `gmm2_weight_scale` must both be "
-                "provided for mega_moe quantized execution."
-            )
-        if has_bias and (l1_bias is None or l2_bias is None):
-            raise ValueError(
-                "`l1_bias` and `l2_bias` must both be provided for A8W4-INT "
-                "mega_moe execution."
-            )
-
-        resolved_quant_mode = (
-            2
-            if has_scales or has_bias
-            else 0 if dispatch_quant_mode is None else dispatch_quant_mode
-        )
-        if resolved_quant_mode not in (0, 2):
-            raise ValueError(
-                "`dispatch_quant_mode` only supports 0 (A16W16) or 2 "
-                "(A8W8-INT/A8W4-INT) in fused_deep_moe mega_moe backend."
-            )
-        if resolved_quant_mode == 0:
-            if has_scales or has_bias:
-                raise ValueError(
-                    "Scale and bias tensors are only valid when "
-                    "`dispatch_quant_mode=2`."
-                )
-            if dispatch_quant_out_dtype is not None:
-                raise ValueError(
-                    "`dispatch_quant_out_dtype` must be None when "
-                    "`dispatch_quant_mode=0`."
-                )
-            return 0, None
-
-        resolved_quant_out_dtype = (
-            torch.int8 if dispatch_quant_out_dtype is None else dispatch_quant_out_dtype
-        )
-        if resolved_quant_out_dtype != torch.int8:
-            raise ValueError(
-                "`dispatch_quant_out_dtype` must be torch.int8 for "
-                "A8W8-INT/A8W4-INT mega_moe execution."
-            )
-        return resolved_quant_mode, resolved_quant_out_dtype
-
-    def _get_or_create_mega_moe_symm_buffer(
-        self,
-        *,
-        num_experts: int,
-        num_max_dispatch_tokens_per_rank: int,
-        num_topk: int,
-        hidden: int,
-        intermediate_hidden: int,
-        max_recv_token_num: int,
-        dispatch_quant_mode: int,
-        dispatch_quant_out_dtype: Optional[torch.dtype],
-        activation: str,
-    ):
-        get_symm_buffer_for_mega_moe, _ = self._require_mega_moe_ops()
-        cache_key = (
-            num_experts,
-            num_max_dispatch_tokens_per_rank,
-            num_topk,
-            hidden,
-            intermediate_hidden,
-            max_recv_token_num,
-            dispatch_quant_mode,
-            dispatch_quant_out_dtype,
-            activation,
-        )
-        sym_buffer = self._mega_moe_symm_buffer_cache.get(cache_key)
-        if sym_buffer is None:
-            sym_buffer = get_symm_buffer_for_mega_moe(
-                self.group,
-                num_experts=num_experts,
-                num_max_tokens_per_rank=num_max_dispatch_tokens_per_rank,
-                num_topk=num_topk,
-                hidden=hidden,
-                intermediate_hidden=intermediate_hidden,
-                max_recv_token_num=max_recv_token_num,
-                dispatch_quant_mode=dispatch_quant_mode,
-                dispatch_quant_out_dtype=dispatch_quant_out_dtype,
-            )
-            self._mega_moe_symm_buffer_cache[cache_key] = sym_buffer
-        return sym_buffer
-
-    def _pad_mega_moe_inputs(
-        self,
-        x: torch.Tensor,
-        topk_idx: torch.Tensor,
-        topk_weights: torch.Tensor,
-        num_max_dispatch_tokens_per_rank: int,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int]:
-        original_num_tokens = x.size(0)
-        if original_num_tokens > num_max_dispatch_tokens_per_rank:
-            raise ValueError(
-                "The number of input tokens exceeds "
-                "`num_max_dispatch_tokens_per_rank`: "
-                f"{original_num_tokens} > {num_max_dispatch_tokens_per_rank}."
-            )
-
-        x_active_mask = torch.zeros(
-            num_max_dispatch_tokens_per_rank,
-            dtype=torch.int8,
-            device=x.device,
-        )
-        x_active_mask[:original_num_tokens] = 1
-
-        if original_num_tokens == num_max_dispatch_tokens_per_rank:
-            return x, topk_idx, topk_weights, x_active_mask, original_num_tokens
-
-        padding_size = num_max_dispatch_tokens_per_rank - original_num_tokens
-        x_padded = torch.cat(
-            (x, x.new_zeros((padding_size, x.size(1)))),
-            dim=0,
-        )
-        topk_idx_padded = torch.cat(
-            (
-                topk_idx,
-                topk_idx.new_zeros((padding_size, topk_idx.size(1))),
-            ),
-            dim=0,
-        )
-        topk_weights_padded = torch.cat(
-            (
-                topk_weights,
-                topk_weights.new_zeros((padding_size, topk_weights.size(1))),
-            ),
-            dim=0,
-        )
-        return (
-            x_padded,
-            topk_idx_padded,
-            topk_weights_padded,
-            x_active_mask,
-            original_num_tokens,
-        )
 
     def _resolve_fused_backend(
         self,
@@ -1032,280 +835,6 @@ class Buffer:
                 return "mega_moe"
             return "deep_ep"
         return backend
-
-    def _fused_deep_moe_with_deep_ep(
-        self,
-        x: torch.Tensor,
-        topk_idx: torch.Tensor,
-        topk_weights: torch.Tensor,
-        gmm1_permuted_weight: TensorOrTensors,
-        gmm1_permuted_weight_scale: Optional[TensorOrTensors],
-        gmm2_weight: TensorOrTensors,
-        gmm2_weight_scale: Optional[TensorOrTensors],
-        num_max_dispatch_tokens_per_rank: int,
-        num_experts: int,
-        quant_mode: int,
-        fuse_mode: FuseMode,
-        activation: str,
-        activation_clamp: Optional[float],
-        beta: float,
-        linear_beta: Optional[float],
-        l1_bias: Optional[TensorOrTensors],
-        l2_bias: Optional[TensorOrTensors],
-        dispatch_quant_mode: Optional[int],
-        dispatch_quant_out_dtype: Optional[torch.dtype],
-        max_recv_token_num: int,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        activation_clamp = self._validate_activation_clamp(activation_clamp)
-        if not self._is_default_beta(beta):
-            raise ValueError("`beta` is only supported by the mega_moe backend.")
-        if activation != "situ" and not self._is_zero_like_linear_beta(linear_beta):
-            raise ValueError('`linear_beta` is only valid when `activation="situ"`.')
-        if activation != "swiglu":
-            raise ValueError(
-                "The deep_ep fused backend only supports activation='swiglu'. "
-                "Use backend='mega_moe' for other activation types."
-            )
-        if activation_clamp is not None:
-            raise ValueError(
-                "`activation_clamp` is only supported by the mega_moe backend."
-            )
-        if not self._is_zero_like_linear_beta(linear_beta):
-            raise ValueError("`linear_beta` is only supported by the mega_moe backend.")
-        if l1_bias is not None or l2_bias is not None:
-            raise ValueError(
-                "`l1_bias` and `l2_bias` are only supported by the mega_moe backend."
-            )
-        if dispatch_quant_mode is not None or dispatch_quant_out_dtype is not None:
-            raise ValueError(
-                "`dispatch_quant_mode` and `dispatch_quant_out_dtype` are only "
-                "supported by the mega_moe backend."
-            )
-        if isinstance(gmm1_permuted_weight, list) or isinstance(gmm2_weight, list):
-            raise TypeError(
-                "The deep_ep fused backend expects Tensor inputs for "
-                "`gmm1_permuted_weight` and `gmm2_weight`."
-            )
-        if isinstance(gmm1_permuted_weight_scale, list) or isinstance(
-            gmm2_weight_scale, list
-        ):
-            raise TypeError(
-                "The deep_ep fused backend expects Tensor inputs for weight scales."
-            )
-        if gmm1_permuted_weight_scale is None or gmm2_weight_scale is None:
-            raise ValueError(
-                "The deep_ep fused backend requires both weight scale tensors."
-            )
-
-        topk_ids = topk_idx.int()
-        if fuse_mode == FuseMode.FUSED_DEEP_MOE:
-            gmm1_permuted_weight_scale = gmm1_permuted_weight_scale.float()
-            gmm2_weight_scale = gmm2_weight_scale.float()
-            output, ep_recv_count = self.runtime.fused_deep_moe(
-                x,
-                topk_ids,
-                gmm1_permuted_weight,
-                gmm1_permuted_weight_scale,
-                gmm2_weight,
-                gmm2_weight_scale,
-                topk_weights,
-                num_max_dispatch_tokens_per_rank,
-                num_experts,
-                quant_mode,
-            )
-            return output, ep_recv_count
-        if fuse_mode == FuseMode.DISPATCH_FFN_COMBINE:
-            max_output_size = num_max_dispatch_tokens_per_rank
-            output, expert_token_nums = self.runtime.dispatch_ffn_combine(
-                x,
-                topk_ids,
-                gmm1_permuted_weight,
-                gmm1_permuted_weight_scale,
-                gmm2_weight,
-                gmm2_weight_scale,
-                topk_weights,
-                max_output_size,
-                num_experts,
-                quant_mode,
-            )
-            return output, expert_token_nums
-        raise NotImplementedError(f"Not support fuse_mode:{fuse_mode}")
-
-    def _fused_deep_moe_with_mega_moe(
-        self,
-        x: torch.Tensor,
-        topk_idx: torch.Tensor,
-        topk_weights: torch.Tensor,
-        gmm1_permuted_weight: TensorOrTensors,
-        gmm1_permuted_weight_scale: Optional[TensorOrTensors],
-        gmm2_weight: TensorOrTensors,
-        gmm2_weight_scale: Optional[TensorOrTensors],
-        num_max_dispatch_tokens_per_rank: int,
-        num_experts: int,
-        fuse_mode: FuseMode,
-        activation: str,
-        activation_clamp: Optional[float],
-        beta: float,
-        linear_beta: Optional[float],
-        l1_bias: Optional[TensorOrTensors],
-        l2_bias: Optional[TensorOrTensors],
-        dispatch_quant_mode: Optional[int],
-        dispatch_quant_out_dtype: Optional[torch.dtype],
-        max_recv_token_num: int,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        _, mega_moe = self._require_mega_moe_ops()
-        activation_clamp = self._validate_activation_clamp(activation_clamp)
-        if activation not in ("swiglu", "swiglu_gpt_oss", "situ"):
-            raise ValueError(
-                f"Unsupported mega_moe activation {activation!r}. Expected one of "
-                "`swiglu`, `swiglu_gpt_oss`, or `situ`."
-            )
-        if activation != "situ" and not self._is_default_beta(beta):
-            raise ValueError('`beta` is only valid when `activation="situ"`.')
-        if activation != "situ" and not self._is_zero_like_linear_beta(linear_beta):
-            raise ValueError('`linear_beta` is only valid when `activation="situ"`.')
-        if fuse_mode != FuseMode.FUSED_DEEP_MOE:
-            raise NotImplementedError(
-                "The mega_moe backend only supports " "FuseMode.FUSED_DEEP_MOE."
-            )
-        expected_num_local_experts = num_experts // self.group_size
-        if expected_num_local_experts * self.group_size != num_experts:
-            raise ValueError(
-                "`num_experts` must be divisible by the process-group size when "
-                "using the mega_moe backend."
-            )
-
-        l1_weights = self._normalize_expert_param(
-            gmm1_permuted_weight,
-            "gmm1_permuted_weight",
-            expected_num_local_experts,
-        )
-        l2_weights = self._normalize_expert_param(
-            gmm2_weight,
-            "gmm2_weight",
-            expected_num_local_experts,
-        )
-        l1_weights_sf = self._normalize_expert_param(
-            gmm1_permuted_weight_scale,
-            "gmm1_permuted_weight_scale",
-            expected_num_local_experts,
-        )
-        l2_weights_sf = self._normalize_expert_param(
-            gmm2_weight_scale,
-            "gmm2_weight_scale",
-            expected_num_local_experts,
-        )
-        l1_bias_list = self._normalize_expert_param(
-            l1_bias,
-            "l1_bias",
-            expected_num_local_experts,
-        )
-        l2_bias_list = self._normalize_expert_param(
-            l2_bias,
-            "l2_bias",
-            expected_num_local_experts,
-        )
-
-        resolved_dispatch_quant_mode, resolved_dispatch_quant_out_dtype = (
-            self._infer_mega_moe_quant_config(
-                l1_weights_sf,
-                l2_weights_sf,
-                l1_bias_list,
-                l2_bias_list,
-                dispatch_quant_mode,
-                dispatch_quant_out_dtype,
-            )
-        )
-        is_a8w4_int = l1_bias_list is not None and l2_bias_list is not None
-
-        hidden = x.size(1)
-        if not l2_weights or l2_weights[0].dim() < 2:
-            raise ValueError(
-                "`gmm2_weight` must contain per-expert 2D tensors in mega_moe layout "
-                "[intermediate_hidden, hidden]."
-            )
-        intermediate_hidden = l2_weights[0].shape[-2]
-        expected_l2_last_dim = hidden // 8 if is_a8w4_int else hidden
-        expected_l1_last_dim = (
-            (intermediate_hidden * 2) // 8 if is_a8w4_int else intermediate_hidden * 2
-        )
-        inferred_scene = (
-            "A8W4-INT"
-            if is_a8w4_int
-            else "A8W8-INT" if resolved_dispatch_quant_mode == 2 else "A16W16"
-        )
-        if l2_weights[0].shape[-1] != expected_l2_last_dim:
-            raise ValueError(
-                "`gmm2_weight` has an invalid mega_moe layout for "
-                f"{inferred_scene}. Expected first local expert shape "
-                f"({intermediate_hidden}, {expected_l2_last_dim}) "
-                f"({'packed INT4 via .view(torch.int32)' if is_a8w4_int else 'unpacked'}) "
-                f"but got {tuple(l2_weights[0].shape)} with hidden={hidden}."
-            )
-        if l1_weights[0].dim() < 2:
-            raise ValueError(
-                "`gmm1_permuted_weight` must contain per-expert 2D tensors in mega_moe "
-                "layout [hidden, 2 * intermediate_hidden]."
-            )
-        if l1_weights[0].shape[-2] != hidden:
-            raise ValueError(
-                "`gmm1_permuted_weight` must use mega_moe layout "
-                "[hidden, 2 * intermediate_hidden] for the mega_moe backend, "
-                f"but got first local expert shape {tuple(l1_weights[0].shape)} "
-                f"with hidden={hidden}."
-            )
-        if l1_weights[0].shape[-1] != expected_l1_last_dim:
-            raise ValueError(
-                "`gmm1_permuted_weight` has an invalid mega_moe layout for "
-                f"{inferred_scene}. Expected first local expert shape "
-                f"({hidden}, {expected_l1_last_dim}) "
-                f"({'packed INT4 via .view(torch.int32)' if is_a8w4_int else 'unpacked'}) "
-                f"but got {tuple(l1_weights[0].shape)}."
-            )
-
-        sym_buffer = self._get_or_create_mega_moe_symm_buffer(
-            num_experts=num_experts,
-            num_max_dispatch_tokens_per_rank=num_max_dispatch_tokens_per_rank,
-            num_topk=topk_idx.size(1),
-            hidden=hidden,
-            intermediate_hidden=intermediate_hidden,
-            max_recv_token_num=max_recv_token_num,
-            dispatch_quant_mode=resolved_dispatch_quant_mode,
-            dispatch_quant_out_dtype=resolved_dispatch_quant_out_dtype,
-            activation=activation,
-        )
-
-        (
-            x_padded,
-            topk_idx_padded,
-            topk_weights_padded,
-            x_active_mask,
-            original_num_tokens,
-        ) = self._pad_mega_moe_inputs(
-            x,
-            topk_idx,
-            topk_weights,
-            num_max_dispatch_tokens_per_rank,
-        )
-
-        output, expert_token_num = mega_moe(
-            x=x_padded,
-            topk_ids=topk_idx_padded,
-            topk_weights=topk_weights_padded,
-            l1_weights=l1_weights,
-            l2_weights=l2_weights,
-            sym_buffer=sym_buffer,
-            l1_weights_sf=l1_weights_sf,
-            l2_weights_sf=l2_weights_sf,
-            l1_bias=l1_bias_list,
-            l2_bias=l2_bias_list,
-            x_active_mask=x_active_mask,
-            activation=activation,
-            activation_clamp=activation_clamp,
-            beta=beta,
-            linear_beta=linear_beta,
-        )
-        return output[:original_num_tokens], expert_token_num
 
     def fused_deep_moe(
         self,
@@ -1415,29 +944,7 @@ class Buffer:
             l2_bias=l2_bias,
             dispatch_quant_mode=dispatch_quant_mode,
         )
-        if resolved_backend == "deep_ep":
-            return self._fused_deep_moe_with_deep_ep(
-                x=x,
-                topk_idx=topk_idx,
-                topk_weights=topk_weights,
-                gmm1_permuted_weight=gmm1_permuted_weight,
-                gmm1_permuted_weight_scale=gmm1_permuted_weight_scale,
-                gmm2_weight=gmm2_weight,
-                gmm2_weight_scale=gmm2_weight_scale,
-                num_max_dispatch_tokens_per_rank=num_max_dispatch_tokens_per_rank,
-                num_experts=num_experts,
-                quant_mode=quant_mode,
-                fuse_mode=fuse_mode,
-                activation=activation,
-                activation_clamp=activation_clamp,
-                beta=beta,
-                linear_beta=linear_beta,
-                l1_bias=l1_bias,
-                l2_bias=l2_bias,
-                dispatch_quant_mode=dispatch_quant_mode,
-                dispatch_quant_out_dtype=dispatch_quant_out_dtype,
-                max_recv_token_num=max_recv_token_num,
-            )
+        strategy = self._fused_strategies[resolved_backend]
         if x.size(0) == 0:
             x = torch.zeros(
                 (1, x.size(1)),
@@ -1456,7 +963,18 @@ class Buffer:
                 dtype=topk_weights.dtype,
                 device=topk_weights.device,
             )
-        output, expert_token_num = self._fused_deep_moe_with_mega_moe(
+        strategy_dispatch_quant_mode = (
+            2
+            if resolved_backend == "mega_moe" and quant_mode == 1
+            else dispatch_quant_mode
+        )
+        strategy_dispatch_quant_out_dtype = (
+            torch.int8
+            if resolved_backend == "mega_moe" and quant_mode == 1
+            else dispatch_quant_out_dtype
+        )
+        output, expert_token_num = strategy.run(
+            buffer=self,
             x=x,
             topk_idx=topk_idx,
             topk_weights=topk_weights,
@@ -1466,6 +984,7 @@ class Buffer:
             gmm2_weight_scale=gmm2_weight_scale,
             num_max_dispatch_tokens_per_rank=num_max_dispatch_tokens_per_rank,
             num_experts=num_experts,
+            quant_mode=quant_mode,
             fuse_mode=fuse_mode,
             activation=activation,
             activation_clamp=activation_clamp,
@@ -1473,10 +992,8 @@ class Buffer:
             linear_beta=linear_beta,
             l1_bias=l1_bias,
             l2_bias=l2_bias,
-            dispatch_quant_mode=2 if quant_mode == 1 else dispatch_quant_mode,
-            dispatch_quant_out_dtype=(
-                torch.int8 if quant_mode == 1 else dispatch_quant_out_dtype
-            ),
+            dispatch_quant_mode=strategy_dispatch_quant_mode,
+            dispatch_quant_out_dtype=strategy_dispatch_quant_out_dtype,
             max_recv_token_num=max_recv_token_num,
         )
         if x.size(0) == 0:

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -1,6 +1,6 @@
 import os
 from enum import IntEnum
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import deep_ep_cpp
 import torch
@@ -17,10 +17,25 @@ from .ep_strategy import (
 )
 from .utils import EventOverlap, log_parameters
 
+try:
+    from cann_ops_transformer.ops import (
+        get_symm_buffer_for_mega_moe as _get_symm_buffer_for_mega_moe,
+    )
+    from cann_ops_transformer.ops import mega_moe as _mega_moe
+
+    _MEGA_MOE_IMPORT_ERROR = None
+except ImportError as exc:
+    _get_symm_buffer_for_mega_moe = None
+    _mega_moe = None
+    _MEGA_MOE_IMPORT_ERROR = exc
+
 
 class FuseMode(IntEnum):
     FUSED_DEEP_MOE = 1
     DISPATCH_FFN_COMBINE = 2
+
+
+TensorOrTensors = Union[torch.Tensor, List[torch.Tensor]]
 
 
 class Buffer:
@@ -92,6 +107,7 @@ class Buffer:
 
         # Initialize low latency mode strategy
         self._init_low_latency_strategy(low_latency_strategy)
+        self._mega_moe_symm_buffer_cache: Dict[tuple, object] = {}
 
     def _init_normal_strategy(self, strategy: Union[str, NormalStrategy]):
         """Initialize normal mode communication strategy"""
@@ -121,6 +137,20 @@ class Buffer:
             init_kwargs["comm_alg"] = comm_alg
 
         self.low_latency_strategy = strategy_cls(**init_kwargs)
+
+    def _destroy_mega_moe_symm_buffers(self) -> None:
+        for sym_buffer in self._mega_moe_symm_buffer_cache.values():
+            try:
+                sym_buffer.destroy()
+            except Exception:
+                pass
+        self._mega_moe_symm_buffer_cache.clear()
+
+    def __del__(self):
+        try:
+            self._destroy_mega_moe_symm_buffers()
+        except Exception:
+            pass
 
     @staticmethod
     def get_dispatch_config(num_ranks: int) -> Config:
@@ -779,92 +809,298 @@ class Buffer:
             out=out,
         )
 
-    def fused_deep_moe(
+    def _require_mega_moe_ops(self) -> Tuple[Callable, Callable]:
+        if _get_symm_buffer_for_mega_moe is None or _mega_moe is None:
+            raise ImportError(
+                "The mega_moe backend requires the optional dependency "
+                "`cann_ops_transformer`. Install or expose `cann_ops_transformer.ops` "
+                'before calling `Buffer.fused_deep_moe(..., backend="mega_moe")`.'
+            ) from _MEGA_MOE_IMPORT_ERROR
+        return _get_symm_buffer_for_mega_moe, _mega_moe
+
+    @staticmethod
+    def _normalize_expert_param(
+        param: Optional[TensorOrTensors],
+        name: str,
+        expected_num_local_experts: int,
+    ) -> Optional[List[torch.Tensor]]:
+        if param is None:
+            return None
+        if isinstance(param, list):
+            if len(param) != expected_num_local_experts:
+                raise ValueError(
+                    f"`{name}` must contain exactly {expected_num_local_experts} "
+                    f"local expert tensors, but got {len(param)}."
+                )
+            return param
+        if not isinstance(param, torch.Tensor):
+            raise TypeError(
+                f"`{name}` must be a Tensor, a list[Tensor], or None, "
+                f"but got {type(param)}."
+            )
+        if param.dim() == 0:
+            raise ValueError(f"`{name}` must not be a scalar tensor.")
+        if param.size(0) != expected_num_local_experts:
+            raise ValueError(
+                f"`{name}` must have leading dimension {expected_num_local_experts} "
+                f"for local experts, but got shape {tuple(param.shape)}."
+            )
+        return [param[i] for i in range(expected_num_local_experts)]
+
+    @staticmethod
+    def _is_zero_like_linear_beta(linear_beta: Optional[float]) -> bool:
+        return linear_beta is None or linear_beta == 0
+
+    @staticmethod
+    def _is_default_beta(beta: float) -> bool:
+        return beta == 1.0
+
+    @staticmethod
+    def _validate_activation_clamp(
+        activation_clamp: Optional[float],
+    ) -> Optional[float]:
+        if activation_clamp is None or activation_clamp == 0:
+            return None
+        if activation_clamp < 0:
+            raise ValueError("`activation_clamp` must be None or >= 0.")
+        return activation_clamp
+
+    @staticmethod
+    def _infer_mega_moe_quant_config(
+        l1_weights_sf: Optional[List[torch.Tensor]],
+        l2_weights_sf: Optional[List[torch.Tensor]],
+        l1_bias: Optional[List[torch.Tensor]],
+        l2_bias: Optional[List[torch.Tensor]],
+        dispatch_quant_mode: Optional[int],
+        dispatch_quant_out_dtype: Optional[torch.dtype],
+    ) -> Tuple[int, Optional[torch.dtype]]:
+        has_scales = l1_weights_sf is not None or l2_weights_sf is not None
+        has_bias = l1_bias is not None or l2_bias is not None
+        if has_scales and (l1_weights_sf is None or l2_weights_sf is None):
+            raise ValueError(
+                "`gmm1_permuted_weight_scale` and `gmm2_weight_scale` must both be "
+                "provided for mega_moe quantized execution."
+            )
+        if has_bias and (l1_bias is None or l2_bias is None):
+            raise ValueError(
+                "`l1_bias` and `l2_bias` must both be provided for A8W4-INT "
+                "mega_moe execution."
+            )
+
+        resolved_quant_mode = (
+            2
+            if has_scales or has_bias
+            else 0 if dispatch_quant_mode is None else dispatch_quant_mode
+        )
+        if resolved_quant_mode not in (0, 2):
+            raise ValueError(
+                "`dispatch_quant_mode` only supports 0 (A16W16) or 2 "
+                "(A8W8-INT/A8W4-INT) in fused_deep_moe mega_moe backend."
+            )
+        if resolved_quant_mode == 0:
+            if has_scales or has_bias:
+                raise ValueError(
+                    "Scale and bias tensors are only valid when "
+                    "`dispatch_quant_mode=2`."
+                )
+            if dispatch_quant_out_dtype is not None:
+                raise ValueError(
+                    "`dispatch_quant_out_dtype` must be None when "
+                    "`dispatch_quant_mode=0`."
+                )
+            return 0, None
+
+        resolved_quant_out_dtype = (
+            torch.int8 if dispatch_quant_out_dtype is None else dispatch_quant_out_dtype
+        )
+        if resolved_quant_out_dtype != torch.int8:
+            raise ValueError(
+                "`dispatch_quant_out_dtype` must be torch.int8 for "
+                "A8W8-INT/A8W4-INT mega_moe execution."
+            )
+        return resolved_quant_mode, resolved_quant_out_dtype
+
+    def _get_or_create_mega_moe_symm_buffer(
+        self,
+        *,
+        num_experts: int,
+        num_max_dispatch_tokens_per_rank: int,
+        num_topk: int,
+        hidden: int,
+        intermediate_hidden: int,
+        max_recv_token_num: int,
+        dispatch_quant_mode: int,
+        dispatch_quant_out_dtype: Optional[torch.dtype],
+        activation: str,
+    ):
+        get_symm_buffer_for_mega_moe, _ = self._require_mega_moe_ops()
+        cache_key = (
+            num_experts,
+            num_max_dispatch_tokens_per_rank,
+            num_topk,
+            hidden,
+            intermediate_hidden,
+            max_recv_token_num,
+            dispatch_quant_mode,
+            dispatch_quant_out_dtype,
+            activation,
+        )
+        sym_buffer = self._mega_moe_symm_buffer_cache.get(cache_key)
+        if sym_buffer is None:
+            sym_buffer = get_symm_buffer_for_mega_moe(
+                self.group,
+                num_experts=num_experts,
+                num_max_tokens_per_rank=num_max_dispatch_tokens_per_rank,
+                num_topk=num_topk,
+                hidden=hidden,
+                intermediate_hidden=intermediate_hidden,
+                max_recv_token_num=max_recv_token_num,
+                dispatch_quant_mode=dispatch_quant_mode,
+                dispatch_quant_out_dtype=dispatch_quant_out_dtype,
+            )
+            self._mega_moe_symm_buffer_cache[cache_key] = sym_buffer
+        return sym_buffer
+
+    def _pad_mega_moe_inputs(
         self,
         x: torch.Tensor,
         topk_idx: torch.Tensor,
         topk_weights: torch.Tensor,
-        gmm1_permuted_weight: torch.Tensor,
-        gmm1_permuted_weight_scale: torch.Tensor,
-        gmm2_weight: torch.Tensor,
-        gmm2_weight_scale: torch.Tensor,
+        num_max_dispatch_tokens_per_rank: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int]:
+        original_num_tokens = x.size(0)
+        if original_num_tokens > num_max_dispatch_tokens_per_rank:
+            raise ValueError(
+                "The number of input tokens exceeds "
+                "`num_max_dispatch_tokens_per_rank`: "
+                f"{original_num_tokens} > {num_max_dispatch_tokens_per_rank}."
+            )
+
+        x_active_mask = torch.zeros(
+            num_max_dispatch_tokens_per_rank,
+            dtype=torch.int8,
+            device=x.device,
+        )
+        x_active_mask[:original_num_tokens] = 1
+
+        if original_num_tokens == num_max_dispatch_tokens_per_rank:
+            return x, topk_idx, topk_weights, x_active_mask, original_num_tokens
+
+        padding_size = num_max_dispatch_tokens_per_rank - original_num_tokens
+        x_padded = torch.cat(
+            (x, x.new_zeros((padding_size, x.size(1)))),
+            dim=0,
+        )
+        topk_idx_padded = torch.cat(
+            (
+                topk_idx,
+                topk_idx.new_zeros((padding_size, topk_idx.size(1))),
+            ),
+            dim=0,
+        )
+        topk_weights_padded = torch.cat(
+            (
+                topk_weights,
+                topk_weights.new_zeros((padding_size, topk_weights.size(1))),
+            ),
+            dim=0,
+        )
+        return (
+            x_padded,
+            topk_idx_padded,
+            topk_weights_padded,
+            x_active_mask,
+            original_num_tokens,
+        )
+
+    def _resolve_fused_backend(
+        self,
+        *,
+        backend: str,
+        activation: str,
+        l1_bias: Optional[TensorOrTensors],
+        l2_bias: Optional[TensorOrTensors],
+        dispatch_quant_mode: Optional[int],
+    ) -> str:
+        if backend not in ("auto", "deep_ep", "mega_moe"):
+            raise ValueError(
+                f"Unsupported backend {backend!r}. Expected one of "
+                "`auto`, `deep_ep`, or `mega_moe`."
+            )
+        if backend == "auto":
+            if activation == "situ":
+                return "mega_moe"
+            return "deep_ep"
+        return backend
+
+    def _fused_deep_moe_with_deep_ep(
+        self,
+        x: torch.Tensor,
+        topk_idx: torch.Tensor,
+        topk_weights: torch.Tensor,
+        gmm1_permuted_weight: TensorOrTensors,
+        gmm1_permuted_weight_scale: Optional[TensorOrTensors],
+        gmm2_weight: TensorOrTensors,
+        gmm2_weight_scale: Optional[TensorOrTensors],
         num_max_dispatch_tokens_per_rank: int,
         num_experts: int,
-        quant_mode: int = 1,
-        fuse_mode: FuseMode = FuseMode.FUSED_DEEP_MOE,
+        quant_mode: int,
+        fuse_mode: FuseMode,
+        activation: str,
+        activation_clamp: Optional[float],
+        beta: float,
+        linear_beta: Optional[float],
+        l1_bias: Optional[TensorOrTensors],
+        l2_bias: Optional[TensorOrTensors],
+        dispatch_quant_mode: Optional[int],
+        dispatch_quant_out_dtype: Optional[torch.dtype],
+        max_recv_token_num: int,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """
-        A fused low-latency implementation for MoE expert forward and combination.
+        activation_clamp = self._validate_activation_clamp(activation_clamp)
+        if not self._is_default_beta(beta):
+            raise ValueError("`beta` is only supported by the mega_moe backend.")
+        if activation != "situ" and not self._is_zero_like_linear_beta(linear_beta):
+            raise ValueError('`linear_beta` is only valid when `activation="situ"`.')
+        if activation != "swiglu":
+            raise ValueError(
+                "The deep_ep fused backend only supports activation='swiglu'. "
+                "Use backend='mega_moe' for other activation types."
+            )
+        if activation_clamp is not None:
+            raise ValueError(
+                "`activation_clamp` is only supported by the mega_moe backend."
+            )
+        if not self._is_zero_like_linear_beta(linear_beta):
+            raise ValueError("`linear_beta` is only supported by the mega_moe backend.")
+        if l1_bias is not None or l2_bias is not None:
+            raise ValueError(
+                "`l1_bias` and `l2_bias` are only supported by the mega_moe backend."
+            )
+        if dispatch_quant_mode is not None or dispatch_quant_out_dtype is not None:
+            raise ValueError(
+                "`dispatch_quant_mode` and `dispatch_quant_out_dtype` are only "
+                "supported by the mega_moe backend."
+            )
+        if isinstance(gmm1_permuted_weight, list) or isinstance(gmm2_weight, list):
+            raise TypeError(
+                "The deep_ep fused backend expects Tensor inputs for "
+                "`gmm1_permuted_weight` and `gmm2_weight`."
+            )
+        if isinstance(gmm1_permuted_weight_scale, list) or isinstance(
+            gmm2_weight_scale, list
+        ):
+            raise TypeError(
+                "The deep_ep fused backend expects Tensor inputs for weight scales."
+            )
+        if gmm1_permuted_weight_scale is None or gmm2_weight_scale is None:
+            raise ValueError(
+                "The deep_ep fused backend requires both weight scale tensors."
+            )
 
-        Two fuse modes are available via the FuseMode enum:
-        - FuseMode.FUSED_DEEP_MOE (1): Full fusion via aclnnFusedDeepMoe.
-          InitRouting + AllToAll + GMM1 + DequantSwigluQuant + GMM2 + Dequant
-          + Unpermute/Combine in a single AscendC kernel.
-        - FuseMode.DISPATCH_FFN_COMBINE (2): Separate dispatch handling via aclnnDispatchFFNCombine.
-          InitRouting + AllToAll dispatch + GMM1 + DequantSwigluQuant + GMM2 + Dequant
-          + Combine in a single AscendC kernel, using a different internal fusion strategy.
-
-        Arguments:
-            x: `[bs, hidden]` with `torch.bfloat16` (or supported precision),
-                the token representations to be processed by selected experts.
-            topk_idx: `[bs, num_topk]` with `torch.int64`, the selected expert indices
-                for each token. `-1` indices are supported (meaning no expert selected).
-            topk_weights: `[bs, num_topk]` with `torch.float32`, the expert weights selected
-                by the dispatched tokens. The received tokens will be reduced with the
-                weights in this tensor.
-            gmm1_permuted_weight: weight tensor for the first stage (up-projection).
-                For FUSED_DEEP_MOE mode, requires tile-N permuted layout to fit
-                Grouped MatMul (see `reshape_fusion_gmm_weight` in test code for
-                reference implementation). For DISPATCH_FFN_COMBINE mode, standard
-                NZ format without permutation.
-            gmm1_permuted_weight_scale: quantization scale tensor for the first stage.
-                For FUSED_DEEP_MOE mode, `torch.float32` dtype (auto-converted to
-                float internally). For DISPATCH_FFN_COMBINE mode, `torch.int64` dtype
-                (float32 scale values reinterpreted as int64 bit patterns; NOT
-                auto-converted by this method — the caller must perform the conversion).
-            gmm2_weight: weight tensor for the second stage (down-projection).
-            gmm2_weight_scale: quantization scale tensor for the second stage.
-                Same dtype rules as gmm1_permuted_weight_scale.
-            num_max_dispatch_tokens_per_rank: for FUSED_DEEP_MOE mode, the maximum
-                number of tokens to dispatch per rank, used for buffer/memory allocation.
-                For DISPATCH_FFN_COMBINE mode, the maximum number of tokens received in
-                dispatch (typically max_bs * num_ranks * topk). All ranks must hold the
-                same value.
-            num_experts: the total number of global experts.
-            quant_mode: quantization mode. Supported values: 0 = no quantization (BF16),
-                1 = INT8 (default). FP8 will be supported in A5 release.
-            fuse_mode: FuseMode enum (default: FuseMode.FUSED_DEEP_MOE).
-                FuseMode is not exported from the package's top-level __init__.py;
-                import via `from deep_ep.buffer import FuseMode` or use integer
-                values 1 or 2 directly.
-
-        Notes:
-            - DISPATCH_FFN_COMBINE mode does NOT support shared experts (unlike
-              FUSED_DEEP_MOE mode which does).
-            - DISPATCH_FFN_COMBINE mode does NOT support BF16 weights (only INT8).
-            - The first dimension of `topk_idx` defines the batch size `bs`.
-            - The second dimension of `x` defines the hidden dimension `hidden`.
-            - Exact shapes of weight/scale tensors depend on GMM permutation and sharding.
-            - If optional scale tensors are empty, the kernel skips those transforms.
-
-        Returns:
-            For fuse_mode=FUSED_DEEP_MOE:
-                output: `torch.Tensor`, shape `[bs, hidden]`, the fused expert output.
-                ep_recv_count: `torch.Tensor`, a 1D tensor of type `torch.int32`,
-                    shape `[num_local_experts * num_ranks]`, indicating the number of
-                    tokens received by each expert across all ranks.
-
-            For fuse_mode=DISPATCH_FFN_COMBINE:
-                output: `torch.Tensor`, shape `[bs, hidden]`, the fused expert output.
-                expert_token_nums: `torch.Tensor`, a 1D tensor of type `torch.int32`,
-                    shape `[num_local_experts]`, indicating the number of tokens received
-                    by each local expert on this rank only.
-        """
         topk_ids = topk_idx.int()
         if fuse_mode == FuseMode.FUSED_DEEP_MOE:
             gmm1_permuted_weight_scale = gmm1_permuted_weight_scale.float()
             gmm2_weight_scale = gmm2_weight_scale.float()
-
             output, ep_recv_count = self.runtime.fused_deep_moe(
                 x,
                 topk_ids,
@@ -878,8 +1114,7 @@ class Buffer:
                 quant_mode,
             )
             return output, ep_recv_count
-        elif fuse_mode == FuseMode.DISPATCH_FFN_COMBINE:
-            # The maximum number of tokens that rank can obtain during dispatch. (max_bs * ranks * topk)
+        if fuse_mode == FuseMode.DISPATCH_FFN_COMBINE:
             max_output_size = num_max_dispatch_tokens_per_rank
             output, expert_token_nums = self.runtime.dispatch_ffn_combine(
                 x,
@@ -894,5 +1129,361 @@ class Buffer:
                 quant_mode,
             )
             return output, expert_token_nums
-        else:
-            raise NotImplementedError(f"Not support fuse_mode:{fuse_mode}")
+        raise NotImplementedError(f"Not support fuse_mode:{fuse_mode}")
+
+    def _fused_deep_moe_with_mega_moe(
+        self,
+        x: torch.Tensor,
+        topk_idx: torch.Tensor,
+        topk_weights: torch.Tensor,
+        gmm1_permuted_weight: TensorOrTensors,
+        gmm1_permuted_weight_scale: Optional[TensorOrTensors],
+        gmm2_weight: TensorOrTensors,
+        gmm2_weight_scale: Optional[TensorOrTensors],
+        num_max_dispatch_tokens_per_rank: int,
+        num_experts: int,
+        fuse_mode: FuseMode,
+        activation: str,
+        activation_clamp: Optional[float],
+        beta: float,
+        linear_beta: Optional[float],
+        l1_bias: Optional[TensorOrTensors],
+        l2_bias: Optional[TensorOrTensors],
+        dispatch_quant_mode: Optional[int],
+        dispatch_quant_out_dtype: Optional[torch.dtype],
+        max_recv_token_num: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        _, mega_moe = self._require_mega_moe_ops()
+        activation_clamp = self._validate_activation_clamp(activation_clamp)
+        if activation not in ("swiglu", "swiglu_gpt_oss", "situ"):
+            raise ValueError(
+                f"Unsupported mega_moe activation {activation!r}. Expected one of "
+                "`swiglu`, `swiglu_gpt_oss`, or `situ`."
+            )
+        if activation != "situ" and not self._is_default_beta(beta):
+            raise ValueError('`beta` is only valid when `activation="situ"`.')
+        if activation != "situ" and not self._is_zero_like_linear_beta(linear_beta):
+            raise ValueError('`linear_beta` is only valid when `activation="situ"`.')
+        if fuse_mode != FuseMode.FUSED_DEEP_MOE:
+            raise NotImplementedError(
+                "The mega_moe backend only supports " "FuseMode.FUSED_DEEP_MOE."
+            )
+        expected_num_local_experts = num_experts // self.group_size
+        if expected_num_local_experts * self.group_size != num_experts:
+            raise ValueError(
+                "`num_experts` must be divisible by the process-group size when "
+                "using the mega_moe backend."
+            )
+
+        l1_weights = self._normalize_expert_param(
+            gmm1_permuted_weight,
+            "gmm1_permuted_weight",
+            expected_num_local_experts,
+        )
+        l2_weights = self._normalize_expert_param(
+            gmm2_weight,
+            "gmm2_weight",
+            expected_num_local_experts,
+        )
+        l1_weights_sf = self._normalize_expert_param(
+            gmm1_permuted_weight_scale,
+            "gmm1_permuted_weight_scale",
+            expected_num_local_experts,
+        )
+        l2_weights_sf = self._normalize_expert_param(
+            gmm2_weight_scale,
+            "gmm2_weight_scale",
+            expected_num_local_experts,
+        )
+        l1_bias_list = self._normalize_expert_param(
+            l1_bias,
+            "l1_bias",
+            expected_num_local_experts,
+        )
+        l2_bias_list = self._normalize_expert_param(
+            l2_bias,
+            "l2_bias",
+            expected_num_local_experts,
+        )
+
+        resolved_dispatch_quant_mode, resolved_dispatch_quant_out_dtype = (
+            self._infer_mega_moe_quant_config(
+                l1_weights_sf,
+                l2_weights_sf,
+                l1_bias_list,
+                l2_bias_list,
+                dispatch_quant_mode,
+                dispatch_quant_out_dtype,
+            )
+        )
+        is_a8w4_int = l1_bias_list is not None and l2_bias_list is not None
+
+        hidden = x.size(1)
+        if not l2_weights or l2_weights[0].dim() < 2:
+            raise ValueError(
+                "`gmm2_weight` must contain per-expert 2D tensors in mega_moe layout "
+                "[intermediate_hidden, hidden]."
+            )
+        intermediate_hidden = l2_weights[0].shape[-2]
+        expected_l2_last_dim = hidden // 8 if is_a8w4_int else hidden
+        expected_l1_last_dim = (
+            (intermediate_hidden * 2) // 8 if is_a8w4_int else intermediate_hidden * 2
+        )
+        inferred_scene = (
+            "A8W4-INT"
+            if is_a8w4_int
+            else "A8W8-INT" if resolved_dispatch_quant_mode == 2 else "A16W16"
+        )
+        if l2_weights[0].shape[-1] != expected_l2_last_dim:
+            raise ValueError(
+                "`gmm2_weight` has an invalid mega_moe layout for "
+                f"{inferred_scene}. Expected first local expert shape "
+                f"({intermediate_hidden}, {expected_l2_last_dim}) "
+                f"({'packed INT4 via .view(torch.int32)' if is_a8w4_int else 'unpacked'}) "
+                f"but got {tuple(l2_weights[0].shape)} with hidden={hidden}."
+            )
+        if l1_weights[0].dim() < 2:
+            raise ValueError(
+                "`gmm1_permuted_weight` must contain per-expert 2D tensors in mega_moe "
+                "layout [hidden, 2 * intermediate_hidden]."
+            )
+        if l1_weights[0].shape[-2] != hidden:
+            raise ValueError(
+                "`gmm1_permuted_weight` must use mega_moe layout "
+                "[hidden, 2 * intermediate_hidden] for the mega_moe backend, "
+                f"but got first local expert shape {tuple(l1_weights[0].shape)} "
+                f"with hidden={hidden}."
+            )
+        if l1_weights[0].shape[-1] != expected_l1_last_dim:
+            raise ValueError(
+                "`gmm1_permuted_weight` has an invalid mega_moe layout for "
+                f"{inferred_scene}. Expected first local expert shape "
+                f"({hidden}, {expected_l1_last_dim}) "
+                f"({'packed INT4 via .view(torch.int32)' if is_a8w4_int else 'unpacked'}) "
+                f"but got {tuple(l1_weights[0].shape)}."
+            )
+
+        sym_buffer = self._get_or_create_mega_moe_symm_buffer(
+            num_experts=num_experts,
+            num_max_dispatch_tokens_per_rank=num_max_dispatch_tokens_per_rank,
+            num_topk=topk_idx.size(1),
+            hidden=hidden,
+            intermediate_hidden=intermediate_hidden,
+            max_recv_token_num=max_recv_token_num,
+            dispatch_quant_mode=resolved_dispatch_quant_mode,
+            dispatch_quant_out_dtype=resolved_dispatch_quant_out_dtype,
+            activation=activation,
+        )
+
+        (
+            x_padded,
+            topk_idx_padded,
+            topk_weights_padded,
+            x_active_mask,
+            original_num_tokens,
+        ) = self._pad_mega_moe_inputs(
+            x,
+            topk_idx,
+            topk_weights,
+            num_max_dispatch_tokens_per_rank,
+        )
+
+        output, expert_token_num = mega_moe(
+            x=x_padded,
+            topk_ids=topk_idx_padded,
+            topk_weights=topk_weights_padded,
+            l1_weights=l1_weights,
+            l2_weights=l2_weights,
+            sym_buffer=sym_buffer,
+            l1_weights_sf=l1_weights_sf,
+            l2_weights_sf=l2_weights_sf,
+            l1_bias=l1_bias_list,
+            l2_bias=l2_bias_list,
+            x_active_mask=x_active_mask,
+            activation=activation,
+            activation_clamp=activation_clamp,
+            beta=beta,
+            linear_beta=linear_beta,
+        )
+        return output[:original_num_tokens], expert_token_num
+
+    def fused_deep_moe(
+        self,
+        x: torch.Tensor,
+        topk_idx: torch.Tensor,
+        topk_weights: torch.Tensor,
+        gmm1_permuted_weight: TensorOrTensors,
+        gmm1_permuted_weight_scale: Optional[TensorOrTensors],
+        gmm2_weight: TensorOrTensors,
+        gmm2_weight_scale: Optional[TensorOrTensors],
+        num_max_dispatch_tokens_per_rank: int,
+        num_experts: int,
+        quant_mode: int = 1,
+        fuse_mode: FuseMode = FuseMode.FUSED_DEEP_MOE,
+        backend: str = "auto",
+        activation: str = "swiglu",
+        activation_clamp: Optional[float] = None,
+        beta: float = 1.0,
+        linear_beta: Optional[float] = None,
+        l1_bias: Optional[TensorOrTensors] = None,
+        l2_bias: Optional[TensorOrTensors] = None,
+        dispatch_quant_mode: Optional[int] = None,
+        dispatch_quant_out_dtype: Optional[torch.dtype] = None,
+        max_recv_token_num: int = 0,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Fused MoE forward entrypoint with backend routing between `deep_ep` and
+        `cann_ops_transformer.ops.mega_moe`.
+
+        Arguments:
+            x: `[bs, hidden]` token tensor. The hidden dimension defines the
+                mega_moe `hidden` parameter.
+            topk_idx: `[bs, num_topk]` token-to-expert routing indices. `-1` means
+                the token does not select that top-k slot.
+            topk_weights: `[bs, num_topk]` routing weights used during combine.
+            gmm1_permuted_weight: First-stage expert weights. For `backend="deep_ep"`,
+                this preserves the legacy fused kernel layout requirements. For
+                `backend="mega_moe"`, this argument is interpreted as mega_moe
+                `l1_weights` and must be either a Tensor whose leading dimension is
+                the local expert count or a `list[Tensor]` of per-expert weights in
+                mega_moe layout `[hidden, 2 * intermediate_hidden]` for
+                A16W16/A8W8-INT, or packed INT4 layout exposed as `torch.int32`
+                with shape `[hidden, (2 * intermediate_hidden) // 8]` for A8W4-INT.
+            gmm1_permuted_weight_scale: First-stage weight scales. Required by the
+                deep_ep backend. Optional for mega_moe A16W16, required for mega_moe
+                A8W8-INT/A8W4-INT. For mega_moe, accepts either a Tensor with leading
+                local-expert dimension or a `list[Tensor]`.
+            gmm2_weight: Second-stage expert weights. For `backend="mega_moe"`, this
+                is interpreted as mega_moe `l2_weights` and must use layout
+                `[intermediate_hidden, hidden]` per local expert for
+                A16W16/A8W8-INT, or packed INT4 layout exposed as `torch.int32`
+                with shape `[intermediate_hidden, hidden // 8]` for A8W4-INT.
+            gmm2_weight_scale: Second-stage weight scales. Same backend and quantized
+                scene rules as `gmm1_permuted_weight_scale`.
+            num_max_dispatch_tokens_per_rank: Maximum token count participating in EP
+                dispatch for each rank. This value is forwarded to either backend and
+                is also part of the mega_moe SymmBuffer cache key.
+            num_experts: Global expert count. For mega_moe, it must be divisible by
+                the process-group size so that local expert counts are well-defined.
+            quant_mode: Legacy deep_ep quantization mode. Supported by `backend="deep_ep"`
+                only. The mega_moe backend infers its scene from scales/biases and
+                `dispatch_quant_mode`.
+            fuse_mode: Fused execution mode. The deep_ep backend supports both
+                `FuseMode.FUSED_DEEP_MOE` and `FuseMode.DISPATCH_FFN_COMBINE`.
+                The mega_moe backend supports only `FuseMode.FUSED_DEEP_MOE`.
+            backend: Backend selector. `"auto"` keeps the existing A5 deep_ep fused
+                path and routes non-A5 or mega_moe-only features to mega_moe.
+            activation: Activation name. Supported values are `"swiglu"`,
+                `"swiglu_gpt_oss"`, and `"situ"` on the mega_moe backend. The
+                deep_ep backend supports only `"swiglu"`.
+            activation_clamp: Optional symmetric clamp value applied by the
+                mega_moe backend activation implementation. This is independent
+                from `linear_beta`, must be `None` or `>= 0`, and is unsupported
+                by the legacy deep_ep backend.
+            beta: Optional beta parameter for the `"situ"` activation. Defaults
+                to `1.0`. Non-default values are unsupported outside
+                `activation="situ"`.
+            linear_beta: Optional linear beta for the `"situ"` activation linear
+                branch. This is distinct from `activation_clamp` and is
+                forwarded to mega_moe as `linear_beta=...`.
+            l1_bias: Optional per-expert first-stage bias tensors used for mega_moe
+                A8W4-INT compensation. Unsupported on the deep_ep backend.
+            l2_bias: Optional per-expert second-stage bias tensors used for mega_moe
+                A8W4-INT compensation. Unsupported on the deep_ep backend.
+            dispatch_quant_mode: Optional mega_moe dispatch quantization selector.
+                Supported values in this wrapper are `0` (A16W16) and `2`
+                (A8W8-INT/A8W4-INT). Unsupported on the deep_ep backend.
+            dispatch_quant_out_dtype: Optional mega_moe dispatch output dtype.
+                This wrapper currently supports only `torch.int8` when
+                `dispatch_quant_mode=2`.
+            max_recv_token_num: Optional mega_moe max receive token hint. Forwarded to
+                mega_moe only.
+
+        Returns:
+            A tuple `(output, aux)` where `output` is the fused expert output tensor.
+            The `aux` tensor is backend-dependent:
+            - deep_ep + `FuseMode.FUSED_DEEP_MOE`: `ep_recv_count`,
+              shape `[num_local_experts * num_ranks]`
+            - deep_ep + `FuseMode.DISPATCH_FFN_COMBINE`: `expert_token_nums`,
+              shape `[num_local_experts]`
+            - mega_moe: `expert_token_nums`, shape `[num_local_experts]`
+        """
+        resolved_backend = self._resolve_fused_backend(
+            backend=backend,
+            activation=activation,
+            l1_bias=l1_bias,
+            l2_bias=l2_bias,
+            dispatch_quant_mode=dispatch_quant_mode,
+        )
+        if resolved_backend == "deep_ep":
+            return self._fused_deep_moe_with_deep_ep(
+                x=x,
+                topk_idx=topk_idx,
+                topk_weights=topk_weights,
+                gmm1_permuted_weight=gmm1_permuted_weight,
+                gmm1_permuted_weight_scale=gmm1_permuted_weight_scale,
+                gmm2_weight=gmm2_weight,
+                gmm2_weight_scale=gmm2_weight_scale,
+                num_max_dispatch_tokens_per_rank=num_max_dispatch_tokens_per_rank,
+                num_experts=num_experts,
+                quant_mode=quant_mode,
+                fuse_mode=fuse_mode,
+                activation=activation,
+                activation_clamp=activation_clamp,
+                beta=beta,
+                linear_beta=linear_beta,
+                l1_bias=l1_bias,
+                l2_bias=l2_bias,
+                dispatch_quant_mode=dispatch_quant_mode,
+                dispatch_quant_out_dtype=dispatch_quant_out_dtype,
+                max_recv_token_num=max_recv_token_num,
+            )
+        if x.size(0) == 0:
+            x = torch.zeros(
+                (1, x.size(1)),
+                dtype=x.dtype,
+                device=x.device,
+            )
+
+            topk_idx = torch.arange(
+                topk_idx.size(1),
+                dtype=topk_idx.dtype,
+                device=topk_idx.device,
+            ).unsqueeze(0)
+
+            topk_weights = torch.zeros(
+                (1, topk_weights.size(1)),
+                dtype=topk_weights.dtype,
+                device=topk_weights.device,
+            )
+        output, expert_token_num = self._fused_deep_moe_with_mega_moe(
+            x=x,
+            topk_idx=topk_idx,
+            topk_weights=topk_weights,
+            gmm1_permuted_weight=gmm1_permuted_weight,
+            gmm1_permuted_weight_scale=gmm1_permuted_weight_scale,
+            gmm2_weight=gmm2_weight,
+            gmm2_weight_scale=gmm2_weight_scale,
+            num_max_dispatch_tokens_per_rank=num_max_dispatch_tokens_per_rank,
+            num_experts=num_experts,
+            fuse_mode=fuse_mode,
+            activation=activation,
+            activation_clamp=activation_clamp,
+            beta=beta,
+            linear_beta=linear_beta,
+            l1_bias=l1_bias,
+            l2_bias=l2_bias,
+            dispatch_quant_mode=2 if quant_mode == 1 else dispatch_quant_mode,
+            dispatch_quant_out_dtype=(
+                torch.int8 if quant_mode == 1 else dispatch_quant_out_dtype
+            ),
+            max_recv_token_num=max_recv_token_num,
+        )
+        if x.size(0) == 0:
+            output = torch.empty(
+                (0, x.size(1)),
+                dtype=x.dtype,
+                device=x.device,
+            )
+
+        return output, expert_token_num

--- a/python/deep_ep/deep_ep/ep_strategy.py
+++ b/python/deep_ep/deep_ep/ep_strategy.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import torch
 import torch.distributed as dist
@@ -26,6 +26,15 @@ class LowLatencyStrategy:
     @classmethod
     def get_all_strategies(cls) -> list:
         return [cls.DEFAULT, cls.OPS, cls.ALLTOALL]
+
+
+class FusedStrategy:
+    DEEP_EP = "deep_ep"
+    MEGA_MOE = "mega_moe"
+
+    @classmethod
+    def get_all_strategies(cls) -> list:
+        return [cls.DEEP_EP, cls.MEGA_MOE]
 
 
 # Normal mode strategy and Low latency mode strategy
@@ -213,6 +222,48 @@ class LowLatencyEPCommStrategy(EPCommStrategy):
         pass
 
 
+class FusedEPStrategy(ABC):
+    """Fused MoE execution strategies base class."""
+
+    def destroy(self) -> None:
+        """Release strategy-owned resources."""
+        return None
+
+    @abstractmethod
+    def get_name(self) -> str:
+        """Get the name of the strategy."""
+        pass
+
+    @abstractmethod
+    def run(
+        self,
+        *,
+        buffer: Any,
+        x: torch.Tensor,
+        topk_idx: torch.Tensor,
+        topk_weights: torch.Tensor,
+        gmm1_permuted_weight,
+        gmm1_permuted_weight_scale,
+        gmm2_weight,
+        gmm2_weight_scale,
+        num_max_dispatch_tokens_per_rank: int,
+        num_experts: int,
+        quant_mode: int,
+        fuse_mode,
+        activation: str,
+        activation_clamp: Optional[float],
+        beta: float,
+        linear_beta: Optional[float],
+        l1_bias,
+        l2_bias,
+        dispatch_quant_mode: Optional[int],
+        dispatch_quant_out_dtype: Optional[torch.dtype],
+        max_recv_token_num: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Execute fused MoE with the bound backend strategy."""
+        pass
+
+
 # ==================== Strategy Registry ====================
 
 # Normal mode strategy registry
@@ -220,6 +271,9 @@ _NORMAL_STRATEGY_REGISTRY: Dict[str, Type[NormalEPCommStrategy]] = {}
 
 # Low latency mode strategy registry
 _LOW_LATENCY_STRATEGY_REGISTRY: Dict[str, Type[LowLatencyEPCommStrategy]] = {}
+
+# Fused mode strategy registry
+_FUSED_STRATEGY_REGISTRY: Dict[str, Type[FusedEPStrategy]] = {}
 
 
 def register_normal_strategy(name: str):
@@ -258,3 +312,22 @@ def get_low_latency_strategy(name: str) -> Type[LowLatencyEPCommStrategy]:
             f"Unknown low latency strategy: {name}. Available: {list(_LOW_LATENCY_STRATEGY_REGISTRY.keys())}"
         )
     return _LOW_LATENCY_STRATEGY_REGISTRY[name]
+
+
+def register_fused_strategy(name: str):
+    """Decorator to register a fused mode strategy."""
+
+    def decorator(cls: Type[FusedEPStrategy]):
+        _FUSED_STRATEGY_REGISTRY[name] = cls
+        return cls
+
+    return decorator
+
+
+def get_fused_strategy(name: str) -> Type[FusedEPStrategy]:
+    """Get a fused mode strategy class by name."""
+    if name not in _FUSED_STRATEGY_REGISTRY:
+        raise ValueError(
+            f"Unknown fused strategy: {name}. Available: {list(_FUSED_STRATEGY_REGISTRY.keys())}"
+        )
+    return _FUSED_STRATEGY_REGISTRY[name]

--- a/python/deep_ep/deep_ep/strategies/__init__.py
+++ b/python/deep_ep/deep_ep/strategies/__init__.py
@@ -9,13 +9,17 @@ separated by mode:
 
 from ..ep_strategy import (
     EPCommStrategy,
+    FusedEPStrategy,
     LowLatencyEPCommStrategy,
     NormalEPCommStrategy,
+    get_fused_strategy,
     get_low_latency_strategy,
     get_normal_strategy,
+    register_fused_strategy,
     register_low_latency_strategy,
     register_normal_strategy,
 )
+from .fused_strategy import DeepEPFusedStrategy, MegaMoeFusedStrategy
 from .low_latency_strategy import (
     DefaultLowLatencyCommStrategy,
     OpsLowLatencyCommStrategy,
@@ -27,15 +31,21 @@ __all__ = [
     "EPCommStrategy",
     "NormalEPCommStrategy",
     "LowLatencyEPCommStrategy",
+    "FusedEPStrategy",
     # Registry functions
     "register_normal_strategy",
     "register_low_latency_strategy",
+    "register_fused_strategy",
     "get_normal_strategy",
     "get_low_latency_strategy",
+    "get_fused_strategy",
     # Normal strategies
     "DefaultNormalCommStrategy",
     "AlltoAllNormalCommStrategy",
     # Low latency strategies
     "DefaultLowLatencyCommStrategy",
     "OpsLowLatencyCommStrategy",
+    # Fused strategies
+    "DeepEPFusedStrategy",
+    "MegaMoeFusedStrategy",
 ]

--- a/python/deep_ep/deep_ep/strategies/fused_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/fused_strategy.py
@@ -1,0 +1,628 @@
+"""
+Fused MoE execution strategies.
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+import torch
+
+from ..ep_strategy import FusedEPStrategy, register_fused_strategy
+
+try:
+    from cann_ops_transformer.ops import (
+        get_symm_buffer_for_mega_moe as _get_symm_buffer_for_mega_moe,
+    )
+    from cann_ops_transformer.ops import mega_moe as _mega_moe
+
+    _MEGA_MOE_IMPORT_ERROR = None
+except ImportError as exc:
+    _get_symm_buffer_for_mega_moe = None
+    _mega_moe = None
+    _MEGA_MOE_IMPORT_ERROR = exc
+
+
+@register_fused_strategy("deep_ep")
+class DeepEPFusedStrategy(FusedEPStrategy):
+    """Fused MoE strategy backed by deep_ep runtime kernels."""
+
+    def get_name(self) -> str:
+        return "deep_ep"
+
+    def run(
+        self,
+        *,
+        buffer,
+        x: torch.Tensor,
+        topk_idx: torch.Tensor,
+        topk_weights: torch.Tensor,
+        gmm1_permuted_weight,
+        gmm1_permuted_weight_scale,
+        gmm2_weight,
+        gmm2_weight_scale,
+        num_max_dispatch_tokens_per_rank: int,
+        num_experts: int,
+        quant_mode: int,
+        fuse_mode,
+        activation: str,
+        activation_clamp: Optional[float],
+        beta: float,
+        linear_beta: Optional[float],
+        l1_bias,
+        l2_bias,
+        dispatch_quant_mode: Optional[int],
+        dispatch_quant_out_dtype: Optional[torch.dtype],
+        max_recv_token_num: int,
+    ):
+        activation_clamp = buffer._validate_activation_clamp(activation_clamp)
+        if not buffer._is_default_beta(beta):
+            raise ValueError("`beta` is only supported by the mega_moe backend.")
+        if activation != "situ" and not buffer._is_zero_like_linear_beta(linear_beta):
+            raise ValueError('`linear_beta` is only valid when `activation="situ"`.')
+        if activation != "swiglu":
+            raise ValueError(
+                "The deep_ep fused backend only supports activation='swiglu'. "
+                "Use backend='mega_moe' for other activation types."
+            )
+        if activation_clamp is not None:
+            raise ValueError(
+                "`activation_clamp` is only supported by the mega_moe backend."
+            )
+        if not buffer._is_zero_like_linear_beta(linear_beta):
+            raise ValueError("`linear_beta` is only supported by the mega_moe backend.")
+        if l1_bias is not None or l2_bias is not None:
+            raise ValueError(
+                "`l1_bias` and `l2_bias` are only supported by the mega_moe backend."
+            )
+        if dispatch_quant_mode is not None or dispatch_quant_out_dtype is not None:
+            raise ValueError(
+                "`dispatch_quant_mode` and `dispatch_quant_out_dtype` are only "
+                "supported by the mega_moe backend."
+            )
+        if isinstance(gmm1_permuted_weight, list) or isinstance(gmm2_weight, list):
+            raise TypeError(
+                "The deep_ep fused backend expects Tensor inputs for "
+                "`gmm1_permuted_weight` and `gmm2_weight`."
+            )
+        if isinstance(gmm1_permuted_weight_scale, list) or isinstance(
+            gmm2_weight_scale, list
+        ):
+            raise TypeError(
+                "The deep_ep fused backend expects Tensor inputs for weight scales."
+            )
+        if gmm1_permuted_weight_scale is None or gmm2_weight_scale is None:
+            raise ValueError(
+                "The deep_ep fused backend requires both weight scale tensors."
+            )
+
+        topk_ids = topk_idx.int()
+        if fuse_mode == buffer.FuseMode.FUSED_DEEP_MOE:
+            gmm1_permuted_weight_scale = gmm1_permuted_weight_scale.float()
+            gmm2_weight_scale = gmm2_weight_scale.float()
+            output, ep_recv_count = buffer.runtime.fused_deep_moe(
+                x,
+                topk_ids,
+                gmm1_permuted_weight,
+                gmm1_permuted_weight_scale,
+                gmm2_weight,
+                gmm2_weight_scale,
+                topk_weights,
+                num_max_dispatch_tokens_per_rank,
+                num_experts,
+                quant_mode,
+            )
+            return output, ep_recv_count
+        if fuse_mode == buffer.FuseMode.DISPATCH_FFN_COMBINE:
+            max_output_size = num_max_dispatch_tokens_per_rank
+            output, expert_token_nums = buffer.runtime.dispatch_ffn_combine(
+                x,
+                topk_ids,
+                gmm1_permuted_weight,
+                gmm1_permuted_weight_scale,
+                gmm2_weight,
+                gmm2_weight_scale,
+                topk_weights,
+                max_output_size,
+                num_experts,
+                quant_mode,
+            )
+            return output, expert_token_nums
+        raise NotImplementedError(f"Not support fuse_mode:{fuse_mode}")
+
+
+@register_fused_strategy("mega_moe")
+class MegaMoeFusedStrategy(FusedEPStrategy):
+    """Fused MoE strategy backed by cann_ops_transformer mega_moe."""
+
+    def __init__(self) -> None:
+        self._symm_buffer_cache: Dict[tuple, object] = {}
+
+    def get_name(self) -> str:
+        return "mega_moe"
+
+    def destroy(self) -> None:
+        for sym_buffer in self._symm_buffer_cache.values():
+            try:
+                sym_buffer.destroy()
+            except Exception:
+                pass
+        self._symm_buffer_cache.clear()
+
+    @staticmethod
+    def _require_mega_moe_ops():
+        if _get_symm_buffer_for_mega_moe is None or _mega_moe is None:
+            raise ImportError(
+                "The mega_moe backend requires the optional dependency "
+                "`cann_ops_transformer`. Install or expose `cann_ops_transformer.ops` "
+                'before calling `Buffer.fused_deep_moe(..., backend="mega_moe")`.'
+            ) from _MEGA_MOE_IMPORT_ERROR
+        return _get_symm_buffer_for_mega_moe, _mega_moe
+
+    @staticmethod
+    def _normalize_expert_param(
+        param,
+        name: str,
+        expected_num_local_experts: int,
+    ) -> Optional[List[torch.Tensor]]:
+        if param is None:
+            return None
+        if isinstance(param, list):
+            if len(param) != expected_num_local_experts:
+                raise ValueError(
+                    f"`{name}` must contain exactly {expected_num_local_experts} "
+                    f"local expert tensors, but got {len(param)}."
+                )
+            return param
+        if not isinstance(param, torch.Tensor):
+            raise TypeError(
+                f"`{name}` must be a Tensor, a list[Tensor], or None, "
+                f"but got {type(param)}."
+            )
+        if param.dim() == 0:
+            raise ValueError(f"`{name}` must not be a scalar tensor.")
+        if param.size(0) != expected_num_local_experts:
+            raise ValueError(
+                f"`{name}` must have leading dimension {expected_num_local_experts} "
+                f"for local experts, but got shape {tuple(param.shape)}."
+            )
+        return [param[i] for i in range(expected_num_local_experts)]
+
+    @staticmethod
+    def _infer_mega_moe_quant_config(
+        l1_weights_sf,
+        l2_weights_sf,
+        l1_bias,
+        l2_bias,
+        dispatch_quant_mode: Optional[int],
+        dispatch_quant_out_dtype: Optional[torch.dtype],
+    ):
+        has_scales = l1_weights_sf is not None or l2_weights_sf is not None
+        has_bias = l1_bias is not None or l2_bias is not None
+        if has_scales and (l1_weights_sf is None or l2_weights_sf is None):
+            raise ValueError(
+                "`gmm1_permuted_weight_scale` and `gmm2_weight_scale` must both be "
+                "provided for mega_moe quantized execution."
+            )
+        if has_bias and (l1_bias is None or l2_bias is None):
+            raise ValueError(
+                "`l1_bias` and `l2_bias` must both be provided for A8W4-INT "
+                "mega_moe execution."
+            )
+
+        resolved_quant_mode = (
+            2
+            if has_scales or has_bias
+            else 0 if dispatch_quant_mode is None else dispatch_quant_mode
+        )
+        if resolved_quant_mode not in (0, 2):
+            raise ValueError(
+                "`dispatch_quant_mode` only supports 0 (A16W16) or 2 "
+                "(A8W8-INT/A8W4-INT) in fused_deep_moe mega_moe backend."
+            )
+        if resolved_quant_mode == 0:
+            if has_scales or has_bias:
+                raise ValueError(
+                    "Scale and bias tensors are only valid when "
+                    "`dispatch_quant_mode=2`."
+                )
+            if dispatch_quant_out_dtype is not None:
+                raise ValueError(
+                    "`dispatch_quant_out_dtype` must be None when "
+                    "`dispatch_quant_mode=0`."
+                )
+            return 0, None
+
+        resolved_quant_out_dtype = (
+            torch.int8 if dispatch_quant_out_dtype is None else dispatch_quant_out_dtype
+        )
+        if resolved_quant_out_dtype != torch.int8:
+            raise ValueError(
+                "`dispatch_quant_out_dtype` must be torch.int8 for "
+                "A8W8-INT/A8W4-INT mega_moe execution."
+            )
+        return resolved_quant_mode, resolved_quant_out_dtype
+
+    def _prepare_quant_scene(
+        self,
+        *,
+        gmm1_permuted_weight,
+        gmm1_permuted_weight_scale,
+        gmm2_weight,
+        gmm2_weight_scale,
+        l1_bias,
+        l2_bias,
+        expected_num_local_experts: int,
+        dispatch_quant_mode: Optional[int],
+        dispatch_quant_out_dtype: Optional[torch.dtype],
+    ):
+        l1_weights = self._normalize_expert_param(
+            gmm1_permuted_weight,
+            "gmm1_permuted_weight",
+            expected_num_local_experts,
+        )
+        l2_weights = self._normalize_expert_param(
+            gmm2_weight,
+            "gmm2_weight",
+            expected_num_local_experts,
+        )
+        l1_weights_sf = self._normalize_expert_param(
+            gmm1_permuted_weight_scale,
+            "gmm1_permuted_weight_scale",
+            expected_num_local_experts,
+        )
+        l2_weights_sf = self._normalize_expert_param(
+            gmm2_weight_scale,
+            "gmm2_weight_scale",
+            expected_num_local_experts,
+        )
+        l1_bias_list = self._normalize_expert_param(
+            l1_bias,
+            "l1_bias",
+            expected_num_local_experts,
+        )
+        l2_bias_list = self._normalize_expert_param(
+            l2_bias,
+            "l2_bias",
+            expected_num_local_experts,
+        )
+        resolved_dispatch_quant_mode, resolved_dispatch_quant_out_dtype = (
+            self._infer_mega_moe_quant_config(
+                l1_weights_sf,
+                l2_weights_sf,
+                l1_bias_list,
+                l2_bias_list,
+                dispatch_quant_mode,
+                dispatch_quant_out_dtype,
+            )
+        )
+        return (
+            l1_weights,
+            l2_weights,
+            l1_weights_sf,
+            l2_weights_sf,
+            l1_bias_list,
+            l2_bias_list,
+            resolved_dispatch_quant_mode,
+            resolved_dispatch_quant_out_dtype,
+        )
+
+    def _get_or_create_mega_moe_symm_buffer(
+        self,
+        *,
+        group,
+        num_experts: int,
+        num_max_dispatch_tokens_per_rank: int,
+        num_topk: int,
+        hidden: int,
+        intermediate_hidden: int,
+        max_recv_token_num: int,
+        dispatch_quant_mode: int,
+        dispatch_quant_out_dtype: Optional[torch.dtype],
+        activation: str,
+    ):
+        get_symm_buffer_for_mega_moe, _ = self._require_mega_moe_ops()
+        cache_key = (
+            num_experts,
+            num_max_dispatch_tokens_per_rank,
+            num_topk,
+            hidden,
+            intermediate_hidden,
+            max_recv_token_num,
+            dispatch_quant_mode,
+            dispatch_quant_out_dtype,
+            activation,
+        )
+        sym_buffer = self._symm_buffer_cache.get(cache_key)
+        if sym_buffer is None:
+            sym_buffer = get_symm_buffer_for_mega_moe(
+                group,
+                num_experts=num_experts,
+                num_max_tokens_per_rank=num_max_dispatch_tokens_per_rank,
+                num_topk=num_topk,
+                hidden=hidden,
+                intermediate_hidden=intermediate_hidden,
+                max_recv_token_num=max_recv_token_num,
+                dispatch_quant_mode=dispatch_quant_mode,
+                dispatch_quant_out_dtype=dispatch_quant_out_dtype,
+            )
+            self._symm_buffer_cache[cache_key] = sym_buffer
+        return sym_buffer
+
+    def _pad_mega_moe_inputs(
+        self,
+        x: torch.Tensor,
+        topk_idx: torch.Tensor,
+        topk_weights: torch.Tensor,
+        num_max_dispatch_tokens_per_rank: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int]:
+        original_num_tokens = x.size(0)
+        if original_num_tokens > num_max_dispatch_tokens_per_rank:
+            raise ValueError(
+                "The number of input tokens exceeds "
+                "`num_max_dispatch_tokens_per_rank`: "
+                f"{original_num_tokens} > {num_max_dispatch_tokens_per_rank}."
+            )
+
+        x_active_mask = torch.zeros(
+            num_max_dispatch_tokens_per_rank,
+            dtype=torch.int8,
+            device=x.device,
+        )
+        x_active_mask[:original_num_tokens] = 1
+
+        if original_num_tokens == num_max_dispatch_tokens_per_rank:
+            return x, topk_idx, topk_weights, x_active_mask, original_num_tokens
+
+        padding_size = num_max_dispatch_tokens_per_rank - original_num_tokens
+        x_padded = torch.cat((x, x.new_zeros((padding_size, x.size(1)))), dim=0)
+        topk_idx_padded = torch.cat(
+            (topk_idx, topk_idx.new_zeros((padding_size, topk_idx.size(1)))),
+            dim=0,
+        )
+        topk_weights_padded = torch.cat(
+            (
+                topk_weights,
+                topk_weights.new_zeros((padding_size, topk_weights.size(1))),
+            ),
+            dim=0,
+        )
+        return (
+            x_padded,
+            topk_idx_padded,
+            topk_weights_padded,
+            x_active_mask,
+            original_num_tokens,
+        )
+
+    def _validate_weight_layout(
+        self,
+        *,
+        l1_weights,
+        l2_weights,
+        hidden: int,
+        resolved_dispatch_quant_mode: int,
+        l1_bias_list,
+        l2_bias_list,
+    ):
+        is_a8w4_int = l1_bias_list is not None and l2_bias_list is not None
+        if not l2_weights or l2_weights[0].dim() < 2:
+            raise ValueError(
+                "`gmm2_weight` must contain per-expert 2D tensors in mega_moe layout "
+                "[intermediate_hidden, hidden]."
+            )
+        intermediate_hidden = l2_weights[0].shape[-2]
+        expected_l2_last_dim = hidden // 8 if is_a8w4_int else hidden
+        expected_l1_last_dim = (
+            (intermediate_hidden * 2) // 8 if is_a8w4_int else intermediate_hidden * 2
+        )
+        inferred_scene = (
+            "A8W4-INT"
+            if is_a8w4_int
+            else "A8W8-INT" if resolved_dispatch_quant_mode == 2 else "A16W16"
+        )
+        if l2_weights[0].shape[-1] != expected_l2_last_dim:
+            raise ValueError(
+                "`gmm2_weight` has an invalid mega_moe layout for "
+                f"{inferred_scene}. Expected first local expert shape "
+                f"({intermediate_hidden}, {expected_l2_last_dim}) "
+                f"({'packed INT4 via .view(torch.int32)' if is_a8w4_int else 'unpacked'}) "
+                f"but got {tuple(l2_weights[0].shape)} with hidden={hidden}."
+            )
+        if l1_weights[0].dim() < 2:
+            raise ValueError(
+                "`gmm1_permuted_weight` must contain per-expert 2D tensors in mega_moe "
+                "layout [hidden, 2 * intermediate_hidden]."
+            )
+        if l1_weights[0].shape[-2] != hidden:
+            raise ValueError(
+                "`gmm1_permuted_weight` must use mega_moe layout "
+                "[hidden, 2 * intermediate_hidden] for the mega_moe backend, "
+                f"but got first local expert shape {tuple(l1_weights[0].shape)} "
+                f"with hidden={hidden}."
+            )
+        if l1_weights[0].shape[-1] != expected_l1_last_dim:
+            raise ValueError(
+                "`gmm1_permuted_weight` has an invalid mega_moe layout for "
+                f"{inferred_scene}. Expected first local expert shape "
+                f"({hidden}, {expected_l1_last_dim}) "
+                f"({'packed INT4 via .view(torch.int32)' if is_a8w4_int else 'unpacked'}) "
+                f"but got {tuple(l1_weights[0].shape)}."
+            )
+        return intermediate_hidden
+
+    def _build_runtime_inputs(
+        self,
+        *,
+        x: torch.Tensor,
+        topk_idx: torch.Tensor,
+        topk_weights: torch.Tensor,
+        num_max_dispatch_tokens_per_rank: int,
+    ):
+        return self._pad_mega_moe_inputs(
+            x,
+            topk_idx,
+            topk_weights,
+            num_max_dispatch_tokens_per_rank,
+        )
+
+    def _execute_mega_moe(
+        self,
+        *,
+        mega_moe,
+        x_padded: torch.Tensor,
+        topk_idx_padded: torch.Tensor,
+        topk_weights_padded: torch.Tensor,
+        l1_weights,
+        l2_weights,
+        sym_buffer,
+        l1_weights_sf,
+        l2_weights_sf,
+        l1_bias_list,
+        l2_bias_list,
+        x_active_mask: torch.Tensor,
+        activation: str,
+        activation_clamp: Optional[float],
+        beta: float,
+        linear_beta: Optional[float],
+    ):
+        return mega_moe(
+            x=x_padded,
+            topk_ids=topk_idx_padded,
+            topk_weights=topk_weights_padded,
+            l1_weights=l1_weights,
+            l2_weights=l2_weights,
+            sym_buffer=sym_buffer,
+            l1_weights_sf=l1_weights_sf,
+            l2_weights_sf=l2_weights_sf,
+            l1_bias=l1_bias_list,
+            l2_bias=l2_bias_list,
+            x_active_mask=x_active_mask,
+            activation=activation,
+            activation_clamp=activation_clamp,
+            beta=beta,
+            linear_beta=linear_beta,
+        )
+
+    def run(
+        self,
+        *,
+        buffer,
+        x: torch.Tensor,
+        topk_idx: torch.Tensor,
+        topk_weights: torch.Tensor,
+        gmm1_permuted_weight,
+        gmm1_permuted_weight_scale,
+        gmm2_weight,
+        gmm2_weight_scale,
+        num_max_dispatch_tokens_per_rank: int,
+        num_experts: int,
+        quant_mode: int,
+        fuse_mode,
+        activation: str,
+        activation_clamp: Optional[float],
+        beta: float,
+        linear_beta: Optional[float],
+        l1_bias,
+        l2_bias,
+        dispatch_quant_mode: Optional[int],
+        dispatch_quant_out_dtype: Optional[torch.dtype],
+        max_recv_token_num: int,
+    ):
+        _, mega_moe = self._require_mega_moe_ops()
+        activation_clamp = buffer._validate_activation_clamp(activation_clamp)
+        if activation not in ("swiglu", "swiglu_gpt_oss", "situ"):
+            raise ValueError(
+                f"Unsupported mega_moe activation {activation!r}. Expected one of "
+                "`swiglu`, `swiglu_gpt_oss`, or `situ`."
+            )
+        if activation != "situ" and not buffer._is_default_beta(beta):
+            raise ValueError('`beta` is only valid when `activation="situ"`.')
+        if activation != "situ" and not buffer._is_zero_like_linear_beta(linear_beta):
+            raise ValueError('`linear_beta` is only valid when `activation="situ"`.')
+        if fuse_mode != buffer.FuseMode.FUSED_DEEP_MOE:
+            raise NotImplementedError(
+                "The mega_moe backend only supports FuseMode.FUSED_DEEP_MOE."
+            )
+
+        expected_num_local_experts = num_experts // buffer.group_size
+        if expected_num_local_experts * buffer.group_size != num_experts:
+            raise ValueError(
+                "`num_experts` must be divisible by the process-group size when "
+                "using the mega_moe backend."
+            )
+
+        (
+            l1_weights,
+            l2_weights,
+            l1_weights_sf,
+            l2_weights_sf,
+            l1_bias_list,
+            l2_bias_list,
+            resolved_dispatch_quant_mode,
+            resolved_dispatch_quant_out_dtype,
+        ) = self._prepare_quant_scene(
+            gmm1_permuted_weight=gmm1_permuted_weight,
+            gmm1_permuted_weight_scale=gmm1_permuted_weight_scale,
+            gmm2_weight=gmm2_weight,
+            gmm2_weight_scale=gmm2_weight_scale,
+            l1_bias=l1_bias,
+            l2_bias=l2_bias,
+            expected_num_local_experts=expected_num_local_experts,
+            dispatch_quant_mode=dispatch_quant_mode,
+            dispatch_quant_out_dtype=dispatch_quant_out_dtype,
+        )
+
+        hidden = x.size(1)
+        intermediate_hidden = self._validate_weight_layout(
+            l1_weights=l1_weights,
+            l2_weights=l2_weights,
+            hidden=hidden,
+            resolved_dispatch_quant_mode=resolved_dispatch_quant_mode,
+            l1_bias_list=l1_bias_list,
+            l2_bias_list=l2_bias_list,
+        )
+
+        sym_buffer = self._get_or_create_mega_moe_symm_buffer(
+            group=buffer.group,
+            num_experts=num_experts,
+            num_max_dispatch_tokens_per_rank=num_max_dispatch_tokens_per_rank,
+            num_topk=topk_idx.size(1),
+            hidden=hidden,
+            intermediate_hidden=intermediate_hidden,
+            max_recv_token_num=max_recv_token_num,
+            dispatch_quant_mode=resolved_dispatch_quant_mode,
+            dispatch_quant_out_dtype=resolved_dispatch_quant_out_dtype,
+            activation=activation,
+        )
+
+        (
+            x_padded,
+            topk_idx_padded,
+            topk_weights_padded,
+            x_active_mask,
+            original_num_tokens,
+        ) = self._build_runtime_inputs(
+            x=x,
+            topk_idx=topk_idx,
+            topk_weights=topk_weights,
+            num_max_dispatch_tokens_per_rank=num_max_dispatch_tokens_per_rank,
+        )
+
+        output, expert_token_num = self._execute_mega_moe(
+            mega_moe=mega_moe,
+            x_padded=x_padded,
+            topk_idx_padded=topk_idx_padded,
+            topk_weights_padded=topk_weights_padded,
+            l1_weights=l1_weights,
+            l2_weights=l2_weights,
+            sym_buffer=sym_buffer,
+            l1_weights_sf=l1_weights_sf,
+            l2_weights_sf=l2_weights_sf,
+            l1_bias_list=l1_bias_list,
+            l2_bias_list=l2_bias_list,
+            x_active_mask=x_active_mask,
+            activation=activation,
+            activation_clamp=activation_clamp,
+            beta=beta,
+            linear_beta=linear_beta,
+        )
+        return output[:original_num_tokens], expert_token_num

--- a/python/deep_ep/doc/FUSED_DEEP_MOE.md
+++ b/python/deep_ep/doc/FUSED_DEEP_MOE.md
@@ -1,201 +1,151 @@
 # Fused Deep MoE API
 
-<div align="center">
+`Buffer.fused_deep_moe(...)` is the unified fused MoE entrypoint in DeepEP-Ascend.
+It now supports two execution backends:
 
-[![Mode](https://img.shields.io/badge/Mode-Fused-purple)]()
-[![Platform](https://img.shields.io/badge/Platform-A3%20only-red)]()
-[![Quant](https://img.shields.io/badge/Quantization-INT8-yellow)]()
+- `deep_ep`: legacy fused kernels exposed by `deep_ep_cpp`
+- `mega_moe`: `cann_ops_transformer.ops.mega_moe`
 
-English | [中文](#中文)
+`backend="auto"` keeps the existing A5 behavior and routes non-A5 or mega_moe-only features to `mega_moe`.
 
-</div>
-
-> [!IMPORTANT]
-> **A3 only.** This API is NOT available on A2 or A5. A5 FP8/MXFP8 support is planned for future release.
-
----
-
-## English
-
-### Introduction
-
-In Mixture of Experts (MoE) models, the `fused_deep_moe` operator implements the hyper-fusion of Dispatch + Experts FFN (2×GMM) + Combine functionalities.
-This operator completes token distribution, expert computation (matrix multiplication, activation, quantization/dequantization), and result aggregation in a single call. Compared with traditional multi-operator implementations, it significantly reduces communication overhead and end-to-end latency.
-The communication latency (Batch size = 32 / 155μs, Dispatch = 80μs, Combine = 75μs) is reduced to less than 85μs, with a 70μs reduction in single-layer communication latency and a 4ms reduction in inference end-to-end latency.
-
-Two fuse modes are available via the `FuseMode` enum:
-
-| FuseMode | Value | CANN Operator | Description |
-|----------|-------|---------------|-------------|
-| `FuseMode.FUSED_DEEP_MOE` | `1` | `aclnnFusedDeepMoe` | Full fusion: InitRouting + AllToAll + GMM1 + DequantSwigluQuant + GMM2 + Dequant + Unpermute/Combine in a single AscendC kernel. |
-| `FuseMode.DISPATCH_FFN_COMBINE` | `2` | `aclnnDispatchFFNCombine` | Separate dispatch handling: InitRouting + AllToAll dispatch + GMM1 + DequantSwigluQuant + GMM2 + Dequant + Combine in a single AscendC kernel, using a different internal fusion strategy. |
-
-> [!NOTE]
-> `FuseMode` is **not** exported from the package's top-level `__init__.py`. Import it explicitly:
-> ```python
-> from deep_ep.buffer import FuseMode
-> ```
-> Or use integer values directly: `fuse_mode=1` (FUSED_DEEP_MOE) or `fuse_mode=2` (DISPATCH_FFN_COMBINE).
-
-#### Key Differences Between Fuse Modes
-
-| Aspect | `FUSED_DEEP_MOE` | `DISPATCH_FFN_COMBINE` |
-|--------|-------------------|------------------------|
-| **Weight scale dtype** | `float32` (auto-converted to `float` internally) | `int64` (float32 values reinterpreted as int64 bit patterns; **not auto-converted** — caller must perform the conversion manually) |
-| **Weight layout (GMM1)** | Permuted via tile-N permutation (`reshape_fusion_gmm_weight` in test code) | Standard NZ format, no additional permutation needed |
-| **`num_max_dispatch_tokens_per_rank`** semantics | Max tokens to dispatch per rank | Max tokens received in dispatch (i.e., `max_bs × num_ranks × topk`) |
-| **Second return value** | `ep_recv_count`, shape `[num_local_experts × num_ranks]` | `expert_token_nums`, shape `[num_local_experts]` (per-rank only) |
-| **Shared expert support** | Supported | **Not supported** |
-| **BF16 weight support** | Available | **Not available** — only INT8 weights are supported currently |
-
-### Python API
+## Python API
 
 ```python
 def fused_deep_moe(
     x: torch.Tensor,
     topk_idx: torch.Tensor,
     topk_weights: torch.Tensor,
-    gmm1_permuted_weight: torch.Tensor,
-    gmm1_permuted_weight_scale: torch.Tensor,
-    gmm2_weight: torch.Tensor,
-    gmm2_weight_scale: torch.Tensor,
+    gmm1_permuted_weight: Union[torch.Tensor, List[torch.Tensor]],
+    gmm1_permuted_weight_scale: Optional[Union[torch.Tensor, List[torch.Tensor]]],
+    gmm2_weight: Union[torch.Tensor, List[torch.Tensor]],
+    gmm2_weight_scale: Optional[Union[torch.Tensor, List[torch.Tensor]]],
     num_max_dispatch_tokens_per_rank: int,
     num_experts: int,
     quant_mode: int = 1,
     fuse_mode: FuseMode = FuseMode.FUSED_DEEP_MOE,
+    backend: str = "auto",
+    activation: str = "swiglu",
+    linear_beta: Optional[float] = None,
+    l1_bias: Optional[Union[torch.Tensor, List[torch.Tensor]]] = None,
+    l2_bias: Optional[Union[torch.Tensor, List[torch.Tensor]]] = None,
+    dispatch_quant_mode: Optional[int] = None,
+    dispatch_quant_out_dtype: Optional[torch.dtype] = None,
+    max_recv_token_num: int = 0,
 ) -> Tuple[torch.Tensor, torch.Tensor]
 ```
 
-### Parameter Description
+## Backend Rules
 
-| Parameter | Type | Shape | Description                                                                                                                                                                                                                                                                                                      |
-|-----------|------|-------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **x** | `torch.Tensor` | `[bs, hidden]` | Input token representations, where each row is the hidden vector of a token (commonly `bfloat16`). **bs** range **[1, 256]**. **hidden** range **[512, 7168]**, must be divisible by **32**.                                                                                                                     |
-| **topk_idx** | `torch.Tensor` | `[bs, num_topk]` | Expert indices for each token, `int32` type. A value of `-1` indicates the token is not dispatched.                                                                                                                                                                                                              |
-| **topk_weights** | `torch.Tensor` | `[bs, num_topk]` | Weighting coefficients for aggregating expert outputs (`float32`).                                                                                                                                                                                                                                               |
-| **gmm1_permuted_weight** | `torch.Tensor` | e.g., `[G, 7168, 4096]` | First-stage (up-projection) expert weights. For `FUSED_DEEP_MOE`, tile-N permuted layout to fit Grouped MatMul (reference implementation `reshape_fusion_gmm_weight` in test code); for `DISPATCH_FFN_COMBINE`, standard NZ format without permutation.                                                          |
-| **gmm1_permuted_weight_scale** | `torch.Tensor` | e.g., `[G, 4096]` | Quantization scale for first-stage weights. For `FUSED_DEEP_MOE`, `float32` dtype (auto-converted internally); for `DISPATCH_FFN_COMBINE`, **`int64` dtype** (float32 scale values reinterpreted as int64 bit patterns — **not auto-converted** by the Python API, caller must perform the conversion manually). |
-| **gmm2_weight** | `torch.Tensor` | e.g., `[G, 7168, 2048]` | Second-stage (down-projection) expert weights.                                                                                                                                                                                                                                                                   |
-| **gmm2_weight_scale** | `torch.Tensor` | e.g., `[G, 7168]` | Quantization scale for second-stage weights. Same dtype rules as `gmm1_permuted_weight_scale`.                                                                                                                                                                                                                   |
-| **num_max_dispatch_tokens_per_rank** | `int` | Scalar | For `FUSED_DEEP_MOE`: maximum number of tokens to dispatch per rank, used for buffer/memory allocation. For `DISPATCH_FFN_COMBINE`: maximum number of tokens received in dispatch (typically `max_bs × num_ranks × topk`). All ranks must hold the same value.                                                   |
-| **num_experts** | `int` | Scalar, range **(0, 512]** | Total number of global experts. Must be divisible by `(num_ranks - shared_expert_rank_num)`; otherwise the tiling check will reject it.                                                                                                                                                                          |
-| **quant_mode** | `int` | Scalar, default `1` | Quantization mode: `0` = no quantization (BF16 weights), `1` = INT8 (default). FP8 will be supported in A5 release.                                                                                                                                                                                              |
-| **fuse_mode** | `FuseMode` | Scalar, default `FuseMode.FUSED_DEEP_MOE` | Fuse mode selection. `FUSED_DEEP_MOE` (1): full fusion via `aclnnFusedDeepMoe`. `DISPATCH_FFN_COMBINE` (2): separate dispatch handling via `aclnnDispatchFFNCombine`.                                                                                                                                            |
+### `backend="auto"`
 
-### Constraints
+- A5 + legacy-compatible arguments: use `deep_ep`
+- `activation="situ"`: use `mega_moe`
+- `l1_bias` or `l2_bias` provided: use `mega_moe`
+- `dispatch_quant_mode` explicitly provided: use `mega_moe`
+- non-A5 build: use `mega_moe`
 
-- **bs** (batch size): range **[0, 256]**.
-- **hidden**: range **[512, 7168]**, must be divisible by **32**.
-- **num_topk** (topk): range **(0, 12]** — the kernel tiling enforces `topk ≤ 12`.
-- **num_experts**: range **(0, 512]** — the kernel tiling enforces `moeExpertNum ≤ 512`. `num_experts` must be divisible by `(num_ranks - shared_expert_rank_num)`.
+### `backend="deep_ep"`
 
-### Return Values
+- Supports `FuseMode.FUSED_DEEP_MOE`
+- Supports `FuseMode.DISPATCH_FFN_COMBINE`
+- Supports only `activation="swiglu"`
+- Uses legacy `quant_mode`
+- Requires tensor-form legacy fused weights/scales
+- Does not support `linear_beta`, `l1_bias`, `l2_bias`, `dispatch_quant_mode`,
+  `dispatch_quant_out_dtype`, or `max_recv_token_num`
 
-#### For `fuse_mode=FUSED_DEEP_MOE` (default)
+### `backend="mega_moe"`
 
-| Parameter | Type | Shape | Description |
-|-----------|------|-------|-------------|
-| **output** | `torch.Tensor` | `[bs, hidden]` | Fused expert outputs. |
-| **ep_recv_count** | `torch.Tensor` | `[num_local_experts × num_ranks]` | Number of tokens received by each expert across all ranks in the EP communication domain, used for subsequent communication synchronization or load balancing statistics. |
+- Supports only `FuseMode.FUSED_DEEP_MOE`
+- Requires `cann_ops_transformer`
+- Supports `activation="swiglu"`, `activation="swiglu_gpt_oss"`, and `activation="situ"`
+- Interprets legacy parameter names as mega_moe inputs:
+  - `gmm1_permuted_weight -> l1_weights`
+  - `gmm1_permuted_weight_scale -> l1_weights_sf`
+  - `gmm2_weight -> l2_weights`
+  - `gmm2_weight_scale -> l2_weights_sf`
+- Accepts either:
+  - a tensor whose leading dimension is the local expert count
+  - or `list[Tensor]` with one tensor per local expert
 
-#### For `fuse_mode=DISPATCH_FFN_COMBINE`
+## Parameter Notes
 
-| Parameter | Type | Shape | Description |
-|-----------|------|-------|-------------|
-| **output** | `torch.Tensor` | `[bs, hidden]` | Fused expert outputs. |
-| **expert_token_nums** | `torch.Tensor` | `[num_local_experts]` | Number of tokens received by each local expert on this rank, used for subsequent communication synchronization or load balancing statistics. |
+| Parameter | Notes |
+|---|---|
+| `x` | `[bs, hidden]` token tensor. |
+| `topk_idx` | `[bs, num_topk]` routing indices. `-1` is allowed. |
+| `topk_weights` | `[bs, num_topk]` combine weights. |
+| `gmm1_permuted_weight` | Legacy name kept for compatibility. On `mega_moe`, it must contain first linear weights in layout `[hidden, 2 * intermediate_hidden]` per expert. |
+| `gmm1_permuted_weight_scale` | Optional on `mega_moe` A16W16. Required on `mega_moe` A8W8-INT/A8W4-INT. |
+| `gmm2_weight` | Legacy name kept for compatibility. On `mega_moe`, it must contain second linear weights in layout `[intermediate_hidden, hidden]` per expert. |
+| `gmm2_weight_scale` | Optional on `mega_moe` A16W16. Required on `mega_moe` A8W8-INT/A8W4-INT. |
+| `num_max_dispatch_tokens_per_rank` | EP dispatch capacity hint shared across ranks. |
+| `num_experts` | Global expert count. On `mega_moe`, it must be divisible by the process-group size. |
+| `quant_mode` | Legacy deep_ep-only quantization selector. |
+| `fuse_mode` | `mega_moe` supports only `FuseMode.FUSED_DEEP_MOE`. |
+| `backend` | `"auto"`, `"deep_ep"`, or `"mega_moe"`. |
+| `activation` | `mega_moe` supports `"swiglu"`, `"swiglu_gpt_oss"`, `"situ"`. `deep_ep` supports only `"swiglu"`. |
+| `linear_beta` | Public replacement for the old `activation_clamp` naming. Only meaningful for `activation="situ"` on `mega_moe`. Internally forwarded as `activation_clamp=linear_beta` when calling mega_moe. |
+| `l1_bias`, `l2_bias` | Optional A8W4-INT compensation biases for `mega_moe` only. |
+| `dispatch_quant_mode` | `mega_moe` wrapper currently supports `0` (A16W16) and `2` (A8W8-INT/A8W4-INT). |
+| `dispatch_quant_out_dtype` | `mega_moe` wrapper currently supports only `torch.int8` when `dispatch_quant_mode=2`. |
+| `max_recv_token_num` | Forwarded to mega_moe SymmBuffer creation only. |
 
----
+## Mega MoE Quantized Scenes
 
-<a id="中文"></a>
+### A16W16
 
-## 中文
+- `dispatch_quant_mode=0`
+- `dispatch_quant_out_dtype=None`
+- `gmm1_permuted_weight_scale=None`
+- `gmm2_weight_scale=None`
+- `l1_bias=None`
+- `l2_bias=None`
 
-### 介绍
+### A8W8-INT
 
-在 MoE（Mixture of Experts，混合专家模型）中，`fused_deep_moe` 算子实现 Dispatch + Experts FFN (2×GMM) + Combine 的超融合功能。
+- `dispatch_quant_mode=2`
+- `dispatch_quant_out_dtype=torch.int8`
+- `gmm1_permuted_weight_scale` required
+- `gmm2_weight_scale` required
+- `l1_bias=None`
+- `l2_bias=None`
 
-该算子在一次调用中完成 token 分发、专家计算（矩阵乘、激活、量化/反量化）以及结果合并操作，相比传统多算子实现显著降低通信开销和端到端时延。
+### A8W4-INT
 
-通信时长（Batch size = 32 / 155μs，Dispatch = 80μs，Combine = 75μs）降低到85μs以内，单层通信时长降低70μs，推理端到端时延降低4ms。
+- `dispatch_quant_mode=2`
+- `dispatch_quant_out_dtype=torch.int8`
+- `gmm1_permuted_weight_scale` required
+- `gmm2_weight_scale` required
+- `l1_bias` required
+- `l2_bias` required
 
-通过 `FuseMode` 枚举提供两种融合模式：
+## `situ` Activation
 
-| FuseMode | 值 | CANN 算子 | 说明 |
-|----------|---|-----------|------|
-| `FuseMode.FUSED_DEEP_MOE` | `1` | `aclnnFusedDeepMoe` | 完整融合：InitRouting + AllToAll + GMM1 + DequantSwigluQuant + GMM2 + Dequant + Unpermute/Combine 在单个 AscendC kernel 中完成。 |
-| `FuseMode.DISPATCH_FFN_COMBINE` | `2` | `aclnnDispatchFFNCombine` | 分离 dispatch 处理：InitRouting + AllToAll 分发 + GMM1 + DequantSwigluQuant + GMM2 + Dequant + Combine 在单个 AscendC kernel 中完成，采用不同的内部融合策略。 |
+`situ` is not implemented in `buffer.py` itself. It is forwarded to `mega_moe`.
 
-> [!NOTE]
-> `FuseMode` **未**从包顶层 `__init__.py` 导出，需显式导入：
-> ```python
-> from deep_ep.buffer import FuseMode
-> ```
-> 或直接使用整数值：`fuse_mode=1`（FUSED_DEEP_MOE）或 `fuse_mode=2`（DISPATCH_FFN_COMBINE）。
+- Public API name: `linear_beta`
+- mega_moe call name: `activation_clamp`
+- `linear_beta=None` or `0`: no extra linear beta term
+- `linear_beta>0`: forwarded as the `situ` linear beta control value
 
-#### 两种融合模式的关键差异
+## Return Value
 
-| 方面 | `FUSED_DEEP_MOE` | `DISPATCH_FFN_COMBINE` |
-|------|-------------------|------------------------|
-| **权重 scale 数据类型** | `float32`（内部自动转换为 `float`） | `int64`（float32 scale 值重新解释为 int64 位模式；**不会自动转换** — 调用者需手动执行转换） |
-| **GMM1 权重布局** | 经 tile-N 重排（参考实现 `reshape_fusion_gmm_weight` 在测试代码中） | 标准 NZ 格式，无需额外重排 |
-| **`num_max_dispatch_tokens_per_rank`** 语义 | 每个 rank 最多分发的 token 数 | dispatch 中最多接收的 token 数（即 `max_bs × num_ranks × topk`） |
-| **第二返回值** | `ep_recv_count`，形状 `[num_local_experts × num_ranks]` | `expert_token_nums`，形状 `[num_local_experts]`（仅本 rank） |
-| **共享专家支持** | 支持 | **不支持** |
+`fused_deep_moe(...)` returns `(output, aux)`:
 
-### Python API
+- `output`: fused MoE output with shape `[bs, hidden]`
+- `aux`:
+  - `deep_ep + FuseMode.FUSED_DEEP_MOE`: `ep_recv_count`
+  - `deep_ep + FuseMode.DISPATCH_FFN_COMBINE`: `expert_token_nums`
+  - `mega_moe`: `expert_token_nums`
+
+## Dependency Note
+
+The `mega_moe` backend depends on:
 
 ```python
-def fused_deep_moe(
-    x: torch.Tensor,
-    topk_idx: torch.Tensor,
-    topk_weights: torch.Tensor,
-    gmm1_permuted_weight: torch.Tensor,
-    gmm1_permuted_weight_scale: torch.Tensor,
-    gmm2_weight: torch.Tensor,
-    gmm2_weight_scale: torch.Tensor,
-    num_max_dispatch_tokens_per_rank: int,
-    num_experts: int,
-    quant_mode: int = 1,
-    fuse_mode: FuseMode = FuseMode.FUSED_DEEP_MOE,
-) -> Tuple[torch.Tensor, torch.Tensor]
+from cann_ops_transformer.ops import get_symm_buffer_for_mega_moe, mega_moe
 ```
 
-### 参数说明
-
-| 参数 | 类型 | 形状 | 说明                                                                                                                                                                  |
-|------|------|------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **x** | `torch.Tensor` | `[bs, hidden]` | 输入 token 表示，每行一个 token 的隐藏向量（常用 `bfloat16`）。**bs** 取值范围 **[1, 256]**。**hidden** 取值范围 **[512, 7168]**，且必须能被 **32** 整除。                                               |
-| **topk_idx** | `torch.Tensor` | `[bs, num_topk]` | 每个 token 的专家索引，`int32` 类型。若值为 `-1` 表示该 token 不分发。                                                                                                                   |
-| **topk_weights** | `torch.Tensor` | `[bs, num_topk]` | 合并专家输出的加权系数（`float32`）。                                                                                                                                             |
-| **gmm1_permuted_weight** | `torch.Tensor` | 例如 `[G, 7168, 4096]` | 第一阶段（上投）专家权重。`FUSED_DEEP_MOE` 模式下需做 tile-N permute 重排（参考实现 `reshape_fusion_gmm_weight` 在测试代码中）；`DISPATCH_FFN_COMBINE` 模式下使用标准 NZ 格式，无需额外重排。                         |
-| **gmm1_permuted_weight_scale** | `torch.Tensor` | 例如 `[G, 4096]` | 第一阶段权重量化 scale。`FUSED_DEEP_MOE` 模式下为 `float32` dtype（内部自动转换）；`DISPATCH_FFN_COMBINE` 模式下为 **`int64` dtype**（float32 scale 值重新解释为 int64 位模式 — **不会自动转换**，调用者需手动执行转换）。 |
-| **gmm2_weight** | `torch.Tensor` | 例如 `[G, 7168, 2048]` | 第二阶段（下投）专家权重 （融合算子需要转置）。                                                                                                                                            |
-| **gmm2_weight_scale** | `torch.Tensor` | 例如 `[G, 7168]` | 第二阶段权重量化 scale。数据类型规则同 `gmm1_permuted_weight_scale`。                                                                                                                |
-| **num_max_dispatch_tokens_per_rank** | `int` | 标量 | `FUSED_DEEP_MOE` 模式：每个 rank 最多分发的 token 数，用于 buffer/内存分配。`DISPATCH_FFN_COMBINE` 模式：dispatch 中最多接收的 token 数（通常为 `max_bs × num_ranks × topk`）。所有 rank 必须持有相同值。        |
-| **num_experts** | `int` | 标量，范围 **(0, 512]** | 全局专家总数。必须能被 `(num_ranks - shared_expert_rank_num)` 整除，否则 tiling 校验会拒绝。                                                                                              |
-| **quant_mode** | `int` | 标量，默认 `1` | 量化模式：`0` = 无量化（BF16 权重），`1` = INT8（默认）；后续 A5 支持 FP8。                                                                                                                |
-| **fuse_mode** | `FuseMode` | 标量，默认 `FuseMode.FUSED_DEEP_MOE` | 融合模式选择。`FUSED_DEEP_MOE`（1）：通过 `aclnnFusedDeepMoe` 完整融合。`DISPATCH_FFN_COMBINE`（2）：通过 `aclnnDispatchFFNCombine` 分离 dispatch 处理。                                       |
-
-### 约束说明
-
-- **bs**（batch size）：取值范围 **[1, 256]**。
-- **hidden**：取值范围 **[512, 7168]**，且必须能被 **32** 整除。
-- **num_topk**（topk）：取值范围 **(0, 12]** — kernel tiling 强制 `topk ≤ 12`。
-- **num_experts**：取值范围 **(0, 512]** — kernel tiling 强制 `moeExpertNum ≤ 512`。`num_experts` 必须能被 `(num_ranks - shared_expert_rank_num)` 整除。
-
-### 返回值
-
-#### `fuse_mode=FUSED_DEEP_MOE`（默认）
-
-| 参数 | 类型 | 形状 | 说明 |
-|------|------|------|------|
-| **output** | `torch.Tensor` | `[bs, hidden]` | 融合专家输出。 |
-| **ep_recv_count** | `torch.Tensor` | `[num_local_experts × num_ranks]` | EP 通信域各专家在各 rank 收到的 token 数量，用于后续通信同步或负载均衡统计。 |
-
-#### `fuse_mode=DISPATCH_FFN_COMBINE`
-
-| 参数 | 类型 | 形状 | 说明 |
-|------|------|------|------|
-| **output** | `torch.Tensor` | `[bs, hidden]` | 融合专家输出。 |
-| **expert_token_nums** | `torch.Tensor` | `[num_local_experts]` | 本 rank 各本地专家收到的 token 数量，用于后续通信同步或负载均衡统计。 |
+If that package is not available, `deep_ep` backend behavior is unchanged, but calls that
+actually route to `mega_moe` will raise an import error with an explicit message.

--- a/tests/python/deepep/test_fused_deep_moe_a3_w4a8_acc.py
+++ b/tests/python/deepep/test_fused_deep_moe_a3_w4a8_acc.py
@@ -1,0 +1,1168 @@
+import argparse
+import os
+import random
+from typing import List, Optional
+
+import deep_ep
+import numpy as np
+import torch
+import torch.distributed as dist
+import torch_npu
+from deep_ep.buffer import FuseMode
+from utils import calc_diff, init_dist
+
+torch_npu.npu.config.allow_internal_format = True
+os.environ["MOE_EXPERT_TOKEN_NUMS_TYPE"] = "1"
+
+ACL_FORMAT_FRACTAL_NZ = torch_npu.Format.FRACTAL_NZ
+W4A8_DIFF_WARNING_THRESHOLD = 5e-3
+EXPERT_TOKEN_NUMS_TYPE_CUMSUM = 0
+EXPERT_TOKEN_NUMS_TYPE_COUNT = 1
+COMM_QUANT_MODE_INT8 = 2
+
+
+def info_rank0(rank: int, message: str):
+    if rank == 0:
+        print(f"[rank0] {message}", flush=True)
+
+
+def warn_rank0(rank: int, message: str):
+    if rank == 0:
+        print(f"[rank0][WARNING] {message}", flush=True)
+
+
+def summarize_value(value) -> str:
+    if isinstance(value, torch.Tensor):
+        return f"Tensor(shape={tuple(value.shape)}, dtype={value.dtype})"
+    if isinstance(value, (list, tuple)):
+        parts = [summarize_value(item) for item in value[:4]]
+        suffix = "" if len(value) <= 4 else ", ..."
+        return f"{type(value).__name__}(len={len(value)}, items=[{', '.join(parts)}{suffix}])"
+    return f"{type(value).__name__}({value})"
+
+
+def set_env_if_provided(name: str, value):
+    if value is not None:
+        os.environ[name] = str(value)
+
+
+def apply_runtime_env_from_args(args: argparse.Namespace):
+    set_env_if_provided("MASTER_ADDR", args.master_addr)
+    set_env_if_provided("MASTER_PORT", args.master_port)
+    set_env_if_provided("WORLD_SIZE", args.num_servers)
+    set_env_if_provided("RANK", args.server_index)
+    set_env_if_provided("HCCL_BUFFSIZE", args.hccl_buffsize)
+
+
+def parse_csv_list(raw: str) -> List[str]:
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def parse_optional_float_list(raw: str) -> List[Optional[float]]:
+    values: List[Optional[float]] = []
+    for item in parse_csv_list(raw):
+        value = float(item)
+        values.append(None if value == 0 else value)
+    return values
+
+
+def parse_float_list(raw: str) -> List[float]:
+    return [float(item) for item in parse_csv_list(raw)]
+
+
+def swiglu_reference(x: torch.Tensor) -> torch.Tensor:
+    d = x.shape[-1] // 2
+    gate = x[..., :d].to(torch.float32)
+    up = x[..., d:].to(torch.float32)
+    return (gate * torch.sigmoid(gate) * up).to(x.dtype)
+
+
+def situ_reference(
+    x: torch.Tensor,
+    *,
+    beta: float,
+    linear_beta: Optional[float],
+    activation_clamp: Optional[float],
+) -> torch.Tensor:
+    d = x.shape[-1] // 2
+    gate = x[..., :d].to(torch.float32)
+    up = x[..., d:].to(torch.float32)
+    if activation_clamp is not None and activation_clamp > 0:
+        gate = torch.clamp(gate, -activation_clamp, activation_clamp)
+    situ_a = beta * torch.tanh(gate / beta) * torch.sigmoid(gate)
+    if linear_beta is not None and linear_beta > 0:
+        up = linear_beta * torch.tanh(up / linear_beta)
+    return (situ_a * up).to(x.dtype)
+
+
+def apply_activation(
+    x: torch.Tensor,
+    activation: str,
+    *,
+    beta: float,
+    linear_beta: Optional[float],
+    activation_clamp: Optional[float],
+) -> torch.Tensor:
+    if activation == "swiglu":
+        return torch_npu.npu_swiglu(x)
+    if activation == "situ":
+        return situ_reference(
+            x,
+            beta=beta,
+            linear_beta=linear_beta,
+            activation_clamp=activation_clamp,
+        )
+    raise ValueError(f"Unsupported activation: {activation}")
+
+
+def make_topk_inputs(
+    num_tokens: int,
+    num_experts: int,
+    num_topk: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    scores = torch.randn((num_tokens, num_experts), dtype=torch.float32, device=device)
+    topk_weights, topk_ids = torch.topk(
+        scores, num_topk, dim=-1, largest=True, sorted=False
+    )
+    return topk_ids.to(torch.int32), topk_weights
+
+
+def validate_topk_inputs(topk_ids_int32: torch.Tensor, num_experts: int):
+    if topk_ids_int32.dtype != torch.int32:
+        raise TypeError(f"topk_ids must be int32, got {topk_ids_int32.dtype}")
+    if torch.any(topk_ids_int32 < 0) or torch.any(topk_ids_int32 >= num_experts):
+        raise ValueError("topk_ids contains out-of-range expert indices.")
+    sorted_ids = torch.sort(topk_ids_int32, dim=-1).values
+    if torch.any(sorted_ids[:, 1:] == sorted_ids[:, :-1]):
+        raise ValueError("topk_ids must be unique within each token's top-k row.")
+
+
+def pack_scale_to_uint64(scale: torch.Tensor) -> torch.Tensor:
+    return scale.contiguous().view(torch.int32).to(torch.int64).view(torch.uint64)
+
+
+def pack_scale_to_int64(scale: torch.Tensor) -> torch.Tensor:
+    return scale.contiguous().view(torch.int32).to(torch.int64)
+
+
+def pack_int4(values: torch.Tensor, pack_dim: int) -> torch.Tensor:
+    """Pack int8 values [-8,7] into int32 (8 values per int32)."""
+    values = values.clamp(-8, 7)
+    values_unsigned = torch.where(values < 0, values + 16, values).to(torch.int32)
+    if pack_dim == 1:
+        K, N_unpacked = values_unsigned.shape
+        N_packed = N_unpacked // 8
+        vals = values_unsigned.view(K, N_packed, 8)
+    else:
+        K_unpacked, N = values_unsigned.shape
+        K_packed = K_unpacked // 8
+        vals = values_unsigned.view(K_packed, 8, N).permute(0, 2, 1)
+    packed = torch.zeros(
+        vals.shape[0],
+        vals.shape[1],
+        dtype=torch.int32,
+        device=values.device,
+    )
+    for i in range(8):
+        packed |= (vals[..., i].to(torch.int32) << (i * 4)).to(torch.int32)
+    return packed
+
+
+def pack_int4_experts_to_int8(weights: torch.Tensor) -> torch.Tensor:
+    if weights.dim() != 3:
+        raise ValueError(f"Expected expert-stacked 3D weight, got {weights.shape}.")
+    if weights.shape[-1] % 8 != 0:
+        raise ValueError(
+            f"logical int4 weight last dim must be divisible by 8, got {weights.shape}."
+        )
+    packed = [
+        pack_int4(weight.contiguous(), 1).view(torch.int8)
+        for weight in weights.unbind(dim=0)
+    ]
+    return torch.stack(packed, dim=0).contiguous()
+
+
+def pack_int4_to_int8(weight: torch.Tensor) -> torch.Tensor:
+    if weight.shape[-1] % 2 != 0:
+        raise ValueError(
+            f"logical int4 weight last dim must be divisible by 2, got {weight.shape}."
+        )
+    packed = (
+        (weight.to(torch.int16) + 8)
+        .to(torch.uint8)
+        .reshape(*weight.shape[:-1], weight.shape[-1] // 2, 2)
+    )
+    return ((packed[..., 1] << 4) | packed[..., 0]).view(torch.int8)
+
+
+def normalize_expert_counts(
+    counts, num_local_experts: int, device: torch.device
+) -> torch.Tensor:
+    if isinstance(counts, torch.Tensor):
+        out = counts.to(device=device, dtype=torch.int64)
+    else:
+        out = torch.tensor(list(counts), device=device, dtype=torch.int64)
+    if out.numel() != num_local_experts:
+        raise ValueError(
+            f"Expected {num_local_experts} local expert counts, got {out.numel()}."
+        )
+    return out
+
+
+def pack_to_int32(weight: torch.Tensor, *, new_quant_version: bool) -> torch.Tensor:
+    if not new_quant_version:
+        raise ValueError("This test only supports new_quant_version=True for A3 W4A8.")
+    if weight.shape[-1] % 4 != 0:
+        raise ValueError(
+            f"Packed int4 weight last dim must be divisible by 4, got {weight.shape}."
+        )
+    return weight.view(torch.int32)
+
+
+def unpack_int4(packed: torch.Tensor, pack_dim: int) -> torch.Tensor:
+    """Unpack int32 → int8. Returns int8 tensor."""
+    K, N = packed.shape
+    # 对每个移位单独操作，避免张量广播问题
+    shifts = [0, 4, 8, 12, 16, 20, 24, 28]
+    vals_list = []
+    for shift in shifts:
+        # 右移并取低4位
+        val = (packed >> shift) & 0xF
+        vals_list.append(val.unsqueeze(-1))
+    vals = torch.cat(vals_list, dim=-1)  # [K, N, 8]
+
+    vals = torch.where(vals >= 8, vals - 16, vals).to(torch.int8)
+
+    if pack_dim == 1:
+        out = vals.reshape(K, -1)
+    else:
+        out = vals.permute(0, 2, 1).contiguous().reshape(-1, N)
+    return out
+
+
+def pack_float_into_int64(dequant_scale_origin: torch.Tensor) -> torch.Tensor:
+    """Pack float32 scale into int64 with marker bit."""
+    scale_int = dequant_scale_origin.view(torch.int32)
+    scale_int = scale_int & 0xFFFFE000  # clear low 13 mantissa bits
+    # Convert to int64 without sign-extension: view as unsigned first
+    out = torch.bitwise_and(
+        scale_int.to(torch.int64),
+        torch.tensor(
+            0xFFFFFFFF,
+            dtype=torch.int64,
+            device=scale_int.device,
+        ),
+    )
+    return out | (1 << 46)
+
+
+def extract_float_from_int64(packed_int64: torch.Tensor) -> torch.Tensor:
+    """Extract low 32 bits of int64 as float32."""
+    return packed_int64.to(torch.int32).view(torch.float32)
+
+
+def compute_bias(
+    weight_packed: torch.Tensor, scale_packed: torch.Tensor, pack_dim: int = 1
+) -> torch.Tensor:
+    """Compute bias = sum(unpacked_weight * scale, dim=0) * 8."""
+    if weight_packed.dtype != torch.int32:
+        raise TypeError(
+            f"compute_bias expects int32 packed weight, got {weight_packed.dtype}"
+        )
+    w_int4 = unpack_int4(weight_packed, pack_dim).float()
+    scale_fp32 = extract_float_from_int64(scale_packed)
+    return (w_int4 * scale_fp32).sum(dim=0) * 8.0
+
+
+def convert_cumsum_group_list_to_count(group_list: torch.Tensor) -> torch.Tensor:
+    if group_list.dim() != 1:
+        raise ValueError(f"group_list must be 1D, got {tuple(group_list.shape)}.")
+    return torch.cat([group_list[:1], torch.diff(group_list, dim=0)])
+
+
+def build_scene_weight_source(
+    hidden: int,
+    intermediate_hidden: int,
+    num_local_experts: int,
+    device: torch.device,
+) -> dict:
+    new_quant_version = True
+
+    # Generate logical int4 weights in int8 containers first. These tensors are
+    # not packed yet; the last dim still represents the full output-channel dim.
+    w13_weight_raw_int4 = torch.randint(
+        -8,
+        8,
+        (num_local_experts, hidden, 2 * intermediate_hidden),
+        dtype=torch.int8,
+        device=device,
+    )
+    w2_weight_raw_int4 = torch.randint(
+        -8,
+        8,
+        (num_local_experts, intermediate_hidden, hidden),
+        dtype=torch.int8,
+        device=device,
+    )
+    w13_weight_scale = torch.empty(
+        (num_local_experts, 2 * intermediate_hidden),
+        dtype=torch.float32,
+        device=device,
+    ).uniform_(0.01, 0.1)
+    w2_weight_scale = torch.empty(
+        (num_local_experts, 1, hidden), dtype=torch.float32, device=device
+    ).uniform_(0.01, 0.1)
+    w13_weight_packed_int8 = pack_int4_experts_to_int8(w13_weight_raw_int4)
+    w2_weight_packed_int8 = pack_int4_experts_to_int8(w2_weight_raw_int4)
+    expected_w13_packed_int8_shape = (
+        num_local_experts,
+        hidden,
+        intermediate_hidden,
+    )
+    expected_w2_packed_int8_shape = (
+        num_local_experts,
+        intermediate_hidden,
+        hidden // 2,
+    )
+    if tuple(w13_weight_packed_int8.shape) != expected_w13_packed_int8_shape:
+        raise ValueError(
+            f"Invalid packed int8 w13 shape: got {tuple(w13_weight_packed_int8.shape)}, "
+            f"expected {expected_w13_packed_int8_shape}."
+        )
+    if tuple(w2_weight_packed_int8.shape) != expected_w2_packed_int8_shape:
+        raise ValueError(
+            f"Invalid packed int8 w2 shape: got {tuple(w2_weight_packed_int8.shape)}, "
+            f"expected {expected_w2_packed_int8_shape}."
+        )
+    w13_scale_int64 = pack_float_into_int64(w13_weight_scale.contiguous())
+    w2_scale_int64 = pack_float_into_int64(w2_weight_scale.contiguous())
+    expected_w13_scale_shape = (num_local_experts, 2 * intermediate_hidden)
+    expected_w2_scale_shape = (num_local_experts, 1, hidden)
+    if tuple(w13_scale_int64.shape) != expected_w13_scale_shape:
+        raise ValueError(
+            f"Invalid packed int64 w13 scale shape: got {tuple(w13_scale_int64.shape)}, "
+            f"expected {expected_w13_scale_shape}."
+        )
+    if tuple(w2_scale_int64.shape) != expected_w2_scale_shape:
+        raise ValueError(
+            f"Invalid packed int64 w2 scale shape: got {tuple(w2_scale_int64.shape)}, "
+            f"expected {expected_w2_scale_shape}."
+        )
+    w13_bias = torch.stack(
+        [
+            compute_bias(
+                pack_to_int32(w.contiguous(), new_quant_version=new_quant_version), s, 1
+            )
+            for w, s in zip(
+                w13_weight_packed_int8.unbind(dim=0), w13_scale_int64.unbind(dim=0)
+            )
+        ],
+        dim=0,
+    ).to(torch.float32)
+    w2_bias = torch.stack(
+        [
+            compute_bias(
+                pack_to_int32(w.contiguous(), new_quant_version=new_quant_version), s, 1
+            )
+            for w, s in zip(
+                w2_weight_packed_int8.unbind(dim=0), w2_scale_int64.unbind(dim=0)
+            )
+        ],
+        dim=0,
+    ).to(torch.float32)
+    expected_w13_bias_shape = (num_local_experts, 2 * intermediate_hidden)
+    expected_w2_bias_shape = (num_local_experts, hidden)
+    if tuple(w13_bias.shape) != expected_w13_bias_shape:
+        raise ValueError(
+            f"Invalid computed w13 bias shape: got {tuple(w13_bias.shape)}, "
+            f"expected {expected_w13_bias_shape}."
+        )
+    if tuple(w2_bias.shape) != expected_w2_bias_shape:
+        raise ValueError(
+            f"Invalid computed w2 bias shape: got {tuple(w2_bias.shape)}, "
+            f"expected {expected_w2_bias_shape}."
+        )
+    return {
+        "hidden": hidden,
+        "intermediate_hidden": intermediate_hidden,
+        "num_local_experts": num_local_experts,
+        "new_quant_version": new_quant_version,
+        "w13_weight_raw_int4": w13_weight_raw_int4,
+        "w2_weight_raw_int4": w2_weight_raw_int4,
+        "w13_weight_packed_int8": w13_weight_packed_int8,
+        "w2_weight_packed_int8": w2_weight_packed_int8,
+        "w13_scale_int64": w13_scale_int64,
+        "w2_scale_int64": w2_scale_int64,
+        "w13_bias": w13_bias,
+        "w2_bias": w2_bias,
+    }
+
+
+def build_baseline_scene_weights(source: dict, device: torch.device) -> dict:
+    new_quant_version = source["new_quant_version"]
+
+    w13_weight_baseline_nz = torch_npu.npu_format_cast(
+        source["w13_weight_packed_int8"].to(device), ACL_FORMAT_FRACTAL_NZ
+    )
+    w2_weight_baseline_nz = torch_npu.npu_format_cast(
+        source["w2_weight_packed_int8"].to(device), ACL_FORMAT_FRACTAL_NZ
+    )
+    w13_weight_packed_stacked = pack_to_int32(
+        w13_weight_baseline_nz, new_quant_version=new_quant_version
+    )
+    w2_weight_packed_stacked = pack_to_int32(
+        w2_weight_baseline_nz, new_quant_version=new_quant_version
+    )
+
+    return {
+        "baseline_l1_weight_stacked": [w13_weight_packed_stacked],
+        "baseline_l2_weight_stacked": [w2_weight_packed_stacked],
+        "baseline_l1_scale_stacked": [
+            source["w13_scale_int64"].to(device).unsqueeze(1).contiguous()
+        ],
+        "baseline_l2_scale_stacked": [source["w2_scale_int64"].to(device).contiguous()],
+        "baseline_l1_bias_stacked": [source["w13_bias"].to(device).contiguous()],
+        "baseline_l2_bias_stacked": [source["w2_bias"].to(device).contiguous()],
+    }
+
+
+def build_fused_scene_weights(source: dict, device: torch.device) -> dict:
+    hidden = source["hidden"]
+    intermediate_hidden = source["intermediate_hidden"]
+    num_local_experts = source["num_local_experts"]
+    new_quant_version = source["new_quant_version"]
+
+    fused_l1_weights = [
+        pack_to_int32(
+            torch_npu.npu_format_cast(
+                weight.contiguous().to(device), ACL_FORMAT_FRACTAL_NZ
+            ),
+            new_quant_version=new_quant_version,
+        )
+        for weight in source["w13_weight_packed_int8"].unbind(dim=0)
+    ]
+    fused_l2_weights = [
+        pack_to_int32(
+            torch_npu.npu_format_cast(
+                weight.contiguous().to(device), ACL_FORMAT_FRACTAL_NZ
+            ),
+            new_quant_version=new_quant_version,
+        )
+        for weight in source["w2_weight_packed_int8"].unbind(dim=0)
+    ]
+    fused_l1_scales = [
+        scale.to(device).reshape(-1).view(torch.uint64)
+        for scale in source["w13_scale_int64"].unbind(dim=0)
+    ]
+    fused_l2_scales = [
+        scale.to(device).reshape(-1).view(torch.uint64)
+        for scale in source["w2_scale_int64"].unbind(dim=0)
+    ]
+    fused_l1_bias = [
+        bias.to(device).reshape(-1).to(torch.float32)
+        for bias in source["w13_bias"].unbind(dim=0)
+    ]
+    fused_l2_bias = [
+        bias.to(device).reshape(-1).to(torch.float32)
+        for bias in source["w2_bias"].unbind(dim=0)
+    ]
+
+    expected_l1_shape = (hidden, (2 * intermediate_hidden) // 8)
+    expected_l2_shape = (intermediate_hidden, hidden // 8)
+    for weight in fused_l1_weights:
+        if weight.dtype != torch.int32 or tuple(weight.shape) != expected_l1_shape:
+            raise ValueError(
+                f"Invalid fused l1 weight shape/dtype: got {tuple(weight.shape)} {weight.dtype}, "
+                f"expected {expected_l1_shape} torch.int32."
+            )
+    for weight in fused_l2_weights:
+        if weight.dtype != torch.int32 or tuple(weight.shape) != expected_l2_shape:
+            raise ValueError(
+                f"Invalid fused l2 weight shape/dtype: got {tuple(weight.shape)} {weight.dtype}, "
+                f"expected {expected_l2_shape} torch.int32."
+            )
+    if (
+        len(fused_l1_weights) != num_local_experts
+        or len(fused_l2_weights) != num_local_experts
+    ):
+        raise ValueError("Fused weight list length mismatch.")
+    if (
+        len(fused_l1_scales) != num_local_experts
+        or len(fused_l2_scales) != num_local_experts
+    ):
+        raise ValueError("Fused scale list length mismatch.")
+    if (
+        len(fused_l1_bias) != num_local_experts
+        or len(fused_l2_bias) != num_local_experts
+    ):
+        raise ValueError("Fused bias list length mismatch.")
+
+    return {
+        "fused_l1_weights": fused_l1_weights,
+        "fused_l2_weights": fused_l2_weights,
+        "fused_l1_scales": fused_l1_scales,
+        "fused_l2_scales": fused_l2_scales,
+        "fused_l1_bias": fused_l1_bias,
+        "fused_l2_bias": fused_l2_bias,
+    }
+
+
+def prepare_scene_weights(
+    hidden: int,
+    intermediate_hidden: int,
+    num_local_experts: int,
+    device: torch.device,
+) -> dict:
+    # The generation of weights and scales for w4a8 must be performed on the CPU;
+    # using the device for these calculations leads to precision mismatches between small operators and large fused operators.
+    source = build_scene_weight_source(
+        hidden,
+        intermediate_hidden,
+        num_local_experts,
+        torch.device("cpu"),
+    )
+    baseline_weights = build_baseline_scene_weights(source, device)
+    print(
+        "[build_fused_scene_weights][source] "
+        + " | ".join(
+            f"{key}={summarize_value(value)}" for key, value in source.items()
+        ),
+        flush=True,
+    )
+    fused_weights = build_fused_scene_weights(source, device)
+    return {
+        "source": source,
+        **baseline_weights,
+        **fused_weights,
+        "dispatch_quant_mode": 2,
+        "dispatch_quant_out_dtype": torch.int8,
+    }
+
+
+def run_grouped_matmul_w4a8(
+    x_int8: torch.Tensor,
+    per_token_scale: torch.Tensor,
+    group_list: torch.Tensor,
+    group_list_type: int,
+    weight: List[torch.Tensor],
+    scale: List[torch.Tensor],
+    bias,
+    rank: int,
+    stage_name: str,
+    barrier_group: dist.ProcessGroup,
+) -> torch.Tensor:
+    bias_list = bias if isinstance(bias, list) else [bias]
+    out = torch_npu.npu_grouped_matmul(
+        x=[x_int8],
+        weight=weight,
+        scale=[scale[0].to(scale[0].dtype)],
+        bias=bias_list,
+        per_token_scale=[per_token_scale],
+        split_item=2,
+        group_list_type=group_list_type,
+        group_type=0,
+        group_list=group_list,
+        output_dtype=torch.bfloat16,
+    )[0]
+    return out
+
+
+def run_mc2_dispatch(
+    x: torch.Tensor,
+    topk_idx: torch.Tensor,
+    *,
+    num_experts: int,
+    global_bs: int,
+    x_active_mask: Optional[torch.Tensor],
+    group_ep: str,
+    barrier_group: dist.ProcessGroup,
+    ep_world_size: int,
+    ep_rank_id: int,
+    enable_dispatch_v2: bool,
+):
+    kwargs = {
+        "x": x,
+        "expert_ids": topk_idx,
+        "expert_shard_type": 0,
+        "shared_expert_rank_num": 0,
+        "moe_expert_num": num_experts,
+        "global_bs": global_bs,
+        "x_active_mask": x_active_mask,
+        "quant_mode": COMM_QUANT_MODE_INT8,
+        "scales": None,
+        "group_ep": group_ep,
+        "ep_world_size": ep_world_size,
+        "ep_rank_id": ep_rank_id,
+        "expert_token_nums_type": EXPERT_TOKEN_NUMS_TYPE_COUNT,
+    }
+    output = (
+        torch_npu.npu_moe_distribute_dispatch_v2(**kwargs)
+        if enable_dispatch_v2
+        else torch_npu.npu_moe_distribute_dispatch(**kwargs)
+    )
+    return output[0:7]
+
+
+def run_mc2_combine(
+    mlp_out: torch.Tensor,
+    topk_idx: torch.Tensor,
+    topk_weights: torch.Tensor,
+    *,
+    num_experts: int,
+    global_bs: int,
+    x_active_mask: Optional[torch.Tensor],
+    ep_recv_counts: torch.Tensor,
+    tp_recv_counts: torch.Tensor,
+    assist_info_for_combine,
+    expand_scales: torch.Tensor,
+    group_ep: str,
+    barrier_group: dist.ProcessGroup,
+    ep_world_size: int,
+    ep_rank_id: int,
+    enable_dispatch_v2: bool,
+) -> torch.Tensor:
+    kwargs = {
+        "expand_x": mlp_out,
+        "expert_ids": topk_idx,
+        "expert_scales": topk_weights.to(torch.float32),
+        "expert_shard_type": 0,
+        "shared_expert_rank_num": 0,
+        "moe_expert_num": num_experts,
+        "global_bs": global_bs,
+        "ep_send_counts": ep_recv_counts,
+        "x_active_mask": x_active_mask,
+        "group_ep": group_ep,
+        "ep_world_size": ep_world_size,
+        "ep_rank_id": ep_rank_id,
+        "expand_scales": expand_scales,
+        "comm_quant_mode": 0,
+    }
+    if enable_dispatch_v2:
+        kwargs["assist_info_for_combine"] = assist_info_for_combine
+        out = torch_npu.npu_moe_distribute_combine_v2(**kwargs)
+    else:
+        kwargs["expand_idx"] = assist_info_for_combine
+        out = torch_npu.npu_moe_distribute_combine(**kwargs)
+    return out
+
+
+def run_baseline_reference(
+    x: torch.Tensor,
+    topk_idx: torch.Tensor,
+    topk_weights: torch.Tensor,
+    num_experts: int,
+    weights: dict,
+    activation: str,
+    beta: float,
+    linear_beta: Optional[float],
+    activation_clamp: Optional[float],
+    group_ep: str,
+    barrier_group: dist.ProcessGroup,
+    ep_world_size: int,
+    ep_rank_id: int,
+    enable_dispatch_v2: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    local_num_tokens = x.size(0)
+    max_num_tokens = 32
+    global_bs = max_num_tokens * ep_world_size
+
+    x_active_mask = torch.zeros(
+        max_num_tokens,
+        dtype=torch.bool,
+        device=x.device,
+    )
+    x_active_mask[:local_num_tokens] = True
+
+    if local_num_tokens == max_num_tokens:
+        x_padded = x
+        topk_idx_padded = topk_idx
+        topk_weights_padded = topk_weights
+    else:
+        padding_size = max_num_tokens - local_num_tokens
+        x_padded = torch.cat(
+            (x, x.new_zeros((padding_size, x.size(1)))),
+            dim=0,
+        )
+        topk_idx_padded = torch.cat(
+            (
+                topk_idx,
+                topk_idx.new_zeros((padding_size, topk_idx.size(1))),
+            ),
+            dim=0,
+        )
+        topk_weights_padded = torch.cat(
+            (
+                topk_weights,
+                topk_weights.new_zeros((padding_size, topk_weights.size(1))),
+            ),
+            dim=0,
+        )
+
+    (
+        recv_x_int8,
+        recv_x_scale,
+        assist_info_for_combine,
+        group_list,
+        ep_recv_counts,
+        tp_recv_counts,
+        expand_scales,
+    ) = run_mc2_dispatch(
+        x_padded,
+        topk_idx_padded,
+        num_experts=num_experts,
+        global_bs=global_bs,
+        x_active_mask=x_active_mask,
+        group_ep=group_ep,
+        barrier_group=barrier_group,
+        ep_world_size=ep_world_size,
+        ep_rank_id=ep_rank_id,
+        enable_dispatch_v2=enable_dispatch_v2,
+    )
+    group_list_type = EXPERT_TOKEN_NUMS_TYPE_COUNT
+    if group_list.numel() != num_experts // dist.get_world_size():
+        group_list = convert_cumsum_group_list_to_count(group_list)
+
+    gate_up = run_grouped_matmul_w4a8(
+        recv_x_int8,
+        recv_x_scale,
+        group_list,
+        group_list_type,
+        weights["baseline_l1_weight_stacked"],
+        weights["baseline_l1_scale_stacked"],
+        weights["baseline_l1_bias_stacked"],
+        ep_rank_id,
+        "gmm1",
+        barrier_group,
+    )
+    act_out = apply_activation(
+        gate_up,
+        activation,
+        beta=beta,
+        linear_beta=linear_beta,
+        activation_clamp=activation_clamp,
+    )
+    act_int8, act_scale = torch_npu.npu_dynamic_quant(act_out)
+    down = run_grouped_matmul_w4a8(
+        act_int8,
+        act_scale,
+        group_list,
+        group_list_type,
+        weights["baseline_l2_weight_stacked"],
+        weights["baseline_l2_scale_stacked"],
+        weights["baseline_l2_bias_stacked"],
+        ep_rank_id,
+        "gmm2",
+        barrier_group,
+    )
+    combined_x = run_mc2_combine(
+        down,
+        topk_idx_padded,
+        topk_weights_padded,
+        num_experts=num_experts,
+        global_bs=global_bs,
+        x_active_mask=x_active_mask,
+        ep_recv_counts=ep_recv_counts,
+        tp_recv_counts=tp_recv_counts,
+        assist_info_for_combine=assist_info_for_combine,
+        expand_scales=expand_scales,
+        group_ep=group_ep,
+        barrier_group=barrier_group,
+        ep_world_size=ep_world_size,
+        ep_rank_id=ep_rank_id,
+        enable_dispatch_v2=enable_dispatch_v2,
+    )
+    return combined_x[:local_num_tokens], normalize_expert_counts(
+        group_list,
+        num_experts // dist.get_world_size(),
+        x.device,
+    )
+
+
+def run_fused_reference(
+    buffer: deep_ep.Buffer,
+    x: torch.Tensor,
+    topk_idx: torch.Tensor,
+    topk_weights: torch.Tensor,
+    num_tokens: int,
+    num_experts: int,
+    weights: dict,
+    activation: str,
+    beta: float,
+    linear_beta: Optional[float],
+    activation_clamp: Optional[float],
+    barrier_group: dist.ProcessGroup,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    out = buffer.fused_deep_moe(
+        x=x,
+        topk_idx=topk_idx,
+        topk_weights=topk_weights,
+        gmm1_permuted_weight=weights["fused_l1_weights"],
+        gmm1_permuted_weight_scale=weights["fused_l1_scales"],
+        gmm2_weight=weights["fused_l2_weights"],
+        gmm2_weight_scale=weights["fused_l2_scales"],
+        num_max_dispatch_tokens_per_rank=32,
+        num_experts=num_experts,
+        backend="mega_moe",
+        fuse_mode=FuseMode.FUSED_DEEP_MOE,
+        activation=activation,
+        activation_clamp=activation_clamp,
+        beta=beta,
+        linear_beta=linear_beta,
+        l1_bias=weights["fused_l1_bias"],
+        l2_bias=weights["fused_l2_bias"],
+        dispatch_quant_mode=weights["dispatch_quant_mode"],
+        dispatch_quant_out_dtype=weights["dispatch_quant_out_dtype"],
+    )
+    return out
+
+
+def build_case_matrix(args: argparse.Namespace) -> list[dict]:
+    activations = parse_csv_list(args.activation)
+    betas = parse_float_list(args.beta)
+    linear_betas = parse_optional_float_list(args.linear_beta)
+    activation_clamps = parse_optional_float_list(args.activation_clamp)
+
+    cases = []
+    for activation in activations:
+        if activation == "swiglu":
+            cases.append(
+                {
+                    "activation": "swiglu",
+                    "beta": 1.0,
+                    "linear_beta": None,
+                    "activation_clamp": None,
+                }
+            )
+            continue
+        if activation != "situ":
+            raise ValueError(f"Unsupported activation case: {activation}")
+        for beta in betas:
+            for linear_beta in linear_betas:
+                for activation_clamp in activation_clamps:
+                    cases.append(
+                        {
+                            "activation": "situ",
+                            "beta": beta,
+                            "linear_beta": linear_beta,
+                            "activation_clamp": activation_clamp,
+                        }
+                    )
+    return cases
+
+
+def launch_case(
+    args: argparse.Namespace,
+    rank: int,
+    num_ranks: int,
+    fused_buffer: deep_ep.Buffer,
+    weights: dict,
+    case: dict,
+    iteration: int,
+    case_index: int,
+    baseline_group_ep: str,
+    baseline_group: dist.ProcessGroup,
+    mega_group: dist.ProcessGroup,
+    enable_dispatch_v2: bool,
+):
+    device = torch.device(f"npu:{torch.npu.current_device()}")
+    num_local_experts = args.num_experts // num_ranks
+
+    torch.manual_seed(args.seed)
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+
+    x = torch.randn((args.num_tokens, args.hidden), dtype=torch.bfloat16, device=device)
+    topk_idx, topk_weights = make_topk_inputs(
+        args.num_tokens, args.num_experts, args.num_topk, device
+    )
+    baseline_out, baseline_counts = run_baseline_reference(
+        x,
+        topk_idx,
+        topk_weights,
+        args.num_experts,
+        weights,
+        case["activation"],
+        case["beta"],
+        case["linear_beta"],
+        case["activation_clamp"],
+        baseline_group_ep,
+        baseline_group,
+        num_ranks,
+        rank,
+        enable_dispatch_v2,
+    )
+    fused_out, fused_counts = run_fused_reference(
+        fused_buffer,
+        x,
+        topk_idx,
+        topk_weights,
+        args.num_tokens,
+        args.num_experts,
+        weights,
+        case["activation"],
+        case["beta"],
+        case["linear_beta"],
+        case["activation_clamp"],
+        mega_group,
+    )
+    info_rank0(
+        rank,
+        f"iter={iteration} case={case_index} activation={case['activation']} "
+        f"baseline_out_shape={tuple(baseline_out.shape)} "
+        f"fused_out_shape={tuple(fused_out.shape)}",
+    )
+
+    return {
+        "case": case,
+        "iteration": iteration,
+        "case_index": case_index,
+        "device": device,
+        "num_local_experts": num_local_experts,
+        "x": x,
+        "topk_idx": topk_idx,
+        "topk_weights": topk_weights,
+        "weights": weights,
+        "baseline_out": baseline_out,
+        "baseline_counts": baseline_counts,
+        "fused_out": fused_out,
+        "fused_counts": fused_counts,
+    }
+
+
+def finalize_case(
+    args: argparse.Namespace,
+    rank: int,
+    launched_case: dict,
+    synchronize_ranks: bool = True,
+):
+    case = launched_case["case"]
+    iteration = launched_case["iteration"]
+    case_index = launched_case["case_index"]
+    device = launched_case["device"]
+    num_local_experts = launched_case["num_local_experts"]
+    x = launched_case["x"]
+    topk_idx = launched_case["topk_idx"]
+    topk_weights = launched_case["topk_weights"]
+    weights = launched_case["weights"]
+    baseline_out = launched_case["baseline_out"]
+    baseline_counts = launched_case["baseline_counts"]
+    fused_out = launched_case["fused_out"]
+    fused_counts = launched_case["fused_counts"]
+
+    local_diff = calc_diff(
+        baseline_out.float(),
+        fused_out.float(),
+    )
+    diff_tensor = torch.tensor(local_diff, dtype=torch.float32, device=device)
+    dist.all_reduce(diff_tensor, op=dist.ReduceOp.MAX)
+
+    counts_match = torch.equal(
+        normalize_expert_counts(baseline_counts, num_local_experts, device),
+        normalize_expert_counts(fused_counts, num_local_experts, device),
+    )
+    counts_mismatch = torch.tensor(
+        0 if counts_match else 1, dtype=torch.int32, device=device
+    )
+    dist.all_reduce(counts_mismatch, op=dist.ReduceOp.MAX)
+
+    case_desc = (
+        f"iter={iteration} activation={case['activation']} beta={case['beta']} "
+        f"linear_beta={case['linear_beta']} activation_clamp={case['activation_clamp']}"
+    )
+    if counts_mismatch.item() != 0:
+        warn_rank0(rank, f"{case_desc} expert_token_nums mismatch across ranks.")
+    max_diff = diff_tensor.item()
+    if max_diff >= W4A8_DIFF_WARNING_THRESHOLD:
+        warn_rank0(
+            rank,
+            f"{case_desc} calc_diff={max_diff} exceeds threshold={W4A8_DIFF_WARNING_THRESHOLD}",
+        )
+    else:
+        info_rank0(
+            rank,
+            f"{case_desc} calc_diff={max_diff} token_counts_match={counts_mismatch.item() == 0}",
+        )
+    if synchronize_ranks:
+        dist.barrier()
+
+
+def test_main(
+    args: argparse.Namespace,
+    rank: int,
+    num_ranks: int,
+    fused_buffer: deep_ep.Buffer,
+    baseline_group_ep: str,
+    mega_group_ep: str,
+    baseline_group: dist.ProcessGroup,
+    mega_group: dist.ProcessGroup,
+    enable_dispatch_v2: bool,
+):
+    if args.num_experts % num_ranks != 0:
+        raise ValueError("num_experts must be divisible by world_size.")
+    if args.enable_performance and args.performance_iters <= 0:
+        raise ValueError("--performance-iters must be greater than zero.")
+
+    iterations = args.performance_iters if args.enable_performance else 1
+    cases = build_case_matrix(args)
+    device = torch.device(f"npu:{torch.npu.current_device()}")
+    num_local_experts = args.num_experts // num_ranks
+    weights = prepare_scene_weights(
+        args.hidden,
+        args.moe_intermediate_size,
+        num_local_experts,
+        device,
+    )
+    info_rank0(
+        rank,
+        f"baseline_group_ep={baseline_group_ep} mega_group_ep={mega_group_ep}",
+    )
+    if args.enable_performance:
+        launched_cases = []
+        for iteration in range(iterations):
+            for case_index, case in enumerate(cases):
+                launched_cases.append(
+                    launch_case(
+                        args,
+                        rank,
+                        num_ranks,
+                        fused_buffer,
+                        weights,
+                        case,
+                        iteration,
+                        case_index,
+                        baseline_group_ep,
+                        baseline_group,
+                        mega_group,
+                        enable_dispatch_v2,
+                    )
+                )
+
+        torch.npu.synchronize()
+        dist.barrier()
+        for launched_case in launched_cases:
+            finalize_case(args, rank, launched_case, synchronize_ranks=False)
+    else:
+        for iteration in range(iterations):
+            for case_index, case in enumerate(cases):
+                finalize_case(
+                    args,
+                    rank,
+                    launch_case(
+                        args,
+                        rank,
+                        num_ranks,
+                        fused_buffer,
+                        weights,
+                        case,
+                        iteration,
+                        case_index,
+                        baseline_group_ep,
+                        baseline_group,
+                        mega_group,
+                        enable_dispatch_v2,
+                    ),
+                )
+    info_rank0(rank, "A3 W4A8 fused_deep_moe accuracy test completed")
+
+
+def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
+    rank, num_ranks, _ = init_dist(local_rank, num_local_ranks)
+    ranks = list(range(num_ranks))
+    baseline_group = dist.new_group(ranks=ranks, backend="hccl")
+    mega_group = dist.new_group(ranks=ranks, backend="hccl")
+    baseline_backend = baseline_group._get_backend(torch.device("npu"))
+    mega_backend = mega_group._get_backend(torch.device("npu"))
+    baseline_group_ep = baseline_backend.get_hccl_comm_name(rank)
+    mega_group_ep = mega_backend.get_hccl_comm_name(rank)
+    enable_dispatch_v2 = hasattr(torch_npu, "npu_moe_distribute_dispatch_v2")
+
+    # if rank == 0:
+    #     args.num_tokens = 32
+    # else:
+    #     args.num_tokens = 1
+
+    fused_buffer = deep_ep.Buffer(
+        mega_group,
+        int(2e9),
+        0,
+        low_latency_mode=False,
+        num_qps_per_rank=1,
+    )
+
+    test_main(
+        args,
+        rank,
+        num_ranks,
+        fused_buffer,
+        baseline_group_ep,
+        mega_group_ep,
+        baseline_group,
+        mega_group,
+        enable_dispatch_v2,
+    )
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="A3 W4A8 fused_deep_moe vs MC2 small-op accuracy test."
+    )
+    parser.add_argument("--num-processes", type=int, default=16)
+    parser.add_argument(
+        "--num-ranks-per-server",
+        type=int,
+        default=None,
+        help=(
+            "Number of local ranks spawned on the current server. Defaults to "
+            "--num-processes and must match it for this launcher."
+        ),
+    )
+    parser.add_argument("--num-servers", type=int, default=1)
+    parser.add_argument("--server-index", type=int, default=0)
+    parser.add_argument(
+        "--master-addr",
+        type=str,
+        default=None,
+        help="Set MASTER_ADDR before spawning local worker processes.",
+    )
+    parser.add_argument(
+        "--master-port",
+        type=int,
+        default=None,
+        help="Set MASTER_PORT before spawning local worker processes.",
+    )
+    parser.add_argument(
+        "--hccl-buffsize",
+        type=int,
+        default=None,
+        help="Set HCCL_BUFFSIZE before spawning.",
+    )
+    parser.add_argument("--num-tokens", type=int, default=64)
+    parser.add_argument("--hidden", type=int, default=7168)
+    parser.add_argument("--moe-intermediate-size", type=int, default=3072)
+    parser.add_argument("--num-topk", type=int, default=6)
+    parser.add_argument("--num-experts", type=int, default=16)
+    parser.add_argument("--activation", type=str, default="swiglu,situ")
+    parser.add_argument("--beta", type=str, default="4.0")
+    parser.add_argument("--linear-beta", type=str, default="25.0")
+    parser.add_argument("--activation-clamp", type=str, default="0")
+    parser.add_argument("--seed", type=int, default=2026)
+    parser.add_argument("--enable-performance", action="store_true")
+    parser.add_argument("--performance-iters", type=int, default=30)
+    args = parser.parse_args()
+    if args.num_ranks_per_server is None:
+        args.num_ranks_per_server = args.num_processes
+    if args.num_ranks_per_server != args.num_processes:
+        raise ValueError(
+            "--num-ranks-per-server must equal --num-processes because this "
+            "script starts one local worker per process."
+        )
+
+    apply_runtime_env_from_args(args)
+    torch.multiprocessing.spawn(
+        test_loop,
+        args=(args.num_ranks_per_server, args),
+        nprocs=args.num_processes,
+    )

--- a/tests/python/deepep/test_fused_deep_moe_a3_w4a8_acc.py
+++ b/tests/python/deepep/test_fused_deep_moe_a3_w4a8_acc.py
@@ -20,6 +20,8 @@ EXPERT_TOKEN_NUMS_TYPE_CUMSUM = 0
 EXPERT_TOKEN_NUMS_TYPE_COUNT = 1
 COMM_QUANT_MODE_INT8 = 2
 
+# export ASCEND_CUSTOM_OPP_PATH=${ASCEND_HOME_PATH}/opp/vendors/custom_transformer
+
 
 def info_rank0(rank: int, message: str):
     if rank == 0:
@@ -651,6 +653,7 @@ def run_baseline_reference(
     x: torch.Tensor,
     topk_idx: torch.Tensor,
     topk_weights: torch.Tensor,
+    max_num_tokens: int,
     num_experts: int,
     weights: dict,
     activation: str,
@@ -664,7 +667,6 @@ def run_baseline_reference(
     enable_dispatch_v2: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     local_num_tokens = x.size(0)
-    max_num_tokens = 32
     global_bs = max_num_tokens * ep_world_size
 
     x_active_mask = torch.zeros(
@@ -785,6 +787,7 @@ def run_fused_reference(
     topk_idx: torch.Tensor,
     topk_weights: torch.Tensor,
     num_tokens: int,
+    num_max_dispatch_tokens_per_rank: int,
     num_experts: int,
     weights: dict,
     activation: str,
@@ -801,7 +804,7 @@ def run_fused_reference(
         gmm1_permuted_weight_scale=weights["fused_l1_scales"],
         gmm2_weight=weights["fused_l2_weights"],
         gmm2_weight_scale=weights["fused_l2_scales"],
-        num_max_dispatch_tokens_per_rank=32,
+        num_max_dispatch_tokens_per_rank=num_max_dispatch_tokens_per_rank,
         num_experts=num_experts,
         backend="mega_moe",
         fuse_mode=FuseMode.FUSED_DEEP_MOE,
@@ -876,10 +879,14 @@ def launch_case(
     topk_idx, topk_weights = make_topk_inputs(
         args.num_tokens, args.num_experts, args.num_topk, device
     )
+    max_num_tokens = torch.tensor(x.size(0), device=device, dtype=torch.int32)
+    dist.all_reduce(max_num_tokens, op=dist.ReduceOp.MAX)
+    max_num_tokens = int(max_num_tokens.item())
     baseline_out, baseline_counts = run_baseline_reference(
         x,
         topk_idx,
         topk_weights,
+        max_num_tokens,
         args.num_experts,
         weights,
         case["activation"],
@@ -898,6 +905,7 @@ def launch_case(
         topk_idx,
         topk_weights,
         args.num_tokens,
+        max_num_tokens,
         args.num_experts,
         weights,
         case["activation"],
@@ -1107,9 +1115,15 @@ def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="A3 W4A8 fused_deep_moe vs MC2 small-op accuracy test."
+        description="A3 W4A8 fused_deep_moe vs MC2 small-op accuracy test.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument("--num-processes", type=int, default=16)
+    parser.add_argument(
+        "--num-processes",
+        type=int,
+        default=16,
+        help="Number of local worker processes to spawn.",
+    )
     parser.add_argument(
         "--num-ranks-per-server",
         type=int,
@@ -1119,8 +1133,18 @@ if __name__ == "__main__":
             "--num-processes and must match it for this launcher."
         ),
     )
-    parser.add_argument("--num-servers", type=int, default=1)
-    parser.add_argument("--server-index", type=int, default=0)
+    parser.add_argument(
+        "--num-servers",
+        type=int,
+        default=1,
+        help="Total number of servers participating in distributed execution.",
+    )
+    parser.add_argument(
+        "--server-index",
+        type=int,
+        default=0,
+        help="Zero-based index of the current server.",
+    )
     parser.add_argument(
         "--master-addr",
         type=str,
@@ -1137,20 +1161,79 @@ if __name__ == "__main__":
         "--hccl-buffsize",
         type=int,
         default=None,
-        help="Set HCCL_BUFFSIZE before spawning.",
+        help="HCCL buffer size in bytes; set HCCL_BUFFSIZE before spawning.",
     )
-    parser.add_argument("--num-tokens", type=int, default=64)
-    parser.add_argument("--hidden", type=int, default=7168)
-    parser.add_argument("--moe-intermediate-size", type=int, default=3072)
-    parser.add_argument("--num-topk", type=int, default=6)
-    parser.add_argument("--num-experts", type=int, default=16)
-    parser.add_argument("--activation", type=str, default="swiglu,situ")
-    parser.add_argument("--beta", type=str, default="4.0")
-    parser.add_argument("--linear-beta", type=str, default="25.0")
-    parser.add_argument("--activation-clamp", type=str, default="0")
-    parser.add_argument("--seed", type=int, default=2026)
-    parser.add_argument("--enable-performance", action="store_true")
-    parser.add_argument("--performance-iters", type=int, default=30)
+    parser.add_argument(
+        "--num-tokens",
+        type=int,
+        default=64,
+        help="Number of input tokens generated on each rank.",
+    )
+    parser.add_argument(
+        "--hidden",
+        type=int,
+        default=7168,
+        help="Hidden size of input and output token.",
+    )
+    parser.add_argument(
+        "--moe-intermediate-size",
+        type=int,
+        default=3072,
+        help="Intermediate hidden size of each MoE expert.",
+    )
+    parser.add_argument(
+        "--num-topk",
+        type=int,
+        default=8,
+        help="Number of experts selected for each token.",
+    )
+    parser.add_argument(
+        "--num-experts",
+        type=int,
+        default=64,
+        help="Global number of MoE experts.",
+    )
+    parser.add_argument(
+        "--activation",
+        type=str,
+        default="situ",
+        help="Comma-separated activation cases, such as situ or swiglu.",
+    )
+    parser.add_argument(
+        "--beta",
+        type=str,
+        default="4.0",
+        help="beta values used by the situ activation.",
+    )
+    parser.add_argument(
+        "--linear-beta",
+        type=str,
+        default="25.0",
+        help="linear beta values used by the situ activation.",
+    )
+    parser.add_argument(
+        "--activation-clamp",
+        type=str,
+        default="0",
+        help="Comma-separated activation clamp values; 0 disables clamping.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=2026,
+        help="Random seed used to generate inputs and weights.",
+    )
+    parser.add_argument(
+        "--enable-performance",
+        action="store_true",
+        help="Run performance measurement after the accuracy checks.",
+    )
+    parser.add_argument(
+        "--performance-iters",
+        type=int,
+        default=30,
+        help="Number of performance iterations.",
+    )
     args = parser.parse_args()
     if args.num_ranks_per_server is None:
         args.num_ranks_per_server = args.num_processes


### PR DESCRIPTION
python3 tests/python/deepep/test_fused_deep_moe_a3_w4a8_acc.py --num-tokens 64
<img width="1503" height="164" alt="image" src="https://github.com/user-attachments/assets/0c4f9b7c-85cb-457a-a2c3-16f6f576276e" />
python3 tests/python/deepep/test_dispatch_ffn_combine.py --num-tokens 64
<img width="1343" height="367" alt="image" src="https://github.com/user-attachments/assets/d7eb0e5d-cb89-467c-ac22-0ae589bf0310" />
python3 tests/python/deepep/test_fused_deep_moe.py --num-tokens 64
<img width="885" height="710" alt="image" src="https://github.com/user-attachments/assets/65d4ccc9-f113-4396-afd7-93c88a712849" />
