### PR TITLE
align speculative Mamba state with sequential decode

### DIFF
--- a/csrc/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule_kernel.cpp
+++ b/csrc/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule_kernel.cpp
@@ -433,6 +433,14 @@ private:
         uint32_t ktShape[2] = {1, alignK_};
         uint32_t deltaShape[2] = {curSingleV, 1};
 
+        out_empty_Attn.wait();
+        if (seq_i > seq0) {
+            // Decode persists BF16 state between tokens. Match that round-trip
+            // during multi-token verification before advancing the recurrence.
+            Cast(stateInUb, stateOutLocal, AscendC::RoundMode::CAST_NONE, alignK_ * curSingleV);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+
         {
             uint64_t gbOffset = head_i + (seq_i - seq0) * NV_;
             gama_ = hasGama_ ? gamaLocal.GetValue(gbOffset) : 1;
@@ -489,8 +497,6 @@ private:
                                            curSingleV, {1, 0, 1, 16, 1, 0});
             AscendC::PipeBarrier<PIPE_V>();
         }
-
-        out_empty_Attn.wait();
 
         Cast(stateOutLocal, stateInUb, AscendC::RoundMode::CAST_RINT, alignK_ * curSingleV);
 

--- a/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d.py
@@ -207,41 +207,41 @@ def _causal_conv1d_update_kernel_npu_tiled(
         )
 
         # define history vectors as zeros then load conditionally
-        col0 = tl.zeros((BLOCK_N,), dtype=tl.float16)
-        col1 = tl.zeros((BLOCK_N,), dtype=tl.float16)
-        col2 = tl.zeros((BLOCK_N,), dtype=tl.float16)
-        col3 = tl.zeros((BLOCK_N,), dtype=tl.float16)
-        col4 = tl.zeros((BLOCK_N,), dtype=tl.float16)
+        col0 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+        col1 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+        col2 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+        col3 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+        col4 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
         if KERNEL_WIDTH >= 2:
             col0 = tl.load(
                 prior_tokens + 0 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(tl.float16)
+            ).to(x_ptr.dtype.element_ty)
         if KERNEL_WIDTH >= 3:
             col1 = tl.load(
                 prior_tokens + 1 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(tl.float16)
+            ).to(x_ptr.dtype.element_ty)
         if KERNEL_WIDTH >= 4:
             col2 = tl.load(
                 prior_tokens + 2 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(tl.float16)
+            ).to(x_ptr.dtype.element_ty)
         if KERNEL_WIDTH >= 5:
             col3 = tl.load(
                 prior_tokens + 3 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(tl.float16)
+            ).to(x_ptr.dtype.element_ty)
         if KERNEL_WIDTH >= 6:
             col4 = tl.load(
                 prior_tokens + 4 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(tl.float16)
+            ).to(x_ptr.dtype.element_ty)
 
         # -------------------------
         # STEP 2: chunked state update (replaces original NP2_STATELEN x BLOCK_N big block)
@@ -352,12 +352,9 @@ def _causal_conv1d_update_kernel_npu_tiled(
         x_base_1d = x_base
         o_base_1d = o_ptr + o_offset + idx_feats * stride_o_dim
 
-        # accumulator preload (bias)
-        acc_preload = acc_bias
-
         # compute each token; keep tl.range so varlen can use seqlen_run as runtime trip count (like original)
         for idx_token in tl.range(seqlen_run):
-            acc = acc_preload
+            acc = tl.zeros((BLOCK_N,), dtype=tl.float32)
 
             # same selection logic as original (unrolled by KERNEL_WIDTH)
             matrix_w = w_col0
@@ -368,7 +365,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                     x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                     matrix_x = tl.load(
                         x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                    ).to(tl.float16)
+                    ).to(x_ptr.dtype.element_ty)
                     matrix_w = w_col0
                 elif KERNEL_WIDTH == 2:
                     if j == 1:
@@ -376,7 +373,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(tl.float16)
+                        ).to(x_ptr.dtype.element_ty)
                 elif KERNEL_WIDTH == 3:
                     if j == 1:
                         matrix_w = w_col1
@@ -386,7 +383,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(tl.float16)
+                        ).to(x_ptr.dtype.element_ty)
                 elif KERNEL_WIDTH == 4:
                     if j == 1:
                         matrix_w = w_col1
@@ -399,7 +396,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(tl.float16)
+                        ).to(x_ptr.dtype.element_ty)
                 elif KERNEL_WIDTH == 5:
                     if j == 1:
                         matrix_w = w_col1
@@ -415,7 +412,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(tl.float16)
+                        ).to(x_ptr.dtype.element_ty)
                 elif KERNEL_WIDTH == 6:
                     if j == 1:
                         matrix_w = w_col1
@@ -434,9 +431,18 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(tl.float16)
+                        ).to(x_ptr.dtype.element_ty)
 
                 acc += matrix_x.to(tl.float32) * matrix_w  # [BLOCK_N]
+
+            if HAS_BIAS:
+                acc += acc_bias
+
+            # Persist one BF16 convolution result per token before SiLU, just
+            # like the one-token decode path.
+            acc = acc.to(
+                x_ptr.dtype.element_ty, fp_downcast_rounding="rtne"
+            )
 
             # roll history window
             if KERNEL_WIDTH == 2:
@@ -461,6 +467,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                 col4 = matrix_x
 
             if SILU_ACTIVATION:
+                acc = acc.to(tl.float32)
                 acc = acc / (1.0 + tl.exp(-acc))
 
             # store output
@@ -1256,7 +1263,17 @@ def torch_causal_conv1d_update_npu(
     else:
         conv_state_update = hidden_states_new[:, :, -state_len:]
 
-    out = torch.sum(hidden_states_new * weight, dim=-1, keepdim=True)
+    # The speculative Triton kernel performs the convolution in FP32 before
+    # persisting BF16 output. Use the same arithmetic for one-token decode so
+    # enabling speculative decoding does not change model numerics.
+    out = torch.sum(
+        hidden_states_new.to(torch.float32) * weight.to(torch.float32),
+        dim=-1,
+        keepdim=True,
+    )
+    if bias is not None:
+        out = out + bias.to(torch.float32)[None, :, None]
+    out = out.to(hidden_state.dtype)
     if activation in ["silu", "swish"]:
         out = F.silu(out)
     out = out.to(hidden_state.dtype)

--- a/python/sgl_kernel_npu/sgl_kernel_npu/mamba/mamba_state_update_triton.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/mamba/mamba_state_update_triton.py
@@ -89,7 +89,7 @@ def move_intermediate_cache(
     dst_indices_tensor,
     src_indices_tensor,
     last_steps_tensor,
-    h_block_size=2,
+    h_block_size=1,
 ):
     """
     Move intermediate cache to SSM states using Triton kernel.
@@ -138,7 +138,8 @@ def move_intermediate_cache(
         dim_v=V,
         dim_k=K,
         num_layers=L,
-        H_BLOCK_SIZE=h_block_size,  # Process 2 h elements per block
+        # Keep the 128x128 state tile within the A2 192 KiB UB.
+        H_BLOCK_SIZE=h_block_size,
         BLOCK_V=triton.next_power_of_2(V),  # Block size for dim_v
         BLOCK_K=triton.next_power_of_2(K),  # Block size for dim_k
     )

--- a/tests/python/sgl_kernel_npu/test_conv1d_update.py
+++ b/tests/python/sgl_kernel_npu/test_conv1d_update.py
@@ -10,6 +10,73 @@ logger = logging.getLogger("TestScript")
 torch.manual_seed(42)
 
 
+def test_speculative_bf16_matches_sequential_decode():
+    from sgl_kernel_npu.mamba.causal_conv1d import (
+        causal_conv1d_update_npu,
+        causal_conv1d_update_v2,
+    )
+
+    torch.npu.set_device("npu:0")
+    torch.manual_seed(42)
+    batch_size, steps, dim, width = 1, 4, 1024, 4
+    x = torch.randn(
+        batch_size, steps, dim, device="npu", dtype=torch.bfloat16
+    )
+    weight = torch.randn(dim, width, device="npu", dtype=torch.bfloat16)
+    bias = torch.randn(dim, device="npu", dtype=torch.bfloat16)
+    history = torch.randn(
+        batch_size, width - 1, dim, device="npu", dtype=torch.bfloat16
+    )
+    cache_indices = torch.tensor([0], device="npu", dtype=torch.int32)
+
+    speculative_state = torch.zeros(
+        batch_size,
+        width - 1 + steps - 1,
+        dim,
+        device="npu",
+        dtype=torch.bfloat16,
+    )
+    speculative_state[:, -(width - 1) :] = history
+    speculative_output = causal_conv1d_update_v2(
+        x.clone(),
+        speculative_state,
+        weight.T.contiguous(),
+        bias=bias,
+        activation="silu",
+        conv_state_indices=cache_indices,
+        num_accepted_tokens=torch.tensor(
+            [steps], device="npu", dtype=torch.int32
+        ),
+        pad_slot_id=-1,
+    )
+
+    sequential_state = history.transpose(1, 2).clone()
+    sequential_output = torch.stack(
+        [
+            causal_conv1d_update_npu(
+                x[:, step].clone(),
+                sequential_state,
+                weight,
+                bias=bias,
+                activation="silu",
+                conv_state_indices=cache_indices,
+            )
+            for step in range(steps)
+        ],
+        dim=1,
+    )
+
+    torch.testing.assert_close(
+        speculative_output, sequential_output, rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        speculative_state[:, -(width - 1) :],
+        sequential_state.transpose(1, 2),
+        rtol=0,
+        atol=0,
+    )
+
+
 # ==========================================
 # 1. Original SGLang implementation
 # ==========================================

--- a/tests/python/sgl_kernel_npu/test_mamba_state_update.py
+++ b/tests/python/sgl_kernel_npu/test_mamba_state_update.py
@@ -162,3 +162,32 @@ def test_move_intermediate_cache(
     )
 
     assert_close("move_cache", dst_cache, dst_cache_clone, 1e-3)
+
+
+@torch.no_grad
+def test_move_intermediate_cache_a2_real_shape():
+    """Compile and validate the Qwen3.6 state tile without overflowing A2 UB."""
+    torch.manual_seed(42)
+    # UB usage depends on H/V/K; keep the outer dimensions small for this regression.
+    L, S, D, H, V, K = 1, 4, 4, 8, 128, 128
+    dst_cache = torch.randn(L, S, H, V, K, device=device, dtype=torch.bfloat16)
+    expected = dst_cache.clone()
+    src_cache = torch.randn(
+        L, S, D, H, V, K, device=device, dtype=torch.bfloat16
+    )
+    dst_indices = torch.tensor([0, 3], device=device, dtype=torch.int32)
+    src_indices = torch.tensor([0, 1], device=device, dtype=torch.int32)
+    last_steps = torch.tensor([0, 3], device=device, dtype=torch.int32)
+    expected[:, dst_indices.to(torch.int64)] = src_cache[
+        :, src_indices.to(torch.int64), last_steps.to(torch.int64)
+    ]
+
+    move_intermediate_cache(
+        dst_cache,
+        src_cache,
+        dst_indices,
+        src_indices,
+        last_steps,
+    )
+
+    assert_close("move_cache_a2_real_shape", expected, dst_cache, 1e-3)

--- a/tests/python/sgl_kernel_npu/test_recurrent_gated_delta_rule.py
+++ b/tests/python/sgl_kernel_npu/test_recurrent_gated_delta_rule.py
@@ -406,6 +406,80 @@ class TestCase:
             return False
 
 
+def test_mtp_matches_sequential_decode():
+    """MTP must preserve the per-token BF16 state round-trip of decode."""
+    torch.npu.set_device("npu:0")
+    torch.manual_seed(42)
+    batch_size, steps, nk, nv, dk, dv = 1, 4, 4, 8, 128, 128
+
+    q = torch.rand(
+        batch_size, steps, nk, dk, dtype=torch.bfloat16, device="npu"
+    )
+    k = torch.rand_like(q)
+    v = torch.rand(
+        batch_size, steps, nv, dv, dtype=torch.bfloat16, device="npu"
+    )
+    mix_qkv = torch.cat(
+        [q.flatten(2), k.flatten(2), v.flatten(2)], dim=-1
+    ).contiguous()
+    beta = torch.rand(
+        batch_size, steps, nv, dtype=torch.bfloat16, device="npu"
+    )
+    g = -torch.rand(batch_size, steps, nv, dtype=torch.float32, device="npu")
+    initial_state = torch.rand(
+        batch_size, nv, dv, dk, dtype=torch.bfloat16, device="npu"
+    )
+    scale = dk**-0.5
+
+    intermediate = torch.empty(
+        batch_size, steps, nv, dv, dk, dtype=torch.bfloat16, device="npu"
+    )
+    mtp_output = torch.ops.npu.recurrent_gated_delta_rule(
+        mix_qkv,
+        initial_state.clone(),
+        beta=beta,
+        scale=scale,
+        actual_seq_lengths=torch.tensor([steps], dtype=torch.int32, device="npu"),
+        ssm_state_indices=torch.arange(
+            steps, dtype=torch.int32, device="npu"
+        ).view(1, steps),
+        nk=nk,
+        nv=nv,
+        intermediate_state=intermediate.view(-1, nv, dv, dk),
+        cache_indices=torch.tensor([0], dtype=torch.int32, device="npu"),
+        num_accepted_tokens=torch.tensor([1], dtype=torch.int32, device="npu"),
+        g=g,
+    )
+
+    sequential_state = initial_state.clone()
+    sequential_outputs = []
+    sequential_states = []
+    one = torch.tensor([1], dtype=torch.int32, device="npu")
+    state_index = torch.zeros((1, 1), dtype=torch.int32, device="npu")
+    for step in range(steps):
+        sequential_outputs.append(
+            torch.ops.npu.recurrent_gated_delta_rule(
+                mix_qkv[:, step : step + 1],
+                sequential_state,
+                beta=beta[:, step : step + 1],
+                scale=scale,
+                actual_seq_lengths=one,
+                ssm_state_indices=state_index,
+                nk=nk,
+                nv=nv,
+                g=g[:, step : step + 1],
+            )
+        )
+        sequential_states.append(sequential_state[0].clone())
+
+    torch.testing.assert_close(
+        mtp_output, torch.cat(sequential_outputs, dim=1), rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        intermediate[0], torch.stack(sequential_states), rtol=0, atol=0
+    )
+
+
 def compatible_cases():
     """Defines the matrix of test cases to be executed."""
     res = []


### PR DESCRIPTION
## Summary

Align the NPU speculative Mamba state update path with sequential single-token decode.

This change fixes numerical inconsistencies in the recurrent gated delta rule and causal Conv1D kernels when multiple MTP tokens are verified in one invocation.

## Problem

MTP target verification processes multiple draft tokens in a single kernel invocation, while normal decode processes one token per invocation.

The two paths previously crossed different state persistence boundaries:

- The recurrent gated delta rule kernel kept FP32 intermediate states between speculative steps, while sequential decode persisted and reloaded BF16 state after every token.
- The multi-token causal Conv1D path forced parts of the computation to FP16 and used a different accumulation and persistence order from the single-token path.

As a result, processing the same token sequence with MTP and sequential decode could produce different intermediate states. The differences accumulated across decode steps and could affect subsequent token selection.

## Changes

### Recurrent gated delta rule

- Round the recurrent state through BF16 between speculative tokens.
- Reload the persisted state before advancing the next recurrence step.
- Match the per-token state transition used by sequential single-token decode.

### Causal Conv1D

- Preserve the input and history tensor dtype instead of forcing FP16.
- Perform convolution multiply-accumulate and bias addition in FP32.
- Persist the BF16 convolution result before applying SiLU.
- Align the single-token and multi-token update paths to use the same operation order and precision boundaries.

## Validation

Added focused BF16 consistency tests:

- Compare one 4-token recurrent gated delta rule invocation with four sequential single-token invocations.
- Compare all recurrent intermediate states with `rtol=0` and `atol=0`.
- Compare one 4-token causal Conv1D update with four sequential single-token updates.
- Compare Conv1D outputs and final convolution state with `rtol=0` and `atol=0`.

Both kernel paths now produce exactly matching outputs and states for the covered cases.

## Scope

This change guarantees consistency between speculative multi-token execution and sequential execution of the same NPU kernels.

It does not claim full-model bitwise equivalence between MTP-enabled and non-MTP inference. Other model layers, different recurrent kernel implementations, and the `M=4` versus `M=1` execution shapes may still introduce numerical differences.