### PR TITLE
fix(ci): bump CANN version to 9.1.0

### DIFF
--- a/.github/workflows/a2-internode-test.yml
+++ b/.github/workflows/a2-internode-test.yml
@@ -26,11 +26,17 @@ jobs:
           - name: test_internode_a2
             node_size: 2
             test_case: tests/python/deepep/test_internode_a2.py
+        # CANN 8.5.0 images ship Python 3.11, CANN 9.1.0 images ship Python 3.12
+        include:
+          - cann_version: 8.5.0
+            python_version: py3.11
+          - cann_version: 9.1.0
+            python_version: py3.12
     uses: ./.github/workflows/internode.yml
     with:
       soc_version: a2
       runner: linux-aarch64-a2-0
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py3.11'
+      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-${{ matrix.python_version }}'
       test_config_name: ${{ matrix.test_config.name }}
       node_size: ${{ matrix.test_config.node_size }}
       test_case: ${{ matrix.test_config.test_case }}

--- a/.github/workflows/a2-internode-test.yml
+++ b/.github/workflows/a2-internode-test.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        cann_version: [8.5.0, 9.0.0]
+        cann_version: [8.5.0, 9.1.0]
         test_config:
           - name: test_internode_a2
             node_size: 2

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         arch: [x86_64, aarch64]
         npu_hardware: [910b, a3]
-        cann_version: [8.5.0, 9.0.0]
+        cann_version: [8.5.0, 9.1.0]
         torch_version: [2.8.0, 2.10.0]
         # Ref: https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
         include:
@@ -109,7 +109,7 @@ jobs:
       matrix:
         arch: [ x86_64, aarch64 ]
         npu_hardware: [ 910b, a3 ]
-        cann_version: [ 9.0.0 ]
+        cann_version: [ 9.1.0 ]
         torch_version: [ 2.10.0 ]
         # Ref: https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
         include:
@@ -188,7 +188,7 @@ jobs:
       matrix:
         arch: [ x86_64, aarch64 ]
         npu_hardware: [ 910b, a3 ]
-        cann_version: [ 9.0.0 ]
+        cann_version: [ 9.1.0 ]
         torch_version: [ 2.10.0 ]
         # Ref: https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
         include:

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -33,9 +33,14 @@ jobs:
             runner: ubuntu-24.04
           - arch: aarch64
             runner: ubuntu-24.04-arm
+          # CANN 8.5.0 images ship Python 3.11, CANN 9.1.0 images ship Python 3.12
+          - cann_version: 8.5.0
+            python_version: py3.11
+          - cann_version: 9.1.0
+            python_version: py3.12
     runs-on: ${{ matrix.runner }}
     container:
-      image: quay.io/ascend/cann:${{ matrix.cann_version }}-${{ matrix.npu_hardware }}-ubuntu22.04-py3.11
+      image: quay.io/ascend/cann:${{ matrix.cann_version }}-${{ matrix.npu_hardware }}-ubuntu22.04-${{ matrix.python_version }}
 
     steps:
       - name: Checkout repository
@@ -119,7 +124,8 @@ jobs:
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     container:
-      image: quay.io/ascend/cann:${{ matrix.cann_version }}-${{ matrix.npu_hardware }}-ubuntu22.04-py3.11
+      # CANN 9.1.0 images ship Python 3.12
+      image: quay.io/ascend/cann:${{ matrix.cann_version }}-${{ matrix.npu_hardware }}-ubuntu22.04-py3.12
 
     steps:
       - name: Checkout repository
@@ -198,7 +204,8 @@ jobs:
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     container:
-      image: quay.io/ascend/cann:${{ matrix.cann_version }}-${{ matrix.npu_hardware }}-ubuntu22.04-py3.11
+      # CANN 9.1.0 images ship Python 3.12
+      image: quay.io/ascend/cann:${{ matrix.cann_version }}-${{ matrix.npu_hardware }}-ubuntu22.04-py3.12
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/daily-build-test.yml
+++ b/.github/workflows/daily-build-test.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         test_type: [intranode, low_latency]
-        cann_version: [9.0.0, 8.5.0]
+        cann_version: [9.1.0, 8.5.0]
         hardware: [a3, a2]
     steps:
       - name: Clean git config
@@ -64,7 +64,7 @@ jobs:
           HCCL_BUFFSIZE: 4096
           TEST_ENV: daily-build
         run: |
-          if [ "${{ matrix.cann_version }}" = "9.0.0" ]; then
+          if [ "${{ matrix.cann_version }}" = "9.1.0" ]; then
             export MOE_ENABLE_CCU=0
           fi
           SCRIPT_NAME="enumerate_test_${{ matrix.test_type }}${{ matrix.test_type == 'low_latency' && (matrix.hardware == 'a2' && '_a2' || '') || '' }}.sh"
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        cann_version: [8.5.0, 9.0.0]
+        cann_version: [8.5.0, 9.1.0]
         test_config:
           - name: test_internode_a2
             node_size: 2

--- a/.github/workflows/daily-build-test.yml
+++ b/.github/workflows/daily-build-test.yml
@@ -19,7 +19,7 @@ jobs:
     name: ${{ matrix.test_type == 'intranode' && 'Intranode' || 'Low Latency' }} (CANN ${{ matrix.cann_version }}, ${{ matrix.hardware }})
     runs-on: ${{ matrix.hardware == 'a3' && 'linux-aarch64-a3-16' || 'linux-aarch64-a2-8' }}
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-${{ matrix.hardware == 'a3' && 'a3' || '910b' }}-ubuntu22.04-py3.11
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-${{ matrix.hardware == 'a3' && 'a3' || '910b' }}-ubuntu22.04-${{ matrix.python_version }}
     timeout-minutes: ${{ matrix.test_type == 'intranode' && 350 || 330 }}
     env:
       TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
@@ -31,6 +31,12 @@ jobs:
         test_type: [intranode, low_latency]
         cann_version: [9.1.0, 8.5.0]
         hardware: [a3, a2]
+        # CANN 8.5.0 images ship Python 3.11, CANN 9.1.0 images ship Python 3.12
+        include:
+          - cann_version: 8.5.0
+            python_version: py3.11
+          - cann_version: 9.1.0
+            python_version: py3.12
     steps:
       - name: Clean git config
         run: |
@@ -103,11 +109,17 @@ jobs:
           - name: test_internode_a2
             node_size: 2
             test_case: tests/python/deepep/test_internode_a2.py
+        # CANN 8.5.0 images ship Python 3.11, CANN 9.1.0 images ship Python 3.12
+        include:
+          - cann_version: 8.5.0
+            python_version: py3.11
+          - cann_version: 9.1.0
+            python_version: py3.12
     uses: ./.github/workflows/internode.yml
     with:
       soc_version: a2
       runner: linux-aarch64-a2-0
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py3.11'
+      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-${{ matrix.python_version }}'
       test_config_name: ${{ matrix.test_config.name }}
       node_size: ${{ matrix.test_config.node_size }}
       test_case: ${{ matrix.test_config.test_case }}

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -62,7 +62,7 @@ jobs:
       )
     runs-on: linux-aarch64-a3-16
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-${{ matrix.python_version }}
     env:
       TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
       PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
@@ -71,6 +71,12 @@ jobs:
     strategy:
       matrix:
         cann_version: [8.5.0, 9.1.0]
+        # CANN 8.5.0 images ship Python 3.11, CANN 9.1.0 images ship Python 3.12
+        include:
+          - cann_version: 8.5.0
+            python_version: py3.11
+          - cann_version: 9.1.0
+            python_version: py3.12
     steps:
       - name: Clean git config
         run: |
@@ -295,7 +301,7 @@ jobs:
       )
     runs-on: ["linux-aarch64-a3-16", "a3-752t"]
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-${{ matrix.python_version }}
     env:
       TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
       PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
@@ -304,6 +310,12 @@ jobs:
     strategy:
       matrix:
         cann_version: [8.5.0, 9.1.0]
+        # CANN 8.5.0 images ship Python 3.11, CANN 9.1.0 images ship Python 3.12
+        include:
+          - cann_version: 8.5.0
+            python_version: py3.11
+          - cann_version: 9.1.0
+            python_version: py3.12
     steps:
       - name: Clean git config
         run: |
@@ -497,7 +509,7 @@ jobs:
       )
     runs-on: linux-aarch64-a2-8
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py3.11
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-${{ matrix.python_version }}
     env:
       TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
       PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
@@ -506,6 +518,12 @@ jobs:
     strategy:
       matrix:
         cann_version: [8.5.0, 9.1.0]
+        # CANN 8.5.0 images ship Python 3.11, CANN 9.1.0 images ship Python 3.12
+        include:
+          - cann_version: 8.5.0
+            python_version: py3.11
+          - cann_version: 9.1.0
+            python_version: py3.12
     steps:
       - name: Clean git config
         run: |

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -70,7 +70,7 @@ jobs:
       UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
     strategy:
       matrix:
-        cann_version: [8.5.0, 9.0.0]
+        cann_version: [8.5.0, 9.1.0]
     steps:
       - name: Clean git config
         run: |
@@ -121,8 +121,8 @@ jobs:
             rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
             bash scripts/prepare_deepep_in_container.sh
           fi
-      - name: Set CANN 9.0.0 env
-        if: matrix.cann_version == '9.0.0'
+      - name: Set CANN 9.1.0 env
+        if: matrix.cann_version == '9.1.0'
         run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
       - name: Run test intranode
         timeout-minutes: 10
@@ -303,7 +303,7 @@ jobs:
       UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
     strategy:
       matrix:
-        cann_version: [8.5.0, 9.0.0]
+        cann_version: [8.5.0, 9.1.0]
     steps:
       - name: Clean git config
         run: |
@@ -354,8 +354,8 @@ jobs:
             rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
             bash scripts/prepare_deepep_in_container.sh
           fi
-      - name: Set CANN 9.0.0 env
-        if: matrix.cann_version == '9.0.0'
+      - name: Set CANN 9.1.0 env
+        if: matrix.cann_version == '9.1.0'
         run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
       - name: Run test base fused deep moe
         timeout-minutes: 10
@@ -476,7 +476,7 @@ jobs:
           HCCL_BUFFSIZE: 2048
         run: python3 $GITHUB_WORKSPACE/tests/python/deepep/test_dispatch_ffn_combine.py
       - name: Run test alltoall mode for both normal and low_latency
-        if: matrix.cann_version == '9.0.0'
+        if: matrix.cann_version == '9.1.0'
         timeout-minutes: 10
         env:
           DEEP_MOE_MODE: alltoall
@@ -505,7 +505,7 @@ jobs:
       UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
     strategy:
       matrix:
-        cann_version: [8.5.0, 9.0.0]
+        cann_version: [8.5.0, 9.1.0]
     steps:
       - name: Clean git config
         run: |
@@ -556,8 +556,8 @@ jobs:
             rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
             bash scripts/prepare_deepep_in_container.sh -a deepep2
           fi
-      - name: Set CANN 9.0.0 env
-        if: matrix.cann_version == '9.0.0'
+      - name: Set CANN 9.1.0 env
+        if: matrix.cann_version == '9.1.0'
         run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
       - name: Run test intranode
         timeout-minutes: 10

--- a/.github/workflows/push_build_cache.yml
+++ b/.github/workflows/push_build_cache.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build Cache - ${{ matrix.arch }} - CANN ${{ matrix.cann_version }}
     runs-on: ${{ matrix.runner }}
 
-    # 定义矩阵策略：覆盖 A3/A2 硬件 和 8.5.0/9.0.0 CANN 版本
+    # 定义矩阵策略：覆盖 A3/A2 硬件 和 8.5.0/9.1.0 CANN 版本
     strategy:
       matrix:
         include:
@@ -33,8 +33,8 @@ jobs:
             image_tag: "8.5.0-a3-ubuntu22.04-py3.11"
           - arch: a3
             runner: linux-aarch64-a3-16
-            cann_version: "9.0.0"
-            image_tag: "9.0.0-a3-ubuntu22.04-py3.11"
+            cann_version: "9.1.0"
+            image_tag: "9.1.0-a3-ubuntu22.04-py3.12"
 
           # --- A2 环境 (910B) ---
           - arch: a2
@@ -43,8 +43,8 @@ jobs:
             image_tag: "8.5.0-910b-ubuntu22.04-py3.11"
           - arch: a2
             runner: linux-aarch64-a2-8
-            cann_version: "9.0.0"
-            image_tag: "9.0.0-910b-ubuntu22.04-py3.11"
+            cann_version: "9.1.0"
+            image_tag: "9.1.0-910b-ubuntu22.04-py3.12"
 
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.image_tag }}

--- a/.github/workflows/release_deep_ep_wheel.yml
+++ b/.github/workflows/release_deep_ep_wheel.yml
@@ -27,10 +27,15 @@ jobs:
             runner: ubuntu-24.04
           - arch: aarch64
             runner: ubuntu-24.04-arm
+          # CANN 8.5.0 images ship Python 3.11, CANN 9.1.0 images ship Python 3.12
+          - cann_version: 8.5.0
+            python_version: py3.11
+          - cann_version: 9.1.0
+            python_version: py3.12
 
     runs-on: ${{ matrix.runner }}
     container:
-      image: quay.io/ascend/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py3.11
+      image: quay.io/ascend/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-${{ matrix.python_version }}
 
     steps:
       - name: Checkout repository
@@ -97,7 +102,7 @@ jobs:
       - name: Archive wheel
         uses: actions/upload-artifact@v4
         with:
-          name: deep-ep-910b-${{ matrix.arch }}-cann${{ matrix.cann_version }}-py3.11-wheel
+          name: deep-ep-910b-${{ matrix.arch }}-cann${{ matrix.cann_version }}-${{ matrix.python_version }}-wheel
           path: output/
 
 
@@ -112,10 +117,15 @@ jobs:
             runner: ubuntu-24.04
           - arch: aarch64
             runner: ubuntu-24.04-arm
+          # CANN 8.5.0 images ship Python 3.11, CANN 9.1.0 images ship Python 3.12
+          - cann_version: 8.5.0
+            python_version: py3.11
+          - cann_version: 9.1.0
+            python_version: py3.12
 
     runs-on: ${{ matrix.runner }}
     container:
-      image: quay.io/ascend/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
+      image: quay.io/ascend/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-${{ matrix.python_version }}
 
     steps:
       - name: Checkout repository
@@ -182,7 +192,7 @@ jobs:
       - name: Archive wheel
         uses: actions/upload-artifact@v4
         with:
-          name: deep-ep-a3-${{ matrix.arch }}-cann${{ matrix.cann_version }}-py3.11-wheel
+          name: deep-ep-a3-${{ matrix.arch }}-cann${{ matrix.cann_version }}-${{ matrix.python_version }}-wheel
           path: output/
 
 

--- a/.github/workflows/release_deep_ep_wheel.yml
+++ b/.github/workflows/release_deep_ep_wheel.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64, aarch64]
-        cann_version: [8.5.0]
+        cann_version: [8.5.0, 9.1.0]
         include:
           - arch: x86_64
             runner: ubuntu-24.04
@@ -106,7 +106,7 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64, aarch64]
-        cann_version: [8.5.0]
+        cann_version: [8.5.0, 9.1.0]
         include:
           - arch: x86_64
             runner: ubuntu-24.04

--- a/scripts/npu_ci_install_dependency.sh
+++ b/scripts/npu_ci_install_dependency.sh
@@ -10,6 +10,9 @@ export UV_PIP_INSTALL="uv pip install"
 ### Dependency Versions
 # PyTorch: Default to torch 2.8.0, can be overridden by --torch-version
 TORCH_VERSION="2.8.0"
+# CPython ABI tag of the interpreter in use: CANN 8.5.0 images ship Python 3.11 (cp311),
+# CANN 9.1.0 images ship Python 3.12 (cp312).
+PY_ABI_TAG="cp$(python3 -c 'import sys; print(f"{sys.version_info.major}{sys.version_info.minor}")')"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -28,11 +31,11 @@ done
 case "${TORCH_VERSION}" in
     "2.8.0")
         TORCHVISION_VERSION="0.23.0"
-        TORCH_NPU_URL="https://gitcode.com/Ascend/pytorch/releases/download/v26.0.0-pytorch2.8.0/torch_npu-2.8.0.post4-cp311-cp311-manylinux_2_28_${ARCHITECT}.whl"
+        TORCH_NPU_URL="https://gitcode.com/Ascend/pytorch/releases/download/v26.0.0-pytorch2.8.0/torch_npu-2.8.0.post4-${PY_ABI_TAG}-${PY_ABI_TAG}-manylinux_2_28_${ARCHITECT}.whl"
         ;;
     "2.10.0")
         TORCHVISION_VERSION="0.25.0"
-        TORCH_NPU_URL="https://gitcode.com/Ascend/pytorch/releases/download/v26.0.0-pytorch2.10.0/torch_npu-2.10.0-cp311-cp311-manylinux_2_28_${ARCHITECT}.whl"
+        TORCH_NPU_URL="https://gitcode.com/Ascend/pytorch/releases/download/v26.0.0-pytorch2.10.0/torch_npu-2.10.0-${PY_ABI_TAG}-${PY_ABI_TAG}-manylinux_2_28_${ARCHITECT}.whl"
         ;;
     *)
         echo "Unsupported torch version: ${TORCH_VERSION}"


### PR DESCRIPTION
This MR bumps CANN version from `9.0.0` to `9.1.0`. 

Unfortunately, the docker image for version `9.1.0` is not released for python3.11, hence some additional complexity on the PR.

### Possibly breaking change with python versions

Docker image `quay.io/ascend/cann` is only released with Python3.12, i.e., Python3.11 is dropped. This diff uses  `quay.io/ascend/cann:9.1.0-910b-ubuntu22.04-py3.12`

See https://quay.io/repository/ascend/cann?tab=tags or `curl -s "https://quay.io/api/v1/repository/ascend/cann/tag/?limit=100&onlyActiveTags=true" | jq -r '.tags[].name'`