### PR TITLE
[perf] split_qkv_rmsnorm_rope_pos_cache_half: wide launch grid at large batch

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/norm/split_qkv_rmsnorm_rope_pos_cache_half_npu.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/norm/split_qkv_rmsnorm_rope_pos_cache_half_npu.py
@@ -224,6 +224,11 @@ def split_qkv_rmsnorm_rope_half_pos_cache_kernel(
         tl.store(v_ptr + outv_off + col, v.to(v_ty), mask=mask)
 
 
+# Largest q_hidden_size whose single-row tile still fits the Unified Buffer on the wide
+# grid (measured on 910B3: 8192 compiles, 12288 raises MLIRCompilationError).
+_WIDE_GRID_MAX_Q_HIDDEN = 8192
+
+
 def split_qkv_rmsnorm_rope_pos_cache_half_npu(
     input_tensor: torch.Tensor,  # [B, q_hidden + 2*kv_hidden]
     positions: torch.Tensor,  # [B]
@@ -238,6 +243,7 @@ def split_qkv_rmsnorm_rope_pos_cache_half_npu(
     k_bias: torch.Tensor = None,
     rope_dim: int = None,
     cast_norm_to_bf16: bool = True,  # cast norm result to bf16 before RoPE
+    wide_grid_min_tokens: int = 1024,  # batch at/above which the wide grid is used
 ):
     """Split QKV from concatenated input, optional RMSNorm on Q/K, RoPE via position-indexed cache, copy V.
 
@@ -265,6 +271,9 @@ def split_qkv_rmsnorm_rope_pos_cache_half_npu(
         k_bias: Optional K RMSNorm bias (length >= head_dim when provided).
         rope_dim: RoPE dimension (default head_dim). Must be even and <= head_dim.
         cast_norm_to_bf16: If True, cast norm output to bf16 with RNE before RoPE; else keep in fp32 then cast.
+        wide_grid_min_tokens: Batch size at/above which the single-column ("wide") launch grid is used
+            instead of the per-head grid. Below it the per-head grid is used with unchanged launch
+            parameters. See the grid selection comment below for the measured crossover.
 
     Returns:
         Tuple of (q_out, k_out, v_out), shapes [B, q_hidden_size], [B, kv_hidden_size], [B, kv_hidden_size].
@@ -294,13 +303,39 @@ def split_qkv_rmsnorm_rope_pos_cache_half_npu(
     # are clamped inside the Triton kernel (see max_seq).
     stride0 = cache.stride(0)
 
-    kv_block_size = triton.next_power_of_2(head_dim)
-    assert kv_block_size == head_dim, "this kernel assumes head_dim is power-of-2"
+    assert (
+        triton.next_power_of_2(head_dim) == head_dim
+    ), "this kernel assumes head_dim is power-of-2"
     assert q_hidden_size % kv_hidden_size == 0
-    q_block_size = (q_hidden_size // kv_hidden_size) * head_dim
+
+    # Launch grid. Each program walks its rows serially (batch // n_rows iterations), so the
+    # per-row scalar/address overhead is paid once per column program. Collapsing to a single
+    # column program (full Q/KV width per row, n_rows = num_vectorcore) cuts that serial
+    # iteration count by n_cols and is up to 2.7x faster at large batch. Device-time measured
+    # on 910B3 (40 vector cores, q_hidden=2048/kv_hidden=512/head_dim=128, bf16): the wide grid
+    # stays near a ~106 us fixed-cost floor while the per-head grid starts climbing above it at
+    # ~1150 tokens (1.13x), reaching 1.9x at 2048 and 2.7x at 4096. Under ~1024 tokens both sit
+    # on that floor, so the default errs low: being early costs nothing measurable, being late
+    # forfeits up to 1.9x.
+    #
+    # The wide grid materializes a q_hidden_size-wide tile per row instead of a
+    # (q_hidden_size // kv_hidden_size) * head_dim one, so it is only taken while that tile
+    # still fits the Unified Buffer. Measured on 910B3: q_hidden_size up to 8192 compiles,
+    # 12288 fails with MLIRCompilationError. Wider models keep the per-head grid, which is
+    # what they use today, rather than failing to compile once the batch grows.
+    if B >= wide_grid_min_tokens and q_hidden_size <= _WIDE_GRID_MAX_Q_HIDDEN:
+        q_block_size = q_hidden_size
+        kv_block_size = kv_hidden_size
+        n_cols = 1
+        n_rows = num_vectorcore
+    else:
+        kv_block_size = head_dim
+        q_block_size = (q_hidden_size // kv_hidden_size) * head_dim
+        n_cols = kv_hidden_size // kv_block_size
+        n_rows = (num_vectorcore + n_cols - 1) // n_cols
 
     q_block_n = q_block_size // head_dim
-    k_block_n = kv_block_size // head_dim  # usually 1
+    k_block_n = kv_block_size // head_dim  # 1 on the per-head grid
 
     q_out = torch.empty(
         (B, q_hidden_size), device=input_tensor.device, dtype=input_tensor.dtype
@@ -311,9 +346,6 @@ def split_qkv_rmsnorm_rope_pos_cache_half_npu(
     v_out = torch.empty(
         (B, kv_hidden_size), device=input_tensor.device, dtype=input_tensor.dtype
     )
-
-    n_cols = kv_hidden_size // kv_block_size
-    n_rows = (num_vectorcore + n_cols - 1) // n_cols
 
     bias = q_bias is not None
     norms = eps is not None

--- a/tests/python/sgl_kernel_npu/test_split_qkv_rmsnorm_rope_pos_cache_half_npu.py
+++ b/tests/python/sgl_kernel_npu/test_split_qkv_rmsnorm_rope_pos_cache_half_npu.py
@@ -271,6 +271,85 @@ class TestSplitQkvRmsnormRopePosCacheHalfNpu(unittest.TestCase):
         _assert_close_fp32(out_k, fk_e, atol=2e-2)
         _assert_close_fp32(out_v, fv_e, atol=2e-2, rtol=2e-2)
 
+    def _run_case_grid_arms(
+        self,
+        bsz: int,
+        q_hidden_size: int,
+        kv_hidden_size: int,
+        head_dim: int,
+        rope_dim: int,
+    ):
+        """The wide grid (B >= wide_grid_min_tokens) must agree with the per-head grid.
+
+        Both arms run the same kernel; only the launch grid differs. V is a plain copy so it
+        is bit-identical; Q/K RMSNorm reduces over head_dim either way, so any difference is a
+        reassociation worth at most one bf16 ULP (relative 2**-7). Measured: Q and V are
+        bit-identical, K differs on < 0.001% of elements by exactly 1 ULP.
+        """
+        eps = 1e-6
+        max_pos = 2048
+        rope_theta = 10000.0
+        torch.manual_seed(0)
+
+        qkv = torch.randn(
+            bsz,
+            q_hidden_size + kv_hidden_size * 2,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        positions = torch.randint(
+            0, max_pos, (bsz,), dtype=torch.int64, device=self.device
+        )
+        cos_sin_cache = _make_cos_sin_cache(
+            max_pos, rope_dim, rope_theta, torch.float32, self.device
+        )
+        q_weight = torch.randn(head_dim, dtype=self.dtype, device=self.device)
+        k_weight = torch.randn(head_dim, dtype=self.dtype, device=self.device)
+
+        def run(wide_grid_min_tokens: int):
+            return split_qkv_rmsnorm_rope_pos_cache_half_npu(
+                qkv,
+                positions,
+                cos_sin_cache,
+                q_hidden_size,
+                kv_hidden_size,
+                head_dim,
+                eps=eps,
+                q_weight=q_weight,
+                k_weight=k_weight,
+                rope_dim=rope_dim,
+                wide_grid_min_tokens=wide_grid_min_tokens,
+            )
+
+        nq, nk, nv = run(bsz + 1)  # per-head grid
+        wq, wk, wv = run(0)  # wide grid
+
+        torch.testing.assert_close(wv.cpu(), nv.cpu(), atol=0, rtol=0)
+        one_bf16_ulp = 2**-7
+        _assert_close_fp32(wq, nq, atol=1e-6, rtol=one_bf16_ulp)
+        _assert_close_fp32(wk, nk, atol=1e-6, rtol=one_bf16_ulp)
+
+    def test_grid_arms_agree_above_threshold(self):
+        """Batch above the default threshold: wide grid vs per-head grid."""
+        self._run_case_grid_arms(
+            bsz=4096,
+            q_hidden_size=2048,
+            kv_hidden_size=512,
+            head_dim=128,
+            rope_dim=64,
+        )
+
+    def test_wide_grid_vs_golden(self):
+        """Batch above the default threshold takes the wide grid; still matches golden."""
+        self._run_case_graph(
+            bsz=2048,
+            q_hidden_size=2048,
+            kv_hidden_size=512,
+            head_dim=128,
+            rope_dim=64,
+            use_qk_norm=True,
+        )
+
     def test_with_qk_norm_full_rope(self):
         """rope_dim == head_dim; fused op in NPU graph."""
         self._run_case_graph(


### PR DESCRIPTION
### Motivation

`split_qkv_rmsnorm_rope_pos_cache_half_npu` pins its launch grid to `(num_vectorcore // n_cols, n_cols)` with `n_cols = kv_hidden_size // head_dim`. Each kernel program then walks its rows serially (`batch // n_rows` iterations of the `tl.range` loop), so the per-row scalar/address overhead is paid once per column program. At small batch that is invisible; at large batch (long prefill, diffusion-LM block decode, RL rollout) it dominates the kernel and the runtime grows linearly with the token count.

### Change

Collapse to a single column program when the batch is large: `n_cols = 1`, `n_rows = num_vectorcore`, and each row processes its full Q/KV width in one pass. That cuts the serial iteration count by `n_cols`.

Small batches gain nothing from the shorter row loop (the kernel is on a fixed-cost floor there, see below), so the grid choice is gated on token count. Under `wide_grid_min_tokens` (new keyword argument, default 1024) the **original per-head grid is used with byte-identical launch parameters** — verified by intercepting the kernel launch and comparing the grid and every kwarg for `B` in {1, 32, 512, 1023} across two dim sets, all identical — so small batches cannot regress. The gate itself is one host-side integer comparison (32 ns, against ~235 us of host enqueue per wrapper call), i.e. not measurable.

The `@triton.jit` kernel is untouched; only host-side grid math changes.

### Measurements

910B3, 40 vector cores, `q_hidden=2048`, `kv_hidden=512`, `head_dim=128`, `rope_dim=64`, bf16. Device time per launch, obtained by queueing a backlog first so the host runs ahead, then timing K launches and subtracting the backlog (a plain wall-clock loop is bounded by host enqueue at this size and hides the kernel entirely):

| tokens | blocks | per-head grid | wide grid | speedup |
| -----: | -----: | ------------: | --------: | ------: |
|     32 |      1 |        106 us |    107 us |   0.99x |
|    256 |      8 |        105 us |    105 us |   1.01x |
|    896 |     28 |        107 us |    107 us |   1.00x |
|   1024 |     32 |        109 us |    106 us |   1.03x |
|   1152 |     36 |        120 us |    106 us |   1.13x |
|   1280 |     40 |        132 us |    107 us |   1.24x |
|   1536 |     48 |        157 us |    109 us |   1.44x |
|   2048 |     64 |        200 us |    106 us |   1.88x |
|   4096 |    128 |        407 us |    149 us |   2.73x |
|   8192 |    256 |        788 us |    289 us |   2.72x |

The wide grid stays near a fixed-cost floor of about 106 us across the whole range, because its row loop is `n_cols` times shorter; the per-head grid sits on the same floor until roughly 1150 tokens and climbs linearly after that. Below the crossover the two are within measurement noise of each other rather than one being a regression.

The default threshold is therefore 1024 tokens, the last measured point where the two arms are still level. The error is deliberately biased low: choosing the threshold too early costs nothing measurable (both arms are on the floor), while choosing it too late forfeits up to 1.9x before 2048 tokens and more beyond.

The win is not specific to those dims — at `q_hidden=6144` / `kv_hidden=1024` / `rope_dim=128`, 2048 tokens: 0.425 ms -> 0.230 ms (1.85x); at `q_hidden=4096` / `kv_hidden=1024` / `rope_dim=64`: 0.417 ms -> 0.242 ms (1.73x).

### Unified Buffer bound

The wide grid materializes a `q_hidden_size`-wide tile per row instead of a `(q_hidden_size // kv_hidden_size) * head_dim` one, so it is only taken while that tile fits the Unified Buffer. Measured on 910B3:

| `q_hidden_size` | per-head grid | wide grid              |
| --------------: | ------------- | ---------------------- |
|   2048 .. 8192  | compiles      | compiles               |
|          12288  | compiles      | `MLIRCompilationError` |
|          16384  | compiles      | `MLIRCompilationError` |

Without a bound this would turn a model that runs today into one that fails to compile as soon as its batch reaches the threshold — a latent failure that only appears under load. The wide grid is therefore also gated on `q_hidden_size <= 8192` (the measured limit); wider models keep the per-head grid they use today. Verified: `q_hidden` 12288 and 16384 at 2048 tokens now run instead of raising.

### Accuracy

Both arms run the same kernel, so the only numerical difference is a reassociation of the RMSNorm reduction over the wider tile. Measured by exact bf16 bit distance at the LLaDA2-mini dims:

| tokens | Q              | K                             | V              |
| -----: | -------------- | ----------------------------- | -------------- |
|   2048 | bit-identical  | 4 / 1048576 elems, 1 ULP max  | bit-identical  |
|   4096 | bit-identical  | 4 / 2097152 elems, 1 ULP max  | bit-identical  |
|   8192 | bit-identical  | 13 / 4194304 elems, 1 ULP max | bit-identical  |

### Tests

`tests/python/sgl_kernel_npu/test_split_qkv_rmsnorm_rope_pos_cache_half_npu.py` gains two cases (the existing three use batches of 8-12, i.e. only the per-head arm):

- `test_grid_arms_agree_above_threshold` — 4096 tokens, runs both arms via `wide_grid_min_tokens` and asserts V bit-identical, Q/K within one bf16 ULP.
- `test_wide_grid_vs_golden` — 2048 tokens through the existing eager + NPU-graph golden harness, so the wide arm is also covered under graph capture/replay.

```
$ PYTHONPATH=python/sgl_kernel_npu python -m pytest \
    tests/python/sgl_kernel_npu/test_split_qkv_rmsnorm_rope_pos_cache_half_npu.py -q
5 passed, 15 warnings in 22.74s
```

### CI

No CI change needed. No workflow under `.github/workflows/` runs `tests/python/sgl_kernel_npu/**` — the NPU workflows (`pr-test-deepep-npu.yml`, `a2-internode-test.yml`, `daily-build-test.yml`, `internode.yml`) only invoke `tests/python/deepep/*`. `lint.yml` (pre-commit) is the only workflow that applies to this PR, and it passes.