### PR TITLE
ci(deepep): skip rebuild on cache hit, preserve -a arch flags

### DIFF
--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -110,15 +110,21 @@ jobs:
           pip install uv
           bash scripts/npu_ci_install_dependency.sh
       - name: Prepare Deepep
-        # Always run prepare_deepep_in_container.sh:
-        # - cache miss: build + install new wheel
-        # - cache hit: install cached wheel only
-        # Pre-step: clear stale wheels from output/ to prevent pip install matching
-        # multiple wheel versions (can happen on shared self-hosted runners across jobs).
-        # Only delete wheel files; keep .so / CMake cache to avoid rebuilding.
+        # - cache hit: install cached wheel only (skip build.sh)
+        # - cache miss: clear stale wheels + build + install
+        # Pre-step (cache miss only): clear stale wheels from output/ to prevent
+        # pip install matching multiple wheel versions on shared self-hosted runners.
         run: |
-          rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
-          bash scripts/prepare_deepep_in_container.sh
+          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+            echo "Cache hit, installing cached wheel only"
+            pip install ${GITHUB_WORKSPACE}/output/deep_ep*.whl --no-cache-dir
+            cd "$(pip show deep-ep | awk '/^Location:/ {print $2}')"
+            ln -s deep_ep/deep_ep_cpp*.so || true
+          else
+            echo "Cache miss, building and installing"
+            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+            bash scripts/prepare_deepep_in_container.sh
+          fi
       - name: Set CANN 9.0.0 env
         if: matrix.cann_version == '9.0.0'
         run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
@@ -338,15 +344,19 @@ jobs:
           pip install uv
           bash scripts/npu_ci_install_dependency.sh
       - name: Prepare Deepep
-        # Always run prepare_deepep_in_container.sh:
-        # - cache miss: build + install new wheel
-        # - cache hit: install cached wheel only
-        # Pre-step: clear stale wheels from output/ to prevent pip install matching
-        # multiple wheel versions (can happen on shared self-hosted runners across jobs).
-        # Only delete wheel files; keep .so / CMake cache to avoid rebuilding.
+        # - cache hit: install cached wheel only (skip build.sh)
+        # - cache miss: clear stale wheels + build + install
         run: |
-          rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
-          bash scripts/prepare_deepep_in_container.sh
+          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+            echo "Cache hit, installing cached wheel only"
+            pip install ${GITHUB_WORKSPACE}/output/deep_ep*.whl --no-cache-dir
+            cd "$(pip show deep-ep | awk '/^Location:/ {print $2}')"
+            ln -s deep_ep/deep_ep_cpp*.so || true
+          else
+            echo "Cache miss, building and installing"
+            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+            bash scripts/prepare_deepep_in_container.sh
+          fi
       - name: Set CANN 9.0.0 env
         if: matrix.cann_version == '9.0.0'
         run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
@@ -521,15 +531,19 @@ jobs:
           pip install uv
           bash scripts/npu_ci_install_dependency.sh
       - name: Prepare Deepep
-        # Always run prepare_deepep_in_container.sh (-a deepep for a3 ops):
-        # - cache miss: build + install new wheel
-        # - cache hit: install cached wheel only
-        # Pre-step: clear stale wheels from output/ to prevent pip install matching
-        # multiple wheel versions (can happen on shared self-hosted runners across jobs).
-        # Only delete wheel files; keep .so / CMake cache to avoid rebuilding.
+        # - cache hit: install cached wheel only (skip build.sh)
+        # - cache miss: clear stale wheels + build (-a deepep) + install
         run: |
-          rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
-          bash scripts/prepare_deepep_in_container.sh -a deepep
+          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+            echo "Cache hit, installing cached wheel only"
+            pip install ${GITHUB_WORKSPACE}/output/deep_ep*.whl --no-cache-dir
+            cd "$(pip show deep-ep | awk '/^Location:/ {print $2}')"
+            ln -s deep_ep/deep_ep_cpp*.so || true
+          else
+            echo "Cache miss, building and installing"
+            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+            bash scripts/prepare_deepep_in_container.sh -a deepep
+          fi
       - name: Set CANN 9.0.0 env
         if: matrix.cann_version == '9.0.0'
         run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
@@ -752,15 +766,19 @@ jobs:
           pip install uv
           bash scripts/npu_ci_install_dependency.sh
       - name: Prepare Deepep
-        # Always run prepare_deepep_in_container.sh (-a deepep for a3 ops):
-        # - cache miss: build + install new wheel
-        # - cache hit: install cached wheel only
-        # Pre-step: clear stale wheels from output/ to prevent pip install matching
-        # multiple wheel versions (can happen on shared self-hosted runners across jobs).
-        # Only delete wheel files; keep .so / CMake cache to avoid rebuilding.
+        # - cache hit: install cached wheel only (skip build.sh)
+        # - cache miss: clear stale wheels + build (-a deepep) + install
         run: |
-          rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
-          bash scripts/prepare_deepep_in_container.sh -a deepep
+          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+            echo "Cache hit, installing cached wheel only"
+            pip install ${GITHUB_WORKSPACE}/output/deep_ep*.whl --no-cache-dir
+            cd "$(pip show deep-ep | awk '/^Location:/ {print $2}')"
+            ln -s deep_ep/deep_ep_cpp*.so || true
+          else
+            echo "Cache miss, building and installing"
+            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+            bash scripts/prepare_deepep_in_container.sh -a deepep
+          fi
       - name: Set CANN 9.0.0 env
         if: matrix.cann_version == '9.0.0'
         run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
@@ -952,15 +970,19 @@ jobs:
           pip install uv
           bash scripts/npu_ci_install_dependency.sh
       - name: Prepare Deepep
-        # Always run prepare_deepep_in_container.sh (-a deepep2 for a2 ops):
-        # - cache miss: build + install new wheel
-        # - cache hit: install cached wheel only
-        # Pre-step: clear stale wheels from output/ to prevent pip install matching
-        # multiple wheel versions (can happen on shared self-hosted runners across jobs).
-        # Only delete wheel files; keep .so / CMake cache to avoid rebuilding.
+        # - cache hit: install cached wheel only (skip build.sh)
+        # - cache miss: clear stale wheels + build (-a deepep2) + install
         run: |
-          rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
-          bash scripts/prepare_deepep_in_container.sh -a deepep2
+          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+            echo "Cache hit, installing cached wheel only"
+            pip install ${GITHUB_WORKSPACE}/output/deep_ep*.whl --no-cache-dir
+            cd "$(pip show deep-ep | awk '/^Location:/ {print $2}')"
+            ln -s deep_ep/deep_ep_cpp*.so || true
+          else
+            echo "Cache miss, building and installing"
+            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+            bash scripts/prepare_deepep_in_container.sh -a deepep2
+          fi
       - name: Set CANN 9.0.0 env
         if: matrix.cann_version == '9.0.0'
         run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -99,7 +99,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v2-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+          key: sgl-kernel-npu-build-v3-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
       - name: Install dependencies
         run: |
           # speed up by using infra cache services
@@ -333,7 +333,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v2-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+          key: sgl-kernel-npu-build-v3-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
       - name: Install dependencies
         run: |
           # speed up by using infra cache services
@@ -520,7 +520,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v2-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+          key: sgl-kernel-npu-build-v3-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
       - name: Install dependencies
         run: |
           # speed up by using infra cache services
@@ -755,7 +755,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v2-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+          key: sgl-kernel-npu-build-v3-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
       - name: Install dependencies
         run: |
           # speed up by using infra cache services
@@ -959,7 +959,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v2-${{ runner.os }}-a2-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+          key: sgl-kernel-npu-build-v3-${{ runner.os }}-a2-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
       - name: Install dependencies
         run: |
           # speed up by using infra cache services

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Get build hash
         id: get_build_hash
         run: |
-          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
             -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
           echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
           CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
@@ -110,16 +110,12 @@ jobs:
           pip install uv
           bash scripts/npu_ci_install_dependency.sh
       - name: Prepare Deepep
-        # - cache hit: install cached wheel only (skip build.sh)
+        # - cache hit: install cached wheel only (skip build via -s flag)
         # - cache miss: clear stale wheels + build + install
-        # Pre-step (cache miss only): clear stale wheels from output/ to prevent
-        # pip install matching multiple wheel versions on shared self-hosted runners.
         run: |
           if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
             echo "Cache hit, installing cached wheel only"
-            pip install ${GITHUB_WORKSPACE}/output/deep_ep*.whl --no-cache-dir
-            cd "$(pip show deep-ep | awk '/^Location:/ {print $2}')"
-            ln -s deep_ep/deep_ep_cpp*.so || true
+            bash scripts/prepare_deepep_in_container.sh -s
           else
             echo "Cache miss, building and installing"
             rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
@@ -321,7 +317,7 @@ jobs:
       - name: Get build hash
         id: get_build_hash
         run: |
-          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
             -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
           echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
           CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
@@ -344,14 +340,12 @@ jobs:
           pip install uv
           bash scripts/npu_ci_install_dependency.sh
       - name: Prepare Deepep
-        # - cache hit: install cached wheel only (skip build.sh)
+        # - cache hit: install cached wheel only (skip build via -s flag)
         # - cache miss: clear stale wheels + build + install
         run: |
           if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
             echo "Cache hit, installing cached wheel only"
-            pip install ${GITHUB_WORKSPACE}/output/deep_ep*.whl --no-cache-dir
-            cd "$(pip show deep-ep | awk '/^Location:/ {print $2}')"
-            ln -s deep_ep/deep_ep_cpp*.so || true
+            bash scripts/prepare_deepep_in_container.sh -s
           else
             echo "Cache miss, building and installing"
             rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
@@ -508,7 +502,7 @@ jobs:
       - name: Get build hash
         id: get_build_hash
         run: |
-          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
             -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
           echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
           CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
@@ -531,14 +525,12 @@ jobs:
           pip install uv
           bash scripts/npu_ci_install_dependency.sh
       - name: Prepare Deepep
-        # - cache hit: install cached wheel only (skip build.sh)
+        # - cache hit: install cached wheel only (skip build via -s flag)
         # - cache miss: clear stale wheels + build (-a deepep) + install
         run: |
           if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
             echo "Cache hit, installing cached wheel only"
-            pip install ${GITHUB_WORKSPACE}/output/deep_ep*.whl --no-cache-dir
-            cd "$(pip show deep-ep | awk '/^Location:/ {print $2}')"
-            ln -s deep_ep/deep_ep_cpp*.so || true
+            bash scripts/prepare_deepep_in_container.sh -s
           else
             echo "Cache miss, building and installing"
             rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
@@ -743,7 +735,7 @@ jobs:
       - name: Get build hash
         id: get_build_hash
         run: |
-          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
             -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
           echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
           CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
@@ -766,14 +758,12 @@ jobs:
           pip install uv
           bash scripts/npu_ci_install_dependency.sh
       - name: Prepare Deepep
-        # - cache hit: install cached wheel only (skip build.sh)
+        # - cache hit: install cached wheel only (skip build via -s flag)
         # - cache miss: clear stale wheels + build (-a deepep) + install
         run: |
           if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
             echo "Cache hit, installing cached wheel only"
-            pip install ${GITHUB_WORKSPACE}/output/deep_ep*.whl --no-cache-dir
-            cd "$(pip show deep-ep | awk '/^Location:/ {print $2}')"
-            ln -s deep_ep/deep_ep_cpp*.so || true
+            bash scripts/prepare_deepep_in_container.sh -s
           else
             echo "Cache miss, building and installing"
             rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
@@ -947,7 +937,7 @@ jobs:
       - name: Get build hash
         id: get_build_hash
         run: |
-          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
             -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
           echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
           CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
@@ -970,14 +960,12 @@ jobs:
           pip install uv
           bash scripts/npu_ci_install_dependency.sh
       - name: Prepare Deepep
-        # - cache hit: install cached wheel only (skip build.sh)
+        # - cache hit: install cached wheel only (skip build via -s flag)
         # - cache miss: clear stale wheels + build (-a deepep2) + install
         run: |
           if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
             echo "Cache hit, installing cached wheel only"
-            pip install ${GITHUB_WORKSPACE}/output/deep_ep*.whl --no-cache-dir
-            cd "$(pip show deep-ep | awk '/^Location:/ {print $2}')"
-            ln -s deep_ep/deep_ep_cpp*.so || true
+            bash scripts/prepare_deepep_in_container.sh -s
           else
             echo "Cache miss, building and installing"
             rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl

--- a/.github/workflows/push_build_cache.yml
+++ b/.github/workflows/push_build_cache.yml
@@ -10,6 +10,7 @@ on:
       - "python/**"
       - "CMakeLists.txt"
       - "scripts/npu_ci_install_dependency.sh"
+      - "scripts/prepare_deepep_in_container.sh"
   workflow_dispatch:
 
 concurrency:
@@ -67,7 +68,7 @@ jobs:
       - name: Get build hash
         id: get_build_hash
         run: |
-          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
             -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
           echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/push_build_cache.yml
+++ b/.github/workflows/push_build_cache.yml
@@ -83,7 +83,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: output
-          key: sgl-kernel-npu-build-v2-${{ runner.os }}-${{ matrix.arch }}-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+          key: sgl-kernel-npu-build-v3-${{ runner.os }}-${{ matrix.arch }}-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
 
       - name: Install dependencies
         if: steps.cache-build.outputs.cache-hit != 'true'
@@ -99,7 +99,14 @@ jobs:
         if: steps.cache-build.outputs.cache-hit != 'true'
         run: |
           echo "🚀 Building for arch: ${{ matrix.arch }}, CANN: ${{ steps.get_build_hash.outputs.CANN_VERSION }}"
-          env -i PATH=${PATH} bash --login -c "
-            export LD_LIBRARY_PATH=${ASCEND_HOME_PATH}/runtime/lib64/stub:${LD_LIBRARY_PATH} && \
-            bash build.sh
-          "
+          if [ "${{ matrix.arch }}" = "a2" ]; then
+            env -i PATH=${PATH} bash --login -c "
+              export LD_LIBRARY_PATH=${ASCEND_HOME_PATH}/runtime/lib64/stub:${LD_LIBRARY_PATH} && \
+              bash build.sh -a deepep2
+            "
+          else
+            env -i PATH=${PATH} bash --login -c "
+              export LD_LIBRARY_PATH=${ASCEND_HOME_PATH}/runtime/lib64/stub:${LD_LIBRARY_PATH} && \
+              bash build.sh -a deepep
+            "
+          fi

--- a/scripts/prepare_deepep_in_container.sh
+++ b/scripts/prepare_deepep_in_container.sh
@@ -1,8 +1,15 @@
+set -e
 
-while getopts ":a:" opt; do
+BUILD_ARGS=""
+SKIP_BUILD=false
+
+while getopts ":a:s" opt; do
     case ${opt} in
         a )
             BUILD_ARGS="$OPTARG"
+            ;;
+        s )
+            SKIP_BUILD=true
             ;;
         \? )
             echo "Error: unknown flag: -$OPTARG" 1>&2
@@ -18,11 +25,21 @@ done
 shift $((OPTIND -1))
 
 cd ${GITHUB_WORKSPACE}
-if [ -n "$BUILD_ARGS" ]; then
-    bash build.sh -a "$BUILD_ARGS"
-else
-    bash build.sh
+
+if [ "$SKIP_BUILD" = false ]; then
+    if [ -n "$BUILD_ARGS" ]; then
+        bash build.sh -a "$BUILD_ARGS"
+    else
+        bash build.sh
+    fi
 fi
+
 pip install ${GITHUB_WORKSPACE}/output/deep_ep*.whl --no-cache-dir
-cd "$(pip show deep-ep | awk '/^Location:/ {print $2}')"
+
+DEEP_EP_LOCATION=$(pip show deep-ep | awk '/^Location:/ {print $2}')
+if [ -z "$DEEP_EP_LOCATION" ]; then
+    echo "Error: deep-ep package not found after pip install" 1>&2
+    exit 1
+fi
+cd "$DEEP_EP_LOCATION"
 ln -s deep_ep/deep_ep_cpp*.so || true


### PR DESCRIPTION
## Problem

`pr-test-deepep-npu.yml` restores the build cache (`output/`) via `runs-on/cache@v4` using the **same cache key** as `push_build_cache.yml`, but the "Prepare Deepep" step **always** runs:

```
rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl # deletes the restored wheel!
bash scripts/prepare_deepep_in_container.sh # rebuilds from scratch
```

This means on cache hit, the restored wheel is immediately deleted and rebuilt — the cache provides **zero benefit** and every PR pays the full build cost (10-15 min per job × 5 jobs).

## Fix

### Commit 1: Skip rebuild on cache hit (`91d2ed7`)

Branch on `steps.cache-build.outputs.cache-hit`:

| Condition | Action |
|---|---|
| cache hit | `pip install` cached wheel + `ln -s` .so (skip `build.sh`) |
| cache miss | `rm` stale wheels + `build.sh` + install (original path) |

Each job retains its original `-a` build target:

| Job | Runner | `-a` flag | Build target |
|---|---|---|---|
| test-all-build-core | a3 | (none) | all modules |
| test-all-build-moe | a3 | (none) | all modules |
| test-build-deepep-a3-core | a3 | `-a deepep` | deepep (A3 ops) |
| test-build-deepep-a3-moe | a3 | `-a deepep` | deepep (A3 ops) |
| test-build-deepep-a2 | a2 | `-a deepep2` | deepep (A2 ops2) |

### Commit 2: Fix A2 cache poisoning (`6ea7c14`)

**Root cause**: `push_build_cache.yml` built with `bash build.sh` (no `-a` flag) for BOTH a2 and a3. The default `all` target hard-codes `SOC_VERSION=Ascend910_9382` (A3) and `DEEPEP_VARIANT=deepep`. So the A2 cache entry contained an A3 deepep wheel, which A2 hardware cannot run.

**Fix**:
1. `push_build_cache.yml`: branch on `matrix.arch`
   - a2 → `build.sh -a deepep2` (Ascend910B1, ops2)
   - a3 → `build.sh -a deepep` (Ascend910_9382, ops)
2. Bump cache key v2 → v3 in both `push_build_cache.yml` and `pr-test-deepep-npu.yml` to invalidate the poisoned A2 cache entries.

**Why A3 jobs passed but A2 failed**: A3 jobs need the `deepep` variant, which is what `bash build.sh` (all target) happened to produce. A2 jobs need the `deepep2` variant, but got `deepep` from the cache — hence the `DispatchLayout` error on A2 hardware.

## Context

- `push_build_cache.yml` is **active** (state=`active`, updated 2026-08-03). Its cache key is identical to what `pr-test-deepep-npu.yml` uses. Commit 2 fixes the arch-specific build variant in `push_build_cache.yml` and bumps the cache key version.
- Corrects PR [添加了缓存命中 #650](https://github.com/sgl-project/sgl-kernel-npu/pull/650) which dropped the `-a deepep` / `-a deepep2` flags — this would build the wrong variant for a3/a2 jobs.

## Verification

### CI Status: All 13 checks passed (Run ID: 30975010744)

| Check | Conclusion |
|-------|-----------|
| Check changed files | success |
| lint | success |
| test-all-build-core (8.5.0) | success |
| test-all-build-core (9.0.0) | success |
| test-all-build-moe (8.5.0) | success |
| test-all-build-moe (9.0.0) | success |
| test-build-deepep-a3-core (8.5.0) | success |
| test-build-deepep-a3-core (9.0.0) | success |
| test-build-deepep-a3-moe (8.5.0) | success |
| test-build-deepep-a3-moe (9.0.0) | success |
| test-build-deepep-a2 (8.5.0) | success |
| test-build-deepep-a2 (9.0.0) | success |
| finish | success |

- `finish` job (checks all dependent job results) passed -> all 5 test job groups verified
- Both A2 jobs passed -> A2 cache poisoning fixed and verified
- Cache hit path: `pip install` + `ln -s` only (same commands as `prepare_deepep_in_container.sh` lines 26-28, minus the build)
- Cache miss path: identical to the original code
- `-a` flags verified for all 5 jobs