### PR TITLE
Delete redundant tests

### DIFF
--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -164,6 +164,7 @@ jobs:
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=4096
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=6144
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=7168
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=8192
       - name: Run test topk num intranode
         timeout-minutes: 10
         env:
@@ -178,6 +179,7 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2 --num-topk=1 --num-experts=2
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=512 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=1024 --num-processes=16
       - name: Run test intranode for active ranks
         timeout-minutes: 10
         env:
@@ -233,12 +235,13 @@ jobs:
       - name: Run test low latency for hidden
         timeout-minutes: 10
         env:
-          HCCL_BUFFSIZE: 1913
+          HCCL_BUFFSIZE: 2200
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=2048
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=4096
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=6144
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=7168
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=8192
       - name: Run test low latency for topk
         timeout-minutes: 10
         env:
@@ -461,237 +464,6 @@ jobs:
           HCCL_BUFFSIZE: 3769
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --test-loop=100 --enable-dynamic-tokens
-
-  test-build-deepep-a3-core:
-    needs: get-changed-files
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call' || (
-        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
-        github.event.pull_request.draft == false &&
-        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
-      )
-    runs-on: linux-aarch64-a3-16
-    container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
-    env:
-      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
-      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
-      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
-      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-    strategy:
-      matrix:
-        cann_version: [8.5.0, 9.0.0]
-    steps:
-      - name: Clean git config
-        run: |
-          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
-          git config --global --unset "$CONFIG_KEY" || true
-      - name: Clean workspace
-        run: |
-          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          clean: true
-          submodules: recursive
-      - name: Get build hash
-        id: get_build_hash
-        run: |
-          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt \
-            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
-          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
-          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
-          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
-          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
-          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
-      - name: Restore build cache
-        id: cache-build
-        uses: runs-on/cache@v4
-        with:
-          path: output
-          key: sgl-kernel-npu-build-v2-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
-      - name: Install dependencies
-        run: |
-          # speed up by using infra cache services
-          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
-          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
-          pip config set global.index-url http://${CACHING_URL}/pypi/simple
-          pip config set global.trusted-host ${CACHING_URL}
-          pip install uv
-          bash scripts/npu_ci_install_dependency.sh
-      - name: Prepare Deepep
-        # Always run prepare_deepep_in_container.sh (-a deepep for a3 ops):
-        # - cache miss: build + install new wheel
-        # - cache hit: install cached wheel only
-        # Pre-step: clear stale wheels from output/ to prevent pip install matching
-        # multiple wheel versions (can happen on shared self-hosted runners across jobs).
-        # Only delete wheel files; keep .so / CMake cache to avoid rebuilding.
-        run: |
-          rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
-          bash scripts/prepare_deepep_in_container.sh -a deepep
-      - name: Set CANN 9.0.0 env
-        if: matrix.cann_version == '9.0.0'
-        run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
-      - name: Run test intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
-      - name: Run test intranode for little bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 4065
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=4
-      - name: Run test intranode for big bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 4065
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=8192
-      - name: Run test multi-round intranode
-        timeout-minutes: 10
-        env:
-          DEEPEP_NORMAL_LONG_SEQ_ROUND: 5
-          DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS: 512
-          HCCL_BUFFSIZE: 1000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2122
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2048
-      - name: Run test little processes intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2241
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2
-      - name: Run test hidden intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=2048
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=4096
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=6144
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=7168
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=8192
-      - name: Run test topk num intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 4065
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=1
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=16
-      - name: Run test experts num intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2 --num-topk=1 --num-experts=2
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=512 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=1024 --num-processes=16
-      - name: Run test intranode for active ranks
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --active-ranks="0,1,3"
-      - name: Run test intranode for DeepXtrace
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-diagnose
-      - name: Run test intranode for int8 quant
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --quant-type=int8
-
-      - name: Run test intranode for output parameters of different types
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-          MOE_EXPERT_TOKEN_NUMS_TYPE: 0
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
-      - name: Run test intranode for dynamic tokens
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-dynamic-tokens
-      - name: Run test low latency
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1913
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=1
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=2
-      - name: Run test low latency for big bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3825
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=512
-      - name: Run test low latency for little num processes
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1913
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2
-      - name: Run test low latency for hidden
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2200
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=2048
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=4096
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=6144
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=7168
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=8192
-      - name: Run test low latency for topk
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1969
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=4
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=16
-      - name: Run test low latency for experts
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 7481
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-experts=1024
-      - name: Run test low latency for drop percent
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1913
-          MOE_ENABLE_TOPK_NEG_ONE: 1
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --drop-percent=0.3
-      - name: Run test low latency for dynamic tokens
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --enable-dynamic-tokens
-      - name: Run test generalization of fused deep moe
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2048
-        run: bash scripts/generalization_test_fused_deep_moe.sh
-      - name: Run test combine only
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3900
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --test-type="low_latency"
 
   test-build-deepep-a3-moe:
     needs: get-changed-files


### PR DESCRIPTION
## Summary

Remove redundant test tasks to reduce the waiting time for PR merging

## Changes

Updated file: .github/workflows/pr-test-deepep-npu.yml, remove redundant job: test-build-deepep-a3-core, Migrate the tests under this job to run in the test-all-build-core job.

