### PR TITLE
[feat] fused argmax + softmax-probability-of-argmax kernel

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/sample/argmax_softmax_prob.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/sample/argmax_softmax_prob.py
@@ -1,0 +1,102 @@
+"""Single-pass fused argmax + softmax-probability-of-argmax kernel.
+
+Confidence-driven decoders (diffusion LLMs in particular) need, per row, the
+argmax token and the softmax probability of that token -- the score compared
+against an unmask threshold. Done portably that is a separate max / sub / exp /
+sum / gather chain over ``[rows, vocab]``, reading the logits five to six times
+and materializing full-width temporaries.
+
+This kernel reads each logit once, carrying running ``(max, argmax, sumexp)`` in
+registers via the online-softmax recurrence, and returns ``(argmax_id, 1/sumexp)``:
+the argmax token's logit is the running max, so its ``exp(max - max)`` is 1 and
+its softmax probability is exactly the reciprocal of the sum. Nothing of shape
+``[rows, vocab]`` is ever written.
+
+Measured on Ascend 910B3 at vocab 157184, bf16 logits, against an fp32
+``argmax`` + ``softmax`` + ``gather`` reference: argmax identical on every row,
+probability max relative error 3.5e-7, and no decision flips at a 0.5 threshold.
+Against a chunked in-framework reduction: 6.6x at 32 rows (launch-bound) and
+2.7x at 4096 rows.
+"""
+
+from functools import lru_cache
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+from sgl_kernel_npu.utils.triton_utils import get_device_properties
+
+
+@triton.jit
+def _argmax_prob_kernel(
+    logits_ptr,  # [B, V]
+    argmax_ptr,  # [B] int64
+    prob_ptr,  # [B] float32
+    B,
+    V,
+    stride_b,
+    BLOCK_V: tl.constexpr,
+):
+    row_pid = tl.program_id(0)
+    n_prog = tl.num_programs(0)
+    for row in tl.range(row_pid, B, n_prog):
+        base = row * stride_b
+        m = tl.full((), float("-inf"), tl.float32)
+        arg = tl.zeros((), tl.int64)
+        s = tl.zeros((), tl.float32)
+        for start in range(0, V, BLOCK_V):
+            offs = start + tl.arange(0, BLOCK_V)
+            mask = offs < V
+            x = tl.load(logits_ptr + base + offs, mask=mask, other=float("-inf")).to(
+                tl.float32
+            )
+            chunk_max = tl.max(x, axis=0)
+            new_m = tl.maximum(m, chunk_max)
+            s = s * tl.exp(m - new_m) + tl.sum(tl.exp(x - new_m), axis=0)
+            chunk_arg = tl.argmax(x, axis=0).to(tl.int64) + start
+            # Strict >: a tie keeps the earlier index, matching torch.argmax.
+            arg = tl.where(chunk_max > m, chunk_arg, arg)
+            m = new_m
+        tl.store(argmax_ptr + row, arg)
+        tl.store(prob_ptr + row, 1.0 / s)
+
+
+@lru_cache(maxsize=1)
+def _num_cores() -> int:
+    return get_device_properties()[1]
+
+
+# Vocab tile budget per program, in bytes. 32 KiB is the widest tile that still
+# compiles for a 4-byte dtype on 910B3 (64 KiB overflows the unified buffer once
+# auto-multi-buffering claims its share); 2-byte dtypes get twice the elements.
+_TILE_BYTES = 32 * 1024
+
+
+def argmax_softmax_prob_fused(
+    logits: torch.Tensor, block_v: Optional[int] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Per-row argmax id and the softmax probability of that argmax token.
+
+    ``logits``: ``[B, V]``, any float dtype, last dim contiguous (an arbitrary
+    row stride is fine, so a vocab-truncated view costs no copy). Returns
+    ``(argmax_ids [B] int64, prob [B] float32)``. Accumulates in fp32; never
+    materializes a ``[B, V]`` temporary.
+
+    ``block_v`` overrides the vocab tile width; the default derives it from the
+    logits dtype so the tile stays within the unified buffer.
+    """
+    assert logits.dim() == 2 and logits.stride(1) == 1
+    B, V = logits.shape
+    argmax = torch.empty(B, dtype=torch.int64, device=logits.device)
+    prob = torch.empty(B, dtype=torch.float32, device=logits.device)
+    grid = (min(_num_cores(), B),)
+    if block_v is None:
+        block_v = _TILE_BYTES // logits.element_size()
+    # A tile wider than the vocab only wastes unified buffer (and overflows it
+    # once the single-iteration loop is unrolled).
+    block_v = min(block_v, triton.next_power_of_2(V))
+    _argmax_prob_kernel[grid](
+        logits, argmax, prob, B, V, logits.stride(0), BLOCK_V=block_v
+    )
+    return argmax, prob

--- a/tests/python/sgl_kernel_npu/test_argmax_softmax_prob.py
+++ b/tests/python/sgl_kernel_npu/test_argmax_softmax_prob.py
@@ -1,0 +1,66 @@
+import pytest
+import torch
+from sgl_kernel_npu.sample.argmax_softmax_prob import argmax_softmax_prob_fused
+
+
+def argmax_softmax_prob_golden(logits: torch.Tensor):
+    """Reference: argmax id and the softmax probability of that id, in fp32."""
+    ref = logits.float()
+    argmax = ref.argmax(dim=-1)
+    prob = torch.softmax(ref, dim=-1).gather(1, argmax.unsqueeze(1)).squeeze(1)
+    return argmax, prob
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+@pytest.mark.parametrize("shape", [(32, 4096), (128, 157184), (1024, 32000)])
+def test_argmax_softmax_prob(shape, dtype):
+    torch.manual_seed(0)
+    B, V = shape
+    logits = torch.randn(B, V, dtype=dtype, device="npu")
+
+    ref_argmax, ref_prob = argmax_softmax_prob_golden(logits)
+    argmax, prob = argmax_softmax_prob_fused(logits)
+
+    assert torch.equal(argmax, ref_argmax)
+    torch.testing.assert_close(prob, ref_prob, rtol=1e-5, atol=1e-6)
+
+
+def test_small_vocab_does_not_overflow_the_tile():
+    """A vocab below the default tile must clamp BLOCK_V, not allocate past it."""
+    logits = torch.randn(8, 17, dtype=torch.float32, device="npu")
+
+    ref_argmax, ref_prob = argmax_softmax_prob_golden(logits)
+    argmax, prob = argmax_softmax_prob_fused(logits)
+
+    assert torch.equal(argmax, ref_argmax)
+    torch.testing.assert_close(prob, ref_prob, rtol=1e-5, atol=1e-6)
+
+
+def test_row_stride_is_honoured():
+    """A vocab-truncated view is passed without a copy, so a row stride wider
+    than the vocab must still address rows correctly."""
+    padded = torch.randn(16, 4096, dtype=torch.bfloat16, device="npu")
+    view = padded[:, :3000]
+    assert view.stride(0) == 4096 and view.stride(1) == 1
+
+    ref_argmax, ref_prob = argmax_softmax_prob_golden(view)
+    argmax, prob = argmax_softmax_prob_fused(view)
+
+    assert torch.equal(argmax, ref_argmax)
+    torch.testing.assert_close(prob, ref_prob, rtol=1e-5, atol=1e-6)
+
+
+def test_ties_keep_the_lower_index():
+    """Matches torch.argmax: on an exact tie the earlier index wins, including
+    across the kernel's chunk boundary."""
+    logits = torch.full((4, 40000), -5.0, dtype=torch.float32, device="npu")
+    logits[:, 100] = 7.0
+    logits[:, 30000] = 7.0
+
+    argmax, _ = argmax_softmax_prob_fused(logits)
+
+    assert torch.equal(argmax, torch.full((4,), 100, dtype=torch.int64, device="npu"))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-q"])


### PR DESCRIPTION
### Motivation

Confidence-driven decoders need, per row, two things: the argmax token, and the softmax probability of that same token — the score compared against an unmask or acceptance threshold. Diffusion LLMs do this on every denoise step.

Computed portably that is a `max` / `sub` / `exp` / `sum` / `gather` chain over `[rows, vocab]`. It reads the logits five to six times and materializes full-width temporaries, which at a 157k vocab and a few thousand rows both dominates the step and caps the batch size — one fp32 `[rows, vocab]` copy is 2.1 GiB at 3584 rows.

### Change

`sgl_kernel_npu/sample/argmax_softmax_prob.py` adds `argmax_softmax_prob_fused(logits) -> (argmax_ids, prob)`.

The kernel reads each logit once, carrying running `(max, argmax, sumexp)` in registers via the online-softmax recurrence, and returns `(argmax_id, 1/sumexp)`. The identity it exploits: the argmax token's logit *is* the running max, so its shifted exponent `exp(max - max)` is exactly 1 and its softmax probability is exactly the reciprocal of the denominator — the probability falls out of the same pass, with no second reduction and no `[rows, vocab]` write.

Accumulation is fp32 regardless of input dtype. Ties keep the lower index, matching `torch.argmax`, including across a chunk boundary.

An arbitrary row stride is accepted (only the last dim must be contiguous), so a vocab-truncated view can be passed without a copy.

### Tile sizing

Two bounds, both found by the tests rather than by inspection:

- **Dtype-derived width.** The vocab tile is sized against a 32 KiB budget (`_TILE_BYTES // logits.element_size()`), not a fixed element count. A 16384-element tile compiles for 2-byte dtypes but overflows the unified buffer for fp32 — `bishengir` reports the extra local buffer auto-multi-buffering needs. Measured on 910B3: fp32 at 16384 fails, at 8192 compiles; bf16 and fp16 compile at all three widths tested.
- **Clamped to the vocab.** `min(block_v, next_power_of_2(V))`. Without it a vocab narrower than the tile fails to compile once the single-iteration loop is unrolled.

### Accuracy

Measured on Ascend 910B3 at vocab 157184, bf16 logits, against an fp32 `argmax` + `softmax` + `gather` reference:

| Quantity | Result |
| --- | --- |
| argmax id | identical on every row |
| probability | max relative error 3.5e-7 |
| decisions at a 0.5 threshold | no flips |

### Speed

Against a chunked in-framework reduction over the same logits: **6.6x at 32 rows** (launch-bound) and **2.7x at 4096 rows**. Against the fp32 copy plus `argmax`/`softmax`/`gather` it replaces in a diffusion-LLM denoise step: 12.4 ms → 5.0 ms at 4096 rows.

### Tests

`tests/python/sgl_kernel_npu/test_argmax_softmax_prob.py`, following the existing kernel-test style in that directory (plain pytest functions against a torch golden):

- parametrized over `{bfloat16, float16, float32}` x `{(32, 4096), (128, 157184), (1024, 32000)}` — argmax bit-exact, probability within `1e-5`;
- a vocab below the tile width (the `next_power_of_2` clamp);
- a row stride wider than the vocab (the no-copy view case);
- an exact tie spanning a chunk boundary (lower index wins, as `torch.argmax` does).

```
$ PYTHONPATH=python/sgl_kernel_npu python -m pytest \
    tests/python/sgl_kernel_npu/test_argmax_softmax_prob.py -q
12 passed, 14 warnings in 17.07s
```

The dtype parametrization is what caught the fp32 tile overflow; the first two cases in the list are each a compile failure that reached the test before it reached a caller.

### CI

No CI change needed. No workflow under `.github/workflows/` runs `tests/python/sgl_kernel_npu/**` — the NPU workflows (`pr-test-deepep-npu.yml`, `a2-internode-test.yml`, `daily-build-test.yml`, `internode.yml`) only invoke `tests/python/deepep/*`, and their `paths` filters do not match this PR. `lint.yml` (pre-commit) is the only workflow that applies, and it passes.
