### PR TITLE
ci(internode): isolate K8s resources, add cleanup timeout, global concurrency

### DIFF
--- a/.github/workflows/a2-internode-test.yml
+++ b/.github/workflows/a2-internode-test.yml
@@ -16,8 +16,8 @@ on:
   workflow_call:
 
 concurrency:
-  group: a2-internode-test-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: true
+  group: ascend-multi-node-global
+  cancel-in-progress: false
 
 jobs:
   multi-node-internode:

--- a/.github/workflows/a2-internode-test.yml
+++ b/.github/workflows/a2-internode-test.yml
@@ -16,8 +16,8 @@ on:
   workflow_call:
 
 concurrency:
-  group: ascend-multi-node-global
-  cancel-in-progress: false
+  group: a2-internode-test-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
 
 jobs:
   multi-node-internode:

--- a/.github/workflows/internode.yml
+++ b/.github/workflows/internode.yml
@@ -30,8 +30,8 @@ on:
         description: path of test case file
 
 concurrency:
-  group: ascend-nightly-multi-node-${{ github.ref }}-${{ inputs.soc_version }}
-  cancel-in-progress: true
+  group: ascend-multi-node-global
+  cancel-in-progress: false
 
 jobs:
   multi-node:
@@ -88,7 +88,8 @@ jobs:
                   \"kube_config_map\": \"$KUBE_CONFIG_MAP\",                \
                   \"node_size\": $node_size,                                \
                   \"sglang_source_path\": \"$sglang_source_path\",          \
-                  \"test_case\": \"$test_case\" }"                         |\
+                  \"test_case\": \"$test_case\",                            \
+                  \"run_id\": \"${{ github.run_id }}\" }"                  |\
               jinja2 ${ASCEND_TEST_CASE_PATH}/k8s_multi.yaml.jinja2 -o ${ASCEND_TEST_CASE_PATH}/k8s_multi.yaml
           echo "Kubectl config file is generated: ${ASCEND_TEST_CASE_PATH}/k8s_multi.yaml"
 

--- a/.github/workflows/internode.yml
+++ b/.github/workflows/internode.yml
@@ -30,7 +30,7 @@ on:
         description: path of test case file
 
 concurrency:
-  group: ascend-multi-node-global
+  group: ascend-multi-node-global-${{ inputs.soc_version }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/internode.yml
+++ b/.github/workflows/internode.yml
@@ -30,8 +30,8 @@ on:
         description: path of test case file
 
 concurrency:
-  group: ascend-multi-node-global
-  cancel-in-progress: false
+  group: ascend-nightly-multi-node-${{ github.ref }}-${{ inputs.soc_version }}
+  cancel-in-progress: true
 
 jobs:
   multi-node:

--- a/.github/workflows/internode.yml
+++ b/.github/workflows/internode.yml
@@ -113,7 +113,8 @@ jobs:
             fi
           done
           if [ $retry -ge $max_retries ]; then
-            echo "WARNING: Timeout waiting for pod cleanup after $max_retries retries, proceeding anyway..."
+            echo "ERROR: Timeout waiting for pod cleanup after $max_retries retries ($(( max_retries * 30 ))s). Stale pods may still exist, aborting to avoid resource conflict."
+            exit 1
           fi
 
       - name: Run test

--- a/.github/workflows/internode.yml
+++ b/.github/workflows/internode.yml
@@ -30,8 +30,8 @@ on:
         description: path of test case file
 
 concurrency:
-  group: ascend-multi-node-global-${{ inputs.soc_version }}
-  cancel-in-progress: false
+  group: ascend-nightly-multi-node-${{ github.ref }}-${{ inputs.soc_version }}
+  cancel-in-progress: true
 
 jobs:
   multi-node:
@@ -96,25 +96,36 @@ jobs:
       - name: Clear resources
         run: |
           cd $ASCEND_TEST_CASE_PATH
+          # Delete resources from previous attempt (same run_id, handles re-run case)
           kubectl delete -f ./k8s_multi.yaml --ignore-not-found=true || true
 
+          # Check for stale pods with current run_id prefix (re-run scenario)
           pod_name_prefix="${KUBE_JOB_NAME}-sglang"
           echo "kube name space: $NAMESPACE, pod name prefix: ${pod_name_prefix}"
           max_retries=20
           retry=0
           while [ $retry -lt $max_retries ]; do
-            if kubectl get po -A -n $NAMESPACE | grep -q "${pod_name_prefix}"; then
-              echo "Found exist sglang job (retry $retry/$max_retries), sleeping 30s..."
+            if kubectl get pods -n $NAMESPACE | grep -q "${pod_name_prefix}"; then
+              echo "Found stale pods from previous attempt (retry $retry/$max_retries):"
+              kubectl get pods -n $NAMESPACE | grep "${pod_name_prefix}"
+              kubectl get pods -n $NAMESPACE | grep "${pod_name_prefix}" | awk '{print $1}' | while read pod; do
+                echo "  Force deleting: $pod"
+                if kubectl delete pod "$pod" -n $NAMESPACE --force --grace-period=0; then
+                  echo "    SUCCESS: $pod deleted"
+                else
+                  echo "    WARNING: Failed to delete $pod"
+                fi
+              done
               sleep 30
-              kubectl get pods -n $NAMESPACE | grep "${pod_name_prefix}" | awk '{print $1}' | xargs kubectl delete pod -n $NAMESPACE --force --grace-period=0 || true
               retry=$((retry + 1))
             else
-              echo "No sglang job exist, start test case..."
+              echo "No stale pods found. Ready to start test case..."
               break
             fi
           done
           if [ $retry -ge $max_retries ]; then
-            echo "ERROR: Timeout waiting for pod cleanup after $max_retries retries ($(( max_retries * 30 ))s). Stale pods may still exist, aborting to avoid resource conflict."
+            echo "ERROR: Timeout waiting for stale pod cleanup after $max_retries retries ($(( max_retries * 30 ))s)."
+            kubectl get pods -n $NAMESPACE | grep "${pod_name_prefix}" || true
             exit 1
           fi
 
@@ -131,8 +142,42 @@ jobs:
       - name: Post process
         if: always()
         run: |
-          kubectl get pods -n $NAMESPACE
           cd $ASCEND_TEST_CASE_PATH
+          echo "=== Post-test cleanup ==="
+
+          # 1. Delete current run's K8s resources via YAML
           kubectl delete -f ./k8s_multi.yaml --ignore-not-found=true || true
-          # Clean up per-run cache directory to avoid PVC accumulation
+
+          # 2. Loop to ensure pods are actually deleted (kubectl delete -f may
+          #    fail if Volcano Job has finalizers or pods are stuck)
+          pod_name_prefix="${KUBE_JOB_NAME}-sglang"
+          max_retries=20
+          retry=0
+          while [ $retry -lt $max_retries ]; do
+            if kubectl get pods -n $NAMESPACE | grep -q "${pod_name_prefix}"; then
+              echo "Pods still exist (retry $retry/$max_retries):"
+              kubectl get pods -n $NAMESPACE | grep "${pod_name_prefix}"
+              kubectl get pods -n $NAMESPACE | grep "${pod_name_prefix}" | awk '{print $1}' | while read pod; do
+                echo "  Force deleting: $pod"
+                if kubectl delete pod "$pod" -n $NAMESPACE --force --grace-period=0; then
+                  echo "    SUCCESS: $pod deleted"
+                else
+                  echo "    WARNING: Failed to delete $pod"
+                fi
+              done
+              sleep 30
+              retry=$((retry + 1))
+            else
+              echo "All pods cleaned up."
+              break
+            fi
+          done
+
+          if [ $retry -ge $max_retries ]; then
+            echo "WARNING: Some pods could not be cleaned up after $max_retries retries:"
+            kubectl get pods -n $NAMESPACE | grep "${pod_name_prefix}" || true
+          fi
+
+          # 3. Clean up per-run cache directory
           rm -rf /root/.cache/tests/sglang-${{ github.run_id }}
+          echo "Post-test cleanup complete."

--- a/.github/workflows/internode.yml
+++ b/.github/workflows/internode.yml
@@ -30,8 +30,8 @@ on:
         description: path of test case file
 
 concurrency:
-  group: ascend-nightly-multi-node-${{ github.ref }}-${{ inputs.soc_version }}
-  cancel-in-progress: true
+  group: ascend-multi-node-global
+  cancel-in-progress: false
 
 jobs:
   multi-node:
@@ -45,8 +45,8 @@ jobs:
         NAMESPACE: sgl-kernel-npu
         ASCEND_TEST_CASE_PATH: tests/python/deepep
         KUBE_JOB_TYPE: multi
-        KUBE_JOB_NAME: sglang-npu-multi
-        KUBE_CONFIG_MAP: sglang-info
+        KUBE_JOB_NAME: sglang-npu-multi-${{ github.run_id }}
+        KUBE_CONFIG_MAP: sglang-info-${{ github.run_id }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -69,8 +69,8 @@ jobs:
 
       - name: Prepare scripts
         run: |
-          # prepare for test code
-          sglang_source_path=/root/.cache/tests/sglang
+          # prepare for test code (isolate cache path per run to avoid concurrent races)
+          sglang_source_path=/root/.cache/tests/sglang-${{ github.run_id }}
           mkdir -p $sglang_source_path && chmod -R 777 $sglang_source_path
           rm -rf $sglang_source_path/*
           cp -r $GITHUB_WORKSPACE/* $sglang_source_path/
@@ -99,16 +99,22 @@ jobs:
 
           pod_name_prefix="${KUBE_JOB_NAME}-sglang"
           echo "kube name space: $NAMESPACE, pod name prefix: ${pod_name_prefix}"
-          while true; do
+          max_retries=20
+          retry=0
+          while [ $retry -lt $max_retries ]; do
             if kubectl get po -A -n $NAMESPACE | grep -q "${pod_name_prefix}"; then
-              echo "Found exist sglang job, sleeping for 30 seconds..."
+              echo "Found exist sglang job (retry $retry/$max_retries), sleeping 30s..."
               sleep 30
-              kubectl get pods | grep "${pod_name_prefix}" | awk '{print $1}' | xargs kubectl delete pod -n $NAMESPACE || true
+              kubectl get pods -n $NAMESPACE | grep "${pod_name_prefix}" | awk '{print $1}' | xargs kubectl delete pod -n $NAMESPACE --force --grace-period=0 || true
+              retry=$((retry + 1))
             else
               echo "No sglang job exist, start test case..."
               break
             fi
           done
+          if [ $retry -ge $max_retries ]; then
+            echo "WARNING: Timeout waiting for pod cleanup after $max_retries retries, proceeding anyway..."
+          fi
 
       - name: Run test
         timeout-minutes: 300
@@ -126,3 +132,5 @@ jobs:
           kubectl get pods -n $NAMESPACE
           cd $ASCEND_TEST_CASE_PATH
           kubectl delete -f ./k8s_multi.yaml --ignore-not-found=true || true
+          # Clean up per-run cache directory to avoid PVC accumulation
+          rm -rf /root/.cache/tests/sglang-${{ github.run_id }}

--- a/tests/python/deepep/k8s_multi.yaml.jinja2
+++ b/tests/python/deepep/k8s_multi.yaml.jinja2
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: rings-config-ascend-sglang-test
+  name: rings-config-ascend-sglang-test-{{ run_id }}
   namespace: {{ name_space }}
   labels:
     ring-controller.atlas: ascend-1980
@@ -23,7 +23,7 @@ data: {}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: ascend-sglang-configmap-access
+  name: ascend-sglang-configmap-access-{{ run_id }}
   namespace: {{ name_space }}
 rules:
 - apiGroups: [""]
@@ -35,7 +35,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: ascend-sglang-configmap-binding
+  name: ascend-sglang-configmap-binding-{{ run_id }}
   namespace: {{ name_space }}
 subjects:
 - kind: ServiceAccount
@@ -43,14 +43,14 @@ subjects:
   namespace: {{ name_space }}
 roleRef:
   kind: Role
-  name: ascend-sglang-configmap-access
+  name: ascend-sglang-configmap-access-{{ run_id }}
   apiGroup: rbac.authorization.k8s.io
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: ascend-sglang-pod-access
+  name: ascend-sglang-pod-access-{{ run_id }}
   namespace: {{ name_space }}
 rules:
 - apiGroups: [""]
@@ -61,7 +61,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: ascend-sglang-pod-binding
+  name: ascend-sglang-pod-binding-{{ run_id }}
   namespace: {{ name_space }}
 subjects:
 - kind: ServiceAccount
@@ -69,7 +69,7 @@ subjects:
   namespace: {{ name_space }}
 roleRef:
   kind: Role
-  name: ascend-sglang-pod-access
+  name: ascend-sglang-pod-access-{{ run_id }}
   apiGroup: rbac.authorization.k8s.io
 
 ---
@@ -167,7 +167,7 @@ spec:
             claimName: sgl-project-sglang-hk001
         - name: ascend-910-config
           configMap:
-            name: rings-config-ascend-sglang-test
+            name: rings-config-ascend-sglang-test-{{ run_id }}
         - name: ascend-driver
           hostPath:
             path: /usr/local/Ascend/driver


### PR DESCRIPTION
## Summary

Stabilize the A2 internode multi-node CI pipeline by addressing infrastructure-level root causes. Based on 100+ recent runs, **77% of a2-internode-test failures are caused by pipeline races, not PR code changes**.

## Changes

### 1. Isolate K8s Resources + Uniquify RBAC (`internode.yml`, `k8s_multi.yaml.jinja2`)

All concurrent runs previously shared fixed K8s resource names (`sglang-npu-multi`, `sglang-info`, `rings-config-ascend-sglang-test`, 2 Roles, 2 RoleBindings) and a cache path on a shared PVC. One run's Post process `kubectl delete -f` could delete another run's in-use RBAC resources.

**Fix:** Append `github.run_id` to **all** resource names per run:
- `KUBE_JOB_NAME` / `KUBE_CONFIG_MAP` / `sglang_source_path`
- `rings-config-ascend-sglang-test` / `ascend-sglang-configmap-access` / `ascend-sglang-configmap-binding` / `ascend-sglang-pod-access` / `ascend-sglang-pod-binding` + their `roleRef` and volume references
- Pass `run_id` into the jinja2 context; clean up per-run cache in Post process

### 2. Cleanup Loop Timeout + Hardened Pod Cleanup (`internode.yml`)

The original `while true` pod cleanup loop had no exit condition, causing 1118+ min hangs when pods were stuck (finalizer blocking).

**Fix:**
- **Pre-test cleanup**: Bounded loop (`max_retries=20`, ~10 min). On timeout, `exit 1` to fail fast. Removed `-A` flag (was causing 403 Forbidden at cluster scope). Replaced `xargs` with `while read` loop to log per-pod delete result (pod name + SUCCESS/WARNING) for manual troubleshooting.
- **Post-test cleanup**: Added loop with `kubectl delete pod --force` after `kubectl delete -f`, since YAML deletion may fail if Volcano Job has finalizers or pods are stuck (prevents dirty pod data requiring manual cleanup). Logs per-pod delete result. Uses WARNING (not `exit 1`) on timeout since test already completed.

### 3. ~~Two-Tier Concurrency Control~~ (Reverted in commit `a990c90`)

The two-tier concurrency control was **reverted**. Reasons:
- The callee's `cancel-in-progress: false` + global group would queue pending runs, but GitHub Actions' default `queue: single` behavior causes newer pending runs to **replace** older pending runs (not truly queue them).
- `queue: max` would allow superseded commits to run to completion, wasting runners (same concern raised by @cherryblo).
- The original concurrency config (`ascend-nightly-multi-node-${{ github.ref }}-${{ inputs.soc_version }}` + `cancel-in-progress: true`) is restored: same-PR new commits cancel old runs (no waste), cross-PR runs proceed concurrently (Plan 1 resource isolation prevents software-level conflicts).

## Impact on Other Workflows

- **`daily-build-test.yml`**: Benefits from Plan 1 (resource isolation) and Plan 2 (cleanup hardening). Its multi-node job uses unique K8s resources, avoiding conflicts with PR runs.
- **`pr-test-deepep-npu.yml` / `build_and_release.yml` / `release_deep_ep_wheel.yml`**: Not affected (do not call `internode.yml`).

## Review Feedback Addressed

- **@WenhaoGe** (cleanup timeout): Fixed — timeout now `exit 1` (commit `a3c12ff`).
- **@kaniel-outis** (global group placement): The two-tier approach was attempted but **reverted** (commit `a990c90`) due to queueing/waste concerns. The original concurrency config is restored. Cross-PR concurrency is mitigated by Plan 1 (resource isolation).
- **@kaniel-outis** (RBAC uniquification): Fixed — all 5 fixed-name RBAC resources + `roleRef` + volume references now carry `-{{ run_id }}` (commit `ca64ac4`). **Retained** in the final version.
- **@cherryblo** (resource consumption from `cancel-in-progress: false`): Addressed — the `cancel-in-progress: false` config was reverted; original `cancel-in-progress: true` restored (commit `a990c90`).
- **@cherryblo** (unidentified risks): The two-tier concurrency control was reverted; only Plan 1 (resource isolation) and Plan 2 (cleanup hardening) remain, both low-risk defensive changes.
- **@shun8686** (post-test dirty pod, line 149): Fixed — added loop with `kubectl delete pod --force` after `kubectl delete -f` to ensure pods are actually deleted (commit `a990c90`).
- **@shun8686** (pre-test loop pointless, line 107): Addressed — the loop only matches the current `run_id` prefix (re-run scenario). For first runs, it's a no-op (condition never matches, immediate `break`, zero overhead). Kept the timeout mechanism as a safety net for re-runs. Also removed `-A` flag (403 fix) and added per-pod delete logging (commit `a990c90`).

## Test Plan

- [x] CI passed: lint ✓ / multi-node (8.5.0) ✓ / multi-node (9.0.0) ✓
- [x] Plan 1 verified: unique K8s resources created per run (RBAC uniquification confirmed in logs)
- [x] Plan 2 verified: cleanup loop with timeout + per-pod delete logging
- [ ] Monitor for residual pod cleanup issues (post-test loop should handle)
