### PR TITLE
[fix]Replace dist.gather with dist.all_gather for hccl backend compatibility

### DIFF
--- a/tests/python/deepep/test_internode.py
+++ b/tests/python/deepep/test_internode.py
@@ -415,12 +415,8 @@ def test_main(
         ):
             if stats is None:
                 continue
-            gather_list = (
-                [torch.zeros_like(stats) for _ in range(group.size())]
-                if rank == 0
-                else None
-            )
-            dist.gather(stats, gather_list=gather_list, group=group, dst=0)
+            gather_list = [torch.zeros_like(stats) for _ in range(group.size())]
+            dist.all_gather(gather_list, stats, group=group)
             if rank == 0:
                 stats_mat = torch.stack(gather_list, dim=0)
                 print(f"{title} stats:")

--- a/tests/python/deepep/test_internode_a2.py
+++ b/tests/python/deepep/test_internode_a2.py
@@ -417,12 +417,8 @@ def test_main(
         ):
             if stats is None:
                 continue
-            gather_list = (
-                [torch.zeros_like(stats) for _ in range(group.size())]
-                if rank == 0
-                else None
-            )
-            dist.gather(stats, gather_list=gather_list, group=group, dst=0)
+            gather_list = [torch.zeros_like(stats) for _ in range(group.size())]
+            dist.all_gather(gather_list, stats, group=group)
             if rank == 0:
                 stats_mat = torch.stack(gather_list, dim=0)
                 print(f"{title} stats:")

--- a/tests/python/deepep/test_intranode.py
+++ b/tests/python/deepep/test_intranode.py
@@ -328,12 +328,8 @@ def test_main(
         ):
             if stats is None:
                 continue
-            gather_list = (
-                [torch.zeros_like(stats) for _ in range(group.size())]
-                if rank == 0
-                else None
-            )
-            dist.gather(stats, gather_list=gather_list, group=group, dst=0)
+            gather_list = [torch.zeros_like(stats) for _ in range(group.size())]
+            dist.all_gather(gather_list, stats, group=group)
             if rank == 0:
                 stats_mat = torch.stack(gather_list, dim=0)
                 print(f"{title} stats:")


### PR DESCRIPTION


## Motivation

fix issue: https://github.com/sgl-project/sgl-kernel-npu/issues/669
Replace dist.gather with dist.all_gather for hccl backend compatibility

## Modifications

 Replace dist.gather calls with dist.all_gather in test_internode, test_internode_a2, and test_intranode so that all ranks allocate the gather buffer list, matching the workaround already applied in tests/python/deepep/utils.py.

## Testing

The test script is verified after the modification.

## Checklist

- [x] Format your code.
- [x] Add unit tests.
- [x] Update documentation.
- [x] Provide accuracy and speed benchmark results.