### PR TITLE
Fix bug Job 'finish' depends on unknown job 'test-build-deepep-a3-core'

### DIFF
--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -939,7 +939,6 @@ jobs:
     needs:
       - test-all-build-core
       - test-all-build-moe
-      - test-build-deepep-a3-core
       - test-build-deepep-a3-moe
       - test-build-deepep-a2
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fix bug Job 'finish' depends on unknown job 'test-build-deepep-a3-core'

## Changes

Updated file: .github/workflows/pr-test-deepep-npu.yml, remove test-build-deepep-a3-core

