### PR TITLE
[feat] (deepep): add A5 normal multi-round ant migration

### DIFF
--- a/csrc/deepep/deep_ep.cpp
+++ b/csrc/deepep/deep_ep.cpp
@@ -72,7 +72,7 @@ Buffer::Buffer(int64_t rank, int64_t num_ranks, int64_t num_nvl_bytes, int64_t n
         long t = std::strtol(tokensEnv, &end, 10);
         EP_HOST_ASSERT(*end == '\0' && t >= MIN_TOKENS_PER_ROUND && t <= MAX_TOKENS_PER_ROUND);
         // 验证乘积限制
-        EP_HOST_ASSERT(r * t <= 131072);
+        EP_HOST_ASSERT(r * t <= MAX_TOTAL_TOKENS);
         round = static_cast<int>(r);
         per_round_tokens = static_cast<int>(t);
     }
@@ -108,6 +108,13 @@ Buffer::get_dispatch_layout(const torch::Tensor &topk_idx, int num_experts, std:
 
     const int num_tokens = topk_idx.size(0);
     const int num_topk = topk_idx.size(1);
+    // 长序列参数边界校验（与 A3 一致，集中在 Host 侧完成）
+    EP_HOST_ASSERT(num_tokens > 0 && num_tokens <= static_cast<int>(MAX_TOTAL_TOKENS));
+    EP_HOST_ASSERT(per_round_tokens >= static_cast<int>(MIN_TOKENS_PER_ROUND) &&
+                   per_round_tokens <= static_cast<int>(MAX_TOKENS_PER_ROUND));
+    EP_HOST_ASSERT(rank >= 0 && rank < num_ranks);
+    const int64_t actual_rounds = (static_cast<int64_t>(num_tokens) + per_round_tokens - 1) / per_round_tokens;
+    EP_HOST_ASSERT(actual_rounds <= static_cast<int>(MAX_ROUNDS));
     const int local_ranksize = LOCAL_RANK_SIZE;
     auto server_num = num_ranks / local_ranksize;
     auto device = topk_idx.device();

--- a/csrc/deepep/ops/op_host/dispatch_layout_tiling.cc
+++ b/csrc/deepep/ops/op_host/dispatch_layout_tiling.cc
@@ -189,24 +189,35 @@ static bool CheckTensorDataType(gert::TilingContext *context, const char *nodeNa
     return true;
 }
 
-static bool CheckTensorShape(gert::TilingContext *context, const char *nodeName)
+static bool CheckTensorShape(gert::TilingContext *context, const char *nodeName,
+                             const DispatchLayoutTilingData &tilingData)
 {
     const gert::StorageShape *topkIdxStorageShape = context->GetInputShape(INPUT_TOPK_IDX_INDEX);
+    OP_TILING_CHECK(topkIdxStorageShape == nullptr, OP_LOGE(nodeName, "topkIdxStorageShape is null."), return false);
 
-    OP_TILING_CHECK((topkIdxStorageShape->GetStorageShape().GetDimNum() != TWO_DIMS),
-                    OP_LOGE(nodeName, "topkIdx must be 2-dimension, but get %lu dim.",
-                            topkIdxStorageShape->GetStorageShape().GetDimNum()),
+    const auto &topkIdxShape = topkIdxStorageShape->GetStorageShape();
+    OP_TILING_CHECK((topkIdxShape.GetDimNum() != TWO_DIMS),
+                    OP_LOGE(nodeName, "topkIdx must be 2-dimension, but get %lu dim.", topkIdxShape.GetDimNum()),
+                    return false);
+    OP_TILING_CHECK((topkIdxShape.GetDim(0) != tilingData.dispatchLayoutInfo.numTokens),
+                    OP_LOGE(nodeName, "topkIdx dim0 must equal numTokens, but got dim0=%ld, numTokens=%u.",
+                            topkIdxShape.GetDim(0), tilingData.dispatchLayoutInfo.numTokens),
+                    return false);
+    OP_TILING_CHECK((topkIdxShape.GetDim(1) != tilingData.dispatchLayoutInfo.numTopk),
+                    OP_LOGE(nodeName, "topkIdx dim1 must equal numTopk, but got dim1=%ld, numTopk=%u.",
+                            topkIdxShape.GetDim(1), tilingData.dispatchLayoutInfo.numTopk),
                     return false);
 
     return true;
 }
 
-static ge::graphStatus TilingCheckTensor(gert::TilingContext *context, const char *nodeName)
+static ge::graphStatus TilingCheckTensor(gert::TilingContext *context, const char *nodeName,
+                                         const DispatchLayoutTilingData &tilingData)
 {
     OP_TILING_CHECK(!CheckTensorDataType(context, nodeName), OP_LOGE(nodeName, "params dataType is invalid."),
                     return ge::GRAPH_FAILED);
 
-    OP_TILING_CHECK(!CheckTensorShape(context, nodeName), OP_LOGE(nodeName, "params dataType is invalid."),
+    OP_TILING_CHECK(!CheckTensorShape(context, nodeName, tilingData), OP_LOGE(nodeName, "params shape is invalid."),
                     return ge::GRAPH_FAILED);
 
     return ge::GRAPH_SUCCESS;
@@ -222,12 +233,14 @@ static ge::graphStatus DispatchLayoutTilingFuncImpl(gert::TilingContext *context
     OP_TILING_CHECK(GetAttrAndSetTilingData(context, nodeName, *tilingData) != ge::GRAPH_SUCCESS,
                     OP_LOGE(nodeName, "Get attr and set tiling data failed."), return ge::GRAPH_FAILED);
 
-    OP_TILING_CHECK(TilingCheckTensor(context, nodeName) != ge::GRAPH_SUCCESS,
+    OP_TILING_CHECK(TilingCheckTensor(context, nodeName, *tilingData) != ge::GRAPH_SUCCESS,
                     OP_LOGE(nodeName, "Tiling check param failed."), return ge::GRAPH_FAILED);
 
     OP_TILING_CHECK(SetWorkSpace(context, nodeName) != ge::GRAPH_SUCCESS,
                     OP_LOGE(nodeName, "Tiling set workspace failed."), return ge::GRAPH_FAILED);
 
+    // A3 and A5 share the generic multi-round DispatchLayout kernel.
+    // A2 uses its dedicated DispatchLayoutA2 kernel.
     int tilingKey = TILING_KEY_INT;
     if (CheckIfA2Machine(context)) {
         tilingKey = tilingKey + TILING_KEY_A2_TYPE;

--- a/csrc/deepep/ops/op_kernel/cam_moe_combine_normal.cpp
+++ b/csrc/deepep/ops/op_kernel/cam_moe_combine_normal.cpp
@@ -34,6 +34,11 @@ extern "C" __global__ __aicore__ void cam_moe_combine_normal(GM_ADDR recvX, GM_A
         op.Init(recvX, tokenSrcInfo, epRecvCount, topkWeights, tokenIdx, tpRecvCount, XOut, sendCostStatsOut,
                 workspaceGM, &pipe, &tilingData);
         op.Process();
+    } else if (TILING_KEY_IS(TILINGKEY_A5_MULTI_ROUND)) {
+        CamMoeCombineNormalMultiRound<DTYPE_RECV_X, DTYPE_X, int32_t> op;
+        op.Init(recvX, tokenSrcInfo, epRecvCount, topkWeights, tokenIdx, tpRecvCount, XOut, sendCostStatsOut,
+                workspaceGM, &pipe, &tilingData);
+        op.Process();
     } else if (TILING_KEY_IS(TILINGKEY_A3_SINGLE_ROUND)) {
         CamMoeCombineNormal<DTYPE_RECV_X, DTYPE_X, int32_t> op;
         op.Init(recvX, tokenSrcInfo, epRecvCount, topkWeights, tokenIdx, tpRecvCount, XOut, sendCostStatsOut,

--- a/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_multi_round.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_multi_round.h
@@ -13,7 +13,11 @@ constexpr uint32_t TOKEN_IDX_OFFSET_IN_SRC_INFO = 1U;
 constexpr uint32_t TOPK_IDX_OFFSET_IN_SRC_INFO = 2U;
 constexpr uint64_t STATE_WIN_SIZE = 4UL * 1024UL * 1024UL;
 constexpr uint64_t STATE_WIN_SIZE_HALF = STATE_WIN_SIZE / 2;
+#ifdef __DAV_C310__
+constexpr uint64_t MAGIC_WIN_OFFSET = 1100UL * 1024UL;
+#else
 constexpr uint64_t MAGIC_WIN_OFFSET = 975UL * 1024UL;
+#endif
 constexpr uint64_t ROUND_STATE_OFFSET = Moe::BASE_ROUND_STATE_OFFSET + Moe::ROUND_STATE_MAX_SIZE * 2UL;  // 458*1024
 constexpr uint32_t TOKEN_SRC_INFO_LEN = 3U;
 constexpr uint32_t UB_32_ALIGN = 32U;
@@ -63,19 +67,15 @@ private:
     __aicore__ inline void SetStatusBySrcInfo(uint32_t srcRankId, uint32_t srcTokenId, uint32_t srcTopkId);
     __aicore__ inline void ReadBufferAndWeightedSum(uint32_t recvXTokenIdx, uint32_t topkWeightTokenIdx);
     __aicore__ inline void InitRoundSendData();
+    __aicore__ inline void InitTokenBalancedRoundSendDataA5();
     __aicore__ inline void SetRoundStatus();
     __aicore__ inline void WaitRoundStatus();
     __aicore__ inline void InitRoundRecvData();
 
     __aicore__ GM_ADDR GetStateAddrByRankId(const int32_t rankId)
     {
-        GM_ADDR bufferAddr;
-        if (epRankId_ == rankId) {
-            bufferAddr = (GM_ADDR)epWinContext_->localWindowsIn;
-        } else {
-            bufferAddr = (GM_ADDR)((HcclRankRelationResV2 *)epWinContext_->remoteRes[rankId].nextDevicePtr)->windowsIn;
-        }
-        return (GM_ADDR)(bufferAddr + winDataSizeOffset_ + Moe::NOTIFY_DISPATCH_BUFF_OFFSET);
+        return GetBaseWindAddrByRankId(epWinContext_, rankId, epRankId_) + winDataSizeOffset_ +
+               Moe::NOTIFY_DISPATCH_BUFF_OFFSET;
     }
 
     __aicore__ GM_ADDR GetBufferAddrByRankId(const int32_t rankId)
@@ -85,11 +85,7 @@ private:
 
     __aicore__ inline GM_ADDR GetRoundStateAddrByRankId(const int32_t rankId)
     {
-        if (epRankId_ == rankId) {
-            return (GM_ADDR)(epWinContext_->localWindowsExp) + roundMagic_ * Moe::ROUND_STATE_MAX_SIZE +
-                   ROUND_STATE_OFFSET;
-        }
-        return (GM_ADDR)(((HcclRankRelationResV2 *)(epWinContext_->remoteRes[rankId].nextDevicePtr))->windowsExp) +
+        return GetBaseWindStateAddrByRankId(epWinContext_, rankId, epRankId_) +
                roundMagic_ * Moe::ROUND_STATE_MAX_SIZE + ROUND_STATE_OFFSET;
     }
 
@@ -108,8 +104,8 @@ private:
         endIdx = startIdx + perCoreNum;
     }
 
-    __gm__ HcclOpResParam *epWinContext_{nullptr};
-    __gm__ HcclOpResParam *tpWinContext_{nullptr};
+    __gm__ HcclOpParam *epWinContext_{nullptr};
+    __gm__ HcclOpParam *tpWinContext_{nullptr};
     uint32_t axisBS_{0};
     uint32_t axisH_{0};
     uint32_t axisK_{0};
@@ -122,6 +118,7 @@ private:
     uint32_t magic_{0};
     uint32_t roundMagic_{0};
     uint64_t winDataSizeOffset_{0};
+    uint64_t baseWinSize_{0};
     uint32_t hRecvXTypeLen_{0};
     uint32_t h32AlignFloatLen_{0};
     uint32_t h256AlignFloatLen_{0};
@@ -196,11 +193,11 @@ template <TemplateMC2TypeClass>
 __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitMagic()
 {
     auto contextGM0 = AscendC::GetHcclContext<HCCL_GROUP_ID_0>();
-    epWinContext_ = (__gm__ HcclOpResParam *)contextGM0;
+    epWinContext_ = (__gm__ HcclOpParam *)contextGM0;
 
     GlobalTensor<int32_t> selfMagicTensor;
     selfMagicTensor.SetGlobalBuffer(
-        (__gm__ int32_t *)((GM_ADDR)epWinContext_->localWindowsExp + MAGIC_WIN_OFFSET + coreIdx_ * WIN_512_ALIGN));
+        (__gm__ int32_t *)(GetStatusDataSpaceGm(epWinContext_) + MAGIC_WIN_OFFSET + coreIdx_ * WIN_512_ALIGN));
     DataCacheCleanAndInvalid<int32_t, CacheLine::SINGLE_CACHE_LINE, DcciDst::CACHELINE_OUT>(selfMagicTensor);
     magic_ = selfMagicTensor(0);
     selfMagicTensor(0) = ((magic_ == 0) ? 1 : 0);
@@ -239,6 +236,11 @@ CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitTilingData(const CamMoeC
     realMaxBs_ = tilingData->camMoeCombineNormalInfo.realMaxBs;
     maxRound_ = tilingData->camMoeCombineNormalInfo.maxRound;
     perRoundTokens_ = tilingData->camMoeCombineNormalInfo.perRoundTokens;
+#ifdef __DAV_C310__
+    baseWinSize_ = tilingData->camMoeCombineNormalInfo.totalWinSize - A5_MTE_STATE_WIN_SIZE;
+#else
+    baseWinSize_ = tilingData->camMoeCombineNormalInfo.totalWinSize;
+#endif
 }
 
 template <TemplateMC2TypeClass>
@@ -256,8 +258,77 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitB
 }
 
 template <TemplateMC2TypeClass>
+__aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitTokenBalancedRoundSendDataA5()
+{
+    uint32_t expertCountLen = moeExpertNum_ * sizeof(int32_t);
+    uint32_t expertCountAlignLen = Ceil(expertCountLen, UB_32_ALIGN) * UB_32_ALIGN;
+    tpipe_->Reset();
+    tpipe_->InitBuffer(tempRecvCountBuf_, expertCountAlignLen);
+    LocalTensor<int32_t> expertEndOffsetLT = tempRecvCountBuf_.Get<int32_t>();
+    const DataCopyExtParams expertCountCopyParams{1U, expertCountLen, 0U, 0U, 0U};
+    const DataCopyPadExtParams<int32_t> expertCountPadParams{false, 0U, 0U, 0U};
+    DataCopyPad(expertEndOffsetLT, epRecvCountGM_, expertCountCopyParams, expertCountPadParams);
+    SyncFunc<HardEvent::MTE2_S>();
+
+    uint32_t selfSendCnt = static_cast<uint32_t>(expertEndOffsetLT(moeExpertNum_ - 1));
+    uint32_t flatStart = 0;
+    uint32_t flatEnd = 0;
+    uint32_t perCoreSendCnt = 0;
+    SplitCoreCal(selfSendCnt, perCoreSendCnt, flatStart, flatEnd);
+    if (perCoreSendCnt == 0) {
+        return;
+    }
+
+    preRecvCount_ = flatStart;
+    needSendTokenCnt_ = perCoreSendCnt;
+    perCoreBlockNum_ = 0;
+    for (uint32_t expertId = 0; expertId < moeExpertNum_; ++expertId) {
+        uint32_t expertStart = expertId == 0 ? 0 : static_cast<uint32_t>(expertEndOffsetLT(expertId - 1));
+        uint32_t expertEnd = static_cast<uint32_t>(expertEndOffsetLT(expertId));
+        uint32_t segmentStart = max(flatStart, expertStart);
+        uint32_t segmentEnd = min(flatEnd, expertEnd);
+        if (segmentStart < segmentEnd) {
+            ++perCoreBlockNum_;
+        }
+    }
+
+    uint32_t sendBlockAlignLen = Ceil(perCoreBlockNum_ * sizeof(int32_t), UB_32_ALIGN) * UB_32_ALIGN;
+    tpipe_->InitBuffer(roundNeedSendCntBuf_, sendBlockAlignLen);
+    tpipe_->InitBuffer(roundSendOffsetBuf_, sendBlockAlignLen);
+    roundNeedSendCntLT_ = roundNeedSendCntBuf_.Get<uint32_t>();
+    roundSendOffsetLT_ = roundSendOffsetBuf_.Get<uint32_t>();
+
+    uint32_t segmentIndex = 0;
+    for (uint32_t expertId = 0; expertId < moeExpertNum_; ++expertId) {
+        uint32_t expertStart = expertId == 0 ? 0 : static_cast<uint32_t>(expertEndOffsetLT(expertId - 1));
+        uint32_t expertEnd = static_cast<uint32_t>(expertEndOffsetLT(expertId));
+        uint32_t segmentStart = max(flatStart, expertStart);
+        uint32_t segmentEnd = min(flatEnd, expertEnd);
+        if (segmentStart < segmentEnd) {
+            roundSendOffsetLT_(segmentIndex) = segmentStart;
+            roundNeedSendCntLT_(segmentIndex) = segmentEnd - segmentStart;
+            ++segmentIndex;
+        }
+    }
+
+    uint32_t srcInfoLen = static_cast<uint32_t>(BATCH_SRC_INFO_CNT * TOKEN_SRC_INFO_LEN * sizeof(SrcInfoType));
+    uint32_t srcInfoAlignLen = Ceil(srcInfoLen, UB_32_ALIGN) * UB_32_ALIGN;
+    tpipe_->InitBuffer(srcInfoBuf_, srcInfoAlignLen);
+    srcInfoLT_ = srcInfoBuf_.Get<SrcInfoType>();
+
+    tpipe_->InitBuffer(setStateBuf_, UB_32_ALIGN);
+    setStateLT_ = setStateBuf_.Get<uint32_t>();
+    Duplicate<uint32_t>(setStateLT_, 0x3F800000, FLOAT_NUM_PER_ALIGN);
+    tpipe_->InitBuffer(localCopyQueue_, DOUBLE_BUFFER, h32AlignRecvXLen_);
+}
+
+template <TemplateMC2TypeClass>
 __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitRoundSendData()
 {
+#ifdef __DAV_C310__
+    InitTokenBalancedRoundSendDataA5();
+    return;
+#endif
     SplitCoreCal(moeExpertNum_, perCoreBlockNum_, startBlockId_,
                  endBlockId_);  // 按专家分核，每个核负责向perBlockRankNum个rank发送数据
     if (perCoreBlockNum_ == 0) {
@@ -348,7 +419,7 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::Init(
     InitBuffLen();
     combineDataBuffSize_ = perRoundTokens_ * axisK_ * h512AlignRecvXLen_;
     PipeBarrier<PIPE_ALL>();
-    winDataSizeOffset_ = static_cast<uint64_t>(magic_) * (tilingData->camMoeCombineNormalInfo.totalWinSize / 2UL);
+    winDataSizeOffset_ = static_cast<uint64_t>(magic_) * (baseWinSize_ / 2UL);
     DataCacheCleanAndInvalid<SrcInfoType, CacheLine::SINGLE_CACHE_LINE, DcciDst::CACHELINE_OUT>(
         epRecvCountGM_[moeExpertNum_ - 1]);
 

--- a/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal.h
@@ -90,12 +90,12 @@ private:
     {
         uint32_t curRankId = ctxIdx == COMM_EP_IDX ? epRankId : tpRankId;
         if (curRankId == rankId) {
-            return (GM_ADDR)(winContext_[ctxIdx]->localWindowsExp) + dataState * Moe::ROUND_STATE_MAX_SIZE +
+            return (GM_ADDR)(winContext_[ctxIdx]->localWindowsExp) + roundMagic * Moe::ROUND_STATE_MAX_SIZE +
                    ROUND_STATE_OFFSET;
         }
         return (GM_ADDR)(((HcclRankRelationResV2 *)(winContext_[ctxIdx]->remoteRes[rankId].nextDevicePtr))
                              ->windowsExp) +
-               dataState * Moe::ROUND_STATE_MAX_SIZE + ROUND_STATE_OFFSET;
+               roundMagic * Moe::ROUND_STATE_MAX_SIZE + ROUND_STATE_OFFSET;
     }
 
     TPipe *tpipe_{nullptr};
@@ -176,6 +176,7 @@ private:
     uint32_t expertIdsCnt{0};
     uint32_t stateOffset{0};
     uint32_t dataState{0};
+    uint32_t roundMagic{0};
     uint32_t winDataSizeOffset{0};
     uint32_t waitRecvCostStatsBufSize{0};
     uint32_t srcRankOffset{0};
@@ -511,6 +512,7 @@ __aicore__ inline void CamMoeDispatchNormal<CamTypeFunc>::SetRoundStatus()
     tpipe_->InitBuffer(roundStatusBuf, epRankSize * UB_ALIGN);
     LocalTensor<float> roundStatusTensor = roundStatusBuf.AllocTensor<float>();
     Duplicate<float>(roundStatusTensor, 1.0, FLOAT_NUM_PER_ALIGN);
+    SyncFunc<AscendC::HardEvent::V_MTE3>();
     for (uint32_t i = 0; i < epRankSize; ++i) {
         uint32_t targetRankId = i;
         uint32_t offset = stateOffset * epRankId;
@@ -650,7 +652,6 @@ __aicore__ inline void CamMoeDispatchNormal<CamTypeFunc>::WaitRoundStatus()
     LocalTensor<float> stateTensorLocal = roundStatusBuf.Get<float>();
     LocalTensor<float> tempRoundStateTensorLocal = tempRoundStatusBuf.Get<float>();
 
-    int64_t systemCycleBefore = AscendC::GetSystemCycle();
     while (current != target) {
         SyncFunc<AscendC::HardEvent::S_MTE2>();
         DataCopy<float>(stateTensorLocal, roundStatusGMTensor, count);
@@ -658,9 +659,6 @@ __aicore__ inline void CamMoeDispatchNormal<CamTypeFunc>::WaitRoundStatus()
         Sum(tempRoundStateTensorLocal, stateTensorLocal, sumPerRankParams);
         SyncFunc<AscendC::HardEvent::V_S>();
         current = tempRoundStateTensorLocal.GetValue(0);
-        if (isEnableDiagnose) {
-            int64_t systemCycleAfter = AscendC::GetSystemCycle();
-        }
     }
 
     SyncFunc<AscendC::HardEvent::S_V>();
@@ -776,6 +774,7 @@ __aicore__ inline void CamMoeDispatchNormal<CamTypeFunc>::Process()
                 SyncAll<true>();
                 SetRoundStatus();
                 WaitRoundStatus();
+                roundMagic = roundMagic == 0 ? 1 : 0;
                 SyncAll<true>();
             }
             roundIndex += 1;

--- a/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal_a5.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal_a5.h
@@ -53,7 +53,6 @@ __aicore__ inline void SyncFunc()
 
 using namespace AscendC;
 using namespace MoeDistributeV2Base;
-
 template <CamTypeClass>
 class CamMoeDispatchNormalA5
 {
@@ -79,6 +78,7 @@ private:
     __aicore__ inline void QuantInit();
     __aicore__ inline void ReduceMaxInplace(const LocalTensor<float> &srcLocal, uint32_t count);
     __aicore__ inline void QuantProcess();
+    __aicore__ inline void GetRInSrcRankOffsetForRound(int32_t index);
 #ifdef __DAV_C310__
     __aicore__ inline void QuantDynamicMx(LocalTensor<ExpandXOutType> &outLocal, LocalTensor<XType> &inLocal,
                                           LocalTensor<float> &tokenF32LT_);
@@ -100,7 +100,7 @@ private:
     {
         uint32_t curRankId = ctxIdx == COMM_EP_IDX ? epRankId : tpRankId;
         return GetBaseWindStateAddrByRankId(winContext_[ctxIdx], rankId, curRankId) +
-               dataState * Moe::ROUND_STATE_MAX_SIZE + ROUND_STATE_OFFSET;
+               roundMagic * Moe::ROUND_STATE_MAX_SIZE + ROUND_STATE_OFFSET;
     }
 
     TPipe *tpipe_{nullptr};
@@ -193,6 +193,7 @@ private:
     uint32_t statusNumPerCore;
     uint32_t remainStatus;
     uint32_t roundIndex;
+    uint32_t roundMagic{0};
     uint32_t hScaleIdxSize;
 
     TQueBind<QuePosition::VECIN, QuePosition::VECOUT, 1> xQueue;
@@ -593,6 +594,7 @@ __aicore__ inline void CamMoeDispatchNormalA5<CamTypeFunc>::SetRoundStatus()
     tpipe_->InitBuffer(roundStatusBuf, epRankSize * UB_ALIGN);
     LocalTensor<float> roundStatusTensor = roundStatusBuf.AllocTensor<float>();
     Duplicate<float>(roundStatusTensor, 1.0, FLOAT_NUM_PER_ALIGN);
+    SyncFunc<AscendC::HardEvent::V_MTE3>();
     for (uint32_t i = 0; i < epRankSize; ++i) {
         uint32_t targetRankId = i;
         uint32_t offset = stateOffset * epRankId;
@@ -732,7 +734,6 @@ __aicore__ inline void CamMoeDispatchNormalA5<CamTypeFunc>::WaitRoundStatus()
     LocalTensor<float> stateTensorLocal = roundStatusBuf.Get<float>();
     LocalTensor<float> tempRoundStateTensorLocal = tempRoundStatusBuf.Get<float>();
 
-    int64_t systemCycleBefore = AscendC::GetSystemCycle();
     while (current != target) {
         SyncFunc<AscendC::HardEvent::S_MTE2>();
         DataCopy<float>(stateTensorLocal, roundStatusGMTensor, count);
@@ -740,7 +741,6 @@ __aicore__ inline void CamMoeDispatchNormalA5<CamTypeFunc>::WaitRoundStatus()
         Sum(tempRoundStateTensorLocal, stateTensorLocal, sumPerRankParams);
         SyncFunc<AscendC::HardEvent::V_S>();
         current = tempRoundStateTensorLocal.GetValue(0);
-        int64_t systemCycleAfter = AscendC::GetSystemCycle();
     }
 
     SyncFunc<AscendC::HardEvent::S_V>();
@@ -748,6 +748,18 @@ __aicore__ inline void CamMoeDispatchNormalA5<CamTypeFunc>::WaitRoundStatus()
     SyncFunc<AscendC::HardEvent::V_MTE3>();
     DataCopy<float>(roundStatusGMTensor, tempRoundStateTensorLocal, count);
     SyncFunc<AscendC::HardEvent::MTE3_S>();
+}
+
+template <CamTypeClass>
+__aicore__ inline void CamMoeDispatchNormalA5<CamTypeFunc>::GetRInSrcRankOffsetForRound(int32_t index)
+{
+    tpipe_->InitBuffer(rInSrcrankOffsetBuf, moeExpertNum * sizeof(int32_t));
+    rInSrcrankOffsetTensor = rInSrcrankOffsetBuf.Get<int32_t>();
+
+    for (uint32_t i = 0; i < moeExpertNum; ++i) {
+        rInSrcrankOffsetTensor.SetValue(i, rInSrcrankOffsetGT.GetValue(i * round + index));
+    }
+    SyncFunc<AscendC::HardEvent::S_MTE2>();
 }
 
 template <CamTypeClass>
@@ -773,11 +785,7 @@ __aicore__ inline void CamMoeDispatchNormalA5<CamTypeFunc>::ShareToOutputLongSeq
     DataCopyPad(srcrankInExpertOffsetTensor, srcrankInExpertOffsetGT, srcrankInExpertOffsetParams,
                 srcrankInExpertOffsetCopyPadExtParams);
 
-    tpipe_->InitBuffer(rInSrcrankOffsetBuf, round * moeExpertNum * sizeof(int32_t));
-    rInSrcrankOffsetTensor = rInSrcrankOffsetBuf.Get<int32_t>();
-    DataCopyExtParams CParams{1U, static_cast<uint32_t>(sizeof(int32_t) * moeExpertNum * round), 0U, 0U, 0U};
-    DataCopyPadExtParams<int32_t> CCopyPadExtParams{false, 0U, 0U, 0U};
-    DataCopyPad(rInSrcrankOffsetTensor, rInSrcrankOffsetGT, CParams, CCopyPadExtParams);
+    GetRInSrcRankOffsetForRound(roundIndex);
 
     uint32_t fromRank, count, preCount, recvOffset, targetOffset, local_e;
     DataCopyParams tokenInParams = {1U, static_cast<uint16_t>(axisHCommu_ * sizeof(ExpandXOutType)), 0U,
@@ -812,7 +820,7 @@ __aicore__ inline void CamMoeDispatchNormalA5<CamTypeFunc>::ShareToOutputLongSeq
         recvOffset = recvOffsetTensor(i);
 
         // 目标地址 = 专家全局起始 + B[es_idx]（源rank在专家内偏移） + r_in_srcrank_offset[c_idx]（轮次在源rank内偏移）
-        int32_t rInSrcrankIndex = local_e * epRankSize * round + fromRank * round + roundIndex;
+        int32_t rInSrcrankIndex = local_e * epRankSize + fromRank;
         int32_t expertGlobalOffset = expertGlobalOffsetTensor(local_e);
         int32_t srcrankInExpertOffset = srcrankInExpertOffsetTensor(i);
         int32_t rInSrcrankOffset = rInSrcrankOffsetTensor(rInSrcrankIndex);
@@ -881,6 +889,7 @@ __aicore__ inline void CamMoeDispatchNormalA5<CamTypeFunc>::Process()
                 SyncAll<true>();
                 SetRoundStatus();
                 WaitRoundStatus();
+                roundMagic = roundMagic == 0 ? 1 : 0;
                 SyncAll<true>();
             }
             roundIndex += 1;

--- a/csrc/deepep/ops/op_kernel/notify_dispatch_a5.h
+++ b/csrc/deepep/ops/op_kernel/notify_dispatch_a5.h
@@ -44,6 +44,8 @@ class NotifyDispatchA5
     // Synchronization flag occupies length
     constexpr static int64_t FLAG_UNIT_INT_NUM = 4;
     constexpr static int64_t MAGIC_MASK = ~((1LL << 32) - 1);
+    constexpr static int32_t EXPERT_NORMAL_NUM = 512;
+    constexpr static int32_t BATCH_ROUND = 16;
 
 public:
     __aicore__ inline NotifyDispatchA5(int rank, int rankSize, uint32_t extraFlag)
@@ -63,14 +65,24 @@ public:
         recvOffset_ = recvOffset;
         maxBs_ = maxBs;
         recvTokensPerExpert_ = recvTokensPerExpert;
-        tokenPerExpertDataAlignLen = Ceil(round * numExperts * sizeof(int32_t), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
-        sendDataOffsetAlignLen = Ceil(round * numExperts * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
-        sendDataAlignLen = Ceil(round * numExperts * sendPerGroup * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
-        recvDataAlignLen = Ceil(round * numExperts * sendPerGroup * sizeof(int32_t), UB_ALIGN_SIZE) *
+        if (round == 1) {
+            batchRounds = 1;
+        } else if (numExperts > EXPERT_NORMAL_NUM) {
+            batchRounds = BATCH_ROUND / 2;
+        } else if (numLocalExperts >= (EXPERT_NORMAL_NUM / 4)) {
+            batchRounds = BATCH_ROUND;
+        } else if (numExperts <= (EXPERT_NORMAL_NUM / 2)) {
+            batchRounds = BATCH_ROUND * 2;
+        } else {
+            batchRounds = BATCH_ROUND;
+        }
+        tokenPerExpertDataAlignLen = Ceil(batchRounds * numExperts * sizeof(int32_t), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        sendDataOffsetAlignLen = Ceil(batchRounds * numExperts * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        sendDataAlignLen = Ceil(batchRounds * numExperts * sendPerGroup * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        recvDataAlignLen = Ceil(batchRounds * numExperts * sendPerGroup * sizeof(int32_t), UB_ALIGN_SIZE) *
                            UB_ALIGN_SIZE;  // 32 * 256 * 3 * 4 = 96KB
         sendTokensPerRankAlignLen = Ceil(numRanks * sizeof(int32_t), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
-        sendCountAlignLen =
-            Ceil(round * numExperts * sizeof(int32_t), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;  // 32 * 256 * 4 = 32KB
+        sendCountAlignLen = Ceil(batchRounds * numExperts * sizeof(int32_t), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
 
         // Initialize core grouping
         InitCoreGroup();
@@ -94,9 +106,6 @@ public:
         sendDataOffsetOutputGt.SetGlobalBuffer((__gm__ T *)sendDataOffsetOutput);
         recvDataOutputGt.SetGlobalBuffer((__gm__ T *)recvDataOutput);
         recvDataOutGt.SetGlobalBuffer((__gm__ int32_t *)recvDataOutput);
-        pipe.InitBuffer(sendCountBuf, tokenPerExpertDataAlignLen);
-        pipe.InitBuffer(sendOffsetBuf, tokenPerExpertDataAlignLen);
-        pipe.InitBuffer(recvDataBuf, recvDataAlignLen);
     }
 
     __aicore__ inline void Process()
@@ -112,7 +121,7 @@ public:
             ShareToShareSlice();
         }
         SyncAll<true>();
-        ReorderOutput();
+        pipe.Reset();
         BuildTotalRecvTokens();  // 出错点
         BuildRecvCount();
         BuildRecvOffset();
@@ -146,7 +155,6 @@ private:
         pipe.InitBuffer(tokenPerExpertDataBuf, tokenPerExpertDataAlignLen);
         pipe.InitBuffer(sendDataBuf, sendDataAlignLen);
         pipe.InitBuffer(sendDataOffsetBuf, sendDataOffsetAlignLen);
-        int batchRounds = 32;
         int localExpertsNum = numExperts / rankSize;
         int newSendDataAlignLen =
             Ceil(batchRounds * localExpertsNum * sendPerGroup * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
@@ -156,80 +164,78 @@ private:
         sendDataTensor = sendDataBuf.Get<T>();
         sendDataOffsetTensor = sendDataOffsetBuf.Get<T>();
         newSendDataTensor = newSendDataBuf.Get<T>();
-        DataCopyExtParams tokenPerExpertParams = {1U, tokenPerExpertDataAlignLen, 0U, 0U, 0U};
-        DataCopyPadExtParams<int32_t> copyPadExtParams{false, 0U, 0U, 0U};
-        DataCopyPad(tokenPerExpertTensor, tokenPerExpertDataInputGt, tokenPerExpertParams, copyPadExtParams);
-
-        AscendC::SetFlag<HardEvent::MTE2_S>(EVENT_ID0);
-        AscendC::WaitFlag<HardEvent::MTE2_S>(EVENT_ID0);
 
         int realRound = (numTokens + perRoundTokens - 1) / perRoundTokens;
         int lastRoundNumTokens = numTokens % perRoundTokens;
         if (lastRoundNumTokens == 0 && numTokens > 0) {
             lastRoundNumTokens = perRoundTokens;
         }
-
-        int prefixSum = 0;
-
-        for (int r = 0; r < realRound; ++r) {
-            prefixSum = 0;
-            for (int i = 0; i < numExperts; ++i) {
-                int numTokensExpert = tokenPerExpertTensor(r * numExperts + i);
-                int baseUB = r * numExperts * sendPerGroup + i * sendPerGroup;
-                sendDataTensor(baseUB) = numTokensExpert;
-                sendDataTensor(baseUB + 1) = prefixSum;
-                int roundNumTokens = (r == realRound - 1 ? lastRoundNumTokens : perRoundTokens);
-                sendDataTensor(baseUB + 2) = roundNumTokens;
-                sendDataOffsetTensor(r * numExperts + i) = prefixSum;
-                prefixSum += numTokensExpert;
-            }
-        }
-
-        for (int r = realRound; r < round; ++r) {
-            for (int i = 0; i < numExperts; ++i) {
-                int baseUB = r * numExperts * sendPerGroup + i * sendPerGroup;
-                sendDataTensor(baseUB) = 0;
-                sendDataTensor(baseUB + 1) = 0;
-                sendDataTensor(baseUB + 2) = 0;
-                sendDataOffsetTensor(r * numExperts + i) = 0;
-            }
-        }
-
         int totalRounds = round;
-        if (round > 1) {
-            for (int tr = 0; tr < rankSize; ++tr) {
-                for (int rBase = 0; rBase < totalRounds; rBase += batchRounds) {
-                    int currentBatch = (rBase + batchRounds > totalRounds) ? (totalRounds - rBase) : batchRounds;
-                    for (int r = 0; r < currentBatch; ++r) {
-                        int absRound = rBase + r;
-                        for (int le = 0; le < localExpertsNum; ++le) {
-                            int globalExpertIdx = tr * localExpertsNum + le;
-                            int srcIdx = (absRound * numExperts + globalExpertIdx) * sendPerGroup;
-                            int dstIdx = (r * localExpertsNum + le) * sendPerGroup;
-                            newSendDataTensor(dstIdx) = sendDataTensor(srcIdx);
-                            newSendDataTensor(dstIdx + 1) = sendDataTensor(srcIdx + 1);
-                            newSendDataTensor(dstIdx + 2) = sendDataTensor(srcIdx + 2);
-                        }
+        DataCopyPadExtParams<int32_t> copyPadExtParams{false, 0U, 0U, 0U};
+        for (int rBase = 0; rBase < totalRounds; rBase += batchRounds) {
+            int currentBatch = (rBase + batchRounds > totalRounds) ? (totalRounds - rBase) : batchRounds;
+            uint32_t tokenPerExpertCopyLen = currentBatch * numExperts * sizeof(int32_t);
+            DataCopyExtParams tokenPerExpertParams = {1U, tokenPerExpertCopyLen, 0U, 0U, 0U};
+            DataCopyPad(tokenPerExpertTensor, tokenPerExpertDataInputGt[rBase * numExperts], tokenPerExpertParams,
+                        copyPadExtParams);
+            AscendC::SetFlag<HardEvent::MTE2_S>(EVENT_ID0);
+            AscendC::WaitFlag<HardEvent::MTE2_S>(EVENT_ID0);
+
+            for (int r = 0; r < currentBatch; ++r) {
+                int absRound = rBase + r;
+                int prefixSum = 0;
+                if (absRound < realRound) {
+                    for (int i = 0; i < numExperts; ++i) {
+                        int numTokensExpert = tokenPerExpertTensor(r * numExperts + i);
+                        int baseUB = (r * numExperts + i) * sendPerGroup;
+                        sendDataTensor(baseUB) = numTokensExpert;
+                        sendDataTensor(baseUB + 1) = prefixSum;
+                        int roundNumTokens = (absRound == realRound - 1 ? lastRoundNumTokens : perRoundTokens);
+                        sendDataTensor(baseUB + 2) = roundNumTokens;
+                        sendDataOffsetTensor(r * numExperts + i) = prefixSum;
+                        prefixSum += numTokensExpert;
                     }
-                    AscendC::SetFlag<HardEvent::S_MTE3>(EVENT_ID0);
-                    AscendC::WaitFlag<HardEvent::S_MTE3>(EVENT_ID0);
-                    uint32_t copyLen = currentBatch * localExpertsNum * sendPerGroup * sizeof(int32_t);
-                    DataCopyExtParams copyParams = {1U, copyLen, 0U, 0U, 0U};
-                    uint64_t gmOffset = (uint64_t)tr * totalRounds * localExpertsNum * sendPerGroup +
-                                        (uint64_t)rBase * localExpertsNum * sendPerGroup;
-                    DataCopyPad(sendDataInputGt[gmOffset], newSendDataTensor[0], copyParams);
-                    AscendC::SetFlag<HardEvent::MTE3_S>(EVENT_ID0);
-                    AscendC::WaitFlag<HardEvent::MTE3_S>(EVENT_ID0);
+                } else {
+                    for (int i = 0; i < numExperts; ++i) {
+                        int baseUB = (r * numExperts + i) * sendPerGroup;
+                        sendDataTensor(baseUB) = 0;
+                        sendDataTensor(baseUB + 1) = 0;
+                        sendDataTensor(baseUB + 2) = 0;
+                        sendDataOffsetTensor(r * numExperts + i) = 0;
+                    }
                 }
             }
-        } else {
-            DataCopyPad(sendDataInputGt, sendDataTensor, {1U, sendDataAlignLen, 0U, 0U, 0U});
-        }
-        DataCopyExtParams sendDataOffsetParams = {1U, sendDataOffsetAlignLen, 0U, 0U, 0U};
-        DataCopyPad(sendDataOffsetOutputGt, sendDataOffsetTensor, sendDataOffsetParams);
 
-        AscendC::SetFlag<HardEvent::MTE3_S>(EVENT_ID0);
-        AscendC::WaitFlag<HardEvent::MTE3_S>(EVENT_ID0);
+            uint32_t offsetCopyLen = currentBatch * numExperts * sizeof(T);
+            DataCopyExtParams sendDataOffsetParams = {1U, offsetCopyLen, 0U, 0U, 0U};
+            AscendC::SetFlag<HardEvent::S_MTE3>(EVENT_ID0);
+            AscendC::WaitFlag<HardEvent::S_MTE3>(EVENT_ID0);
+            DataCopyPad(sendDataOffsetOutputGt[rBase * numExperts], sendDataOffsetTensor, sendDataOffsetParams);
+            AscendC::SetFlag<HardEvent::MTE3_S>(EVENT_ID0);
+            AscendC::WaitFlag<HardEvent::MTE3_S>(EVENT_ID0);
+
+            for (int tr = 0; tr < rankSize; ++tr) {
+                for (int r = 0; r < currentBatch; ++r) {
+                    for (int le = 0; le < localExpertsNum; ++le) {
+                        int globalExpertIdx = tr * localExpertsNum + le;
+                        int srcIdx = (r * numExperts + globalExpertIdx) * sendPerGroup;
+                        int dstIdx = (r * localExpertsNum + le) * sendPerGroup;
+                        newSendDataTensor(dstIdx) = sendDataTensor(srcIdx);
+                        newSendDataTensor(dstIdx + 1) = sendDataTensor(srcIdx + 1);
+                        newSendDataTensor(dstIdx + 2) = sendDataTensor(srcIdx + 2);
+                    }
+                }
+                AscendC::SetFlag<HardEvent::S_MTE3>(EVENT_ID0);
+                AscendC::WaitFlag<HardEvent::S_MTE3>(EVENT_ID0);
+                uint32_t copyLen = currentBatch * localExpertsNum * sendPerGroup * sizeof(T);
+                DataCopyExtParams copyParams = {1U, copyLen, 0U, 0U, 0U};
+                uint64_t gmOffset = static_cast<uint64_t>(tr) * totalRounds * localExpertsNum * sendPerGroup +
+                                    static_cast<uint64_t>(rBase) * localExpertsNum * sendPerGroup;
+                DataCopyPad(sendDataInputGt[gmOffset], newSendDataTensor[0], copyParams);
+                AscendC::SetFlag<HardEvent::MTE3_S>(EVENT_ID0);
+                AscendC::WaitFlag<HardEvent::MTE3_S>(EVENT_ID0);
+            }
+        }
     }
 
     // copy input to other rank share
@@ -326,78 +332,64 @@ private:
         }
     }
 
-    __aicore__ inline void ReorderOutput()
+    __aicore__ inline void ReorderOutput(uint32_t rStart, uint32_t currentBatchRounds)
     {
-        pipe.Reset();
-        pipe.InitBuffer(recvDataBuf, recvDataAlignLen);
         recvDataTensor = recvDataBuf.Get<T>();
-        DataCopyExtParams recvDataParams = {1U, static_cast<uint32_t>(recvDataAlignLen), 0, 0, 0};
+
+        uint32_t singleRankTotalElemCount = round * numLocalExperts * sendPerGroup;
+        uint32_t singleRankBatchElemCount = currentBatchRounds * numLocalExperts * sendPerGroup;
+        uint32_t singleRankBatchDataLen = singleRankBatchElemCount * sizeof(T);
+        uint32_t alignedDataLen = Ceil(singleRankBatchDataLen, UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        uint32_t strideElem = alignedDataLen / sizeof(T);
+        DataCopyExtParams recvDataParams = {1U, singleRankBatchDataLen, 0, 0, 0};
         DataCopyPadExtParams<T> DataCopyPadExtParams{false, 0U, 0U, 0U};
-        DataCopyPad(recvDataTensor, recvDataOutputGt, recvDataParams, DataCopyPadExtParams);
+        for (uint32_t srcRank = 0; srcRank < rankSize; ++srcRank) {
+            uint32_t srcOffset = srcRank * singleRankTotalElemCount + rStart * numLocalExperts * sendPerGroup;
+            uint32_t dstOffset = srcRank * strideElem;
+            DataCopyPad(recvDataTensor[dstOffset], recvDataOutputGt[srcOffset], recvDataParams, DataCopyPadExtParams);
+        }
+        SyncFunc<AscendC::HardEvent::MTE2_S>();
     }
 
-    __aicore__ inline void ReorderSendCountOutput()
+    __aicore__ inline void ReorderSendCountOutput(uint32_t currentBatchRounds)
     {
-        pipe.InitBuffer(sendCountBuf, sendCountAlignLen);
         sendCountTensor = sendCountBuf.Get<T>();
-        Duplicate<T>(sendCountTensor, 0, sendCountAlignLen / sizeof(int32_t));
+        Duplicate<T>(sendCountTensor, 0, sendCountAlignLen / sizeof(T));
         SyncFunc<AscendC::HardEvent::V_S>();
-        SyncFunc<AscendC::HardEvent::MTE2_S>();
-        for (uint32_t r = 0; r < round; ++r) {
+
+        uint32_t singleRankBatchDataLen = currentBatchRounds * numLocalExperts * sendPerGroup * sizeof(T);
+        uint32_t alignedDataLen = Ceil(singleRankBatchDataLen, UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        uint32_t strideElem = alignedDataLen / sizeof(T);
+        for (uint32_t r = 0; r < currentBatchRounds; ++r) {
             for (uint32_t expId = 0; expId < numLocalExperts; ++expId) {
                 for (uint32_t srcRank = 0; srcRank < rankSize; ++srcRank) {
                     uint32_t index = expId * rankSize + srcRank;
-                    uint32_t pair_idx =
-                        sendPerGroup * (srcRank * numLocalExperts * round + r * numLocalExperts + expId);
+                    uint32_t offsetInRank = sendPerGroup * (r * numLocalExperts + expId);
+                    uint32_t pair_idx = srcRank * strideElem + offsetInRank;
                     sendCountTensor(r * numExperts + index) = recvDataTensor(pair_idx);
                 }
             }
         }
     }
 
-    __aicore__ inline void ReorderSendOffsetOutput()
+    __aicore__ inline void ReorderSendOffsetOutput(uint32_t currentBatchRounds)
     {
-        pipe.InitBuffer(sendOffsetBuf, sendCountAlignLen);
         sendOffsetTensor = sendOffsetBuf.Get<T>();
-        Duplicate<T>(sendOffsetTensor, 0, sendCountAlignLen / sizeof(int32_t));
+        Duplicate<T>(sendOffsetTensor, 0, sendCountAlignLen / sizeof(T));
         SyncFunc<AscendC::HardEvent::V_S>();
-        SyncFunc<AscendC::HardEvent::MTE2_S>();
-        for (uint32_t r = 0; r < round; ++r) {
+
+        uint32_t singleRankBatchDataLen = currentBatchRounds * numLocalExperts * sendPerGroup * sizeof(T);
+        uint32_t alignedDataLen = Ceil(singleRankBatchDataLen, UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        uint32_t strideElem = alignedDataLen / sizeof(T);
+        for (uint32_t r = 0; r < currentBatchRounds; ++r) {
             for (uint32_t expId = 0; expId < numLocalExperts; ++expId) {
                 for (uint32_t srcRank = 0; srcRank < rankSize; ++srcRank) {
                     uint32_t index = expId * rankSize + srcRank;
-                    uint32_t pair_idx =
-                        sendPerGroup * (srcRank * numLocalExperts * round + r * numLocalExperts + expId);
+                    uint32_t offsetInRank = sendPerGroup * (r * numLocalExperts + expId);
+                    uint32_t pair_idx = srcRank * strideElem + offsetInRank;
                     sendOffsetTensor(r * numExperts + index) = recvDataTensor(pair_idx + 1);
                 }
             }
-        }
-    }
-
-    __aicore__ inline void ReorderSendTokensPerRankOutput()
-    {
-        pipe.InitBuffer(sendTokensPerRankBuf, sendTokensPerRankAlignLen);
-        pipe.InitBuffer(seenRoundBuf, sendTokensPerRankAlignLen);
-        sendTokensPerRankTensor = sendTokensPerRankBuf.Get<int32_t>();
-        seenRoundTensor = seenRoundBuf.Get<int32_t>();
-        Duplicate<int32_t>(sendTokensPerRankTensor, 0, sendTokensPerRankAlignLen / sizeof(int32_t));
-        SyncFunc<AscendC::HardEvent::V_S>();
-        SyncFunc<AscendC::HardEvent::MTE2_S>();
-        for (uint32_t r = 0; r < round; ++r) {
-            Duplicate<int32_t>(seenRoundTensor, 0, sendTokensPerRankAlignLen / sizeof(int32_t));
-            SyncFunc<AscendC::HardEvent::V_S>();
-            for (uint32_t expId = 0; expId < numLocalExperts; ++expId) {
-                for (uint32_t srcRank = 0; srcRank < rankSize; ++srcRank) {
-                    uint32_t index = expId * rankSize + srcRank;
-                    uint32_t pair_idx =
-                        sendPerGroup * (srcRank * numLocalExperts * round + r * numLocalExperts + expId);
-                    if (!seenRoundTensor(srcRank)) {
-                        sendTokensPerRankTensor(srcRank) += recvDataTensor(pair_idx + 2);
-                        seenRoundTensor(srcRank) = 1;
-                    }
-                }
-            }
-            SyncFunc<AscendC::HardEvent::S_V>();
         }
     }
 
@@ -407,30 +399,40 @@ private:
             return;
         }
 
-        ReorderSendCountOutput();
+        int32_t sumVal = 0;
+        uint32_t singleRankMaxElem = batchRounds * numLocalExperts * sendPerGroup;
+        uint32_t singleRankAlignLen = Ceil(singleRankMaxElem * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        recvDataAlignLen = rankSize * singleRankAlignLen;
+        pipe.InitBuffer(recvDataBuf, recvDataAlignLen);
+        sendCountAlignLen = Ceil(batchRounds * numExperts * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        pipe.InitBuffer(sendCountBuf, sendCountAlignLen);
+        pipe.InitBuffer(tmpBuf2_, Ceil(batchRounds * numExperts * sizeof(float), UB_ALIGN_SIZE) * UB_ALIGN_SIZE);
+        for (uint32_t rStart = 0; rStart < round; rStart += batchRounds) {
+            uint32_t currentBatchRounds = (rStart + batchRounds > round) ? (round - rStart) : batchRounds;
+            ReorderOutput(rStart, currentBatchRounds);
+            ReorderSendCountOutput(currentBatchRounds);
+            LocalTensor<float> batchCntFloat = tmpBuf2_.Get<float>();
+            LocalTensor<float> batchSumCntLt = sendCountBuf.Get<float>();
+            LocalTensor<float> sharedTmpBuffer = recvDataBuf.Get<float>();
+            uint32_t currComputeNum = currentBatchRounds * numExperts;
+            SyncFunc<AscendC::HardEvent::S_V>();
+            Cast(batchCntFloat, sendCountTensor, RoundMode::CAST_NONE, currComputeNum);
+            PipeBarrier<PIPE_V>();
+            ReduceSum(batchSumCntLt, batchCntFloat, sharedTmpBuffer, currComputeNum);
+            SyncFunc<AscendC::HardEvent::V_S>();
+            sumVal += static_cast<int32_t>(batchSumCntLt.GetValue(0));
+            SyncFunc<AscendC::HardEvent::S_V>();
+        }
         pipe.InitBuffer(tmpBuf_, UB_ALIGN_SIZE);
-        pipe.InitBuffer(tmpBuf2_, Ceil(round * numExperts * sizeof(float), UB_ALIGN_SIZE) * UB_ALIGN_SIZE);
-
         LocalTensor<int32_t> totalCntLt = tmpBuf_.Get<int32_t>();
-        LocalTensor<float> floatExpTokenCntLt = tmpBuf2_.Get<float>();
-        LocalTensor<float> floatExpTokenSumCntLt = sendCountBuf.Get<float>();
-        LocalTensor<float> sharedTmpBuffer = recvDataBuf.Get<float>();
-
-        SyncFunc<AscendC::HardEvent::S_V>();
-        Cast(floatExpTokenCntLt, sendCountTensor, RoundMode::CAST_NONE, round * numExperts);
-        PipeBarrier<PIPE_V>();
-        ReduceSum(floatExpTokenSumCntLt, floatExpTokenCntLt, sharedTmpBuffer, round * numExperts);
-        SyncFunc<AscendC::HardEvent::V_S>();
-        int32_t sumVal = static_cast<int32_t>(floatExpTokenSumCntLt.GetValue(0));
-        PipeBarrier<PIPE_V>();
         totalCntLt(0) = sumVal;
-        PipeBarrier<PIPE_V>();
-        SyncFunc<AscendC::HardEvent::MTE2_MTE3>();
+        SyncFunc<AscendC::HardEvent::S_MTE3>();
         // 拷贝到outputGT
         GlobalTensor<int32_t> totalCntGt;
         totalCntGt.SetGlobalBuffer((__gm__ int32_t *)totalRecvTokens_);
         DataCopyExtParams copyParams{1, static_cast<uint32_t>(1 * sizeof(int32_t)), 0, 0, 0};
         DataCopyPad(totalCntGt, totalCntLt, copyParams);
+        SyncFunc<AscendC::HardEvent::MTE3_MTE2>();
     }
 
     __aicore__ inline void BuildRecvCount()
@@ -439,22 +441,35 @@ private:
         if (blockIdx != RECV_COUNT_CORE) {
             return;
         }
-        ReorderSendCountOutput();
-        for (uint32_t r = 0; r < round; ++r) {
-            int32_t recvCountNum = 0;
-            for (uint32_t expId = 0; expId < numExperts / rankSize; ++expId) {
-                for (uint32_t srcRank = 0; srcRank < rankSize; ++srcRank) {
-                    uint32_t index = r * numExperts + expId * rankSize + srcRank;
-                    recvCountNum += sendCountTensor(index);
-                    sendCountTensor(index) = recvCountNum;
+        uint32_t singleRankMaxElem = batchRounds * numLocalExperts * sendPerGroup;
+        uint32_t singleRankAlignLen = Ceil(singleRankMaxElem * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        recvDataAlignLen = rankSize * singleRankAlignLen;
+        pipe.InitBuffer(recvDataBuf, recvDataAlignLen);
+        sendCountAlignLen = Ceil(batchRounds * numExperts * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        pipe.InitBuffer(sendCountBuf, sendCountAlignLen);
+        for (uint32_t rStart = 0; rStart < round; rStart += batchRounds) {
+            uint32_t currentBatchRounds = (rStart + batchRounds > round) ? (round - rStart) : batchRounds;
+            ReorderOutput(rStart, currentBatchRounds);
+            ReorderSendCountOutput(currentBatchRounds);
+            for (uint32_t r = 0; r < currentBatchRounds; ++r) {
+                int32_t recvCountNum = 0;
+                for (uint32_t expId = 0; expId < numLocalExperts; ++expId) {
+                    for (uint32_t srcRank = 0; srcRank < rankSize; ++srcRank) {
+                        uint32_t index = r * numExperts + expId * rankSize + srcRank;
+                        recvCountNum += sendCountTensor(index);
+                        sendCountTensor(index) = recvCountNum;
+                    }
                 }
             }
+            GlobalTensor<int32_t> recvCntGt;
+            recvCntGt.SetGlobalBuffer((__gm__ int32_t *)recvCount_);
+            uint32_t globalOffset = rStart * numExperts;
+            DataCopyExtParams copyParams{1, static_cast<uint32_t>(currentBatchRounds * numExperts * sizeof(int32_t)), 0,
+                                         0, 0};
+            SyncFunc<AscendC::HardEvent::S_MTE3>();
+            DataCopyPad(recvCntGt[globalOffset], sendCountTensor, copyParams);
+            SyncFunc<AscendC::HardEvent::MTE3_MTE2>();
         }
-        GlobalTensor<int32_t> recvCntGt;
-        recvCntGt.SetGlobalBuffer((__gm__ int32_t *)recvCount_);
-        DataCopyExtParams copyParams{1, static_cast<uint32_t>(round * numExperts * sizeof(int32_t)), 0, 0, 0};
-        SyncFunc<AscendC::HardEvent::S_MTE3>();
-        DataCopyPad(recvCntGt, sendCountTensor, copyParams);
     }
 
     __aicore__ inline void BuildRecvOffset()
@@ -463,12 +478,25 @@ private:
         if (blockIdx != RECV_OFFSET_CORE) {
             return;
         }
-        ReorderSendOffsetOutput();
-        GlobalTensor<T> recvOffsetGt;
-        recvOffsetGt.SetGlobalBuffer((__gm__ int32_t *)recvOffset_);
-        DataCopyExtParams copyParams{1, static_cast<uint32_t>(round * numExperts * sizeof(int32_t)), 0, 0, 0};
-        SyncFunc<AscendC::HardEvent::S_MTE3>();
-        DataCopyPad(recvOffsetGt, sendOffsetTensor, copyParams);
+        uint32_t singleRankMaxElem = batchRounds * numLocalExperts * sendPerGroup;
+        uint32_t singleRankAlignLen = Ceil(singleRankMaxElem * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        recvDataAlignLen = rankSize * singleRankAlignLen;
+        pipe.InitBuffer(recvDataBuf, recvDataAlignLen);
+        sendCountAlignLen = Ceil(batchRounds * numExperts * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        pipe.InitBuffer(sendOffsetBuf, sendCountAlignLen);
+        for (uint32_t rStart = 0; rStart < round; rStart += batchRounds) {
+            uint32_t currentBatchRounds = (rStart + batchRounds > round) ? (round - rStart) : batchRounds;
+            ReorderOutput(rStart, currentBatchRounds);
+            ReorderSendOffsetOutput(currentBatchRounds);
+            GlobalTensor<T> recvOffsetGt;
+            recvOffsetGt.SetGlobalBuffer((__gm__ T *)recvOffset_);
+            uint32_t globalOffset = rStart * numExperts;
+            DataCopyExtParams copyParams{1, static_cast<uint32_t>(currentBatchRounds * numExperts * sizeof(T)), 0, 0,
+                                         0};
+            SyncFunc<AscendC::HardEvent::S_MTE3>();
+            DataCopyPad(recvOffsetGt[globalOffset], sendOffsetTensor, copyParams);
+            SyncFunc<AscendC::HardEvent::MTE3_MTE2>();
+        }
     }
 
     __aicore__ inline void BuildMaxBs()
@@ -477,7 +505,38 @@ private:
         if (blockIdx != MAX_BS_CORE) {
             return;
         }
-        ReorderSendTokensPerRankOutput();
+        uint32_t singleRankMaxElem = batchRounds * numLocalExperts * sendPerGroup;
+        uint32_t singleRankAlignLen = Ceil(singleRankMaxElem * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        recvDataAlignLen = rankSize * singleRankAlignLen;
+        pipe.InitBuffer(recvDataBuf, recvDataAlignLen);
+        pipe.InitBuffer(sendTokensPerRankBuf, sendTokensPerRankAlignLen);
+        pipe.InitBuffer(seenRoundBuf, sendTokensPerRankAlignLen);
+        sendTokensPerRankTensor = sendTokensPerRankBuf.Get<int32_t>();
+        seenRoundTensor = seenRoundBuf.Get<int32_t>();
+        Duplicate<int32_t>(sendTokensPerRankTensor, 0, sendTokensPerRankAlignLen / sizeof(int32_t));
+        SyncFunc<AscendC::HardEvent::V_S>();
+        for (uint32_t rStart = 0; rStart < round; rStart += batchRounds) {
+            uint32_t currentBatchRounds = (rStart + batchRounds > round) ? (round - rStart) : batchRounds;
+            uint32_t singleRankBatchDataLen = currentBatchRounds * numLocalExperts * sendPerGroup * sizeof(T);
+            uint32_t alignedDataLen = Ceil(singleRankBatchDataLen, UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+            uint32_t strideElem = alignedDataLen / sizeof(T);
+            ReorderOutput(rStart, currentBatchRounds);
+            for (uint32_t r = 0; r < currentBatchRounds; ++r) {
+                Duplicate<int32_t>(seenRoundTensor, 0, sendTokensPerRankAlignLen / sizeof(int32_t));
+                SyncFunc<AscendC::HardEvent::V_S>();
+                for (uint32_t expId = 0; expId < numLocalExperts; ++expId) {
+                    for (uint32_t srcRank = 0; srcRank < rankSize; ++srcRank) {
+                        uint32_t offsetInRank = sendPerGroup * (r * numLocalExperts + expId);
+                        uint32_t pair_idx = srcRank * strideElem + offsetInRank;
+                        if (!seenRoundTensor(srcRank)) {
+                            sendTokensPerRankTensor(srcRank) += recvDataTensor(pair_idx + 2);
+                            seenRoundTensor(srcRank) = 1;
+                        }
+                    }
+                }
+            }
+            SyncFunc<AscendC::HardEvent::S_V>();
+        }
         for (uint32_t srcRank = 0; srcRank < numRanks; ++srcRank) {
             uint32_t tempBs = sendTokensPerRankTensor(srcRank);
             maxBsNum = maxBsNum >= tempBs ? maxBsNum : tempBs;
@@ -494,24 +553,40 @@ private:
         if (blockIdx != RECV_TOKEN_PER_EXP_CORE) {
             return;
         }
-        ReorderSendCountOutput();
-        pipe.InitBuffer(tmpBuf_, Ceil(round * numLocalExperts * sizeof(int32_t), UB_ALIGN_SIZE) * UB_ALIGN_SIZE);
+        uint32_t singleRankMaxElem = batchRounds * numLocalExperts * sendPerGroup;
+        uint32_t singleRankAlignLen = Ceil(singleRankMaxElem * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        recvDataAlignLen = rankSize * singleRankAlignLen;
+        pipe.InitBuffer(recvDataBuf, recvDataAlignLen);
+        sendCountAlignLen = Ceil(batchRounds * numExperts * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        pipe.InitBuffer(sendCountBuf, sendCountAlignLen);
+        pipe.InitBuffer(tmpBuf_, Ceil(batchRounds * numLocalExperts * sizeof(int32_t), UB_ALIGN_SIZE) * UB_ALIGN_SIZE);
         LocalTensor<int32_t> tmpTensor = tmpBuf_.Get<int32_t>();
-        for (uint32_t r = 0; r < round; r++) {
-            for (uint32_t expId = 0; expId < numLocalExperts; ++expId) {
-                int32_t localRecvCount = 0;
-                for (uint32_t srcRank = 0; srcRank < rankSize; ++srcRank) {
-                    uint32_t index = r * numExperts + expId * rankSize + srcRank;
-                    localRecvCount += sendCountTensor(index);
-                }
-                tmpTensor(r * numLocalExperts + expId) = localRecvCount;
-            }
-        }
         GlobalTensor<int32_t> recvTokenPerExpGt;
         recvTokenPerExpGt.SetGlobalBuffer((__gm__ int32_t *)recvTokensPerExpert_);
-        DataCopyExtParams copyParams{1, static_cast<uint32_t>(round * numLocalExperts * sizeof(int32_t)), 0, 0, 0};
-        SyncFunc<AscendC::HardEvent::S_MTE3>();
-        DataCopyPad(recvTokenPerExpGt, tmpTensor, copyParams);
+        for (uint32_t rStart = 0; rStart < round; rStart += batchRounds) {
+            uint32_t currentBatchRounds = (rStart + batchRounds > round) ? (round - rStart) : batchRounds;
+            SyncFunc<AscendC::HardEvent::MTE3_V>();
+            Duplicate<int32_t>(tmpTensor, 0, batchRounds * numLocalExperts);
+            ReorderOutput(rStart, currentBatchRounds);
+            ReorderSendCountOutput(currentBatchRounds);
+            for (uint32_t r = 0; r < currentBatchRounds; ++r) {
+                for (uint32_t expId = 0; expId < numLocalExperts; ++expId) {
+                    int32_t localRecvCount = 0;
+                    for (uint32_t srcRank = 0; srcRank < rankSize; ++srcRank) {
+                        uint32_t index = r * numExperts + expId * rankSize + srcRank;
+                        localRecvCount += sendCountTensor(index);
+                    }
+                    tmpTensor(r * numLocalExperts + expId) = localRecvCount;
+                }
+            }
+            SyncFunc<AscendC::HardEvent::S_V>();
+            DataCopyExtParams copyParams{
+                1, static_cast<uint32_t>(currentBatchRounds * numLocalExperts * sizeof(int32_t)), 0, 0, 0};
+            SyncFunc<AscendC::HardEvent::S_MTE3>();
+            SyncFunc<AscendC::HardEvent::V_MTE3>();
+            DataCopyPad(recvTokenPerExpGt[rStart * numLocalExperts], tmpTensor, copyParams);
+            SyncFunc<AscendC::HardEvent::MTE3_MTE2>();
+        }
     }
 
     __aicore__ inline void BuildExpGlobalOffset()
@@ -520,7 +595,12 @@ private:
         if (blockIdx != EXP_GLOBAL_OFFSET_CORE) {
             return;
         }
-        ReorderSendCountOutput();
+        uint32_t singleRankMaxElem = batchRounds * numLocalExperts * sendPerGroup;
+        uint32_t singleRankAlignLen = Ceil(singleRankMaxElem * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        recvDataAlignLen = rankSize * singleRankAlignLen;
+        pipe.InitBuffer(recvDataBuf, recvDataAlignLen);
+        sendCountAlignLen = Ceil(batchRounds * numExperts * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        pipe.InitBuffer(sendCountBuf, sendCountAlignLen);
         pipe.InitBuffer(tmpBuf_, Ceil(numLocalExperts * sizeof(int32_t), UB_ALIGN_SIZE) * UB_ALIGN_SIZE);
         pipe.InitBuffer(tmpBuf2_, Ceil(numLocalExperts * sizeof(int32_t), UB_ALIGN_SIZE) * UB_ALIGN_SIZE);
         LocalTensor<int32_t> tmpTensor = tmpBuf_.Get<int32_t>();
@@ -528,16 +608,21 @@ private:
         Duplicate<int32_t>(tmpTensor, 0, numLocalExperts);
         expTensor(0) = 0;
         SyncFunc<AscendC::HardEvent::V_S>();
-        int32_t localExpTotal = 0;
-        for (uint32_t r = 0; r < round; r++) {
-            for (uint32_t expId = 0; expId < numLocalExperts; ++expId) {
-                int32_t localRecvCount = 0;
-                for (uint32_t srcRank = 0; srcRank < rankSize; ++srcRank) {
-                    uint32_t index = r * numExperts + expId * rankSize + srcRank;
-                    localRecvCount += sendCountTensor(index);
+        for (uint32_t rStart = 0; rStart < round; rStart += batchRounds) {
+            uint32_t currentBatchRounds = (rStart + batchRounds > round) ? (round - rStart) : batchRounds;
+            ReorderOutput(rStart, currentBatchRounds);
+            ReorderSendCountOutput(currentBatchRounds);
+            for (uint32_t r = 0; r < currentBatchRounds; ++r) {
+                for (uint32_t expId = 0; expId < numLocalExperts; ++expId) {
+                    int32_t localRecvCount = 0;
+                    for (uint32_t srcRank = 0; srcRank < rankSize; ++srcRank) {
+                        uint32_t index = r * numExperts + expId * rankSize + srcRank;
+                        localRecvCount += sendCountTensor(index);
+                    }
+                    tmpTensor(expId) += localRecvCount;
                 }
-                tmpTensor(expId) += localRecvCount;
             }
+            SyncFunc<AscendC::HardEvent::S_V>();
         }
         for (uint32_t expId = 1; expId < numLocalExperts; ++expId) {
             expTensor(expId) = expTensor(expId - 1) + tmpTensor(expId - 1);
@@ -554,21 +639,29 @@ private:
         if (blockIdx != SRC_RANK_EXP_OFFSET_CORE) {
             return;
         }
-        ReorderSendCountOutput();
+        uint32_t singleRankMaxElem = batchRounds * numLocalExperts * sendPerGroup;
+        uint32_t singleRankAlignLen = Ceil(singleRankMaxElem * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        recvDataAlignLen = rankSize * singleRankAlignLen;
+        pipe.InitBuffer(recvDataBuf, recvDataAlignLen);
+        sendCountAlignLen = Ceil(batchRounds * numExperts * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        pipe.InitBuffer(sendCountBuf, sendCountAlignLen);
         pipe.InitBuffer(tmpBuf_, Ceil(numRanks * numLocalExperts * sizeof(int32_t), UB_ALIGN_SIZE) * UB_ALIGN_SIZE);
         pipe.InitBuffer(tmpBuf2_, Ceil(numRanks * numLocalExperts * sizeof(int32_t), UB_ALIGN_SIZE) * UB_ALIGN_SIZE);
         LocalTensor<int32_t> expSrcTotalTensor = tmpBuf_.Get<int32_t>();
         LocalTensor<int32_t> srcRankInExpOffsetTensor = tmpBuf2_.Get<int32_t>();
         Duplicate<int32_t>(expSrcTotalTensor, 0, numExperts);
         SyncFunc<AscendC::HardEvent::V_S>();
-        int32_t localExpTotal = 0;
-        for (uint32_t r = 0; r < round; r++) {
-            for (uint32_t expId = 0; expId < numLocalExperts; ++expId) {
-                int32_t localRecvCount = 0;
-                for (uint32_t srcRank = 0; srcRank < rankSize; ++srcRank) {
-                    uint32_t index = r * numExperts + expId * rankSize + srcRank;
-                    localRecvCount = sendCountTensor(index);
-                    expSrcTotalTensor(expId * numRanks + srcRank) += localRecvCount;
+        for (uint32_t rStart = 0; rStart < round; rStart += batchRounds) {
+            uint32_t currentBatchRounds = (rStart + batchRounds > round) ? (round - rStart) : batchRounds;
+            ReorderOutput(rStart, currentBatchRounds);
+            ReorderSendCountOutput(currentBatchRounds);
+            SyncFunc<AscendC::HardEvent::S_V>();
+            for (uint32_t r = 0; r < currentBatchRounds; ++r) {
+                for (uint32_t expId = 0; expId < numLocalExperts; ++expId) {
+                    for (uint32_t srcRank = 0; srcRank < rankSize; ++srcRank) {
+                        uint32_t index = r * numExperts + expId * rankSize + srcRank;
+                        expSrcTotalTensor(expId * numRanks + srcRank) += sendCountTensor(index);
+                    }
                 }
             }
         }
@@ -591,32 +684,52 @@ private:
         if (blockIdx != R_IN_SRCRANK_OFFSET_CORE) {
             return;
         }
-        ReorderSendCountOutput();
-        pipe.InitBuffer(tmpBuf_, Ceil(round * numExperts * sizeof(int32_t), UB_ALIGN_SIZE) * UB_ALIGN_SIZE);
+        uint32_t singleRankMaxElem = batchRounds * numLocalExperts * sendPerGroup;
+        uint32_t singleRankAlignLen = Ceil(singleRankMaxElem * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        recvDataAlignLen = rankSize * singleRankAlignLen;
+        pipe.InitBuffer(recvDataBuf, recvDataAlignLen);
+        sendCountAlignLen = Ceil(batchRounds * numExperts * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+        pipe.InitBuffer(sendCountBuf, sendCountAlignLen);
+
         pipe.InitBuffer(tmpBuf2_, Ceil(numRanks * numLocalExperts * sizeof(int32_t), UB_ALIGN_SIZE) * UB_ALIGN_SIZE);
-        LocalTensor<int32_t> rInSrcrankOffsetTensor = tmpBuf_.Get<int32_t>();
         LocalTensor<int32_t> expSrcCumPrevTensor = tmpBuf2_.Get<int32_t>();
         Duplicate<int32_t>(expSrcCumPrevTensor, 0, numExperts);
         SyncFunc<AscendC::HardEvent::V_S>();
-        for (uint32_t r = 0; r < round; r++) {
-            for (uint32_t expId = 0; expId < numLocalExperts; ++expId) {
-                int32_t localRecvCount = 0;
-                for (uint32_t srcRank = 0; srcRank < rankSize; ++srcRank) {
-                    uint32_t pairIdx = r * numExperts + expId * rankSize + srcRank;
-                    uint32_t index = expId * rankSize + srcRank;
-                    uint32_t cIdx = expId * numRanks * round + srcRank * round + r;
-                    int32_t recvCnt = sendCountTensor(pairIdx);
-                    int32_t offset = expSrcCumPrevTensor(index);
-                    rInSrcrankOffsetTensor(cIdx) = offset;
-                    expSrcCumPrevTensor(index) = offset + recvCnt;
-                }
-            }
-        }
+
+        pipe.InitBuffer(tmpBuf_, Ceil(batchRounds * numExperts * sizeof(int32_t), UB_ALIGN_SIZE) * UB_ALIGN_SIZE);
+        LocalTensor<int32_t> rInSrcrankOffsetTensor = tmpBuf_.Get<int32_t>();
         GlobalTensor<int32_t> rInSrcrankOffsetGt;
         rInSrcrankOffsetGt.SetGlobalBuffer((__gm__ int32_t *)rInSrcrankOffset_);
-        DataCopyExtParams copyParams{1, static_cast<uint32_t>(round * numExperts * sizeof(int32_t)), 0, 0, 0};
-        SyncFunc<AscendC::HardEvent::S_MTE3>();
-        DataCopyPad(rInSrcrankOffsetGt, rInSrcrankOffsetTensor, copyParams);
+        for (uint32_t rStart = 0; rStart < round; rStart += batchRounds) {
+            uint32_t currentBatchRounds = (rStart + batchRounds > round) ? (round - rStart) : batchRounds;
+            ReorderOutput(rStart, currentBatchRounds);
+            ReorderSendCountOutput(currentBatchRounds);
+            DataCopyExtParams copyParams{1, static_cast<uint32_t>(currentBatchRounds * sizeof(int32_t)), 0, 0, 0};
+
+            for (uint32_t expId = 0; expId < numLocalExperts; ++expId) {
+                for (uint32_t srcRank = 0; srcRank < rankSize; ++srcRank) {
+                    uint32_t index = expId * rankSize + srcRank;
+                    uint32_t ubBlockOffset = index * currentBatchRounds;
+                    uint32_t ubBlockOffsetAlign = Ceil(ubBlockOffset * sizeof(int32_t), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
+                    uint32_t ubBlockAlignIndex = ubBlockOffsetAlign / sizeof(int32_t);
+                    uint32_t gmOffset = expId * numRanks * round + srcRank * round + rStart;
+
+                    Duplicate<int32_t>(rInSrcrankOffsetTensor, 0, currentBatchRounds * numExperts);
+                    SyncFunc<AscendC::HardEvent::V_S>();
+                    for (uint32_t r = 0; r < currentBatchRounds; ++r) {
+                        uint32_t pairIdx = r * numExperts + index;
+                        int32_t recvCnt = sendCountTensor(pairIdx);
+                        int32_t offset = expSrcCumPrevTensor(index);
+                        rInSrcrankOffsetTensor(ubBlockAlignIndex + r) = offset;
+                        expSrcCumPrevTensor(index) = offset + recvCnt;
+                    }
+                    SyncFunc<AscendC::HardEvent::S_MTE3>();
+                    DataCopyPad(rInSrcrankOffsetGt[gmOffset], rInSrcrankOffsetTensor[ubBlockAlignIndex], copyParams);
+                    SyncFunc<AscendC::HardEvent::MTE3_V>();
+                }
+            }
+            SyncFunc<AscendC::HardEvent::MTE3_MTE2>();
+        }
     }
 
     __aicore__ inline int64_t GetDataCount(const int64_t dataLen, const int64_t useBlockNum);
@@ -684,6 +797,7 @@ private:
     int32_t blockNum;  // Total number of aicores for the current rank
     uint32_t maxBsNum{0};
     uint32_t baseWindSize{0};
+    int batchRounds{32};
     GM_ADDR scale;
     GM_ADDR shareAddrs[CAM_MAX_RANK_SIZE];  // List of shared memory addresses
     GM_ADDR totalRecvTokens_;

--- a/tests/python/deepep/run_a5_ant_migration_regression.sh
+++ b/tests/python/deepep/run_a5_ant_migration_regression.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+TEST_SCRIPT="${SCRIPT_DIR}/test_intranode.py"
+
+NUM_PROCESSES="${A5_ANT_NUM_PROCESSES:-4}"
+HIDDEN="${A5_ANT_HIDDEN:-7168}"
+NUM_EXPERTS="${A5_ANT_NUM_EXPERTS:-256}"
+HCCL_BUFFER_MB="${HCCL_BUFFSIZE:-2300}"
+LAUNCH_BLOCKING="${ASCEND_LAUNCH_BLOCKING:-1}"
+
+RUN_MAX_BOUNDARY="${A5_ANT_RUN_MAX_BOUNDARY:-0}"
+RUN_ALL_QUANT="${A5_ANT_RUN_ALL_QUANT:-0}"
+RUN_EXPERT_MATRIX="${A5_ANT_RUN_EXPERT_MATRIX:-0}"
+SKIP_DEVICE_CHECK="${A5_ANT_SKIP_DEVICE_CHECK:-0}"
+
+require_positive_integer()
+{
+    local name="$1"
+    local value="$2"
+    if ! [[ "${value}" =~ ^[0-9]+$ ]] || (( value < 1 )); then
+        echo "${name} must be a positive integer, got '${value}'." >&2
+        exit 1
+    fi
+}
+
+require_boolean()
+{
+    local name="$1"
+    local value="$2"
+    if [[ "${value}" != "0" && "${value}" != "1" ]]; then
+        echo "${name} must be 0 or 1, got '${value}'." >&2
+        exit 1
+    fi
+}
+
+require_positive_integer "A5_ANT_NUM_PROCESSES" "${NUM_PROCESSES}"
+require_positive_integer "A5_ANT_HIDDEN" "${HIDDEN}"
+require_positive_integer "A5_ANT_NUM_EXPERTS" "${NUM_EXPERTS}"
+require_positive_integer "HCCL_BUFFSIZE" "${HCCL_BUFFER_MB}"
+require_boolean "ASCEND_LAUNCH_BLOCKING" "${LAUNCH_BLOCKING}"
+require_boolean "A5_ANT_RUN_MAX_BOUNDARY" "${RUN_MAX_BOUNDARY}"
+require_boolean "A5_ANT_RUN_ALL_QUANT" "${RUN_ALL_QUANT}"
+require_boolean "A5_ANT_RUN_EXPERT_MATRIX" "${RUN_EXPERT_MATRIX}"
+require_boolean "A5_ANT_SKIP_DEVICE_CHECK" "${SKIP_DEVICE_CHECK}"
+
+if (( NUM_PROCESSES < 2 )); then
+    echo "A5_ANT_NUM_PROCESSES must be at least 2." >&2
+    exit 1
+fi
+
+if [[ ! -f "${TEST_SCRIPT}" ]]; then
+    echo "Cannot find test script: ${TEST_SCRIPT}" >&2
+    exit 1
+fi
+
+if [[ "${SKIP_DEVICE_CHECK}" != "1" ]]; then
+    if ! command -v npu-smi >/dev/null 2>&1; then
+        echo "npu-smi is required to verify the A5 test target." >&2
+        echo "Set A5_ANT_SKIP_DEVICE_CHECK=1 only when the target is already known to be A5." >&2
+        exit 1
+    fi
+
+    BOARD_INFO="$(npu-smi info -t board -i 0 2>/dev/null || true)"
+    if ! printf '%s\n' "${BOARD_INFO}" | grep -Eiq 'Chip Name[[:space:]]*:[[:space:]]*Ascend[[:space:]_-]*950'; then
+        echo "This regression must run on Ascend950 (A5)." >&2
+        echo "Detected board information:" >&2
+        printf '%s\n' "${BOARD_INFO}" >&2
+        exit 1
+    fi
+fi
+
+run_case()
+{
+    local name="$1"
+    local rounds="$2"
+    local per_round_tokens="$3"
+    local num_tokens="$4"
+    local quant_type="$5"
+    local combine_long_seq="$6"
+    local hidden="${7:-${HIDDEN}}"
+    local num_experts="${8:-${NUM_EXPERTS}}"
+    local num_topk="${9:-8}"
+
+    require_positive_integer "${name}: rounds" "${rounds}"
+    require_positive_integer "${name}: per_round_tokens" "${per_round_tokens}"
+    require_positive_integer "${name}: num_tokens" "${num_tokens}"
+    require_positive_integer "${name}: hidden" "${hidden}"
+    require_positive_integer "${name}: num_experts" "${num_experts}"
+    require_positive_integer "${name}: num_topk" "${num_topk}"
+    require_boolean "${name}: combine_long_seq" "${combine_long_seq}"
+
+    if (( rounds > 256 )); then
+        echo "${name}: rounds=${rounds} exceeds the supported maximum of 256." >&2
+        exit 1
+    fi
+    if (( per_round_tokens < 32 || per_round_tokens > 8192 )); then
+        echo "${name}: per_round_tokens must be in [32, 8192]." >&2
+        exit 1
+    fi
+    if (( rounds * per_round_tokens > 131072 )); then
+        echo "${name}: rounds * per_round_tokens exceeds 131072." >&2
+        exit 1
+    fi
+    if (( num_tokens > rounds * per_round_tokens )); then
+        echo "${name}: ${num_tokens} tokens cannot fit in ${rounds} rounds." >&2
+        exit 1
+    fi
+    if (( num_experts % NUM_PROCESSES != 0 )); then
+        echo "${name}: num_experts=${num_experts} must be divisible by num_processes=${NUM_PROCESSES}." >&2
+        exit 1
+    fi
+
+    local actual_rounds=$(( (num_tokens + per_round_tokens - 1) / per_round_tokens ))
+    echo
+    echo "===== ${name} ====="
+    echo "configured_rounds=${rounds}, actual_rounds=${actual_rounds}, per_round_tokens=${per_round_tokens}"
+    echo "tokens=${num_tokens}, hidden=${hidden}, experts=${num_experts}, topk=${num_topk}, quant=${quant_type}, combine_long_seq=${combine_long_seq}"
+
+    ASCEND_LAUNCH_BLOCKING="${LAUNCH_BLOCKING}" \
+    DEEPEP_NORMAL_LONG_SEQ_ROUND="${rounds}" \
+    DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS="${per_round_tokens}" \
+    DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ="${combine_long_seq}" \
+    HCCL_BUFFSIZE="${HCCL_BUFFER_MB}" \
+        python3 "${TEST_SCRIPT}" \
+            --num-processes="${NUM_PROCESSES}" \
+            --num-tokens="${num_tokens}" \
+            --hidden="${hidden}" \
+            --num-experts="${num_experts}" \
+            --num-topk="${num_topk}" \
+            --quant-type="${quant_type}"
+}
+
+# Legacy single-round path.
+run_case "single-round-regression" 1 8192 4096 bf16 0
+
+# Five configured dispatch rounds with an empty padding round.
+run_case "multi-round-padding" 5 512 2048 bf16 1
+
+# Five full dispatch rounds.
+run_case "multi-round-exact" 5 512 2560 bf16 1
+
+# Four full dispatch rounds and a 74-token tail.
+run_case "multi-round-partial-tail" 5 512 2122 bf16 1
+
+# Notify's largest single UB round batch.
+run_case "notify-32-round-boundary" 32 32 1024 bf16 1 1024
+
+# Cross the 32-round UB batch boundary and process a partial final round.
+run_case "notify-33-round-cross-batch" 33 32 1040 bf16 1 1024
+
+# Cover Notify's smaller expert-matrix batch modes introduced by A5 migration.
+# With four ranks these select batchRounds 16 and 8 respectively.
+run_case "notify-batch-16" 17 128 2176 bf16 1 1024 512
+run_case "notify-batch-8" 9 256 2304 bf16 1 1024 1024
+
+if [[ "${RUN_MAX_BOUNDARY}" == "1" ]]; then
+    # Maximum supported runtime round count.
+    run_case "max-256-round-boundary" 256 32 8192 bf16 1 1024
+
+    # 8192 * topk(8) * 32 bytes = 2 MiB, exactly one combine state ping-pong slot.
+    run_case "max-combine-state-slot" 2 8192 8193 bf16 1 1024 256 8
+fi
+
+if [[ "${RUN_ALL_QUANT}" == "1" ]]; then
+    for quant_type in int8 pertoken_fp8_e4m3 mx_fp8_e4m3 mx_fp8_e5m2 mx_fp4_e2m1; do
+        run_case "multi-round-${quant_type}" 5 512 2122 "${quant_type}" 1
+    done
+fi
+
+if [[ "${RUN_EXPERT_MATRIX}" == "1" ]]; then
+    # With four ranks these select Notify batch sizes 32, 16, and 8.
+    # The 16/8 cases are part of the default regression because they cover
+    # the new expert-dependent batching paths in NotifyDispatchA5.
+    run_case "notify-batch-32" 33 64 2112 bf16 1 1024 256
+fi
+
+echo
+echo "All A5 ant-migration regression cases passed."


### PR DESCRIPTION
## Motivation
- DeepEP Normal mode already supports multi-round long-sequence processing on A3, but the A5 normal-mode path used for the ant-migration workflow still treated long-sequence communication as a single-round workflow.
- For long-sequence MoE workloads, processing all tokens in one round increases UB and HCCL window pressure on A5. As token count, expert count, or round count grows, this can lead to UB allocation failures, communication-window overflow, or synchronization-state conflicts.
- This PR adds opt-in A5 support for multi-round long-sequence processing in the Normal-mode dispatch/combine path, while keeping the existing single-round behavior as the default. Existing A2 and A3 paths remain unchanged.

## Modification
- Updated the A5 multi-round dispatch/combine path used in ant migration.
- Fixed round-state ping-pong synchronization for A5 multi-round dispatch/combine.
- Reworked `NotifyDispatchA5` metadata reordering into expert-dependent batches to fit UB constraints.
- Added stronger `DispatchLayout` shape validation for `topk_idx`.
- Added and expanded A5 ant-migration regression coverage, including default coverage for Notify `batchRounds=16` and `batchRounds=8`.

## Testing
- bash tests/python/deepep/run_a5_ant_migration_regression.sh 
- A5_ANT_RUN_EXPERT_MATRIX=1 bash tests/python/deepep/run_a5_ant_migration_regression.sh
- A5_ANT_RUN_ALL_QUANT=1 bash tests/python/deepep/run_a5_ant_migration_regression.sh
- All A5 ant-migration regression cases passed.

## Benchmarking and Testing
### BS 2048

| 场景 | ROUNDS | PER_ROUND_TOKENS | HCCL_BUFFSIZE (MB) | dispatch (us) | dispatch (GB/s) | combine (us) | combine (GB/s) |
|------|--------|------------------|---------------------|---------------|-----------------|-------------|----------------|
| 不开蚂蚁搬家 | — | — | 1556 | 2565.34 | 91.79 | 1462.37 | 161.02 |
| 蚂蚁搬家 | 8 | 256 | 380 | 2403.88 | 97.52 | 1437.67 | 163.07 |
| 蚂蚁搬家 | 4 | 512 | 548 | 2339.77 | 100.44 | 1442.56 | 162.91 |
| 蚂蚁搬家 | 2 | 1024 | 884 | 2465.86 | 94.30 | 1462.24 | 159.02 |

### BS 4096

| 场景 | ROUNDS | PER_ROUND_TOKENS | HCCL_BUFFSIZE (MB) | dispatch (us) | dispatch (GB/s) | combine (us) | combine (GB/s) |
|------|--------|------------------|---------------------|---------------|-----------------|-------------|----------------|
| 不开蚂蚁搬家 | — | — | 2900 | 4256.54 | 110.40 | 2915.82 | 161.16 |
| 蚂蚁搬家 | 16 | 256 | 380 | 4368.49 | 108.21 | 2921.53 | 161.53 |
| 蚂蚁搬家 | 8 | 512 | 548 | 4207.51 | 111.81 | 2892.38 | 162.64 |
| 蚂蚁搬家 | 4 | 1024 | 884 | 4311.57 | 108.47 | 2834.98 | 164.96 |

### BS 8192

| 场景 | ROUNDS | PER_ROUND_TOKENS | HCCL_BUFFSIZE (MB) | dispatch (us) | dispatch (GB/s) | combine (us) | combine (GB/s) |
|------|--------|------------------|---------------------|---------------|-----------------|-------------|----------------|
| 不开蚂蚁搬家 | — | — | 5588 | 8230.78 | 114.34 | 5615.56 | 167.59 |
| 蚂蚁搬家 | 32 | 256 | 380 | 8578.33 | 109.32 | 5556.89 | 168.75 |
| 蚂蚁搬家 | 16 | 512 | 548 | 8122.64 | 115.83 | 5697.63 | 165.14 |
| 蚂蚁搬家 | 8 | 1024 | 884 | 8122.69 | 114.95 | 5699.14 | 163.83 |
| 蚂蚁搬家 | 4 | 2048 | 1556 | 8103.71 | 116.13 | 5551.64 | 169.52 |

### BS 16384

| 场景 | ROUNDS | PER_ROUND_TOKENS | HCCL_BUFFSIZE (MB) | dispatch (us) | dispatch (GB/s) | combine (us) | combine (GB/s) |
|------|--------|------------------|---------------------|---------------|-----------------|-------------|----------------|
| 蚂蚁搬家 | 64 | 256 | 296 | 17339.34 | 108.56 | 11105.42 | 169.50 |
| 蚂蚁搬家 | 32 | 512 | 548 | 16267.29 | 115.48 | 11700.18 | 160.56 |
| 蚂蚁搬家 | 16 | 1024 | 884 | 15980.49 | 117.40 | 11386.40 | 164.76 |
| 蚂蚁搬家 | 8 | 2048 | 1556 | 15776.98 | 118.80 | 11385.56 | 164.62 |

**结论**：四种 BS 规格下，开启蚂蚁搬家后 HCCL 缓冲区均大幅下降，dispatch/combine 延迟和吞吐量基本持平。多轮拆分在保证通信性能不变的前提下，显著降低了 HCCL 窗口压力。

## Checklist
- [x] Format your code
- [x] Add unit tests
- [x] Update documentation
- [x] Provide accuracy and speed benchmark results