### PR TITLE
fix(mega_chunk_gdn): upstream mega GDN kernel for A5

### DIFF
--- a/csrc/mega_chunk_gdn/op_host/mega_chunk_gdn.cpp
+++ b/csrc/mega_chunk_gdn/op_host/mega_chunk_gdn.cpp
@@ -14,6 +14,9 @@ namespace npu_kernel {
 
 namespace {
 constexpr int64_t kHeadDim = 128;
+// Must match GDN_MAX_HEADS in mega_kernel.cpp / chunk_cumsum.cpp. NumValueHeads is a runtime kernel argument, and the
+// transpose/cumsum UB tiles are sized for this ceiling, so a larger head count would overrun them on device.
+constexpr int64_t kMaxValueHeads = 64;
 
 bool is_supported_head_pair(int64_t value_heads, int64_t key_heads)
 {
@@ -38,6 +41,7 @@ void check_shape(const at::Tensor &q, const at::Tensor &k, const at::Tensor &v, 
     check(q.size(0) == 1, "mega_chunk_gdn currently supports packed B=1 input");
     check(q.sizes() == k.sizes(), "q and k must have the same shape");
     check(q.size(1) == v.size(1), "q/k and v sequence lengths must match");
+    check(v.size(2) <= kMaxValueHeads, "mega_chunk_gdn supports at most 64 NumValueHeads");
     check(is_supported_head_pair(v.size(2), q.size(2)), "unsupported mega_chunk_gdn (NumValueHeads, NumKeyHeads) pair");
     check(q.size(3) == kHeadDim && v.size(3) == kHeadDim, "mega_chunk_gdn supports head dimension 128");
 

--- a/csrc/mega_chunk_gdn/op_kernel/chunk_cumsum.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/chunk_cumsum.cpp
@@ -48,51 +48,122 @@
 //
 // ============================================================================
 
-#include <pto/pto-inst.hpp>
-#include "acl/acl.h"
-using namespace pto;
+#include <runtime/rt_ffts.h>
 
-// NumHeads and ChunkSize are template parameters so the compiler can optimize
-// tile sizes, unroll loops, and compute UB addresses at compile time.
+#include <pto/pto-inst.hpp>
+
+#include "acl/acl.h"
+#include "mega_kernel_utils.h"
+
+using namespace pto;
+using namespace mega_kernel_utils;
+
+// GDN_C: Compile-time chunk size injected by the build system.
+// Using compile-time constants allows the compiler to optimize tile sizes,
+// unroll loops, and compute UB addresses at compile time.
 #ifndef GDN_C
 #define GDN_C 128
 #endif
+
+// GDN_MAX_HEADS: compile-time ceiling on the value-head count. NumHeads is now
+// a RUNTIME argument (one .so serves every head count), but the UB tiles must
+// still be sized at compile time, so they are sized for the worst case
+// HTC=align(MAX,8). Any NumHeads <= GDN_MAX_HEADS works; the unused columns are
+// zero-padded and ride along the SIMD lanes harmlessly. Must match the
+// host-side _MAX_HEADS guard.
+#ifndef GDN_MAX_HEADS
+#define GDN_MAX_HEADS 64
+#endif
+
+// ── Recurrent prefix-sum chain synchronization ──────────────────────────────
+// The recurrent chain alternates TADD(acc,acc,g_i) (Vec) and TMOV(s_i,acc)
+// (Vec) with TASSIGN address/descriptor setup on each row. TADD/TMOV lower to
+// PIPE_V, but TASSIGN is a SCALAR op (PIPE_S, see opPipeList in
+// pto/common/event.hpp), and on this core the scalar unit ISSUES the vec
+// instructions. So the ordering edge that actually matters is Vec→Scalar:
+// without it, the scalar issuer launches the next TADD/TMOV before the previous
+// vec write to acc_ub has committed → a RAW race on acc_ub.
+//
+// pipe_barrier(PIPE_V) only fences Vec-vs-Vec and never enforces this V↔S edge,
+// so it is insufficient under the fused kernel — the recurrence races and
+// corrupts the last rows of each chunk non-deterministically (surfaced at H=64,
+// whose wider tile lengthens the race window). It happens to be harmless
+// standalone because the scheduler there doesn't reorder across the boundary
+// the same way.
+//
+// The fix is an explicit Vec→Scalar sync: set_flag(PIPE_V, PIPE_S) + wait_flag,
+// here via PtoSetWaitFlag<PIPE_V, PIPE_S>(). This stalls the scalar issuer
+// until the vec pipe drains, serializing the recurrence correctly. EVENT_ID2 is
+// used to avoid colliding with the EVENT_ID0 V↔MTE3 flags already live in this
+// stage.
+//
+// MINIMAL placement (per-site bisection, H=64, 50-run determinism + e2e +
+// partial chunks): the V↔S sync is needed at EXACTLY ONE site — immediately
+// after the per-row TADD(acc,acc,g_i) write inside the main loop (in both the
+// fixed-length and varlen paths). That single sync serializes the whole
+// recurrence; every other site (the row-0 prologue, the per-row TMOV(s_i,acc)
+// read, and the partial-chunk tail zero-fill) is fine as a plain
+// pipe_barrier(PIPE_V). Verified: bit2-only is correct AND deterministic for
+// full and partial chunks; all-PIPE_V or prologue-only-V↔S races. (The
+// post-read TMOV site is an equally-valid single choice; we sync after the
+// write because it orders acc before every consumer.)
+//
+// Two things that do NOT work, for the record:
+//   • pipe_barrier(PIPE_ALL) also fixes it, but only incidentally — it is a
+//   superset
+//     fence that happens to include the V↔S edge. It is heavier and obscures
+//     the real cause, so we use the targeted V↔S sync instead.
+//   • set_flag(PIPE_V, PIPE_MTE3) does NOT help: it targets the wrong pipe pair
+//     (store-DMA, not the scalar issuer), leaving the real edge unenforced and
+//     producing deterministic-but-WRONG output (~20% frob error) that the
+//     run-to-run determinism test cannot detect — always run the cumsum
+//     *correctness* test.
 
 // ── PTO type aliases (device-only, guarded by __CCE_AICORE__) ───────────────
 // UB tile in row-major (ND) layout, used by Vec engine.
 // T=dtype, R×C=static shape, RV×CV=valid region, P=pad value for TLOAD.
 //
-// Think of UbND as: torch.empty((R, C), dtype=T) allocated in on-chip SRAM (UB).
-//   - TileType::Vec  = this tile lives in UB, operated on by the Vec (SIMD) engine
+// Think of UbND as: torch.empty((R, C), dtype=T) allocated in on-chip SRAM
+// (UB).
+//   - TileType::Vec  = this tile lives in UB, operated on by the Vec (SIMD)
+//   engine
 //   - BLayout::RowMajor = row-major storage, like C arrays or numpy default
-//   - RV, CV = "valid" region within the R×C buffer (for handling partial/tail chunks)
-//   - PadValue = what to fill outside the valid region during TLOAD (Zero or Null)
+//   - RV, CV = "valid" region within the R×C buffer (for handling partial/tail
+//   chunks)
+//   - PadValue = what to fill outside the valid region during TLOAD (Zero or
+//   Null)
 //   - 512 = alignment in bytes (hardware requirement for efficient DMA)
 #ifdef __CCE_AICORE__
 template <typename T, int R, int C, int RV = R, int CV = C, pto::PadValue P = pto::PadValue::Null>
 using UbND = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::RowMajor, RV, CV, pto::SLayout::NoneBox, 512, P>;
 #endif
 
-template <int32_t NumHeads, int32_t ChunkSize>
+template <int32_t ChunkSize>
 AICORE void cumsum_kernel(__gm__ float *g_ptr, __gm__ float *g_sum_ptr, __gm__ int32_t *cu_seqlens, int64_t batch_size,
-                          int64_t seq_len)
+                          int64_t seq_len, int32_t NumHeads, uint64_t ffts_addr)
 {
     // get_block_idx(): Returns this AI core's index (0..block_num-1).
     //   Like blockIdx.x in CUDA — identifies which core this code runs on.
-    // get_block_num(): Total number of AI cores launched (like gridDim.x in CUDA).
-    // get_subblockid(): Returns 0 or 1 — selects which Vec sub-block within the core.
+    // get_block_num(): Total number of AI cores launched (like gridDim.x in
+    // CUDA). get_subblockid(): Returns 0 or 1 — selects which Vec sub-block
+    // within the core.
     //   Each AI core has 2 Vec sub-blocks that can run in parallel.
     auto cid = get_block_idx();
     auto block_num = get_block_num();
     auto vid = get_subblockid();
+    // set_ffts_base_addr(ffts_addr): Configure the base address for FFTS
+    // (Fast Fine-grained Task Synchronization) — the cross-core signaling
+    // mechanism. Required before any cross-core sync (ffts_cross_core_sync /
+    // wait_flag_dev).
+    set_ffts_base_addr(ffts_addr);
 
-// #if defined(__DAV_C220_VEC__): This block only compiles for the Vec core pass.
+// #if defined(__DAV_VEC__): This block only compiles for the Vec core pass.
 // The bisheng compiler makes 3 passes over the same source file:
-//   Pass 1: __DAV_C220_VEC__  defined → compiles Vec (SIMD) code
-//   Pass 2: __DAV_C220_CUBE__ defined → compiles Cube (matrix) code
+//   Pass 1: __DAV_VEC__  defined → compiles Vec (SIMD) code
+//   Pass 2: __DAV_CUBE__ defined → compiles Cube (matrix) code
 //   Pass 3: neither defined → compiles host (CPU) launcher code
 // Using these guards lets us put Vec, Cube, and host code in one file.
-#if defined(__DAV_C220_VEC__)
+#if defined(__DAV_VEC__)
     if (vid != 0) return;
 
     // set_mask_norm(): Reset Vec mask to normal mode (all lanes active).
@@ -102,14 +173,14 @@ AICORE void cumsum_kernel(__gm__ float *g_ptr, __gm__ float *g_sum_ptr, __gm__ i
     set_mask_norm();
     set_vector_mask(-1, -1);
 
-    // HeadTileCols: NumHeads rounded up to 8-element alignment (32B for float)
-    // HTC = NumHeads rounded up to nearest multiple of 8.
-    // Why? The Vec engine processes data in 32-byte granularity.
-    // For float (4 bytes), that's 8 elements per SIMD "word".
-    // Rounding up ensures every row is a whole number of SIMD words,
-    // avoiding partial-lane issues. The extra columns are zero-padded.
-    // Example: NumHeads=16 → HTC=16 (already aligned), NumHeads=13 → HTC=16.
-    constexpr int32_t HTC = ((NumHeads + 7) / 8) * 8;
+    // HeadTileCols: worst-case head count rounded up to 8-element alignment (32B
+    // for float). NumHeads is a runtime value, so the UB tiles are sized for the
+    // compile-time ceiling GDN_MAX_HEADS; the actual NumHeads columns are used
+    // and the padding columns (NumHeads..HTC) are zero-filled, so the prefix sum
+    // over them stays zero and only rides the SIMD lanes at no correctness cost.
+    // Why 8-alignment? The Vec engine processes data in 32-byte granularity;
+    // for float (4 bytes) that's 8 elements per SIMD "word".
+    constexpr int32_t HTC = ((GDN_MAX_HEADS + 7) / 8) * 8;
     constexpr int32_t BlockBytes = ChunkSize * HTC * static_cast<int32_t>(sizeof(float));
     constexpr int32_t RowBytes = HTC * static_cast<int32_t>(sizeof(float));
 
@@ -128,20 +199,25 @@ AICORE void cumsum_kernel(__gm__ float *g_ptr, __gm__ float *g_sum_ptr, __gm__ i
     //   GlobalTensor<dtype, Shape, Stride>(base_ptr, shape)
     // Shape<1,1,1,DYNAMIC,DYNAMIC> = 5D shape where first 3 dims are 1 (unused),
     //   last 2 dims are set at runtime (valid rows × NumHeads).
-    // Stride<1,1,1,NumHeads,1> = stride between elements. The 4th stride = NumHeads
+    // Stride<1,1,1,NumHeads,1> = stride between elements. The 4th stride =
+    // NumHeads
     //   means consecutive rows in GM are NumHeads elements apart (BSND layout:
     //   token[t] at offset t*NumHeads, head[h] at offset h within that token).
     // This is equivalent to:
-    //   g_gm = torch.as_strided(g_ptr, size=[valid, NumHeads], stride=[NumHeads, 1])
+    //   g_gm = torch.as_strided(g_ptr, size=[valid, NumHeads], stride=[NumHeads,
+    //   1])
     using GmShape = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
-    using GmStride = Stride<1, 1, 1, NumHeads, 1>;
+    using GmStride = pto::Stride<1, 1, 1, DYNAMIC, 1>;
     using GmFloat = GlobalTensor<float, GmShape, GmStride>;
+    // Runtime row pitch = NumHeads elements (BSND: token t at offset t*NumHeads).
+    GmStride g_stride(NumHeads);
 
     // Pre-assign row accumulator at fixed UB address
-    // TASSIGN(tile, address): Binds a tile descriptor to a fixed byte address in UB.
-    // Think of it as: tile = ub_memory[address:address+sizeof(tile)]
-    // This does NOT allocate or move data — it just tells the hardware where the tile lives.
-    // We manually manage UB memory layout (like a memory pool) via compile-time addresses.
+    // TASSIGN(tile, address): Binds a tile descriptor to a fixed byte address in
+    // UB. Think of it as: tile = ub_memory[address:address+sizeof(tile)] This
+    // does NOT allocate or move data — it just tells the hardware where the tile
+    // lives. We manually manage UB memory layout (like a memory pool) via
+    // compile-time addresses.
     UbND<float, 1, HTC> acc_ub;
     TASSIGN(acc_ub, AccUbAddr);
 
@@ -152,9 +228,9 @@ AICORE void cumsum_kernel(__gm__ float *g_ptr, __gm__ float *g_sum_ptr, __gm__ i
         int64_t chunks_per_seq = (seq_len + ChunkSize - 1) / ChunkSize;
         int64_t total_chunks = num_seqs * chunks_per_seq;
 
-        // Work distribution: Each AI core processes chunks in a round-robin pattern.
-        // Core `cid` handles chunks cid, cid+block_num, cid+2*block_num, ...
-        // This is the NPU equivalent of CUDA's grid-stride loop:
+        // Work distribution: Each AI core processes chunks in a round-robin
+        // pattern. Core `cid` handles chunks cid, cid+block_num, cid+2*block_num,
+        // ... This is the NPU equivalent of CUDA's grid-stride loop:
         //   for (int i = blockIdx.x; i < total; i += gridDim.x)
         for (int64_t gi = static_cast<int64_t>(cid); gi < total_chunks; gi += static_cast<int64_t>(block_num)) {
             int64_t seq_idx = gi / chunks_per_seq;
@@ -172,24 +248,25 @@ AICORE void cumsum_kernel(__gm__ float *g_ptr, __gm__ float *g_sum_ptr, __gm__ i
                 GmShape gs;
                 gs.shape[3] = valid;
                 gs.shape[4] = NumHeads;
-                GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs);
+                GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs, g_stride);
                 UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC, PadValue::Zero> g_load(valid, NumHeads);
                 TASSIGN(g_load, GUbAddr);
                 // TLOAD(ub_tile, gm_tensor): DMA transfer from GM → UB.
-                // Equivalent to: ub_tile[:valid, :NumHeads] = gm_tensor[:valid, :NumHeads]
-                // This is an ASYNC operation on the MTE2 pipe — the CPU/Vec engine can do
-                // other work while DMA is in progress. You must call set_flag/wait_flag
-                // before reading the loaded data.
+                // Equivalent to: ub_tile[:valid, :NumHeads] = gm_tensor[:valid,
+                // :NumHeads] This is an ASYNC operation on the MTE2 pipe — the CPU/Vec
+                // engine can do other work while DMA is in progress. You must call
+                // set_flag/wait_flag before reading the loaded data.
                 TLOAD(g_load, g_gm);
                 if (valid != ChunkSize || NumHeads != HTC) {
                     UbND<float, ChunkSize, HTC, ChunkSize, HTC, PadValue::Zero> g_pad;
                     TASSIGN(g_pad, GUbAddr);
-                    // TFILLPAD_INPLACE(full_tile, partial_tile): Zero-fills the region outside
-                    // the valid area of partial_tile.
-                    // Equivalent to:
+                    // TFILLPAD_INPLACE(full_tile, partial_tile): Zero-fills the region
+                    // outside the valid area of partial_tile. Equivalent to:
                     //   full_tile[valid:ChunkSize, :] = 0  # zero rows beyond valid
-                    //   full_tile[:, NumHeads:HTC] = 0     # zero cols beyond NumHeads (alignment padding)
-                    // This ensures downstream Vec operations see clean zeros in padded regions.
+                    //   full_tile[:, NumHeads:HTC] = 0     # zero cols beyond NumHeads
+                    //   (alignment padding)
+                    // This ensures downstream Vec operations see clean zeros in padded
+                    // regions.
                     TFILLPAD_INPLACE(g_pad, g_load);
                 }
             }
@@ -210,17 +287,12 @@ AICORE void cumsum_kernel(__gm__ float *g_ptr, __gm__ float *g_sum_ptr, __gm__ i
             TASSIGN(g_row_0, GUbAddr);
             // TMOV(dst, src): Element-wise copy, like dst = src.clone() in UB.
             TMOV(acc_ub, g_row_0);
-            // pipe_barrier(PIPE_V): Ensures all pending Vec (SIMD) operations complete
-            // before the next Vec instruction begins. Needed because Vec ops are pipelined
-            // and may not finish in order. Think of it as a local __syncthreads() for the
-            // Vec engine only. Much lighter than set_flag/wait_flag (which sync across
-            // different hardware units).
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
 
             UbND<float, 1, HTC> s_row_0;
             TASSIGN(s_row_0, SUbAddr);
             TMOV(s_row_0, acc_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
 
             // Rows 1..valid-1:  acc[h] += g[i,h];  g_sum[i,h] = acc[h]
             for (int32_t i = 1; i < valid; ++i) {
@@ -228,32 +300,36 @@ AICORE void cumsum_kernel(__gm__ float *g_ptr, __gm__ float *g_sum_ptr, __gm__ i
                 TASSIGN(g_row_i, GUbAddr + i * RowBytes);
                 // TADD(dst, a, b): Element-wise add, like dst = a + b. All in UB.
                 // Operates on all HTC elements in parallel (SIMD).
+                // *** The one load-bearing sync (see chain-sync note above): Vec→Scalar
+                // after this per-row write to acc_ub, ordering it before the scalar
+                // issuer launches the next row. Every other barrier in this chain is
+                // plain PIPE_V.
                 TADD(acc_ub, acc_ub, g_row_i);
-                pipe_barrier(PIPE_V);
+                PtoSetWaitFlag<PIPE_V, PIPE_S>(EVENT_ID2, EVENT_ID2);
 
                 UbND<float, 1, HTC> s_row_i;
                 TASSIGN(s_row_i, SUbAddr + i * RowBytes);
                 TMOV(s_row_i, acc_ub);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
             }
 
             // Zero-fill rows beyond valid (tail padding for downstream kernels)
             // TEXPANDS(tile, scalar): Fill entire tile with a scalar value.
             // Equivalent to: tile[:] = scalar  (like torch.full_like(tile, scalar))
             TEXPANDS(acc_ub, 0.0f);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             for (int32_t i = valid; i < ChunkSize; ++i) {
                 UbND<float, 1, HTC> s_row_i;
                 TASSIGN(s_row_i, SUbAddr + i * RowBytes);
                 TMOV(s_row_i, acc_ub);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
             }
 
             // ── DMA: store g_sum from UB → GM (MTE3 pipe) ────────────────────
             // ── Synchronization: Vec → MTE3 ───────────────────────────────────
-            // Vec signals MTE3 that computation is done and UB data is ready to store.
-            // MTE3 (DMA store engine) waits for this before reading UB for TSTORE.
-            // Without this sync, MTE3 might read stale/partial data from UB.
+            // Vec signals MTE3 that computation is done and UB data is ready to
+            // store. MTE3 (DMA store engine) waits for this before reading UB for
+            // TSTORE. Without this sync, MTE3 might read stale/partial data from UB.
             // Vec → MTE3 sync: ensure Vec writes to UB are visible before DMA
             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -262,20 +338,20 @@ AICORE void cumsum_kernel(__gm__ float *g_ptr, __gm__ float *g_sum_ptr, __gm__ i
                 GmShape ss;
                 ss.shape[3] = valid;
                 ss.shape[4] = NumHeads;
-                GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss);
+                GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss, g_stride);
                 UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC> s_store(valid, NumHeads);
                 TASSIGN(s_store, SUbAddr);
                 // TSTORE(gm_tensor, ub_tile): DMA transfer from UB → GM.
-                // Equivalent to: gm_tensor[:valid, :NumHeads] = ub_tile[:valid, :NumHeads]
-                // Async on MTE3 pipe. Must sync (Vec→MTE3) before calling, and sync
-                // (MTE3→Vec) after if reusing the same UB region.
+                // Equivalent to: gm_tensor[:valid, :NumHeads] = ub_tile[:valid,
+                // :NumHeads] Async on MTE3 pipe. Must sync (Vec→MTE3) before calling,
+                // and sync (MTE3→Vec) after if reusing the same UB region.
                 TSTORE(gs_gm, s_store);
             }
             // ── Synchronization: MTE3 → Vec ───────────────────────────────────
             // MTE3 signals Vec that the DMA store is complete and UB can be reused.
-            // Vec waits before starting the next iteration's TLOAD into the same UB region.
-            // Without this, the next TLOAD could overwrite data still being stored.
-            // MTE3 → Vec sync: wait for DMA store before reusing UB next iter
+            // Vec waits before starting the next iteration's TLOAD into the same UB
+            // region. Without this, the next TLOAD could overwrite data still being
+            // stored. MTE3 → Vec sync: wait for DMA store before reusing UB next iter
             set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
             wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
         }
@@ -300,7 +376,7 @@ AICORE void cumsum_kernel(__gm__ float *g_ptr, __gm__ float *g_sum_ptr, __gm__ i
                         GmShape gs;
                         gs.shape[3] = valid;
                         gs.shape[4] = NumHeads;
-                        GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs);
+                        GmFloat g_gm(g_ptr + chunk_start * NumHeads, gs, g_stride);
                         UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC, PadValue::Zero> g_load(valid, NumHeads);
                         TASSIGN(g_load, GUbAddr);
                         TLOAD(g_load, g_gm);
@@ -317,34 +393,37 @@ AICORE void cumsum_kernel(__gm__ float *g_ptr, __gm__ float *g_sum_ptr, __gm__ i
                     UbND<float, 1, HTC> g_row_0;
                     TASSIGN(g_row_0, GUbAddr);
                     TMOV(acc_ub, g_row_0);
-                    pipe_barrier(PIPE_V);
+                    PipeBarrierVec();
 
                     UbND<float, 1, HTC> s_row_0;
                     TASSIGN(s_row_0, SUbAddr);
                     TMOV(s_row_0, acc_ub);
-                    pipe_barrier(PIPE_V);
+                    PipeBarrierVec();
 
                     // acc += g[i]; g_sum[i] = acc
                     for (int32_t i = 1; i < valid; ++i) {
                         UbND<float, 1, HTC> g_row_i;
                         TASSIGN(g_row_i, GUbAddr + i * RowBytes);
+                        // The one load-bearing sync (see chain-sync note above): Vec→Scalar
+                        // after this per-row write to acc_ub. All other barriers here are
+                        // PIPE_V.
                         TADD(acc_ub, acc_ub, g_row_i);
-                        pipe_barrier(PIPE_V);
+                        PtoSetWaitFlag<PIPE_V, PIPE_S>(EVENT_ID2, EVENT_ID2);
 
                         UbND<float, 1, HTC> s_row_i;
                         TASSIGN(s_row_i, SUbAddr + i * RowBytes);
                         TMOV(s_row_i, acc_ub);
-                        pipe_barrier(PIPE_V);
+                        PipeBarrierVec();
                     }
 
                     // Zero-fill padding rows
                     TEXPANDS(acc_ub, 0.0f);
-                    pipe_barrier(PIPE_V);
+                    PipeBarrierVec();
                     for (int32_t i = valid; i < ChunkSize; ++i) {
                         UbND<float, 1, HTC> s_row_i;
                         TASSIGN(s_row_i, SUbAddr + i * RowBytes);
                         TMOV(s_row_i, acc_ub);
-                        pipe_barrier(PIPE_V);
+                        PipeBarrierVec();
                     }
 
                     // Store g_sum to GM
@@ -355,7 +434,7 @@ AICORE void cumsum_kernel(__gm__ float *g_ptr, __gm__ float *g_sum_ptr, __gm__ i
                         GmShape ss;
                         ss.shape[3] = valid;
                         ss.shape[4] = NumHeads;
-                        GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss);
+                        GmFloat gs_gm(g_sum_ptr + chunk_start * NumHeads, ss, g_stride);
                         UbND<float, ChunkSize, HTC, DYNAMIC, DYNAMIC> s_store(valid, NumHeads);
                         TASSIGN(s_store, SUbAddr);
                         TSTORE(gs_gm, s_store);

--- a/csrc/mega_chunk_gdn/op_kernel/chunk_cumsum.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/chunk_cumsum.cpp
@@ -140,7 +140,7 @@ using UbND = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::RowMajor, RV, 
 
 template <int32_t ChunkSize>
 AICORE void cumsum_kernel(__gm__ float *g_ptr, __gm__ float *g_sum_ptr, __gm__ int32_t *cu_seqlens, int64_t batch_size,
-                          int64_t seq_len, int32_t NumHeads, uint64_t ffts_addr)
+                          int64_t seq_len, int32_t NumHeads)
 {
     // get_block_idx(): Returns this AI core's index (0..block_num-1).
     //   Like blockIdx.x in CUDA — identifies which core this code runs on.
@@ -151,11 +151,6 @@ AICORE void cumsum_kernel(__gm__ float *g_ptr, __gm__ float *g_sum_ptr, __gm__ i
     auto cid = get_block_idx();
     auto block_num = get_block_num();
     auto vid = get_subblockid();
-    // set_ffts_base_addr(ffts_addr): Configure the base address for FFTS
-    // (Fast Fine-grained Task Synchronization) — the cross-core signaling
-    // mechanism. Required before any cross-core sync (ffts_cross_core_sync /
-    // wait_flag_dev).
-    set_ffts_base_addr(ffts_addr);
 
 // #if defined(__DAV_VEC__): This block only compiles for the Vec core pass.
 // The bisheng compiler makes 3 passes over the same source file:

--- a/csrc/mega_chunk_gdn/op_kernel/chunk_h.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/chunk_h.cpp
@@ -52,25 +52,22 @@
 // Key PTO APIs (numpy/torch equivalents):
 //   TLOAD(dst, gm)          — dst = gm_data        (DMA: GM→L1 or GM→UB)
 //   TSTORE(gm, src)         — gm_data = src        (DMA: UB/L0C→GM)
-//   TASSIGN(tile, addr)     — tile = memory[addr]   (bind tile to buffer address)
-//   TCVT(dst, src, mode)    — dst = src.float()/.half()
-//   TMOV(dst, src)          — dst = src.clone()
-//   TADD(d, a, b)           — d = a + b
-//   TSUB(d, a, b)           — d = a - b
-//   TMUL(d, a, b)           — d = a * b
-//   TMULS(d, s, scalar)     — d = s * scalar       (scalar multiply)
-//   TADDS(d, s, scalar)     — d = s + scalar       (scalar add)
-//   TEXP(d, s)              — d = torch.exp(s)
-//   TEXPANDS(tile, scalar)  — tile[:] = scalar     (fill with constant)
-//   TROWEXPAND(2d, col)     — 2d[i,j] = col[i]    (broadcast col across row dim)
-//   TFILLPAD(dst, src)      — zero-fill L1 tile padding (for tail chunks)
-//   TEXTRACT(l0, l1, r, c)  — L1 sub-tile → L0A/L0B
-//   TRESHAPE(zn, nz)        — reinterpret layout NZ↔ZN (logical transpose, free)
-//   TMATMUL(C, A, B)        — C = A @ B (Cube GEMM, fp16 inputs → fp32 accum)
-//   set_flag/wait_flag      — pipe sync within same core
-//   ffts_cross_core_sync    — cross-core signal Cube↔Vec
+//   TASSIGN(tile, addr)     — tile = memory[addr]   (bind tile to buffer
+//   address) TCVT(dst, src, mode)    — dst = src.float()/.half() TMOV(dst, src)
+//   — dst = src.clone() TADD(d, a, b)           — d = a + b TSUB(d, a, b) — d =
+//   a - b TMUL(d, a, b)           — d = a * b TMULS(d, s, scalar)     — d = s *
+//   scalar       (scalar multiply) TADDS(d, s, scalar)     — d = s + scalar
+//   (scalar add) TEXP(d, s)              — d = torch.exp(s) TEXPANDS(tile,
+//   scalar)  — tile[:] = scalar     (fill with constant) TROWEXPAND(2d, col) —
+//   2d[i,j] = col[i]    (broadcast col across row dim) TFILLPAD(dst, src) —
+//   zero-fill L1 tile padding (for tail chunks) TEXTRACT(l0, l1, r, c)  — L1
+//   sub-tile → L0A/L0B TRESHAPE(zn, nz)        — reinterpret layout NZ↔ZN
+//   (logical transpose, free) TMATMUL(C, A, B)        — C = A @ B (Cube GEMM,
+//   fp16 inputs → fp32 accum) set_flag/wait_flag      — pipe sync within same
+//   core ffts_cross_core_sync    — cross-core signal Cube↔Vec
 //   wait_flag_dev(flag)     — wait for cross-core signal
-//   GetValue(idx)           — read a single scalar from a UB tile (slow, use sparingly)
+//   GetValue(idx)           — read a single scalar from a UB tile (slow, use
+//   sparingly)
 //
 // ── Workspace memory layout (shared between Cube and Vec via GM) ──────
 // Each AI core has its own workspace region to avoid contention:
@@ -81,17 +78,31 @@
 //
 // Data flow per chunk (think of it as a ping-pong between Cube and Vec):
 //   Vec: write S₀ to WS_S → signal Cube (flag 3)
-//   Cube: read S from WS_S, load W → compute WS = W@S → write WS_WS → signal Vec (flag 0)
-//   Vec: read WS, compute V_new = U - WS, compute K_scaled → write WS_K → signal Cube (flag 1)
-//   Cube: read K from WS_K, load V → compute KV = K^T@V → write WS_KV → signal Vec (flag 2)
-//   Vec: read KV, update S = exp(g_last)*S + KV → write S to WS_S → signal Cube (flag 3)
+//   Cube: read S from WS_S, load W → compute WS = W@S → write WS_WS → signal
+//   Vec (flag 0) Vec: read WS, compute V_new = U - WS, compute K_scaled → write
+//   WS_K → signal Cube (flag 1) Cube: read K from WS_K, load V → compute KV =
+//   K^T@V → write WS_KV → signal Vec (flag 2) Vec: read KV, update S =
+//   exp(g_last)*S + KV → write S to WS_S → signal Cube (flag 3)
 //   ... repeat for next chunk ...
 // ============================================================================
 
+#include <runtime/rt_ffts.h>
+
 #include <pto/pto-inst.hpp>
 #include <type_traits>
+
 #include "acl/acl.h"
+#include "mega_kernel_utils.h"
 using namespace pto;
+using namespace mega_kernel_utils;
+
+#ifndef GDN_D
+#define GDN_D 128
+#endif
+
+#ifndef GDN_C
+#define GDN_C 128
+#endif
 
 #ifdef __CCE_AICORE__
 
@@ -123,11 +134,11 @@ using TileMatL1ZN = pto::Tile<pto::TileType::Mat, T, Rows, Cols, pto::BLayout::R
                               pto::SLayout::ColMajor, 512, pto::PadValue::Zero>;
 
 template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows, int32_t ColValid = Cols>
-using TileMatL0A = pto::Tile<pto::TileType::Left, T, Rows, Cols, pto::BLayout::RowMajor, RowValid, ColValid,
+using TileMatL0A = pto::Tile<pto::TileType::Left, T, Rows, Cols, GetOuterLayout(/*is_left=*/true), RowValid, ColValid,
                              pto::SLayout::RowMajor, 512, pto::PadValue::Zero>;
 
 template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows, int32_t ColValid = Cols>
-using TileMatL0B = pto::Tile<pto::TileType::Right, T, Rows, Cols, pto::BLayout::RowMajor, RowValid, ColValid,
+using TileMatL0B = pto::Tile<pto::TileType::Right, T, Rows, Cols, GetOuterLayout(/*is_left=*/false), RowValid, ColValid,
                              pto::SLayout::ColMajor, 512, pto::PadValue::Zero>;
 
 template <typename T, int32_t Rows, int32_t Cols, int32_t RowValid = Rows, int32_t ColValid = Cols,
@@ -262,11 +273,12 @@ gemm_v0(std::conditional_t<transpose_A, TileMatL1<T1, K, M, validK, validM>, Til
 
 #endif
 
-template <int32_t NumHeads, int32_t HiddenSize, int32_t ChunkSize>
+template <int32_t HiddenSize, int32_t ChunkSize>
 AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ half *U_handle, __gm__ float *G_handle,
                            __gm__ half *S_handle, __gm__ half *V_handle, __gm__ half *FS_handle, __gm__ half *H0_handle,
-                           int64_t has_initial_state, __gm__ half *workspace_handle, __gm__ int32_t *cu_seqlens,
-                           int64_t batch_size, int64_t seq_len, int64_t total_tokens, uint32_t num_key_heads)
+                           int64_t has_initial_state, int64_t output_final_state, __gm__ half *workspace_handle,
+                           __gm__ int32_t *cu_seqlens, int64_t batch_size, int64_t seq_len, int64_t total_tokens,
+                           uint32_t num_heads, uint32_t num_key_heads, uint64_t ffts_addr)
 {
     // chunk_h advances the recurrent hidden state chunk by chunk:
     //   ws_i      = W_i @ S_i
@@ -291,15 +303,16 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
     //   Vec does the elementwise gating/decay and carries the running state.
     auto cid = get_block_idx();
     auto block_num = get_block_num();
+    set_ffts_base_addr(ffts_addr);
 
     constexpr int32_t D = HiddenSize;
     constexpr int32_t C = ChunkSize;
-    constexpr int32_t H = NumHeads;
+    const int32_t H = static_cast<int32_t>(num_heads);
     const int32_t Hg = static_cast<int32_t>(num_key_heads);
-    if (Hg <= 0 || (H % Hg) != 0) return;
+    if (H <= 0 || Hg <= 0 || (H % Hg) != 0) return;
     const int32_t GROUP = H / Hg;
     constexpr int32_t HalfC = C / 2;
-    constexpr int32_t BSND_QKV_STRIDE = H * D;
+    const int32_t BSND_QKV_STRIDE = H * D;
     const int32_t BSND_K_STRIDE = Hg * D;
     constexpr int32_t DD = D * D;
 
@@ -323,8 +336,9 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
     TASSIGN(kv_l0, C * D * sizeof(float));
 
     constexpr int32_t G_BLOCK_UB = 0;
-    // Leading UB scratch: legacy kernels used ``C * NumHeads * sizeof(float)``, which overflows UB when
-    // ``NumHeads`` is 32/48/64. Keep the same slack as the historical ``GDN_H=16`` build (8192 bytes).
+    // Leading UB scratch: legacy kernels used ``C * H * sizeof(float)``, which
+    // overflows UB when Keep the same slack as the historical H=16 build (8192
+    // bytes).
     constexpr int32_t ZERO_UB = ChunkSize * 16 * static_cast<int32_t>(sizeof(float));
     constexpr int32_t S_UB = ZERO_UB + 64 * sizeof(float);
     constexpr int32_t K_UB_HALF = S_UB + HalfC * D * sizeof(float);
@@ -368,7 +382,7 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
     int64_t num_seqs = batch_size;
     int64_t total_work = num_seqs * H;
 
-#if defined(__DAV_C220_CUBE__)
+#if defined(__DAV_CUBE__)
     for (int64_t wi = 0; wi < (total_work + block_num - 1) / block_num; ++wi) {
         int64_t pid = wi * block_num + cid;
         if (pid >= total_work) break;
@@ -401,7 +415,16 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
         //   WS_KV : k_tilde^T @ v_i_new
 
         for (int32_t ci = 0; ci < num_chunks; ++ci) {
+            // Wait Vec: S workspace ready (flag 3).
+            // A2: Cube and Vec are separate cores → FFTS cross-core flag.
+            // A5: Cube and both Vec sub-blocks share ONE core → intra-block flags,
+            //     with each Vec sub-block signalling its own flag (base, base+16).
+#if __CCE_AICORE__ == 220
             wait_flag_dev(3);
+#else
+            WaitBothVecOnA5<PIPE_MTE2>(3);
+            pipe_barrier(PIPE_ALL);
+#endif
 
             int64_t chunk_start = bos + static_cast<int64_t>(ci) * C;
             int64_t valid = slen - static_cast<int64_t>(ci) * C;
@@ -444,9 +467,22 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
                 // Save ws_i so the Vec phase can do `v_new = U_i - ws_i`.
                 TSTORE(ws_global, ws_store);
             }
-            ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (0 << 8));
+            // Signal Vec: WS workspace ready (flag 0)
+            // ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (0 << 8));
+#if __CCE_AICORE__ == 220
+            SetCrossFlag<PIPE_FIX>(0);
+#else
+            pipe_barrier(PIPE_ALL);
+            SignalBothVecOnA5<PIPE_FIX>(0);
+#endif
 
+            // Wait Vec: k_tilde workspace ready (flag 1)
+#if __CCE_AICORE__ == 220
             wait_flag_dev(1);
+#else
+            WaitBothVecOnA5<PIPE_MTE2>(1);
+            pipe_barrier(PIPE_ALL);
+#endif
 
             {
                 GmShape2D k_shape(D, C);
@@ -472,7 +508,8 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
 
             set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
             wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
-            // This chunk contributes the additive update K_i^T V_i to the state recurrence.
+            // This chunk contributes the additive update K_i^T V_i to the state
+            // recurrence.
             gemm_v0<half, float, D, D, C, D, D, C, C, true, false>(k_l1, v_l1, kv_l0, (bool)1);
 
             {
@@ -484,11 +521,18 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
                 // Save kv = k_tilde^T @ v_i_new so Vec can finish the state update.
                 TSTORE(kv_global, kv_store);
             }
-            ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (2 << 8));
+            // Signal Vec: KV workspace ready (flag 2)
+            // ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (2 << 8));
+#if __CCE_AICORE__ == 220
+            SetCrossFlag<PIPE_FIX>(2);
+#else
+            pipe_barrier(PIPE_ALL);
+            SignalBothVecOnA5<PIPE_FIX>(2);
+#endif
         }
     }
 #endif
-#if defined(__DAV_C220_VEC__)
+#if defined(__DAV_VEC__)
     set_mask_norm();
     set_vector_mask(-1, -1);
 
@@ -544,7 +588,8 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         {
-            // `workspace_handle` is a `half*`, so all offsets here are in half elements.
+            // `workspace_handle` is a `half*`, so all offsets here are in half
+            // elements.
             GmShape2D s_shape(HalfC, D);
             GmStride2D s_stride(D);
             GmTensor2D<half> s_global(workspace_handle + ws_base + WS_S + vid * HalfC * D, s_shape, s_stride);
@@ -561,7 +606,14 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
             TASSIGN(s_out_store, S_UB_HALF);
             TSTORE(s_out_global, s_out_store);
         }
-        ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+        // Signal Cube: S workspace ready (flag 3)
+        // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+#if __CCE_AICORE__ == 220
+        SetCrossFlag<PIPE_MTE3>(3);
+#else
+        pipe_barrier(PIPE_ALL);
+        set_intra_block(PIPE_MTE3, 3);
+#endif
 
         int64_t chunk_start_0 = bos;
         int64_t valid0 = slen;
@@ -647,13 +699,13 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
             set_flag(PIPE_V, PIPE_S, EVENT_ID0);
             wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
             float g_last = g_ub.GetValue(static_cast<int32_t>(valid) - 1);
-            // Rebase the chunk gate around g_last so the intra-chunk decay stays numerically local.
-            // Torch-like:
+            // Rebase the chunk gate around g_last so the intra-chunk decay stays
+            // numerically local. Torch-like:
             //   coeff = exp(g_last - g_rows_owned_by_this_subblock)
             TADDS(coeff_ub, g_v_ub, -g_last);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TSUB(coeff_ub, zero_ub, coeff_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TEXP(coeff_ub, coeff_ub);
 
             TEXP(g_ub, g_ub);
@@ -669,12 +721,18 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
             // Broadcast one decay scalar per token row across the D feature columns:
             //   coeff_2d[row, :] = coeff[row]
             TROWEXPAND(coeff_2d_ub, coeff_col_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             // `k_ub` now holds k_tilde = exp(g_last - g_i) * K_i.
             TMUL(k_ub, k_ub, coeff_2d_ub);
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
 
+            // Wait Cube: WS workspace ready (flag 0)
+#if __CCE_AICORE__ == 220
             wait_flag_dev(0);
+#else
+            wait_intra_block(PIPE_MTE3, 0);
+            pipe_barrier(PIPE_ALL);
+#endif
             {
                 GmShape2D ws_shape(HalfC, D);
                 GmStride2D ws_stride(D);
@@ -718,12 +776,20 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
                 TSTORE(k_global, k_store);
             }
 
-            ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+            // Signal Cube: k_tilde workspace ready (flag 1)
+            // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+#if __CCE_AICORE__ == 220
+            SetCrossFlag<PIPE_MTE3>(1);
+#else
+            pipe_barrier(PIPE_ALL);
+            set_intra_block(PIPE_MTE3, 1);
+#endif
 
             set_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
             wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
             float exp_g_last = g_ub.GetValue(static_cast<int32_t>(valid) - 1);
-            // Carry the recurrence across chunks: S_{i+1} = exp(g_last) * S_i + K_i^T V_i.
+            // Carry the recurrence across chunks: S_{i+1} = exp(g_last) * S_i + K_i^T
+            // V_i.
             TMULS(s_ub, s_ub, exp_g_last);
 
             set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
@@ -768,7 +834,13 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
                 }
             }
 
+            // Wait Cube: KV workspace ready (flag 2)
+#if __CCE_AICORE__ == 220
             wait_flag_dev(2);
+#else
+            wait_intra_block(PIPE_MTE3, 2);
+            pipe_barrier(PIPE_ALL);
+#endif
             {
                 GmShape2D kv_shape(HalfC, D);
                 GmStride2D kv_stride(D);
@@ -800,8 +872,8 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
                     TSTORE(s_global, s_store);
                 }
 
-                // Expose the post-chunk state so the next chunk (and debug/verification
-                // outputs) can see S_{i+1}. Conceptually:
+                // Expose the post-chunk state so the next chunk and output snapshot
+                // can see S_{i+1}. Conceptually:
                 //   S_handle[chunk_idx + 1, head] = S_{i+1}
                 int64_t s_out_offset = ((chunk_offset + ci + 1) * H + head) * DD;
                 {
@@ -812,7 +884,14 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
                     TASSIGN(s_out_store, S_UB_HALF);
                     TSTORE(s_out_global, s_out_store);
                 }
-                ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+                // Signal Cube: S workspace ready (flag 3)
+                // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+#if __CCE_AICORE__ == 220
+                SetCrossFlag<PIPE_MTE3>(3);
+#else
+                pipe_barrier(PIPE_ALL);
+                set_intra_block(PIPE_MTE3, 3);
+#endif
             }
 
             if (ci + 1 < static_cast<int32_t>(num_chunks)) {
@@ -821,19 +900,21 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
             }
         }
 
-        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        int64_t fs_offset = (seq_idx * H + head) * DD;
-        {
-            GmShape2D fs_shape(HalfC, D);
-            GmStride2D fs_stride(D);
-            GmTensor2D<half> fs_global(FS_handle + fs_offset + vid * HalfC * D, fs_shape, fs_stride);
-            DynVecTile<half, HalfC, D> fs_store(HalfC, D);
-            TASSIGN(fs_store, S_UB_HALF);
-            TSTORE(fs_global, fs_store);
+        if (output_final_state != 0) {
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            int64_t fs_offset = (seq_idx * H + head) * DD;
+            {
+                GmShape2D fs_shape(HalfC, D);
+                GmStride2D fs_stride(D);
+                GmTensor2D<half> fs_global(FS_handle + fs_offset + vid * HalfC * D, fs_shape, fs_stride);
+                DynVecTile<half, HalfC, D> fs_store(HalfC, D);
+                TASSIGN(fs_store, S_UB_HALF);
+                TSTORE(fs_global, fs_store);
+            }
+            set_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+            wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
         }
-        set_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
-        wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
     }
 #endif
 }

--- a/csrc/mega_chunk_gdn/op_kernel/chunk_h.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/chunk_h.cpp
@@ -278,7 +278,7 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
                            __gm__ half *S_handle, __gm__ half *V_handle, __gm__ half *FS_handle, __gm__ half *H0_handle,
                            int64_t has_initial_state, int64_t output_final_state, __gm__ half *workspace_handle,
                            __gm__ int32_t *cu_seqlens, int64_t batch_size, int64_t seq_len, int64_t total_tokens,
-                           uint32_t num_heads, uint32_t num_key_heads, uint64_t ffts_addr)
+                           uint32_t num_heads, uint32_t num_key_heads)
 {
     // chunk_h advances the recurrent hidden state chunk by chunk:
     //   ws_i      = W_i @ S_i
@@ -303,7 +303,6 @@ AICORE void chunk_h_kernel(__gm__ half *K_handle, __gm__ half *W_handle, __gm__ 
     //   Vec does the elementwise gating/decay and carries the running state.
     auto cid = get_block_idx();
     auto block_num = get_block_num();
-    set_ffts_base_addr(ffts_addr);
 
     constexpr int32_t D = HiddenSize;
     constexpr int32_t C = ChunkSize;

--- a/csrc/mega_chunk_gdn/op_kernel/chunk_o.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/chunk_o.cpp
@@ -51,9 +51,10 @@
 // numpy pseudocode for the entire chunk computation:
 //   QK = Q @ K.T                                          # GEMM 1
 //   QS = Q @ S                                            # GEMM 2
-//   coeff = exp(min(g_row - g_col, 0)) * mask             # gating (dynamic PTO)
-//   (``static_baseline/run_chunk_o_static.py`` uses exp(g_row-g_col) without min.)
-//   QK_gated = QK * coeff                                 # apply gating
+//   coeff = exp(min(g_row - g_col, 0)) * mask             # gating (dynamic
+//   PTO)
+//   (``static_baseline/run_chunk_o_static.py`` uses exp(g_row-g_col) without
+//   min.) QK_gated = QK * coeff                                 # apply gating
 //   QKV = QK_gated @ V                                    # GEMM 3
 //   O = QKV + QS * np.exp(g_row).reshape(-1, 1)           # final output
 //
@@ -78,10 +79,17 @@
 //   wait_flag_dev(flag)     — wait for cross-core signal
 // ============================================================================
 
-#include <pto/pto-inst.hpp>
-#include "acl/acl.h"
-using namespace pto;
+#include <runtime/rt_ffts.h>
 
+#include <pto/pto-inst.hpp>
+
+#include "acl/acl.h"
+#include "mega_kernel_utils.h"
+using namespace pto;
+using namespace mega_kernel_utils;
+
+// ── Compile-time configuration (overridable at build time via -D flags) ──
+// D/C stay compile-time because tile shapes depend on them. H/Hg are runtime.
 #ifndef GDN_D
 #define GDN_D 128
 #endif
@@ -118,7 +126,8 @@ using L1Mat = pto::Tile<pto::TileType::Mat, T, R, C, pto::BLayout::ColMajor, RV,
                         pto::PadValue::Zero>;
 
 // L1MatZN = ZN fractal format — used for transposed GEMM operands.
-//   TRESHAPE(l1_zn, l1_nz) converts NZ→ZN = logical matrix transpose (free, no data movement).
+//   TRESHAPE(l1_zn, l1_nz) converts NZ→ZN = logical matrix transpose (free, no
+//   data movement).
 template <typename T, int R, int C, int RV = R, int CV = C>
 using L1MatZN = pto::Tile<pto::TileType::Mat, T, R, C, pto::BLayout::RowMajor, RV, CV, pto::SLayout::ColMajor, 512,
                           pto::PadValue::Zero>;
@@ -131,26 +140,30 @@ using GmTensor2D = pto::GlobalTensor<T, GmShape2D, GmStride2D>;
 
 #endif  // __CCE_AICORE__
 
-template <int32_t NumHeads, int32_t HiddenSize, int32_t ChunkSize>
-static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_handle, __gm__ half *V_handle,
-                                         __gm__ half *S_handle, __gm__ float *G_handle, __gm__ float *Msk_handle,
-                                         __gm__ half *workspace_qk_handle, __gm__ half *workspace_qs_qkv_handle,
-                                         __gm__ half *workspace_qk_gated_handle, __gm__ half *O_handle,
-                                         __gm__ int32_t *cu_seqlens, int64_t batch_size, int64_t seq_len,
-                                         int64_t total_tokens, uint32_t num_key_heads)
+template <int32_t HiddenSize, int32_t ChunkSize>
+AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_handle, __gm__ half *V_handle, __gm__ half *S_handle,
+                           __gm__ float *G_handle, __gm__ float *Msk_handle, __gm__ half *workspace_qk_handle,
+                           __gm__ half *workspace_qs_qkv_handle, __gm__ half *workspace_qk_gated_handle,
+                           __gm__ half *O_handle, __gm__ int32_t *cu_seqlens, int64_t batch_size, int64_t seq_len,
+                           int64_t total_tokens, uint32_t num_heads, uint32_t num_key_heads, uint64_t ffts_addr)
 {
+    // To avoid ambiguity with bisheng intrinsic header's global `enum class
+    // Stride`
+    using pto::Stride;
+
     // Half the chunk — each Vec sub-block handles C/2 rows independently.
     constexpr int32_t HalfChunk = ChunkSize / 2;
     // KTail / CTail: the number of valid elements in the last 128-element tile
-    // when D or C isn't a multiple of 128. Used internally by PTO for partial tiles.
+    // when D or C isn't a multiple of 128. Used internally by PTO for partial
+    // tiles.
     constexpr uint32_t KTail = (HiddenSize % 128 == 0) ? 128 : (HiddenSize % 128);
     constexpr uint32_t CTail = (ChunkSize % 128 == 0) ? 128 : (ChunkSize % 128);
 
-    constexpr int32_t H = NumHeads;
+    const int32_t H = static_cast<int32_t>(num_heads);
     const int32_t Hg = static_cast<int32_t>(num_key_heads);
-    if (Hg <= 0 || (H % Hg) != 0) return;
+    if (H <= 0 || Hg <= 0 || (H % Hg) != 0) return;
     const int32_t GROUP = H / Hg;
-    constexpr int32_t BSND_V_STRIDE = H * HiddenSize;
+    const int32_t BSND_V_STRIDE = H * HiddenSize;
     const int32_t BSND_QK_STRIDE = Hg * HiddenSize;
 
     // Workspace sizes (in elements) shared between Cube and Vec via GM
@@ -170,6 +183,8 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
     constexpr int32_t OHalfUbAddr = 164608;
     constexpr int32_t OUbAddr = QKUbAddr;
 
+    // Initialize the cross-core FFTS signaling base address for this AI core.
+    set_ffts_base_addr(ffts_addr);
     // cid = which AI core am I? (0..block_num-1). Used to partition work items.
     auto cid = get_block_idx();
     // block_num = total number of AI cores running this kernel in parallel.
@@ -187,10 +202,10 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
     // ── L1 tile layout for Cube GEMMs ────────────────────────────────────
     // L1 cache (~1MB) is manually partitioned for the 3 GEMMs:
     //   q_l1   at 0:      Q [C×D]       — shared by GEMM 1 and GEMM 2
-    //   k_l1   at 32768:  K [C×D]       — used in GEMM 1 (transposed via TRESHAPE)
-    //   s_l1   at 65536:  S [D×D]       — accumulated state, used in GEMM 2
-    //   qk_gated at 98304: QK_gated [C×C] — from Vec, used in GEMM 3
-    //   v_l1   at 131072: V [C×D]       — values, used in GEMM 3
+    //   k_l1   at 32768:  K [C×D]       — used in GEMM 1 (transposed via
+    //   TRESHAPE) s_l1   at 65536:  S [D×D]       — accumulated state, used in
+    //   GEMM 2 qk_gated at 98304: QK_gated [C×C] — from Vec, used in GEMM 3 v_l1
+    //   at 131072: V [C×D]       — values, used in GEMM 3
     L1Mat<half, ChunkSize, HiddenSize> q_l1;
     TASSIGN(q_l1, 0);
     L1Mat<half, ChunkSize, HiddenSize> k_l1;
@@ -217,15 +232,16 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
     // matrices. The UB layout (byte addresses) is designed so all needed tiles
     // fit simultaneously in the ~256KB UB without overlapping:
     //   g_ub:       gate values [1, C] float            @ 0
-    //   msk_ub:     causal mask [C/2, C] float          @ 512     (loaded once, reused)
-    //   qk_ub:      QK scores in float [C/2, C]         @ 33280   (after cast from half)
-    //   g_v_ub:     this sub-block's gate slice [1, C/2] @ 66048
+    //   msk_ub:     causal mask [C/2, C] float          @ 512     (loaded once,
+    //   reused) qk_ub:      QK scores in float [C/2, C]         @ 33280   (after
+    //   cast from half) g_v_ub:     this sub-block's gate slice [1, C/2] @ 66048
     //   coeff_ub:   gating coefficients [C/2, C] float  @ 66304
     //   qk_ub_half: QK in half [C/2, C]                @ 99072
     //   qs_ub_half: QS in half [C/2, D]                @ 115456
     //   qs_ub:      QS in float [C/2, D]               @ 131840
     //   o_ub_half:  output O in half [C/2, D]           @ 164608
-    //   o_ub:       output O in float [C/2, D]          @ QKUbAddr (reuses qk_ub space)
+    //   o_ub:       output O in float [C/2, D]          @ QKUbAddr (reuses qk_ub
+    //   space)
     UbND<float, 1, ChunkSize> g_ub;
     TASSIGN(g_ub, GUbAddr);
     UbND<float, HalfChunk, ChunkSize> msk_ub;
@@ -252,7 +268,7 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
     int64_t total_work = 0;
     if (cu_seqlens == nullptr) {
         int64_t chunks_per_seq = (seq_len + ChunkSize - 1) / ChunkSize;
-        total_work = num_seqs * chunks_per_seq * NumHeads;
+        total_work = num_seqs * chunks_per_seq * H;
     }
 
 // =====================================================================
@@ -261,7 +277,7 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
 // performs the heavy matmuls, then writes results to GM workspace for
 // the Vec engine to apply gating and produce the final output.
 // =====================================================================
-#if defined(__DAV_C220_CUBE__)
+#if defined(__DAV_CUBE__)
     if (cu_seqlens == nullptr) {
         // ── Fixed-length sequence path ──────────────────────────────────────
         int64_t chunks_per_seq = (seq_len + ChunkSize - 1) / ChunkSize;
@@ -270,14 +286,24 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
 
         for (int64_t work_idx = static_cast<int64_t>(cid); work_idx < total_work;
              work_idx += static_cast<int64_t>(block_num)) {
-            // Wait for Vec to finish with previous chunk's workspace (flag 3)
-            if (!first_cube_iter) wait_flag_dev(3);
+            // Wait for Vec to finish with previous chunk's workspace (flag 3).
+            // A2: Cube and Vec are separate cores → FFTS cross-core flag.
+            // A5: Cube and both Vec sub-blocks share ONE core → intra-block flags,
+            //     with each Vec sub-block signalling its own flag (base, base+16).
+            if (!first_cube_iter) {
+#if __CCE_AICORE__ == 220
+                wait_flag_dev(3);
+#else
+                WaitBothVecOnA5<PIPE_MTE2>(3);
+                pipe_barrier(PIPE_ALL);
+#endif
+            }
             set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
             wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
 
-            int32_t head_idx = static_cast<int32_t>(work_idx % NumHeads);
+            int32_t head_idx = static_cast<int32_t>(work_idx % H);
             int32_t head_g = head_idx / GROUP;
-            int64_t chunk_head_idx = work_idx / NumHeads;
+            int64_t chunk_head_idx = work_idx / H;
             int64_t seq_idx = chunk_head_idx / chunks_per_seq;
             int64_t ci = chunk_head_idx % chunks_per_seq;
 
@@ -298,8 +324,8 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
                             static_cast<int64_t>(HiddenSize);
 
             int64_t chunk_global_idx = seq_idx * chunks_per_seq + ci;
-            int64_t s_offset = (chunk_global_idx * NumHeads + head_idx) * static_cast<int64_t>(HiddenSize) *
-                               static_cast<int64_t>(HiddenSize);
+            int64_t s_offset =
+                (chunk_global_idx * H + head_idx) * static_cast<int64_t>(HiddenSize) * static_cast<int64_t>(HiddenSize);
 
             // ── Load Q [valid_rows × D] from GM → L1 ────────────────────────
             // GlobalTensor describes the GM layout with BSND strides.
@@ -331,9 +357,9 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
             //
             // How transpose works on NPU:
             //   K is loaded into L1 in NZ (col-major fractal) format.
-            //   TRESHAPE(l1_zn, k_l1) reinterprets it as ZN (row-major fractal) = K^T.
-            //   This is a ZERO-COST operation — no data movement, just metadata change.
-            //   TEXTRACT then loads the transposed view into L0B.
+            //   TRESHAPE(l1_zn, k_l1) reinterprets it as ZN (row-major fractal) =
+            //   K^T. This is a ZERO-COST operation — no data movement, just metadata
+            //   change. TEXTRACT then loads the transposed view into L0B.
             //
             // Cube GEMM pipeline:
             //   TEXTRACT(l0a, q_l1, 0, 0)  — Q → L0A (left operand)
@@ -426,8 +452,8 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
             // Signal Vec: QK and QS are ready (flag 0, Cube→Vec)
             // ── Cross-core sync protocol ──────────────────────────────────────
             // Cube and Vec are SEPARATE physical cores. They exchange data through GM
-            // and coordinate via FFTS flags. Think of it as two processes communicating
-            // through shared memory with semaphores.
+            // and coordinate via FFTS flags. Think of it as two processes
+            // communicating through shared memory with semaphores.
             //
             // ffts_cross_core_sync(PIPE_FIX, config):
             //   config = 1 | (mode << 4) | (flag_id << 8)
@@ -439,10 +465,21 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
             //   flag 1: Vec→Cube "QK_gated is ready for GEMM 3"
             //   flag 2: Cube→Vec "QKV (GEMM 3 result) is ready"
             //   flag 3: Vec→Cube "I'm done with this chunk, you can reuse workspace"
-            ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (0 << 8));
+            // ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (0 << 8));
+#if __CCE_AICORE__ == 220
+            SetCrossFlag<PIPE_FIX>(0);
+#else
+            pipe_barrier(PIPE_ALL);
+            SignalBothVecOnA5<PIPE_FIX>(0);
+#endif
 
             // Wait for Vec to write QK_gated back (flag 1, Vec→Cube)
+#if __CCE_AICORE__ == 220
             wait_flag_dev(1);
+#else
+            WaitBothVecOnA5<PIPE_MTE2>(1);
+            pipe_barrier(PIPE_ALL);
+#endif
 
             set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
             wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
@@ -465,7 +502,8 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
                 Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
                 _gs.shape[3] = valid_rows;
                 _gs.shape[4] = HiddenSize;
-                GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, BSND_V_STRIDE, 1>> _gm(V_handle + v_off, _gs);
+                GmStride2D _stride(BSND_V_STRIDE);
+                GmTensor2D<half> _gm(V_handle + v_off, _gs, _stride);
                 TLOAD(_l1, _gm);
                 if (valid_rows != ChunkSize) TFILLPAD(_l1, _l1);
             }
@@ -513,7 +551,13 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
             }
 
             // Signal Vec: QKV is ready (flag 2, Cube→Vec)
-            ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (2 << 8));
+            // ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (2 << 8));
+#if __CCE_AICORE__ == 220
+            SetCrossFlag<PIPE_FIX>(2);
+#else
+            pipe_barrier(PIPE_ALL);
+            SignalBothVecOnA5<PIPE_FIX>(2);
+#endif
             first_cube_iter = false;
         }
     } else {
@@ -528,9 +572,17 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
             int64_t nc = (slen + ChunkSize - 1) / ChunkSize;
 
             for (int64_t ci = 0; ci < nc; ++ci) {
-                for (int32_t h = 0; h < NumHeads; ++h) {
+                for (int32_t h = 0; h < H; ++h) {
                     if (gi % static_cast<int64_t>(block_num) == static_cast<int64_t>(cid)) {
-                        if (!first_cube_iter_v) wait_flag_dev(3);
+                        // Wait Vec: workspace free (flag 3)
+                        if (!first_cube_iter_v) {
+#if __CCE_AICORE__ == 220
+                            wait_flag_dev(3);
+#else
+                            WaitBothVecOnA5<PIPE_MTE2>(3);
+                            pipe_barrier(PIPE_ALL);
+#endif
+                        }
                         set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
                         wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
 
@@ -545,7 +597,7 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
                                          static_cast<int64_t>(HiddenSize);
                         int64_t v_off = (chunk_token_start * static_cast<int64_t>(H) + static_cast<int64_t>(head_idx)) *
                                         static_cast<int64_t>(HiddenSize);
-                        int64_t s_offset = (chunk_global_idx * NumHeads + head_idx) * static_cast<int64_t>(HiddenSize) *
+                        int64_t s_offset = (chunk_global_idx * H + head_idx) * static_cast<int64_t>(HiddenSize) *
                                            static_cast<int64_t>(HiddenSize);
 
                         // Load Q
@@ -652,10 +704,21 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
                         }
 
                         // Cube→Vec: QK & QS ready (flag 0)
-                        ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (0 << 8));
+                        // ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (0 << 8));
+#if __CCE_AICORE__ == 220
+                        SetCrossFlag<PIPE_FIX>(0);
+#else
+                        pipe_barrier(PIPE_ALL);
+                        SignalBothVecOnA5<PIPE_FIX>(0);
+#endif
 
                         // Wait Vec→Cube: QK_gated ready (flag 1)
+#if __CCE_AICORE__ == 220
                         wait_flag_dev(1);
+#else
+                        WaitBothVecOnA5<PIPE_MTE2>(1);
+                        pipe_barrier(PIPE_ALL);
+#endif
 
                         set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
                         wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
@@ -678,8 +741,8 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
                             Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
                             _gs.shape[3] = valid_rows;
                             _gs.shape[4] = HiddenSize;
-                            GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, BSND_V_STRIDE, 1>> _gm(V_handle + v_off,
-                                                                                                     _gs);
+                            GmStride2D _stride(BSND_V_STRIDE);
+                            GmTensor2D<half> _gm(V_handle + v_off, _gs, _stride);
                             TLOAD(_l1, _gm);
                             if (valid_rows != ChunkSize) TFILLPAD(_l1, _l1);
                         }
@@ -717,7 +780,14 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
                             TSTORE(_gm, _l0);
                         }
 
-                        ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (2 << 8));
+                        // Signal Vec: QKV is ready (flag 2, Cube→Vec)
+                        // ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (2 << 8));
+#if __CCE_AICORE__ == 220
+                        SetCrossFlag<PIPE_FIX>(2);
+#else
+                        pipe_barrier(PIPE_ALL);
+                        SignalBothVecOnA5<PIPE_FIX>(2);
+#endif
                         first_cube_iter_v = false;
                     }
                     gi++;
@@ -737,7 +807,7 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
 //   3. Scales the Cube's QS result by exp(g)
 //   4. Combines QKV + scaled QS → final output O
 // =====================================================================
-#if defined(__DAV_C220_VEC__)
+#if defined(__DAV_VEC__)
     // Vec engine initialization: set_mask_norm selects "normal" masking mode,
     // and set_vector_mask(-1, -1) enables ALL SIMD lanes (no masking).
     set_mask_norm();
@@ -770,8 +840,8 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
 
         for (int64_t work_idx = static_cast<int64_t>(cid); work_idx < total_work;
              work_idx += static_cast<int64_t>(block_num)) {
-            int32_t head_idx = static_cast<int32_t>(work_idx % NumHeads);
-            int64_t chunk_head_idx = work_idx / NumHeads;
+            int32_t head_idx = static_cast<int32_t>(work_idx % H);
+            int64_t chunk_head_idx = work_idx / H;
             int64_t seq_idx = chunk_head_idx / chunks_per_seq;
             int64_t ci = chunk_head_idx % chunks_per_seq;
 
@@ -809,7 +879,8 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
 
                 // ── Compute gating coefficients ──────────────────────────────────
                 // ── Gating coefficient computation (numpy pseudocode) ─────────────
-                // For this sub-block's rows (vid=0: rows 0..C/2-1, vid=1: rows C/2..C-1):
+                // For this sub-block's rows (vid=0: rows 0..C/2-1, vid=1: rows
+                // C/2..C-1):
                 //
                 //   g_row = g[my_start:my_start+C/2]    # my gates (shape [C/2])
                 //   g_col = g[0:C]                       # full chunk gates (shape [C])
@@ -834,22 +905,38 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
                 TROWEXPAND(g_r_2d, g_v_col);       // g_r_2d[i,j] = g_row[i]
                 TCOLEXPAND(coeff_ub, g_ub);        // coeff[i,j] = g_col[j]
                 TSUB(coeff_ub, g_r_2d, coeff_ub);  // d = g_row - g_col
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
                 TMINS(coeff_ub, coeff_ub, 0.0f);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
                 TEXP(coeff_ub, coeff_ub);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
                 TMUL(coeff_ub, coeff_ub, msk_ub);
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
                 TEXP(g_v_ub, g_v_ub);  // exp(g_row) for QS scaling
             }
 
             // ── Wait for Cube→Vec flag 0: QK & QS ready ─────────────────────
+#if __CCE_AICORE__ == 220
             wait_flag_dev(0);
+#else
+            wait_intra_block(PIPE_MTE3, 0);
+            pipe_barrier(PIPE_ALL);
+#endif
             if (local_rows == 0) {
-                ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+                // Nothing to do for this chunk — still run the full flag handshake so
+                // Cube's wait counts stay balanced.
+                // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+                // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+#if __CCE_AICORE__ == 220
+                SetCrossFlag<PIPE_MTE3>(1);
                 wait_flag_dev(2);
-                ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+                SetCrossFlag<PIPE_MTE3>(3);
+#else
+                pipe_barrier(PIPE_ALL);
+                set_intra_block(PIPE_MTE3, 1);
+                wait_intra_block(PIPE_MTE3, 2);
+                set_intra_block(PIPE_MTE3, 3);
+#endif
                 continue;
             }
 
@@ -914,14 +1001,20 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
                 TSTORE(_gm, _st);
             }
             // Vec→Cube: QK_gated ready (flag 1)
-            ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+            // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+#if __CCE_AICORE__ == 220
+            SetCrossFlag<PIPE_MTE3>(1);
+#else
+            pipe_barrier(PIPE_ALL);
+            set_intra_block(PIPE_MTE3, 1);
+#endif
 
             // ── Scale QS by exp(g): QS_gated = QS * exp(g_row) ──────────────
             // ── Scale QS by exp(g): inter-chunk state contribution ────────────
-            // numpy: QS_scaled = QS * np.exp(g_row)[:, None]   (broadcast across D columns)
-            // TROWEXPAND broadcasts the scalar exp(g[i]) for each row i across all D columns,
-            // then TMUL applies it element-wise. This gates how much the accumulated state
-            // contributes to each token's output.
+            // numpy: QS_scaled = QS * np.exp(g_row)[:, None]   (broadcast across D
+            // columns) TROWEXPAND broadcasts the scalar exp(g[i]) for each row i
+            // across all D columns, then TMUL applies it element-wise. This gates how
+            // much the accumulated state contributes to each token's output.
             set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
             wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
             TCVT(qs_ub, qs_ub_half, pto::RoundMode::CAST_NONE);
@@ -930,11 +1023,16 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
             UbDN<float, HalfChunk, 1> g_v_col2;
             TASSIGN(g_v_col2, GvUbAddr);
             TROWEXPAND(g_exp_2d, g_v_col2);  // broadcast exp(g_row) across columns
-            pipe_barrier(PIPE_V);
+            PipeBarrierVec();
             TMUL(qs_ub, qs_ub, g_exp_2d);  // QS_gated = QS * exp(g_row)
 
             // ── Wait for Cube→Vec flag 2: QKV ready ─────────────────────────
+#if __CCE_AICORE__ == 220
             wait_flag_dev(2);
+#else
+            wait_intra_block(PIPE_MTE3, 2);
+            pipe_barrier(PIPE_ALL);
+#endif
 
             // ── Load QKV [C/2 × D] from workspace → UB ──────────────────────
             {
@@ -977,14 +1075,21 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
                 Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
                 _gs.shape[3] = local_rows;
                 _gs.shape[4] = HiddenSize;
-                GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, BSND_V_STRIDE, 1>> _gm(O_handle + o_offset, _gs);
+                GmStride2D _stride(BSND_V_STRIDE);
+                GmTensor2D<half> _gm(O_handle + o_offset, _gs, _stride);
                 UbND<half, HalfChunk, HiddenSize, DYNAMIC, DYNAMIC> _st(local_rows, HiddenSize);
                 TASSIGN(_st, OHalfUbAddr);
                 TSTORE(_gm, _st);
             }
 
             // Vec→Cube: done with this chunk (flag 3)
-            ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+            // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+#if __CCE_AICORE__ == 220
+            SetCrossFlag<PIPE_MTE3>(3);
+#else
+            pipe_barrier(PIPE_ALL);
+            set_intra_block(PIPE_MTE3, 3);
+#endif
         }
     } else {
         // ── Variable-length sequence path (cu_seqlens != nullptr) ──────────
@@ -996,7 +1101,7 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
             int64_t nc = (slen + ChunkSize - 1) / ChunkSize;
 
             for (int64_t ci = 0; ci < nc; ++ci) {
-                for (int32_t h = 0; h < NumHeads; ++h) {
+                for (int32_t h = 0; h < H; ++h) {
                     if (gi % static_cast<int64_t>(block_num) == static_cast<int64_t>(cid)) {
                         int64_t chunk_start = ci * ChunkSize;
                         int64_t remaining = slen - chunk_start;
@@ -1028,8 +1133,8 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
                             set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
                             wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
-                            // Compute gating coefficients (same math as fixed-length path — see detailed pseudocode
-                            // above)
+                            // Compute gating coefficients (same math as fixed-length path —
+                            // see detailed pseudocode above)
                             UbND<float, 1, HalfChunk> g_ub_temp_v;
                             TASSIGN(g_ub_temp_v, GUbAddr + static_cast<int32_t>(vid) * HalfChunk *
                                                                static_cast<int32_t>(sizeof(float)));
@@ -1042,21 +1147,37 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
                             TROWEXPAND(g_r_2d_v, g_v_col_v);
                             TCOLEXPAND(coeff_ub, g_ub);
                             TSUB(coeff_ub, g_r_2d_v, coeff_ub);  // d = g_row - g_col
-                            pipe_barrier(PIPE_V);
+                            PipeBarrierVec();
                             TMINS(coeff_ub, coeff_ub, 0.0f);
-                            pipe_barrier(PIPE_V);
+                            PipeBarrierVec();
                             TEXP(coeff_ub, coeff_ub);
-                            pipe_barrier(PIPE_V);
+                            PipeBarrierVec();
                             TMUL(coeff_ub, coeff_ub, msk_ub);
-                            pipe_barrier(PIPE_V);
+                            PipeBarrierVec();
                             TEXP(g_v_ub, g_v_ub);
                         }
 
+                        // ── Wait for Cube→Vec flag 0: QK & QS ready ─────────────────
+#if __CCE_AICORE__ == 220
                         wait_flag_dev(0);
+#else
+                        wait_intra_block(PIPE_MTE3, 0);
+                        pipe_barrier(PIPE_ALL);
+#endif
                         if (local_rows == 0) {
-                            ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+                            // Nothing to do — still run the handshake so Cube stays balanced.
+                            // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+                            // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+#if __CCE_AICORE__ == 220
+                            SetCrossFlag<PIPE_MTE3>(1);
                             wait_flag_dev(2);
-                            ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+                            SetCrossFlag<PIPE_MTE3>(3);
+#else
+                            pipe_barrier(PIPE_ALL);
+                            set_intra_block(PIPE_MTE3, 1);
+                            wait_intra_block(PIPE_MTE3, 2);
+                            set_intra_block(PIPE_MTE3, 3);
+#endif
                         } else {
                             // Load QK from workspace
                             {
@@ -1102,7 +1223,8 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
                             }
 
                             TMUL(qk_ub, qk_ub, coeff_ub);
-                            TCVT(qk_ub_half, qk_ub, pto::RoundMode::CAST_NONE);  // float→half for GM store
+                            TCVT(qk_ub_half, qk_ub,
+                                 pto::RoundMode::CAST_NONE);  // float→half for GM store
 
                             // Store QK_gated → workspace
                             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -1120,23 +1242,36 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
                                 TSTORE(_gm, _st);
                             }
                             // Vec→Cube: QK_gated ready (flag 1)
-                            ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+                            // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+#if __CCE_AICORE__ == 220
+                            SetCrossFlag<PIPE_MTE3>(1);
+#else
+                            pipe_barrier(PIPE_ALL);
+                            set_intra_block(PIPE_MTE3, 1);
+#endif
 
                             // Scale QS by exp(g): QS_scaled = QS * exp(g_row)[:, None]
                             // (same inter-chunk state scaling as fixed-length path)
                             set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
                             wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-                            TCVT(qs_ub, qs_ub_half, pto::RoundMode::CAST_NONE);  // half→float for Vec math
+                            TCVT(qs_ub, qs_ub_half,
+                                 pto::RoundMode::CAST_NONE);  // half→float for Vec math
 
                             UbND<float, HalfChunk, HiddenSize> g_exp_2d_v;
                             TASSIGN(g_exp_2d_v, CoeffUbAddr);
                             UbDN<float, HalfChunk, 1> g_v_col2_v;
                             TASSIGN(g_v_col2_v, GvUbAddr);
                             TROWEXPAND(g_exp_2d_v, g_v_col2_v);
-                            pipe_barrier(PIPE_V);
+                            PipeBarrierVec();
                             TMUL(qs_ub, qs_ub, g_exp_2d_v);
 
+                            // Wait for Cube→Vec flag 2: QKV ready
+#if __CCE_AICORE__ == 220
                             wait_flag_dev(2);
+#else
+                            wait_intra_block(PIPE_MTE3, 2);
+                            pipe_barrier(PIPE_ALL);
+#endif
 
                             // Load QKV from workspace
                             {
@@ -1159,10 +1294,12 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
                             set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
                             wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
-                            // O = QS_gated + QKV  (final output: intra-chunk attention + inter-chunk state)
+                            // O = QS_gated + QKV  (final output: intra-chunk attention +
+                            // inter-chunk state)
                             TCVT(o_ub, o_ub_half, pto::RoundMode::CAST_NONE);  // half→float
                             TADD(o_ub, qs_ub, o_ub);                           // O = QS_scaled + QKV
-                            TCVT(o_ub_half, o_ub, pto::RoundMode::CAST_NONE);  // float→half for GM store
+                            TCVT(o_ub_half, o_ub,
+                                 pto::RoundMode::CAST_NONE);  // float→half for GM store
 
                             // Store O → GM
                             set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
@@ -1177,15 +1314,21 @@ static inline AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_h
                                 Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
                                 _gs.shape[3] = local_rows;
                                 _gs.shape[4] = HiddenSize;
-                                GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, BSND_V_STRIDE, 1>> _gm(
-                                    O_handle + o_offset, _gs);
+                                GmStride2D _stride(BSND_V_STRIDE);
+                                GmTensor2D<half> _gm(O_handle + o_offset, _gs, _stride);
                                 UbND<half, HalfChunk, HiddenSize, DYNAMIC, DYNAMIC> _st(local_rows, HiddenSize);
                                 TASSIGN(_st, OHalfUbAddr);
                                 TSTORE(_gm, _st);
                             }
 
                             // Vec→Cube: done with this chunk (flag 3)
-                            ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+                            // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+#if __CCE_AICORE__ == 220
+                            SetCrossFlag<PIPE_MTE3>(3);
+#else
+                            pipe_barrier(PIPE_ALL);
+                            set_intra_block(PIPE_MTE3, 3);
+#endif
                         }
                     }
                     gi++;

--- a/csrc/mega_chunk_gdn/op_kernel/chunk_o.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/chunk_o.cpp
@@ -145,7 +145,7 @@ AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_handle, __gm__ 
                            __gm__ float *G_handle, __gm__ float *Msk_handle, __gm__ half *workspace_qk_handle,
                            __gm__ half *workspace_qs_qkv_handle, __gm__ half *workspace_qk_gated_handle,
                            __gm__ half *O_handle, __gm__ int32_t *cu_seqlens, int64_t batch_size, int64_t seq_len,
-                           int64_t total_tokens, uint32_t num_heads, uint32_t num_key_heads, uint64_t ffts_addr)
+                           int64_t total_tokens, uint32_t num_heads, uint32_t num_key_heads)
 {
     // To avoid ambiguity with bisheng intrinsic header's global `enum class
     // Stride`
@@ -183,8 +183,6 @@ AICORE void chunk_o_kernel(__gm__ half *Q_handle, __gm__ half *K_handle, __gm__ 
     constexpr int32_t OHalfUbAddr = 164608;
     constexpr int32_t OUbAddr = QKUbAddr;
 
-    // Initialize the cross-core FFTS signaling base address for this AI core.
-    set_ffts_base_addr(ffts_addr);
     // cid = which AI core am I? (0..block_num-1). Used to partition work items.
     auto cid = get_block_idx();
     // block_num = total number of AI cores running this kernel in parallel.

--- a/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
@@ -107,11 +107,15 @@ AICORE inline void mega_transpose_TH_to_HT(__gm__ T *src, __gm__ T *dst, int64_t
     UBTmp ub_tmp;
     TASSIGN(ub_tmp, TMP_UB);
 
-    int64_t num_tok_blocks = (T_len + BLOCK - 1) / BLOCK;
+    const int64_t num_tok_blocks = (T_len + BLOCK - 1) / BLOCK;
 
     for (int64_t bi = static_cast<int64_t>(cid); bi < num_tok_blocks; bi += static_cast<int64_t>(block_num)) {
-        int64_t t0 = bi * BLOCK;
+        const int64_t t0 = bi * BLOCK;
         int32_t valid = (t0 + BLOCK <= T_len) ? BLOCK : static_cast<int32_t>(T_len - t0);
+
+        if (valid <= 0){
+            break;
+        }
 
         {
             Gm2D gs;

--- a/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
@@ -1,7 +1,9 @@
-// mega_kernel.cpp — GDN Mega-Kernel (group-value / GQA): all PTO stages in one launch
+// mega_kernel.cpp — GDN Mega-Kernel (group-value / GQA): all PTO stages in one
+// launch
 //
-// Same pipeline as pto_mega_kernel, with value heads (H) and key heads (Hg)
-// passed at runtime. H dispatches to finite compile-time specializations.
+// Same pipeline as pto_mega_kernel, but scaled_dot_kkt / wy_fast / chunk_h /
+// chunk_o use runtime H/Hg dispatch from dynamic_bsnd_groupvalue; cumsum still
+// uses H (value heads) like dynamic_bsnd.
 //
 // Stages:
 //   1. cumsum      (Vec)
@@ -18,65 +20,39 @@
 #ifndef GDN_C
 #define GDN_C 128
 #endif
-#ifndef MEMORY_BASE
-#define MEMORY_BASE
+// GDN_MAX_HEADS: compile-time ceiling on the value-head count. num_heads is a
+// RUNTIME argument (one .so serves every head count), so the transpose/cumsum
+// UB tiles are sized for this worst case; any num_heads <= GDN_MAX_HEADS works
+// with the unused columns zero-padded. Must match the host-side _MAX_HEADS
+// guard and the GDN_MAX_HEADS in chunk_cumsum.cpp.
+#ifndef GDN_MAX_HEADS
+#define GDN_MAX_HEADS 64
 #endif
-#ifndef GDN_KERNEL_NAME
-#define GDN_KERNEL_NAME launch_mega_kernel
-#endif
-// Note the codegen parser does not support arguments of form "type *name", only "type* name"
-// clang-format off
-#ifndef GM_ADDR
-#define GM_ADDR __gm__ uint8_t*
-#endif
-// clang-format off
+
+#include <runtime/rt_ffts.h>
 
 #include <pto/pto-inst.hpp>
-#include "acl/acl.h"
 #include <type_traits>
+
+#include "acl/acl.h"
+#include "mega_kernel_utils.h"
+
 using namespace pto;
+using namespace mega_kernel_utils;
 
 // ===================================================================
 // Device-only helpers (shared with standard mega-kernel)
 // ===================================================================
 #ifdef __CCE_AICORE__
 
-constexpr uint16_t SYNC_AIV_FLAG = 12;
-constexpr uint16_t SYNC_AIC_FLAG = 11;
-constexpr uint16_t SYNC_AIC_AIV_FLAG = 13;
-constexpr uint16_t SYNC_AIV_ONLY_ALL = 14;
-constexpr uint16_t SYNC_MODE_SHIFT_VALUE = 4;
-constexpr uint16_t SYNC_FLAG_SHIFT_VALUE = 8;
-
-AICORE inline uint16_t GetffstMsg(uint16_t mode, uint16_t flagId)
+template <typename T>
+AICORE void mega_transpose_TH_to_HT(__gm__ T *src, __gm__ T *dst, int64_t T_len, int32_t H)
 {
-    return (0x1 + ((mode & 0x3) << SYNC_MODE_SHIFT_VALUE) + ((flagId & 0xf) << SYNC_FLAG_SHIFT_VALUE));
-}
+    // To avoid ambiguity with bisheng intrinsic header's global `enum class
+    // Stride`
+    using pto::Stride;
 
-template <bool isAIVOnly = true>
-AICORE inline void SyncAllImpl()
-{
-    pipe_barrier(PIPE_ALL);
-    if constexpr (isAIVOnly) {
-        ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x0, SYNC_AIV_ONLY_ALL));
-        wait_flag_dev(SYNC_AIV_ONLY_ALL);
-        return;
-    }
-#if defined(__DAV_C220_CUBE__)
-    wait_flag_dev(SYNC_AIV_FLAG);
-    ffts_cross_core_sync(PIPE_FIX, GetffstMsg(0x0, SYNC_AIC_FLAG));
-    wait_flag_dev(SYNC_AIC_FLAG);
-    ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x02, SYNC_AIC_AIV_FLAG));
-#elif defined(__DAV_C220_VEC__)
-    ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x02, SYNC_AIV_FLAG));
-    wait_flag_dev(SYNC_AIC_AIV_FLAG);
-#endif
-}
-
-template <typename T, int32_t H_val>
-AICORE inline void mega_transpose_TH_to_HT(__gm__ T *src, __gm__ T *dst, int64_t T_len)
-{
-#if defined(__DAV_C220_VEC__)
+#if defined(__DAV_VEC__)
     if (get_subblockid() != 0) return;
     set_mask_norm();
     set_vector_mask(-1, -1);
@@ -85,13 +61,14 @@ AICORE inline void mega_transpose_TH_to_HT(__gm__ T *src, __gm__ T *dst, int64_t
     auto block_num = get_block_num();
 
     constexpr int32_t BLOCK = 128;
-    constexpr int32_t H = static_cast<int32_t>(H_val);
     constexpr int32_t ES = static_cast<int32_t>(sizeof(T));
-    constexpr int32_t AlignBytes = 32;
-    constexpr int32_t AlignRows = AlignBytes / ES;
     constexpr int32_t MinTransposeCols = 16;
-    constexpr int32_t AlignElems = (AlignRows > MinTransposeCols) ? AlignRows : MinTransposeCols;
-    constexpr int32_t HP = ((H + AlignElems - 1) / AlignElems) * AlignElems;
+    constexpr int32_t AlignElems = ((32 / ES) > MinTransposeCols) ? (32 / ES) : MinTransposeCols;
+    // H is runtime; size the UB tiles for the worst-case head count. TTRANS
+    // always processes the full BLOCK×HP tile (unused cols H..HP are
+    // zero-padded), and the store loop below writes only the first H transposed
+    // rows.
+    constexpr int32_t HP = ((GDN_MAX_HEADS + AlignElems - 1) / AlignElems) * AlignElems;
     constexpr int32_t SRC_UB = 0;
     constexpr int32_t DST_UB = SRC_UB + BLOCK * HP * ES;
     constexpr int32_t TMP_UB = DST_UB + HP * BLOCK * ES;
@@ -106,42 +83,12 @@ AICORE inline void mega_transpose_TH_to_HT(__gm__ T *src, __gm__ T *dst, int64_t
 
     using UBRow = Tile<TileType::Vec, T, 1, BLOCK, BLayout::RowMajor, 1, BLOCK, SLayout::NoneBox, 512>;
     using UBRowDyn = Tile<TileType::Vec, T, 1, BLOCK, BLayout::RowMajor, DYNAMIC, DYNAMIC, SLayout::NoneBox, 512>;
-    using UBHeadDyn = Tile<TileType::Vec, T, AlignRows, BLOCK, BLayout::ColMajor, 1, DYNAMIC, SLayout::NoneBox, 512>;
 
     using Gm2D = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
     using Gm1D = Shape<1, 1, 1, 1, DYNAMIC>;
-    using GmSrcS = Stride<1, 1, 1, H, 1>;
-    using GmHeadS = Stride<1, 1, 1, 1, H>;
+    using GmSrcS = Stride<1, 1, 1, DYNAMIC, 1>;
     using GmS1 = Stride<1, 1, 1, 1, 1>;
-
-    if constexpr (H < MinTransposeCols) {
-        int64_t num_tok_blocks = (T_len + BLOCK - 1) / BLOCK;
-        for (int64_t bi = static_cast<int64_t>(cid); bi < num_tok_blocks; bi += static_cast<int64_t>(block_num)) {
-            int64_t t0 = bi * BLOCK;
-            int32_t valid = (t0 + BLOCK <= T_len) ? BLOCK : static_cast<int32_t>(T_len - t0);
-
-            for (int32_t h = 0; h < H; ++h) {
-                Gm1D gs;
-                gs.shape[4] = valid;
-                UBHeadDyn row(valid);
-                TASSIGN(row, SRC_UB);
-                {
-                    // DN layout makes each token a one-element burst with stride H.
-                    GlobalTensor<T, Gm1D, GmHeadS, Layout::DN> gm(src + t0 * H + h, gs);
-                    TLOAD(row, gm);
-                }
-                set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-                wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-                {
-                    GlobalTensor<T, Gm1D, GmS1, Layout::DN> gm(dst + h * T_len + t0, gs);
-                    TSTORE(gm, row);
-                }
-                set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-                wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-            }
-        }
-        return;
-    }
+    GmSrcS src_stride(H);  // runtime row pitch = H elements (skip other heads)
 
     UBSrcFull ub_src;
     TASSIGN(ub_src, SRC_UB);
@@ -160,7 +107,7 @@ AICORE inline void mega_transpose_TH_to_HT(__gm__ T *src, __gm__ T *dst, int64_t
             Gm2D gs;
             gs.shape[3] = valid;
             gs.shape[4] = H;
-            GlobalTensor<T, Gm2D, GmSrcS> gm(src + t0 * H, gs);
+            GlobalTensor<T, Gm2D, GmSrcS> gm(src + t0 * H, gs, src_stride);
             UBSrcDyn ld(valid, H);
             TASSIGN(ld, SRC_UB);
             TLOAD(ld, gm);
@@ -189,10 +136,13 @@ AICORE inline void mega_transpose_TH_to_HT(__gm__ T *src, __gm__ T *dst, int64_t
 }
 
 template <int32_t H, int32_t C>
-AICORE inline void mega_cast_fp32_to_fp16_bsnd(__gm__ float *src, __gm__ half *dst, uint32_t num_matrices,
-                                               int64_t total_tokens)
+AICORE void mega_cast_fp32_to_fp16_bsnd(__gm__ float *src, __gm__ half *dst, uint32_t num_matrices,
+                                        int64_t total_tokens)
 {
-#if defined(__DAV_C220_VEC__)
+    // See mega_transpose_TH_to_HT above — hides the global `enum class Stride`.
+    using pto::Stride;
+
+#if defined(__DAV_VEC__)
     if (get_subblockid() != 0) return;
     set_mask_norm();
     set_vector_mask(-1, -1);
@@ -259,57 +209,68 @@ AICORE inline void mega_cast_fp32_to_fp16_bsnd(__gm__ float *src, __gm__ half *d
 // Include original kernel implementations in separate namespaces.
 // ===================================================================
 
+#define call_kernel _mk_unused_gv_ck_cumsum
 namespace mk_cumsum {
 #include "chunk_cumsum.cpp"
 }
+#undef call_kernel
 
+#define call_kernel _mk_unused_gv_ck_kkt
 namespace mk_kkt {
 #include "scaled_dot_kkt.cpp"
 }
+#undef call_kernel
 
 namespace mk_solve {
 #include "tri_inverse_impl.cpp"
 }
 
+#define call_kernel _mk_unused_gv_ck_wy
 namespace mk_wy {
 #include "wy_fast.cpp"
 }
+#undef call_kernel
 
+#define call_kernel _mk_unused_gv_ck_h
 namespace mk_h {
 #include "chunk_h.cpp"
 }
+#undef call_kernel
 
+#define call_kernel _mk_unused_gv_ck_o
 namespace mk_o {
 #include "chunk_o.cpp"
 }
+#undef call_kernel
 
-AICORE inline void mega_solve_tril(__gm__ half *out, __gm__ half *in, __gm__ half *minus_id, uint32_t matrix_size,
-                                   uint32_t num_matrices, uint32_t num_bsnd_heads, __gm__ int32_t *cu_seqlens,
-                                   uint32_t is_lower)
+AICORE void mega_solve_tril(__gm__ half *out, __gm__ half *in, __gm__ half *minus_id, uint32_t matrix_size,
+                            uint32_t num_matrices, uint32_t num_bsnd_heads, __gm__ int32_t *cu_seqlens,
+                            uint32_t is_lower)
 {
     if (num_matrices <= get_block_num())
-        mk_solve::runKernelTriInvRecUnroll<half, float, GDN_C, 1, true, half>(out, in, minus_id, num_matrices,
-                                                                              num_bsnd_heads, cu_seqlens, is_lower);
+        mk_solve::runKernelTriInvRecUnroll<half, half, GDN_C, 1, true>(out, in, minus_id, num_matrices, num_bsnd_heads,
+                                                                       is_lower, cu_seqlens);
     else if (num_matrices <= 2u * get_block_num())
-        mk_solve::runKernelTriInvRecUnroll<half, float, GDN_C, 2, true, half>(out, in, minus_id, num_matrices,
-                                                                              num_bsnd_heads, cu_seqlens, is_lower);
+        mk_solve::runKernelTriInvRecUnroll<half, half, GDN_C, 2, true>(out, in, minus_id, num_matrices, num_bsnd_heads,
+                                                                       is_lower, cu_seqlens);
     else
-        mk_solve::runKernelTriInvRecUnroll<half, float, GDN_C, 4, true, half>(out, in, minus_id, num_matrices,
-                                                                              num_bsnd_heads, cu_seqlens, is_lower);
+        mk_solve::runKernelTriInvRecUnroll<half, half, GDN_C, 4, true>(out, in, minus_id, num_matrices, num_bsnd_heads,
+                                                                       is_lower, cu_seqlens);
 }
 
-template <int32_t H>
-AICORE inline void mega_kernel_impl(GM_ADDR q_ptr, GM_ADDR k_ptr, GM_ADDR v_ptr, GM_ADDR g_in_ptr, GM_ADDR beta_ptr,
-                                    GM_ADDR msk_lower_ptr, GM_ADDR msk_full_ptr, GM_ADDR minus_id_ptr,
-                                    GM_ADDR cu_seqlens_ptr, GM_ADDR o_ptr, GM_ADDR g_sum_ptr, GM_ADDR g_t_ptr,
-                                    GM_ADDR beta_t_ptr, GM_ADDR A_ptr, GM_ADDR A_inv_f32_ptr, GM_ADDR A_inv_ptr,
-                                    GM_ADDR w_ptr, GM_ADDR u_ptr, GM_ADDR s_ptr, GM_ADDR v_new_ptr, GM_ADDR fs_ptr,
-                                    GM_ADDR h0_ptr, int64_t has_initial_state, GM_ADDR kkt_ws_ptr,
-                                    GM_ADDR wy_ws_a1_ptr, GM_ADDR wy_ws_a2_ptr, GM_ADDR h_ws_ptr,
-                                    GM_ADDR o_ws_qk_ptr, GM_ADDR o_ws_qs_ptr, GM_ADDR o_ws_gated_ptr,
-                                    uint32_t num_key_heads, int64_t batch_size, int64_t seq_len,
-                                    int64_t total_tokens, uint32_t num_matrices)
+AICORE inline void mega_kernel_impl(
+    __gm__ uint8_t *q_ptr, __gm__ uint8_t *k_ptr, __gm__ uint8_t *v_ptr, __gm__ uint8_t *g_in_ptr,
+    __gm__ uint8_t *beta_ptr, __gm__ uint8_t *msk_lower_ptr, __gm__ uint8_t *msk_full_ptr, __gm__ uint8_t *minus_id_ptr,
+    __gm__ uint8_t *cu_seqlens_ptr, __gm__ uint8_t *o_ptr, __gm__ uint8_t *g_sum_ptr, __gm__ uint8_t *g_t_ptr,
+    __gm__ uint8_t *beta_t_ptr, __gm__ uint8_t *A_ptr, __gm__ uint8_t *A_inv_f32_ptr, __gm__ uint8_t *A_inv_ptr,
+    __gm__ uint8_t *w_ptr, __gm__ uint8_t *u_ptr, __gm__ uint8_t *s_ptr, __gm__ uint8_t *v_new_ptr,
+    __gm__ uint8_t *fs_ptr, __gm__ uint8_t *h0_ptr, int64_t has_initial_state, __gm__ uint8_t *kkt_ws_ptr,
+    __gm__ uint8_t *wy_ws_a1_ptr, __gm__ uint8_t *wy_ws_a2_ptr, __gm__ uint8_t *h_ws_ptr, __gm__ uint8_t *o_ws_qk_ptr,
+    __gm__ uint8_t *o_ws_qs_ptr, __gm__ uint8_t *o_ws_gated_ptr, int32_t H, uint32_t num_key_heads, int64_t batch_size,
+    int64_t seq_len, int64_t total_tokens, uint32_t num_matrices, uint64_t ffts_addr)
 {
+    set_ffts_base_addr(ffts_addr);
+
     constexpr int32_t D = GDN_D;
     constexpr int32_t C = GDN_C;
 
@@ -317,43 +278,53 @@ AICORE inline void mega_kernel_impl(GM_ADDR q_ptr, GM_ADDR k_ptr, GM_ADDR v_ptr,
         return;
     }
 
-    mk_cumsum::cumsum_kernel<H, C>(reinterpret_cast<__gm__ float *>(g_in_ptr),
-                                   reinterpret_cast<__gm__ float *>(g_sum_ptr),
-                                   reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), batch_size, seq_len);
+    mk_cumsum::cumsum_kernel<C>(reinterpret_cast<__gm__ float *>(g_in_ptr), reinterpret_cast<__gm__ float *>(g_sum_ptr),
+                                reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), batch_size, seq_len, H, ffts_addr);
 
 #ifdef MEGA_STOP_AFTER_CUMSUM
     pipe_barrier(PIPE_ALL);
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
 #ifdef MEGA_STOP_AFTER_SYNC1
     return;
 #endif
 
-    mega_transpose_TH_to_HT<float, H>(reinterpret_cast<__gm__ float *>(g_sum_ptr),
-                                      reinterpret_cast<__gm__ float *>(g_t_ptr), total_tokens);
-    mega_transpose_TH_to_HT<half, H>(reinterpret_cast<__gm__ half *>(beta_ptr),
-                                     reinterpret_cast<__gm__ half *>(beta_t_ptr), total_tokens);
+    mega_transpose_TH_to_HT<float>(reinterpret_cast<__gm__ float *>(g_sum_ptr),
+                                   reinterpret_cast<__gm__ float *>(g_t_ptr), total_tokens, H);
+    mega_transpose_TH_to_HT<half>(reinterpret_cast<__gm__ half *>(beta_ptr),
+                                  reinterpret_cast<__gm__ half *>(beta_t_ptr), total_tokens, H);
 
 #ifdef MEGA_STOP_AFTER_TRANSPOSE
     pipe_barrier(PIPE_ALL);
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
-    mk_kkt::kkt_kernel<H, D, C>(
-        reinterpret_cast<__gm__ half *>(k_ptr), reinterpret_cast<__gm__ half *>(beta_t_ptr),
-        reinterpret_cast<__gm__ float *>(g_t_ptr), reinterpret_cast<__gm__ float *>(msk_lower_ptr),
-        reinterpret_cast<__gm__ half *>(kkt_ws_ptr), reinterpret_cast<__gm__ half *>(A_ptr),
-        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), batch_size, seq_len, total_tokens, num_key_heads);
+    mk_kkt::kkt_kernel<D, C>(reinterpret_cast<__gm__ half *>(k_ptr), reinterpret_cast<__gm__ half *>(beta_t_ptr),
+                             reinterpret_cast<__gm__ float *>(g_t_ptr), reinterpret_cast<__gm__ float *>(msk_lower_ptr),
+                             reinterpret_cast<__gm__ half *>(kkt_ws_ptr), reinterpret_cast<__gm__ half *>(A_ptr),
+                             reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), batch_size, seq_len, total_tokens,
+                             static_cast<uint32_t>(H), num_key_heads, ffts_addr);
 
-#if defined(__DAV_C220_CUBE__)
+// Drain the kkt handshake: Vec released both workspace slots (flags 2/3) one
+// last time after Cube's final iteration, so consume them before the next
+// stage. A2: Vec is a separate core → FFTS cross-core flag. A5: both Vec
+// sub-blocks share Cube's core → each signals its own intra-block
+//     flag (base, base + 16).
+#if defined(__DAV_CUBE__)
     pipe_barrier(PIPE_ALL);
+#if __CCE_AICORE__ == 220
     wait_flag_dev(2);
     wait_flag_dev(3);
+#else
+    WaitBothVecOnA5<PIPE_MTE2>(2);
+    WaitBothVecOnA5<PIPE_MTE2>(3);
+    pipe_barrier(PIPE_ALL);
+#endif
 #endif
 
 #ifdef MEGA_STOP_AFTER_KKT
@@ -361,7 +332,7 @@ AICORE inline void mega_kernel_impl(GM_ADDR q_ptr, GM_ADDR k_ptr, GM_ADDR v_ptr,
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
     mega_solve_tril(reinterpret_cast<__gm__ half *>(A_inv_ptr), reinterpret_cast<__gm__ half *>(A_ptr),
                     reinterpret_cast<__gm__ half *>(minus_id_ptr), C, num_matrices, H,
@@ -372,32 +343,42 @@ AICORE inline void mega_kernel_impl(GM_ADDR q_ptr, GM_ADDR k_ptr, GM_ADDR v_ptr,
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
 #ifdef MEGA_STOP_AFTER_CAST
     pipe_barrier(PIPE_ALL);
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
 #ifdef MEGA_STOP_AFTER_SYNC_BEFORE_WY
     return;
 #endif
 
-    mk_wy::wy_fast_kernel<H, D, C>(
+    mk_wy::wy_fast_kernel<D, C>(
         reinterpret_cast<__gm__ half *>(k_ptr), reinterpret_cast<__gm__ half *>(v_ptr),
         reinterpret_cast<__gm__ half *>(beta_t_ptr), reinterpret_cast<__gm__ float *>(g_t_ptr),
         reinterpret_cast<__gm__ half *>(A_inv_ptr), reinterpret_cast<__gm__ half *>(wy_ws_a1_ptr),
         reinterpret_cast<__gm__ half *>(wy_ws_a2_ptr), reinterpret_cast<__gm__ half *>(w_ptr),
         reinterpret_cast<__gm__ half *>(u_ptr), reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), batch_size, seq_len,
-        total_tokens, num_key_heads);
+        total_tokens, static_cast<uint32_t>(H), num_key_heads, ffts_addr);
 
-#if defined(__DAV_C220_VEC__)
+// Drain the wy_fast handshake: Cube freed the A2/A1 slots (flags 3/4) one last
+// time after Vec's final iteration.
+// A5: Cube signalled both sub-blocks (base, base + 16); each sub-block waits on
+//     its own flag, so a plain intra-block wait is what mirrors the signal.
+#if defined(__DAV_VEC__)
     if (get_block_idx() < num_matrices) {
         pipe_barrier(PIPE_ALL);
+#if __CCE_AICORE__ == 220
         wait_flag_dev(3);
         wait_flag_dev(4);
+#else
+        wait_intra_block(PIPE_MTE3, 3);
+        wait_intra_block(PIPE_MTE3, 4);
+        pipe_barrier(PIPE_ALL);
+#endif
     }
 #endif
 
@@ -406,70 +387,43 @@ AICORE inline void mega_kernel_impl(GM_ADDR q_ptr, GM_ADDR k_ptr, GM_ADDR v_ptr,
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
-    mk_h::chunk_h_kernel<H, D, C>(
-        reinterpret_cast<__gm__ half *>(k_ptr), reinterpret_cast<__gm__ half *>(w_ptr),
-        reinterpret_cast<__gm__ half *>(u_ptr), reinterpret_cast<__gm__ float *>(g_t_ptr),
-        reinterpret_cast<__gm__ half *>(s_ptr), reinterpret_cast<__gm__ half *>(v_new_ptr),
-        reinterpret_cast<__gm__ half *>(fs_ptr), reinterpret_cast<__gm__ half *>(h0_ptr), has_initial_state,
-        reinterpret_cast<__gm__ half *>(h_ws_ptr), reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), batch_size,
-        seq_len, total_tokens, num_key_heads);
+    mk_h::chunk_h_kernel<D, C>(reinterpret_cast<__gm__ half *>(k_ptr), reinterpret_cast<__gm__ half *>(w_ptr),
+                               reinterpret_cast<__gm__ half *>(u_ptr), reinterpret_cast<__gm__ float *>(g_t_ptr),
+                               reinterpret_cast<__gm__ half *>(s_ptr), reinterpret_cast<__gm__ half *>(v_new_ptr),
+                               reinterpret_cast<__gm__ half *>(fs_ptr), reinterpret_cast<__gm__ half *>(h0_ptr),
+                               has_initial_state, 1, reinterpret_cast<__gm__ half *>(h_ws_ptr),
+                               reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), batch_size, seq_len, total_tokens,
+                               static_cast<uint32_t>(H), num_key_heads, ffts_addr);
 
 #ifdef MEGA_STOP_AFTER_H
     pipe_barrier(PIPE_ALL);
     return;
 #endif
 
-    SyncAllImpl<false>();
+    SyncAllMegaKernel<false>();
 
-    mk_o::chunk_o_kernel<H, D, C>(
+    mk_o::chunk_o_kernel<D, C>(
         reinterpret_cast<__gm__ half *>(q_ptr), reinterpret_cast<__gm__ half *>(k_ptr),
         reinterpret_cast<__gm__ half *>(v_new_ptr), reinterpret_cast<__gm__ half *>(s_ptr),
         reinterpret_cast<__gm__ float *>(g_t_ptr), reinterpret_cast<__gm__ float *>(msk_full_ptr),
         reinterpret_cast<__gm__ half *>(o_ws_qk_ptr), reinterpret_cast<__gm__ half *>(o_ws_qs_ptr),
         reinterpret_cast<__gm__ half *>(o_ws_gated_ptr), reinterpret_cast<__gm__ half *>(o_ptr),
-        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), batch_size, seq_len, total_tokens, num_key_heads);
+        reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), batch_size, seq_len, total_tokens, static_cast<uint32_t>(H),
+        num_key_heads, ffts_addr);
 
-#if defined(__DAV_C220_CUBE__)
+// Drain the chunk_o handshake: Vec's final "workspace free" (flag 3) is never
+// consumed by Cube's loop, so consume it here.
+#if defined(__DAV_CUBE__)
     if (get_block_idx() < num_matrices) {
         pipe_barrier(PIPE_ALL);
+#if __CCE_AICORE__ == 220
         wait_flag_dev(3);
+#else
+        WaitBothVecOnA5<PIPE_MTE2>(3);
+        pipe_barrier(PIPE_ALL);
+#endif
     }
 #endif
-}
-
-// Note the codegen parser does not support arguments of form "type *name", only "type* name"
-extern "C" __global__ AICORE void
-GDN_KERNEL_NAME(GM_ADDR q_ptr, GM_ADDR k_ptr, GM_ADDR v_ptr, GM_ADDR g_in_ptr, GM_ADDR beta_ptr, GM_ADDR msk_lower_ptr,
-                GM_ADDR msk_full_ptr, GM_ADDR minus_id_ptr, GM_ADDR cu_seqlens_ptr, GM_ADDR o_ptr, GM_ADDR g_sum_ptr,
-                GM_ADDR g_t_ptr, GM_ADDR beta_t_ptr, GM_ADDR A_ptr, GM_ADDR A_inv_f32_ptr, GM_ADDR A_inv_ptr,
-                GM_ADDR w_ptr, GM_ADDR u_ptr, GM_ADDR s_ptr, GM_ADDR v_new_ptr, GM_ADDR fs_ptr, GM_ADDR h0_ptr,
-                int64_t has_initial_state, GM_ADDR kkt_ws_ptr, GM_ADDR wy_ws_a1_ptr, GM_ADDR wy_ws_a2_ptr,
-                GM_ADDR h_ws_ptr, GM_ADDR o_ws_qk_ptr, GM_ADDR o_ws_qs_ptr, GM_ADDR o_ws_gated_ptr,
-                uint32_t num_heads, uint32_t num_key_heads, int64_t batch_size, int64_t seq_len,
-                int64_t total_tokens, uint32_t num_matrices)
-{
-#define DISPATCH_MEGA_H(H)                                                                                         \
-    case H:                                                                                                        \
-        mega_kernel_impl<H>(q_ptr, k_ptr, v_ptr, g_in_ptr, beta_ptr, msk_lower_ptr, msk_full_ptr, minus_id_ptr,    \
-                            cu_seqlens_ptr, o_ptr, g_sum_ptr, g_t_ptr, beta_t_ptr, A_ptr, A_inv_f32_ptr, A_inv_ptr, \
-                            w_ptr, u_ptr, s_ptr, v_new_ptr, fs_ptr, h0_ptr, has_initial_state, kkt_ws_ptr,          \
-                            wy_ws_a1_ptr, wy_ws_a2_ptr, h_ws_ptr, o_ws_qk_ptr, o_ws_qs_ptr, o_ws_gated_ptr,         \
-                            num_key_heads, batch_size, seq_len, total_tokens, num_matrices);                       \
-        return
-
-    switch (num_heads) {
-        DISPATCH_MEGA_H(8);
-        DISPATCH_MEGA_H(12);
-        DISPATCH_MEGA_H(16);
-        DISPATCH_MEGA_H(24);
-        DISPATCH_MEGA_H(32);
-        DISPATCH_MEGA_H(48);
-        DISPATCH_MEGA_H(64);
-        default:
-            return;
-    }
-
-#undef DISPATCH_MEGA_H
 }

--- a/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
@@ -253,7 +253,7 @@ namespace mk_o {
 }
 #undef call_kernel
 
-AICORE void mega_solve_tril(__gm__ half *out, __gm__ half *in, __gm__ half *minus_id, uint32_t matrix_size,
+AICORE inline void mega_solve_tril(__gm__ half *out, __gm__ half *in, __gm__ half *minus_id, uint32_t matrix_size,
                             uint32_t num_matrices, uint32_t num_bsnd_heads, __gm__ int32_t *cu_seqlens,
                             uint32_t is_lower)
 {

--- a/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
@@ -285,29 +285,19 @@ AICORE inline void mega_kernel_impl(
         return;
     }
 
+    SyncAllMegaKernel<false>();
+
     mk_cumsum::cumsum_kernel<C>(reinterpret_cast<__gm__ float *>(g_in_ptr), reinterpret_cast<__gm__ float *>(g_sum_ptr),
                                 reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), batch_size, seq_len, H);
 
-#ifdef MEGA_STOP_AFTER_CUMSUM
-    pipe_barrier(PIPE_ALL);
-    return;
-#endif
 
     SyncAllMegaKernel<false>();
-
-#ifdef MEGA_STOP_AFTER_SYNC1
-    return;
-#endif
 
     mega_transpose_TH_to_HT<float>(reinterpret_cast<__gm__ float *>(g_sum_ptr),
                                    reinterpret_cast<__gm__ float *>(g_t_ptr), total_tokens, H);
     mega_transpose_TH_to_HT<half>(reinterpret_cast<__gm__ half *>(beta_ptr),
                                   reinterpret_cast<__gm__ half *>(beta_t_ptr), total_tokens, H);
 
-#ifdef MEGA_STOP_AFTER_TRANSPOSE
-    pipe_barrier(PIPE_ALL);
-    return;
-#endif
 
     SyncAllMegaKernel<false>();
 
@@ -334,10 +324,6 @@ AICORE inline void mega_kernel_impl(
 #endif
 #endif
 
-#ifdef MEGA_STOP_AFTER_KKT
-    pipe_barrier(PIPE_ALL);
-    return;
-#endif
 
     SyncAllMegaKernel<false>();
 
@@ -345,23 +331,8 @@ AICORE inline void mega_kernel_impl(
                     reinterpret_cast<__gm__ half *>(minus_id_ptr), C, num_matrices, H,
                     reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), 1);
 
-#ifdef MEGA_STOP_AFTER_SOLVE
-    pipe_barrier(PIPE_ALL);
-    return;
-#endif
 
     SyncAllMegaKernel<false>();
-
-#ifdef MEGA_STOP_AFTER_CAST
-    pipe_barrier(PIPE_ALL);
-    return;
-#endif
-
-    SyncAllMegaKernel<false>();
-
-#ifdef MEGA_STOP_AFTER_SYNC_BEFORE_WY
-    return;
-#endif
 
     mk_wy::wy_fast_kernel<D, C>(
         reinterpret_cast<__gm__ half *>(k_ptr), reinterpret_cast<__gm__ half *>(v_ptr),
@@ -389,10 +360,6 @@ AICORE inline void mega_kernel_impl(
     }
 #endif
 
-#ifdef MEGA_STOP_AFTER_WY
-    pipe_barrier(PIPE_ALL);
-    return;
-#endif
 
     SyncAllMegaKernel<false>();
 
@@ -403,11 +370,6 @@ AICORE inline void mega_kernel_impl(
                                has_initial_state, 1, reinterpret_cast<__gm__ half *>(h_ws_ptr),
                                reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), batch_size, seq_len, total_tokens,
                                static_cast<uint32_t>(H), num_key_heads);
-
-#ifdef MEGA_STOP_AFTER_H
-    pipe_barrier(PIPE_ALL);
-    return;
-#endif
 
     SyncAllMegaKernel<false>();
 

--- a/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
@@ -20,6 +20,16 @@
 #ifndef GDN_C
 #define GDN_C 128
 #endif
+// TODO(anastasios): this should be fixed for A5.
+#ifndef MEMORY_BASE
+#define MEMORY_BASE
+#endif
+// Note the codegen parser does not support arguments of form "type *name", only "type* name"
+// clang-format off
+#ifndef GM_ADDR
+#define GM_ADDR __gm__ uint8_t*
+#endif
+// clang-format off
 // GDN_MAX_HEADS: compile-time ceiling on the value-head count. num_heads is a
 // RUNTIME argument (one .so serves every head count), so the transpose/cumsum
 // UB tiles are sized for this worst case; any num_heads <= GDN_MAX_HEADS works
@@ -267,9 +277,8 @@ AICORE inline void mega_kernel_impl(
     __gm__ uint8_t *fs_ptr, __gm__ uint8_t *h0_ptr, int64_t has_initial_state, __gm__ uint8_t *kkt_ws_ptr,
     __gm__ uint8_t *wy_ws_a1_ptr, __gm__ uint8_t *wy_ws_a2_ptr, __gm__ uint8_t *h_ws_ptr, __gm__ uint8_t *o_ws_qk_ptr,
     __gm__ uint8_t *o_ws_qs_ptr, __gm__ uint8_t *o_ws_gated_ptr, int32_t H, uint32_t num_key_heads, int64_t batch_size,
-    int64_t seq_len, int64_t total_tokens, uint32_t num_matrices, uint64_t ffts_addr)
+    int64_t seq_len, int64_t total_tokens, uint32_t num_matrices)
 {
-    set_ffts_base_addr(ffts_addr);
 
     constexpr int32_t D = GDN_D;
     constexpr int32_t C = GDN_C;
@@ -279,7 +288,7 @@ AICORE inline void mega_kernel_impl(
     }
 
     mk_cumsum::cumsum_kernel<C>(reinterpret_cast<__gm__ float *>(g_in_ptr), reinterpret_cast<__gm__ float *>(g_sum_ptr),
-                                reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), batch_size, seq_len, H, ffts_addr);
+                                reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), batch_size, seq_len, H);
 
 #ifdef MEGA_STOP_AFTER_CUMSUM
     pipe_barrier(PIPE_ALL);
@@ -308,7 +317,7 @@ AICORE inline void mega_kernel_impl(
                              reinterpret_cast<__gm__ float *>(g_t_ptr), reinterpret_cast<__gm__ float *>(msk_lower_ptr),
                              reinterpret_cast<__gm__ half *>(kkt_ws_ptr), reinterpret_cast<__gm__ half *>(A_ptr),
                              reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), batch_size, seq_len, total_tokens,
-                             static_cast<uint32_t>(H), num_key_heads, ffts_addr);
+                             static_cast<uint32_t>(H), num_key_heads);
 
 // Drain the kkt handshake: Vec released both workspace slots (flags 2/3) one
 // last time after Cube's final iteration, so consume them before the next
@@ -362,7 +371,7 @@ AICORE inline void mega_kernel_impl(
         reinterpret_cast<__gm__ half *>(A_inv_ptr), reinterpret_cast<__gm__ half *>(wy_ws_a1_ptr),
         reinterpret_cast<__gm__ half *>(wy_ws_a2_ptr), reinterpret_cast<__gm__ half *>(w_ptr),
         reinterpret_cast<__gm__ half *>(u_ptr), reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), batch_size, seq_len,
-        total_tokens, static_cast<uint32_t>(H), num_key_heads, ffts_addr);
+        total_tokens, static_cast<uint32_t>(H), num_key_heads);
 
 // Drain the wy_fast handshake: Cube freed the A2/A1 slots (flags 3/4) one last
 // time after Vec's final iteration.
@@ -395,7 +404,7 @@ AICORE inline void mega_kernel_impl(
                                reinterpret_cast<__gm__ half *>(fs_ptr), reinterpret_cast<__gm__ half *>(h0_ptr),
                                has_initial_state, 1, reinterpret_cast<__gm__ half *>(h_ws_ptr),
                                reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), batch_size, seq_len, total_tokens,
-                               static_cast<uint32_t>(H), num_key_heads, ffts_addr);
+                               static_cast<uint32_t>(H), num_key_heads);
 
 #ifdef MEGA_STOP_AFTER_H
     pipe_barrier(PIPE_ALL);
@@ -411,7 +420,7 @@ AICORE inline void mega_kernel_impl(
         reinterpret_cast<__gm__ half *>(o_ws_qk_ptr), reinterpret_cast<__gm__ half *>(o_ws_qs_ptr),
         reinterpret_cast<__gm__ half *>(o_ws_gated_ptr), reinterpret_cast<__gm__ half *>(o_ptr),
         reinterpret_cast<__gm__ int32_t *>(cu_seqlens_ptr), batch_size, seq_len, total_tokens, static_cast<uint32_t>(H),
-        num_key_heads, ffts_addr);
+        num_key_heads);
 
 // Drain the chunk_o handshake: Vec's final "workspace free" (flag 3) is never
 // consumed by Cube's loop, so consume it here.
@@ -427,3 +436,21 @@ AICORE inline void mega_kernel_impl(
     }
 #endif
 }
+
+// Note the codegen parser does not support arguments of form "type *name", only "type* name"
+extern "C" __global__ AICORE void launch_mega_kernel(
+    GM_ADDR q_ptr, GM_ADDR k_ptr, GM_ADDR v_ptr, GM_ADDR g_in_ptr, GM_ADDR beta_ptr, GM_ADDR msk_lower_ptr,
+    GM_ADDR msk_full_ptr, GM_ADDR minus_id_ptr, GM_ADDR cu_seqlens_ptr, GM_ADDR o_ptr, GM_ADDR g_sum_ptr,
+    GM_ADDR g_t_ptr, GM_ADDR beta_t_ptr, GM_ADDR A_ptr, GM_ADDR A_inv_f32_ptr, GM_ADDR A_inv_ptr, GM_ADDR w_ptr,
+    GM_ADDR u_ptr, GM_ADDR s_ptr, GM_ADDR v_new_ptr, GM_ADDR fs_ptr, GM_ADDR h0_ptr, int64_t has_initial_state,
+    GM_ADDR kkt_ws_ptr, GM_ADDR wy_ws_a1_ptr, GM_ADDR wy_ws_a2_ptr, GM_ADDR h_ws_ptr, GM_ADDR o_ws_qk_ptr,
+    GM_ADDR o_ws_qs_ptr, GM_ADDR o_ws_gated_ptr, uint32_t num_heads, uint32_t num_key_heads, int64_t batch_size,
+    int64_t seq_len, int64_t total_tokens, uint32_t num_matrices)
+{
+
+        mega_kernel_impl(q_ptr, k_ptr, v_ptr, g_in_ptr, beta_ptr, msk_lower_ptr, msk_full_ptr, minus_id_ptr,
+                            cu_seqlens_ptr, o_ptr, g_sum_ptr, g_t_ptr, beta_t_ptr, A_ptr, A_inv_f32_ptr, A_inv_ptr,
+                            w_ptr, u_ptr, s_ptr, v_new_ptr, fs_ptr, h0_ptr, has_initial_state, kkt_ws_ptr,
+                            wy_ws_a1_ptr, wy_ws_a2_ptr, h_ws_ptr, o_ws_qk_ptr, o_ws_qs_ptr, o_ws_gated_ptr,
+                            num_heads, num_key_heads, batch_size, seq_len, total_tokens, num_matrices);
+    }

--- a/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
@@ -146,7 +146,7 @@ AICORE void mega_transpose_TH_to_HT(__gm__ T *src, __gm__ T *dst, int64_t T_len,
 }
 
 template <int32_t H, int32_t C>
-AICORE void mega_cast_fp32_to_fp16_bsnd(__gm__ float *src, __gm__ half *dst, uint32_t num_matrices,
+AICORE inline void mega_cast_fp32_to_fp16_bsnd(__gm__ float *src, __gm__ half *dst, uint32_t num_matrices,
                                         int64_t total_tokens)
 {
     // See mega_transpose_TH_to_HT above — hides the global `enum class Stride`.
@@ -269,14 +269,12 @@ AICORE inline void mega_solve_tril(__gm__ half *out, __gm__ half *in, __gm__ hal
 }
 
 AICORE inline void mega_kernel_impl(
-    __gm__ uint8_t *q_ptr, __gm__ uint8_t *k_ptr, __gm__ uint8_t *v_ptr, __gm__ uint8_t *g_in_ptr,
-    __gm__ uint8_t *beta_ptr, __gm__ uint8_t *msk_lower_ptr, __gm__ uint8_t *msk_full_ptr, __gm__ uint8_t *minus_id_ptr,
-    __gm__ uint8_t *cu_seqlens_ptr, __gm__ uint8_t *o_ptr, __gm__ uint8_t *g_sum_ptr, __gm__ uint8_t *g_t_ptr,
-    __gm__ uint8_t *beta_t_ptr, __gm__ uint8_t *A_ptr, __gm__ uint8_t *A_inv_f32_ptr, __gm__ uint8_t *A_inv_ptr,
-    __gm__ uint8_t *w_ptr, __gm__ uint8_t *u_ptr, __gm__ uint8_t *s_ptr, __gm__ uint8_t *v_new_ptr,
-    __gm__ uint8_t *fs_ptr, __gm__ uint8_t *h0_ptr, int64_t has_initial_state, __gm__ uint8_t *kkt_ws_ptr,
-    __gm__ uint8_t *wy_ws_a1_ptr, __gm__ uint8_t *wy_ws_a2_ptr, __gm__ uint8_t *h_ws_ptr, __gm__ uint8_t *o_ws_qk_ptr,
-    __gm__ uint8_t *o_ws_qs_ptr, __gm__ uint8_t *o_ws_gated_ptr, int32_t H, uint32_t num_key_heads, int64_t batch_size,
+    GM_ADDR q_ptr, GM_ADDR k_ptr, GM_ADDR v_ptr, GM_ADDR g_in_ptr, GM_ADDR beta_ptr, GM_ADDR msk_lower_ptr,
+    GM_ADDR msk_full_ptr, GM_ADDR minus_id_ptr, GM_ADDR cu_seqlens_ptr, GM_ADDR o_ptr, GM_ADDR g_sum_ptr,
+    GM_ADDR g_t_ptr, GM_ADDR beta_t_ptr, GM_ADDR A_ptr, GM_ADDR A_inv_f32_ptr, GM_ADDR A_inv_ptr, GM_ADDR w_ptr,
+    GM_ADDR u_ptr, GM_ADDR s_ptr, GM_ADDR v_new_ptr, GM_ADDR fs_ptr, GM_ADDR h0_ptr, int64_t has_initial_state,
+    GM_ADDR kkt_ws_ptr, GM_ADDR wy_ws_a1_ptr, GM_ADDR wy_ws_a2_ptr, GM_ADDR h_ws_ptr, GM_ADDR o_ws_qk_ptr,
+    GM_ADDR o_ws_qs_ptr, GM_ADDR o_ws_gated_ptr, int32_t H, uint32_t num_key_heads, int64_t batch_size,
     int64_t seq_len, int64_t total_tokens, uint32_t num_matrices)
 {
 

--- a/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
@@ -56,7 +56,7 @@ using namespace mega_kernel_utils;
 #ifdef __CCE_AICORE__
 
 template <typename T>
-AICORE void mega_transpose_TH_to_HT(__gm__ T *src, __gm__ T *dst, int64_t T_len, int32_t H)
+AICORE inline void mega_transpose_TH_to_HT(__gm__ T *src, __gm__ T *dst, int64_t T_len, int32_t H)
 {
     // To avoid ambiguity with bisheng intrinsic header's global `enum class
     // Stride`
@@ -141,6 +141,12 @@ AICORE void mega_transpose_TH_to_HT(__gm__ T *src, __gm__ T *dst, int64_t T_len,
         }
         set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
         wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
+        // WAR on ub_src: the flag above only protects DST_UB (store → next
+        // TTRANS). Nothing orders MTE2 against V, so hold the next TLOAD until
+        // TTRANS has finished reading SRC_UB — both this loop's next iteration
+        // and the beta_t call that reuses these same UB offsets.
+        set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
     }
 #endif
 }

--- a/csrc/mega_chunk_gdn/op_kernel/mega_kernel_utils.h
+++ b/csrc/mega_chunk_gdn/op_kernel/mega_kernel_utils.h
@@ -1,0 +1,175 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+All rights reserved.
+
+See LICENSE in the root of the software repository:
+https://github.com/huawei-csl/pto-kernels/
+for the full License text.
+*/
+#pragma once
+
+#include <pto/pto-inst.hpp>
+#include <type_traits>
+
+namespace mega_kernel_utils {
+/**
+ * @brief Do a sync step (set-wait flag) between two pipes.
+ *
+ * @tparam SrcPipe The pipe that sets the flag.
+ * @tparam DstPipe The pipe that waits for the flag.
+ * @param [in] id The event id to sync for.
+ */
+template <pipe_t SrcPipe, pipe_t DstPipe>
+AICORE inline void SetWaitFlag(uint32_t id)
+{
+    set_flag(SrcPipe, DstPipe, static_cast<event_t>(id));
+    wait_flag(SrcPipe, DstPipe, static_cast<event_t>(id));
+}
+
+/**
+ * @brief Performs a division on two integral numbers and rounds the result up
+ * to the nearest integer.
+ *
+ * @tparam T1 Data type of dividend.
+ * @tparam T2 Data type of divisor.
+ * @param [in] value Dividend.
+ * @param [in] divisor Divisor.
+ * @return Result of division.
+ */
+template <typename T1, typename T2,
+          typename std::enable_if<std::is_integral<T1>::value && std::is_integral<T2>::value, int>::type = 0>
+AICORE inline T1 CeilDiv(T1 value, T2 divisor)
+{
+    return (value + divisor - 1) / divisor;
+}
+
+template <pipe_t Pipe, uint8_t VEC_NUM = 2>
+AICORE inline void SetCrossFlag(int32_t flag)
+{
+    ffts_cross_core_sync(Pipe, 1 | (VEC_NUM << 4) | (flag << 8));
+}
+
+template <pipe_t Pipe>
+AICORE inline void SignalBothVecOnA5(uint16_t flag)
+{
+    // A5: the flag offset is 16 on new core.
+    constexpr uint16_t VEC_FLAG_OFFSET = 16;
+
+    set_intra_block(Pipe, flag);
+    set_intra_block(Pipe, flag + VEC_FLAG_OFFSET);
+}
+
+template <pipe_t Pipe>
+AICORE inline void WaitBothVecOnA5(uint16_t flag)
+{
+    // A5: the flag offset is 16 on new core.
+    constexpr uint16_t VEC_FLAG_OFFSET = 16;
+
+    wait_intra_block(Pipe, flag);
+    wait_intra_block(Pipe, flag + VEC_FLAG_OFFSET);
+}
+
+/**
+ * @brief Returns the outer matrix layout based on the target architecture and
+ * matrix orientation.
+ *
+ * On DAV C310 targets, the layout depends on whether the matrix is "left-sided"
+ * (L0A). DAV C310: L0A is NZ, L0B is ZN. Older: L0A is ZZ, L0B is ZN.
+ *
+ * Link:
+ * https://pto-isa.github.io/docs/isa/cube/nz-fractal-layout/#per-buffer-nz-layouts
+ *
+ * @param is_left Whether the matrix is on the left side (L0A) or not (L0B).
+ * @return The appropriate @c BLayout for the target architecture.
+ */
+constexpr inline pto::BLayout GetOuterLayout(bool is_left)
+{
+#ifdef __DAV_C310__
+    return is_left ? pto::BLayout::ColMajor : pto::BLayout::RowMajor;
+#else
+    return pto::BLayout::RowMajor;
+#endif
+}
+
+/**
+ * @brief Pipe in-core barrier for vector core that is a no-op for A5.
+ *
+ */
+AICORE inline void PipeBarrierVec()
+{
+#if __CCE_AICORE__ == 220
+    pipe_barrier(PIPE_V);
+#endif
+}
+
+AICORE inline uint16_t GetffstMsg(uint16_t mode, uint16_t flagId)
+{
+    constexpr uint16_t SYNC_MODE_SHIFT_VALUE = 4;
+    constexpr uint16_t SYNC_FLAG_SHIFT_VALUE = 8;
+    return (0x1 + ((mode & 0x3) << SYNC_MODE_SHIFT_VALUE) + ((flagId & 0xf) << SYNC_FLAG_SHIFT_VALUE));
+}
+
+template <bool isAIVOnly = true>
+AICORE inline void SyncAllA2A3()
+{
+// These constants are defined on A5
+#if __CCE_AICORE__ == 220
+    constexpr uint16_t SYNC_AIV_FLAG = 12;
+    constexpr uint16_t SYNC_AIC_FLAG = 11;
+    constexpr uint16_t SYNC_AIC_AIV_FLAG = 13;
+    constexpr uint16_t SYNC_AIV_ONLY_ALL = 14;
+    pipe_barrier(PIPE_ALL);
+    if constexpr (isAIVOnly) {
+        ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x0, SYNC_AIV_ONLY_ALL));
+        wait_flag_dev(SYNC_AIV_ONLY_ALL);
+        return;
+    }
+#if defined(__DAV_CUBE__)
+    wait_flag_dev(SYNC_AIV_FLAG);
+    ffts_cross_core_sync(PIPE_FIX, GetffstMsg(0x0, SYNC_AIC_FLAG));
+    wait_flag_dev(SYNC_AIC_FLAG);
+    ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x02, SYNC_AIC_AIV_FLAG));
+#elif defined(__DAV_VEC__)
+    ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x02, SYNC_AIV_FLAG));
+    wait_flag_dev(SYNC_AIC_AIV_FLAG);
+#endif
+#endif
+}
+
+// ── A5 ── mirrors include/pto/npu/a5/SyncAll.hpp:101-111
+// Requires: getFFTSMsg from <pto/npu/a5/SyncAll.hpp> (A5 defines its own)
+AICORE inline void SyncAllMixA5()
+{
+#if __CCE_AICORE__ != 220
+    pipe_barrier(PIPE_ALL);
+#if defined(__DAV_CUBE__)
+    // 1. Wait for both paired AIVs: one flag ID per subblock (base, base +
+    // SYNC_FLAG_ID_MAX).
+    wait_intra_block(PIPE_S, SYNC_AIV_FLAG);
+    wait_intra_block(PIPE_S, SYNC_AIV_FLAG + SYNC_FLAG_ID_MAX);
+    // 2. Global all-AIC barrier.
+    ffts_cross_core_sync(PIPE_FIX, getFFTSMsg(0x0, SYNC_AIC_FLAG));
+    wait_flag_dev(PIPE_S, SYNC_AIC_FLAG);
+    // 3. Release both paired AIVs.
+    set_intra_block(PIPE_S, SYNC_AIC_AIV_FLAG);
+    set_intra_block(PIPE_S, SYNC_AIC_AIV_FLAG + SYNC_FLAG_ID_MAX);
+#elif defined(__DAV_VEC__)
+    // Set on MTE3 so prior stores drain; wait on PIPE_S.
+    set_intra_block(PIPE_MTE3, SYNC_AIV_FLAG);
+    wait_intra_block(PIPE_S, SYNC_AIC_AIV_FLAG);
+#endif
+#endif
+}
+
+template <bool isAIVOnly = true>
+AICORE inline void SyncAllMegaKernel()
+{
+#if __CCE_AICORE__ == 220
+    SyncAllA2A3<isAIVOnly>();
+#else
+    static_assert(isAIVOnly == false, "No support for AIV only global sync");
+    SyncAllMixA5();
+#endif
+}
+
+}  // namespace mega_kernel_utils

--- a/csrc/mega_chunk_gdn/op_kernel/scaled_dot_kkt.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/scaled_dot_kkt.cpp
@@ -7,10 +7,11 @@
 //   A[i,j] = KK^T[i,j] · coeff[i,j] · causal_mask[i,j]
 //
 // Inputs:
-//   K       [total_tokens, Hg, D] half  — key vectors (BSND along seq; stride Hg * D)
-//   Beta    [H, total_tokens]     half  — gate bias per **value** head (pre-transposed)
-//   G       [H, total_tokens]     float — cumulative gate sum per **value** head
-//   Msk     [C, C]                float — lower-triangular causal mask
+//   K       [total_tokens, Hg, D] half  — key vectors (BSND along seq; stride
+//   Hg * D) Beta    [H, total_tokens]     half  — gate bias per **value** head
+//   (pre-transposed) G       [H, total_tokens]     float — cumulative gate sum
+//   per **value** head Msk     [C, C]                float — lower-triangular
+//   causal mask
 //
 // Output:
 //   A       [total_tokens, H, C]  half  — gated attention matrix in BSND
@@ -33,47 +34,55 @@
 // ── PTO / NPU Primer for This Kernel ──────────────────────────────────
 // NPU Architecture (simplified):
 //   Each "AI Core" (like a GPU SM) has:
-//     - Cube engine: matrix multiply unit (like GPU Tensor Cores), works on L0A/L0B/L0C
-//     - Vec engine: SIMD vector unit (like GPU CUDA cores), works on UB (Unified Buffer)
+//     - Cube engine: matrix multiply unit (like GPU Tensor Cores), works on
+//     L0A/L0B/L0C
+//     - Vec engine: SIMD vector unit (like GPU CUDA cores), works on UB
+//     (Unified Buffer)
 //     - MTE2: DMA engine for loading data: GM → L1 or GM → UB
 //     - MTE3: DMA engine for storing data: UB → GM or L0C → GM
 //     - MTE1: DMA engine for L1 → L0A/L0B transfers (internal to Cube pipeline)
-//   Memory hierarchy (fast→slow): L0 registers > L1 cache > UB (SRAM) > GM (HBM)
-//   Cube and Vec run on SEPARATE cores — they communicate via GM + cross-core flags.
+//   Memory hierarchy (fast→slow): L0 registers > L1 cache > UB (SRAM) > GM
+//   (HBM) Cube and Vec run on SEPARATE cores — they communicate via GM +
+//   cross-core flags.
 //
 // Key PTO APIs used in this kernel (with numpy/torch equivalents):
-//   TASSIGN(tile, addr)     — Bind tile to UB/L1/L0 address (tile = memory[addr])
-//   TLOAD(dst, gm_tensor)   — DMA load: dst = gm_tensor (async, MTE2 pipe)
-//   TSTORE(gm, src)         — DMA store: gm = src (async, MTE3 pipe)
+//   TASSIGN(tile, addr)     — Bind tile to UB/L1/L0 address (tile =
+//   memory[addr]) TLOAD(dst, gm_tensor)   — DMA load: dst = gm_tensor (async,
+//   MTE2 pipe) TSTORE(gm, src)         — DMA store: gm = src (async, MTE3 pipe)
 //   TFILLPAD(dst, src)      — Zero-fill padding: dst[outside valid] = 0
 //   TFILLPAD_INPLACE(d, s)  — Same but in-place for UB tiles
 //   TEXTRACT(l0, l1, r, c)  — Copy L1 sub-block → L0A or L0B (MTE1 pipe)
 //   TRESHAPE(dst, src)      — Reinterpret L1 tile layout (NZ↔ZN for transpose)
 //   TMATMUL(C, A, B)        — Matrix multiply: C = A @ B in Cube engine
-//   TCVT(dst, src, mode)    — Type conversion: like dst = src.float() or src.half()
-//   TMOV(dst, src)          — Copy: dst = src.clone()
-//   TADD(d, a, b)           — Element-wise add: d = a + b
-//   TSUB(d, a, b)           — Element-wise subtract: d = a - b
-//   TMUL(d, a, b)           — Element-wise multiply: d = a * b
-//   TMINS(d, s, val)        — Clamp max: d = torch.clamp(s, max=val)
+//   TCVT(dst, src, mode)    — Type conversion: like dst = src.float() or
+//   src.half() TMOV(dst, src)          — Copy: dst = src.clone() TADD(d, a, b)
+//   — Element-wise add: d = a + b TSUB(d, a, b)           — Element-wise
+//   subtract: d = a - b TMUL(d, a, b)           — Element-wise multiply: d = a
+//   * b TMINS(d, s, val)        — Clamp max: d = torch.clamp(s, max=val)
 //   TEXP(d, s)              — Element-wise exp: d = torch.exp(s)
 //   TLOG(d, s)              — Element-wise log: d = torch.log(s)
 //   TROWEXPAND(2d, col)     — Broadcast column → rows: 2d[i,j] = col[i]
 //   TCOLEXPAND(2d, row)     — Broadcast row → cols: 2d[i,j] = row[j]
-//   set_flag(P1, P2, EVT)   — Signal from pipe P1 to pipe P2 (like a semaphore post)
-//   wait_flag(P1, P2, EVT)  — Wait for signal from P1 (like a semaphore wait)
-//   pipe_barrier(PIPE_V)    — Local Vec barrier (ensure all Vec ops complete)
-//   pipe_barrier(PIPE_ALL)  — Barrier for all local pipes
-//   ffts_cross_core_sync()  — Cross-core signal (Cube↔Vec, different physical cores)
-//   wait_flag_dev(flag)     — Wait for cross-core signal
+//   set_flag(P1, P2, EVT)   — Signal from pipe P1 to pipe P2 (like a semaphore
+//   post) wait_flag(P1, P2, EVT)  — Wait for signal from P1 (like a semaphore
+//   wait) pipe_barrier(PIPE_V)    — Local Vec barrier (ensure all Vec ops
+//   complete) pipe_barrier(PIPE_ALL)  — Barrier for all local pipes
+//   ffts_cross_core_sync()  — Cross-core signal (Cube↔Vec, different physical
+//   cores) wait_flag_dev(flag)     — Wait for cross-core signal
 // ============================================================================
 
-#include <pto/pto-inst.hpp>  // PTO (Performance Tile Operator): NPU kernel API
-#include "acl/acl.h"         // ACL (Ascend Computing Language): runtime API
-using namespace pto;
+#include <runtime/rt_ffts.h>  // FFTS: cross-core synchronization primitives
 
-// NumHeads, HiddenSize, and ChunkSize are template parameters. The mega kernel
-// dispatches NumHeads from a runtime value to a finite set of specializations.
+#include <pto/pto-inst.hpp>  // PTO (Performance Tile Operator): NPU kernel API
+
+#include "acl/acl.h"  // ACL (Ascend Computing Language): runtime API
+#include "mega_kernel_utils.h"
+
+using namespace pto;
+using namespace mega_kernel_utils;
+
+// ── Compile-time constants (set by the JIT compiler from Python) ──────
+// D/C stay compile-time because tile shapes depend on them. H/Hg are runtime.
 #ifndef GDN_D
 #define GDN_D 128  // D = hidden dimension per head
 #endif
@@ -83,13 +92,15 @@ using namespace pto;
 #endif
 
 // ── PTO type aliases (device-only, guarded by __CCE_AICORE__) ───────────────
-// These are only compiled for the NPU device compiler (__CCE_AICORE__ is defined
-// when compiling for AI Core hardware, similar to __CUDA_ARCH__ in CUDA).
+// These are only compiled for the NPU device compiler (__CCE_AICORE__ is
+// defined when compiling for AI Core hardware, similar to __CUDA_ARCH__ in
+// CUDA).
 #ifdef __CCE_AICORE__
 // UbND = UB tile in row-major (ND) layout for Vec engine.
 //   Think of it as: torch.empty((R, C), dtype=T) in on-chip SRAM.
-//   RV, CV = valid region (for dynamic shapes, like a[:valid_rows, :valid_cols])
-//   The Vec engine (SIMD unit) reads/writes these tiles for element-wise ops.
+//   RV, CV = valid region (for dynamic shapes, like a[:valid_rows,
+//   :valid_cols]) The Vec engine (SIMD unit) reads/writes these tiles for
+//   element-wise ops.
 template <typename T, int R, int C, int RV = R, int CV = C, pto::PadValue P = pto::PadValue::Null>
 using UbND = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::RowMajor, RV, CV, pto::SLayout::NoneBox, 512, P>;
 
@@ -99,10 +110,12 @@ using UbND = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::RowMajor, RV, 
 template <typename T, int R, int C, int RV = R, int CV = C>
 using UbDN = pto::Tile<pto::TileType::Vec, T, R, C, pto::BLayout::ColMajor, RV, CV, pto::SLayout::NoneBox, 512>;
 
-// L1Mat = L1 cache tile in NZ fractal format (col-major blocks, row-major within).
+// L1Mat = L1 cache tile in NZ fractal format (col-major blocks, row-major
+// within).
 //   This is the standard input format for the Cube matrix engine.
 //   Think of it as a matrix in L1 cache ready for GEMM.
-//   NZ = "Normal-Z": the default fractal layout that Cube expects for left/right operands.
+//   NZ = "Normal-Z": the default fractal layout that Cube expects for
+//   left/right operands.
 template <typename T, int R, int C, int RV = R, int CV = C>
 using L1Mat = pto::Tile<pto::TileType::Mat, T, R, C, pto::BLayout::ColMajor, RV, CV, pto::SLayout::RowMajor, 512,
                         pto::PadValue::Zero>;
@@ -110,7 +123,8 @@ using L1Mat = pto::Tile<pto::TileType::Mat, T, R, C, pto::BLayout::ColMajor, RV,
 // L1MatZN = L1 tile in ZN fractal format (row-major blocks, col-major within).
 //   Used when you need to transpose a matrix before GEMM:
 //   TRESHAPE(l1_zn, l1_nz) reinterprets NZ→ZN layout = logical transpose.
-//   This is FREE (no data movement) — it just changes how the Cube reads the bits.
+//   This is FREE (no data movement) — it just changes how the Cube reads the
+//   bits.
 template <typename T, int R, int C, int RV = R, int CV = C>
 using L1MatZN = pto::Tile<pto::TileType::Mat, T, R, C, pto::BLayout::RowMajor, RV, CV, pto::SLayout::ColMajor, 512,
                           pto::PadValue::Zero>;
@@ -123,22 +137,26 @@ using GmTensor2D = pto::GlobalTensor<T, GmShape2D, GmStride2D>;
 #endif
 
 // ── Main kernel function (runs on each AI core) ──────────────────────
-// Template parameters: NumHeads (H value), HiddenSize, ChunkSize.
+// Template parameters: HiddenSize, ChunkSize.
 // GROUP = H/Hg; Cube loads K at head_g = head_idx / GROUP.
 //
 // __gm__: Marks pointers as Global Memory (HBM) — the NPU equivalent of
 // CUDA's device memory. All input/output tensors live in GM.
-template <int32_t NumHeads, int32_t HiddenSize, int32_t ChunkSize>
-AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ float *G_handle,
-                       __gm__ float *Msk_handle, __gm__ half *workspace_handle, __gm__ half *A_handle,
-                       __gm__ int32_t *cu_seqlens, int64_t batch_size, int64_t seq_len, int64_t total_tokens,
-                       uint32_t num_key_heads)
+template <int32_t HiddenSize, int32_t ChunkSize>
+AICORE inline void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ float *G_handle,
+                              __gm__ float *Msk_handle, __gm__ half *workspace_handle, __gm__ half *A_handle,
+                              __gm__ int32_t *cu_seqlens, int64_t batch_size, int64_t seq_len, int64_t total_tokens,
+                              uint32_t num_heads, uint32_t num_key_heads, uint64_t ffts_addr)
 {
+    // To avoid ambiguity with bisheng intrinsic header's global `enum class
+    // Stride`
+    using pto::Stride;
     constexpr int32_t HalfChunk = ChunkSize / 2;
     constexpr int32_t ChunkSquare = ChunkSize * ChunkSize;
+    const int32_t H = static_cast<int32_t>(num_heads);
     const int32_t key_heads = static_cast<int32_t>(num_key_heads);
-    if (key_heads <= 0 || (NumHeads % key_heads) != 0) return;
-    const int32_t group = NumHeads / key_heads;
+    if (H <= 0 || key_heads <= 0 || (H % key_heads) != 0) return;
+    const int32_t group = H / key_heads;
     const int32_t bsnd_qk_stride = key_heads * HiddenSize;
     // KTail: number of valid columns in the last 128-wide fractal block of K.
     // If HiddenSize is a multiple of 128, the last block is fully used (128).
@@ -162,6 +180,10 @@ AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ f
     // a_ub_half overlaps g_r_2d — safe because they're never live simultaneously
     constexpr int32_t AUbHalfAddr = GR2dUbAddr;
 
+    // set_ffts_base_addr: Tell the hardware where the cross-core flag table
+    // lives. This is a one-time setup so ffts_cross_core_sync / wait_flag_dev
+    // know which memory region to read/write for inter-core signaling.
+    set_ffts_base_addr(ffts_addr);
     auto cid = get_block_idx();        // Which AI core am I? (like CUDA blockIdx.x)
     auto block_num = get_block_num();  // Total AI cores launched (like CUDA gridDim.x)
     // ── Vec sub-block parallelism ─────────────────────────────────────────
@@ -174,7 +196,7 @@ AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ f
     // Work distribution: each (sequence, head) pair is one "work item".
     // AI cores split work round-robin, just like CUDA blocks split a grid.
     int64_t num_seqs = batch_size;
-    int64_t total_work = num_seqs * NumHeads;
+    int64_t total_work = num_seqs * H;
 
     // ── Cube-side tile declarations ─────────────────────────────────────
     // Cube-side tiles: K in L1 (NZ format), accumulator in L0C
@@ -182,15 +204,16 @@ AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ f
     TASSIGN(k_l1, 0);
     // TileAcc<float, C, C>: L0C accumulator tile for GEMM results.
     // The Cube engine always accumulates in float32 for precision, even when
-    // inputs are fp16. Think of it as: result = torch.matmul(a.half(), b.half()).float()
-    // When stored to GM via TSTORE with a half GlobalTensor, automatic fp32→fp16 cast occurs.
+    // inputs are fp16. Think of it as: result = torch.matmul(a.half(),
+    // b.half()).float() When stored to GM via TSTORE with a half GlobalTensor,
+    // automatic fp32→fp16 cast occurs.
     TileAcc<float, ChunkSize, ChunkSize, ChunkSize, ChunkSize> a_l0;
     TASSIGN(a_l0, 0);
 
     // ── Vec-side UB tile declarations ────────────────────────────────────
     // These tiles live in UB (Unified Buffer, the Vec engine's SRAM scratchpad).
-    // Each TASSIGN binds a tile handle to a fixed UB byte offset (our manual alloc).
-    // Vec-side UB tiles for gating computation
+    // Each TASSIGN binds a tile handle to a fixed UB byte offset (our manual
+    // alloc). Vec-side UB tiles for gating computation
     UbND<float, 1, ChunkSize, 1, ChunkSize> g_ub;
     TASSIGN(g_ub, GUbAddr);
     UbND<half, 1, HalfChunk, 1, HalfChunk> beta_ub_half;
@@ -229,29 +252,36 @@ AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ f
     // For K @ K^T:  (numpy: KK_T = K @ K.T)
     //   Left operand: K [C×D] loaded into L1 in NZ format
     //   Right operand: K^T — same data, but we TRESHAPE to ZN format
-    //     (TRESHAPE is FREE — it just reinterprets the fractal layout as transposed)
-    //   Result: KK^T [C×C] in L0C (float32 accumulator, even though inputs are fp16)
+    //     (TRESHAPE is FREE — it just reinterprets the fractal layout as
+    //     transposed)
+    //   Result: KK^T [C×C] in L0C (float32 accumulator, even though inputs are
+    //   fp16)
     // ========================================================================
-    // __DAV_C220_CUBE__: This code only compiles for the Cube core.
-    // On NPU, Cube and Vec are separate compilation targets (like two different GPUs).
-#if defined(__DAV_C220_CUBE__)
-    // Outer loop: iterate over all (sequence, head) work items assigned to this core
+    // __DAV_CUBE__: This code only compiles for the Cube core.
+    // On NPU, Cube and Vec are separate compilation targets (like two different
+    // GPUs).
+#if defined(__DAV_CUBE__)
+    // Outer loop: iterate over all (sequence, head) work items assigned to this
+    // core
     for (int64_t work_idx = 0; work_idx < (total_work + block_num - 1) / block_num; ++work_idx) {
         int64_t pid = work_idx * static_cast<int64_t>(block_num) + static_cast<int64_t>(cid);
         if (pid >= total_work) continue;
 
         // Map linear work index → (sequence, head) pair
-        int32_t head_idx = static_cast<int32_t>(pid % NumHeads);
-        int64_t seq_idx = pid / NumHeads;
+        int32_t head_idx = static_cast<int32_t>(pid % H);
+        int64_t seq_idx = pid / H;
 
-        // Resolve sequence boundaries: cu_seqlens for variable-length, else fixed stride
+        // Resolve sequence boundaries: cu_seqlens for variable-length, else fixed
+        // stride
         int64_t bos, slen;
         if (cu_seqlens != nullptr) {
-            // Variable-length sequences (packed tensor): cu_seqlens = [0, len0, len0+len1, ...]
+            // Variable-length sequences (packed tensor): cu_seqlens = [0, len0,
+            // len0+len1, ...]
             bos = static_cast<int64_t>(cu_seqlens[seq_idx]);
             slen = static_cast<int64_t>(cu_seqlens[seq_idx + 1]) - bos;
         } else {
-            // Fixed-length sequences: each is seq_len tokens starting at seq_idx*seq_len
+            // Fixed-length sequences: each is seq_len tokens starting at
+            // seq_idx*seq_len
             bos = seq_idx * seq_len;
             slen = seq_len;
         }
@@ -265,8 +295,15 @@ AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ f
         // This overlaps Cube computation with Vec computation for pipelining.
         for (int64_t ci = 0; ci < num_chunks; ++ci) {
             int32_t slot = static_cast<int32_t>(ci & 1);
-            // Wait for Vec to finish reading the previous KK^T from this slot
+            // Wait for Vec to finish reading the previous KK^T from this slot.
+            // A2: Cube and Vec are separate cores → FFTS cross-core flag.
+            // A5: Cube and both Vec sub-blocks live in ONE core → intra-block flags,
+            //     and each Vec sub-block signals its own flag (base and base+16).
+#if __CCE_AICORE__ == 220
             wait_flag_dev(2 + slot);
+#else
+            WaitBothVecOnA5<PIPE_MTE2>(2 + slot);
+#endif
             pipe_barrier(PIPE_ALL);
 
             int64_t chunk_start = ci * ChunkSize;
@@ -274,7 +311,8 @@ AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ f
             int32_t valid_rows = static_cast<int32_t>(remaining < ChunkSize ? remaining : ChunkSize);
 
             // BSND key layout [Seq, Hg, D]: token stride Hg * D (see BSND_QK_STRIDE).
-            // Value head head_idx maps to head_g = head_idx / GROUP for shared K rows.
+            // Value head head_idx maps to head_g = head_idx / GROUP for shared K
+            // rows.
             int32_t head_g = head_idx / group;
             int64_t k_offset = ((bos + chunk_start) * static_cast<int64_t>(key_heads) + static_cast<int64_t>(head_g)) *
                                static_cast<int64_t>(HiddenSize);
@@ -282,8 +320,8 @@ AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ f
             // ── Load K chunk from GM → L1 (MTE2 pipe) ──────────────────────
             // DYNAMIC shape: valid_rows may be < ChunkSize for the last chunk.
             // GlobalTensor describes the GM layout with strides (BSND interleaved).
-            // TLOAD triggers the MTE2 DMA engine to copy from GM (HBM) → L1 (on-chip cache).
-            // If the chunk is partial, TFILLPAD zero-fills the padding region
+            // TLOAD triggers the MTE2 DMA engine to copy from GM (HBM) → L1 (on-chip
+            // cache). If the chunk is partial, TFILLPAD zero-fills the padding region
             // so the GEMM doesn't produce garbage from uninitialized memory.
             {
                 L1Mat<half, ChunkSize, HiddenSize, DYNAMIC, DYNAMIC> _l1(valid_rows, HiddenSize);
@@ -301,7 +339,8 @@ AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ f
             // ── WAR (Write-After-Read) synchronization ────────────────────────
             // Before TEXTRACT (MTE1) writes new data to L0A/L0B, we must ensure:
             //   1. MTE2 has finished loading L1 (MTE2→MTE1 sync)
-            //   2. Cube M pipe has finished reading previous L0A/L0B data (M→MTE1 sync)
+            //   2. Cube M pipe has finished reading previous L0A/L0B data (M→MTE1
+            //   sync)
             // After TEXTRACT, before TMATMUL:
             //   3. MTE1→M sync ensures L0A/L0B data is ready for the matrix engine
             // After TMATMUL completes:
@@ -347,21 +386,29 @@ AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ f
 
             // ── Cross-core synchronization (Cube → Vec) ──────────────────────
             // ffts_cross_core_sync(pipe, config): Signal across physical cores.
-            // Unlike set_flag/wait_flag (which sync pipes within ONE core), this syncs
-            // between the Cube core and Vec core (they are separate hardware units).
+            // Unlike set_flag/wait_flag (which sync pipes within ONE core), this
+            // syncs between the Cube core and Vec core (they are separate hardware
+            // units).
             //
             // Config encoding: 1 | (mode << 4) | (flag_id << 8)
             //   mode=2: broadcast to all cores on same block
             //   flag_id: which flag to set (0,1,2,3...)
             //
-            // The receiving side calls wait_flag_dev(flag_id) to wait for this signal.
+            // The receiving side calls wait_flag_dev(flag_id) to wait for this
+            // signal.
             //
             // In this kernel:
             //   Cube sets flag 0/1 → Vec waits on wait_flag_dev(0/1) (KK^T ready)
             //   Vec sets flag 2/3 → Cube waits on wait_flag_dev(2/3) (workspace free)
             //
             // Signal Vec that this slot's KK^T is ready
-            ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (slot << 8));
+            // ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (slot << 8));
+#if __CCE_AICORE__ == 220
+            SetCrossFlag<PIPE_FIX>(slot);
+#else
+            pipe_barrier(PIPE_ALL);
+            SignalBothVecOnA5<PIPE_FIX>(slot);
+#endif
         }
     }
 #endif
@@ -388,8 +435,8 @@ AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ f
     // # Final: A = KK_T * coeff * causal_mask
     // A = KK_T[my_rows] * coeff * mask[my_rows]           # TMUL × 2
     // ========================================================================
-    // __DAV_C220_VEC__: This code only compiles for the Vec core.
-#if defined(__DAV_C220_VEC__)
+    // __DAV_VEC__: This code only compiles for the Vec core.
+#if defined(__DAV_VEC__)
     // set_mask_norm / set_vector_mask: configure the SIMD mask for Vec ops.
     // (-1, -1) means "all lanes active" — process every element.
     // (Like CUDA's __activemask() returning all 1s for a full warp.)
@@ -416,15 +463,22 @@ AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ f
     // Initial cross-core sync: release both workspace slots so Cube can start.
     // Vec tells Cube "slots 0 and 1 are free" by setting flags 2 and 3.
     // Without this, Cube would hang on wait_flag_dev(2/3) at the first iteration.
-    ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (2 << 8));
-    ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+    // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (2 << 8));
+    // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (3 << 8));
+#if __CCE_AICORE__ == 220
+    SetCrossFlag<PIPE_MTE3>(2);
+    SetCrossFlag<PIPE_MTE3>(3);
+#else
+    set_intra_block(PIPE_MTE3, 2);
+    set_intra_block(PIPE_MTE3, 3);
+#endif
 
     for (int64_t work_idx = 0; work_idx < (total_work + block_num - 1) / block_num; ++work_idx) {
         int64_t pid = work_idx * static_cast<int64_t>(block_num) + static_cast<int64_t>(cid);
         if (pid >= total_work) continue;
 
-        int32_t head_idx = static_cast<int32_t>(pid % NumHeads);
-        int64_t seq_idx = pid / NumHeads;
+        int32_t head_idx = static_cast<int32_t>(pid % H);
+        int64_t seq_idx = pid / H;
 
         int64_t bos, slen;
         if (cu_seqlens != nullptr) {
@@ -490,7 +544,11 @@ AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ f
             }
 
             // Wait for Cube to finish writing KK^T for this slot
+#if __CCE_AICORE__ == 220
             wait_flag_dev(slot);
+#else
+            wait_intra_block(PIPE_MTE3, slot);
+#endif
             pipe_barrier(PIPE_ALL);
 
             if (local_valid > 0) {
@@ -498,23 +556,25 @@ AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ f
                 // Step 1: Convert beta from fp16→fp32 for precision
                 // Step 2: g_v[i] = g[row_offset+i] + log(β[i])  — combined row gate
                 // Step 3: Broadcast g_v (rows) and g (cols) to 2D matrices
-                // Step 4: coeff = exp(min(g_v_2d - g_2d, 0)) — clamped exponential gating
-                // g_v[i] = g[row_offset+i] + log(β[i])  — combined row gate
+                // Step 4: coeff = exp(min(g_v_2d - g_2d, 0)) — clamped exponential
+                // gating g_v[i] = g[row_offset+i] + log(β[i])  — combined row gate
                 TCVT(beta_ub, beta_ub_half, pto::RoundMode::CAST_NONE);
-                // g_ub_temp points to the sub-block's portion of g within the full g_ub.
-                // row_offset * sizeof(float) is the byte offset into the g_ub tile.
+                // g_ub_temp points to the sub-block's portion of g within the full
+                // g_ub. row_offset * sizeof(float) is the byte offset into the g_ub
+                // tile.
                 UbND<float, 1, HalfChunk, 1, HalfChunk> g_ub_temp;
                 TASSIGN(g_ub_temp, GUbAddr + row_offset * static_cast<int32_t>(sizeof(float)));
                 TMOV(g_v_ub, g_ub_temp);  // g_v = g[row_offset:row_offset+C/2]
-                pipe_barrier(PIPE_V);     // Wait for TMOV to complete
+                PipeBarrierVec();         // Wait for TMOV to complete
 
                 TLOG(beta_ub, beta_ub);  // beta_ub = log(beta) in-place
-                pipe_barrier(PIPE_V);
-                TADD(g_v_ub, g_v_ub, beta_ub);  // g_v = g_sub + log(beta) — the combined gate
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
+                TADD(g_v_ub, g_v_ub,
+                     beta_ub);  // g_v = g_sub + log(beta) — the combined gate
+                PipeBarrierVec();
                 TMOV(g_r_ub, g_v_ub);  // Copy to g_r for row-broadcast
                 TMOV(g_c_ub, g_ub);    // Copy full g to g_c for col-broadcast
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
 
                 // Broadcast g_v to rows, g to columns → 2D gating matrix
                 // coeff[i,j] = exp(min(g_v[i] - g[j], 0))
@@ -525,16 +585,18 @@ AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ f
                 TASSIGN(g_r_ub_temp, GRUbAddr);
                 TROWEXPAND(g_r_2d_ub, g_r_ub_temp);  // g_r_2d[i,j] = g_v[i] for all j
                 TCOLEXPAND(g_c_2d_ub, g_c_ub);       // g_c_2d[i,j] = g[j] for all i
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
                 TSUB(coeff_ub, g_r_2d_ub, g_c_2d_ub);  // coeff[i,j] = g_v[i] - g[j]
-                pipe_barrier(PIPE_V);
-                TMINS(coeff_ub, coeff_ub, 0.0f);  // clamp to ≤ 0 (coeff will be ≤ 1 after exp)
-                pipe_barrier(PIPE_V);
+                PipeBarrierVec();
+                TMINS(coeff_ub, coeff_ub,
+                      0.0f);  // clamp to ≤ 0 (coeff will be ≤ 1 after exp)
+                PipeBarrierVec();
                 TEXP(coeff_ub, coeff_ub);  // coeff = exp(clamped_diff) ∈ (0, 1]
 
                 // V→MTE2 sync: ensure gating computation is done before we start
-                // loading KK^T from workspace (we need coeff ready for the multiply later,
-                // and we want to overlap the DMA load with the preceding Vec work).
+                // loading KK^T from workspace (we need coeff ready for the multiply
+                // later, and we want to overlap the DMA load with the preceding Vec
+                // work).
                 set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
                 wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
 
@@ -559,11 +621,13 @@ AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ f
                 wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
                 // ── Apply gating and mask: A = KK^T · coeff · mask ───────────
-                // 1. Convert KK^T from fp16 → fp32 (Cube stored it as fp16 to save GM bandwidth)
+                // 1. Convert KK^T from fp16 → fp32 (Cube stored it as fp16 to save GM
+                // bandwidth)
                 TCVT(a_ub, a_ub_half, pto::RoundMode::CAST_NONE);
                 // 2. Element-wise multiply by gating coefficient
                 TMUL(a_ub, a_ub, coeff_ub);
-                // 3. Element-wise multiply by causal mask (lower triangular, zeros above diagonal)
+                // 3. Element-wise multiply by causal mask (lower triangular, zeros
+                // above diagonal)
                 TMUL(a_ub, a_ub, msk_ub);
                 // 4. Convert result back to fp16 for output
                 TCVT(a_ub_half, a_ub, pto::RoundMode::CAST_NONE);
@@ -573,18 +637,17 @@ AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ f
                 wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
 
                 // ── Store A sub-block to output GM ────────────────────────────
-                // Output A is in BSND layout: [total_tokens, NumHeads, ChunkSize]
-                // Each row of A corresponds to one token's attention weights for this head.
-                // Stride between consecutive tokens = NumHeads * ChunkSize (BSND interleaved).
+                // Output A is in BSND layout: [total_tokens, H, ChunkSize]
+                // Each row of A corresponds to one token's attention weights for this
+                // head. Stride between consecutive tokens = H * ChunkSize (BSND
+                // interleaved).
                 int64_t a_gm_offset =
-                    ((bos + chunk_start + row_offset) * NumHeads + head_idx) * static_cast<int64_t>(ChunkSize);
+                    ((bos + chunk_start + row_offset) * H + head_idx) * static_cast<int64_t>(ChunkSize);
 
                 {
-                    Shape<1, 1, 1, DYNAMIC, DYNAMIC> _gs;
-                    _gs.shape[3] = local_valid;
-                    _gs.shape[4] = ChunkSize;
-                    GlobalTensor<half, decltype(_gs), Stride<1, 1, 1, NumHeads * ChunkSize, 1>> _gm(
-                        A_handle + a_gm_offset, _gs);
+                    GmShape2D _gs(local_valid, ChunkSize);
+                    GmStride2D _stride(H * ChunkSize);
+                    GmTensor2D<half> _gm(A_handle + a_gm_offset, _gs, _stride);
                     UbND<half, HalfChunk, ChunkSize, DYNAMIC, DYNAMIC> _st(local_valid, ChunkSize);
                     TASSIGN(_st, AUbHalfAddr);
                     TSTORE(_gm, _st);
@@ -595,7 +658,12 @@ AICORE void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ f
             // Signal Cube that this workspace slot is free for reuse.
             // Flag (2+slot): slot 0 → flag 2, slot 1 → flag 3.
             // Cube is waiting on wait_flag_dev(2+slot) before writing the next chunk.
-            ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | ((2 + slot) << 8));
+            // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | ((2 + slot) << 8));
+#if __CCE_AICORE__ == 220
+            SetCrossFlag<PIPE_MTE3>(2 + slot);
+#else
+            set_intra_block(PIPE_MTE3, 2 + slot);
+#endif
         }
     }
 #endif

--- a/csrc/mega_chunk_gdn/op_kernel/scaled_dot_kkt.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/scaled_dot_kkt.cpp
@@ -146,7 +146,7 @@ template <int32_t HiddenSize, int32_t ChunkSize>
 AICORE inline void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, __gm__ float *G_handle,
                               __gm__ float *Msk_handle, __gm__ half *workspace_handle, __gm__ half *A_handle,
                               __gm__ int32_t *cu_seqlens, int64_t batch_size, int64_t seq_len, int64_t total_tokens,
-                              uint32_t num_heads, uint32_t num_key_heads, uint64_t ffts_addr)
+                              uint32_t num_heads, uint32_t num_key_heads)
 {
     // To avoid ambiguity with bisheng intrinsic header's global `enum class
     // Stride`
@@ -183,7 +183,6 @@ AICORE inline void kkt_kernel(__gm__ half *K_handle, __gm__ half *Beta_handle, _
     // set_ffts_base_addr: Tell the hardware where the cross-core flag table
     // lives. This is a one-time setup so ffts_cross_core_sync / wait_flag_dev
     // know which memory region to read/write for inter-core signaling.
-    set_ffts_base_addr(ffts_addr);
     auto cid = get_block_idx();        // Which AI core am I? (like CUDA blockIdx.x)
     auto block_num = get_block_num();  // Total AI cores launched (like CUDA gridDim.x)
     // ── Vec sub-block parallelism ─────────────────────────────────────────

--- a/csrc/mega_chunk_gdn/op_kernel/tri_inverse_impl.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/tri_inverse_impl.cpp
@@ -7,17 +7,12 @@ https://github.com/huawei-csl/pto-kernels/
 for the full License text.
 */
 
-#ifndef MEMORY_BASE
-#define MEMORY_BASE
-#endif
 #include <pto/pto-inst.hpp>
 
-using namespace pto;
+#include "mega_kernel_utils.h"
 
-AICORE inline uint32_t CeilDiv(uint32_t value, uint32_t divisor)
-{
-    return (value + divisor - 1) / divisor;
-}
+using namespace pto;
+using namespace mega_kernel_utils;
 
 #define BSND_OFFSET(tile_id, N, S, D) (((tile_id) / (N)) * (S) * (N) * (D) + ((tile_id) % (N)) * (D))
 
@@ -54,7 +49,7 @@ AICORE inline BSNDVarlenTileInfo GetBSNDVarlenTileInfoFromCuSeqlens(uint32_t til
     for (uint32_t seq_idx = 0;; ++seq_idx) {
         const uint32_t seq_end = static_cast<uint32_t>(cu_seqlens[seq_idx + 1]);
         const uint32_t seq_len = seq_end - seq_start;
-        const uint32_t seq_num_chunks = CeilDiv(seq_len, matrix_size);
+        const uint32_t seq_num_chunks = mega_kernel_utils::CeilDiv(seq_len, matrix_size);
         if (chunk_idx < accumulated_chunks + seq_num_chunks) {
             const uint32_t local_chunk_idx = chunk_idx - accumulated_chunks;
             const uint32_t row_start = seq_start + local_chunk_idx * matrix_size;
@@ -66,7 +61,7 @@ AICORE inline BSNDVarlenTileInfo GetBSNDVarlenTileInfoFromCuSeqlens(uint32_t til
     }
 }
 
-/*
+/**
  * @brief: Takes as input two matrices of size MatrixSize * MatrixSize each.
  * The src matrix lies in L1, while the dst matrix lies either in L0A or L0B.
  * This kernel copies only the diagonal blocks (fractals) of size FractalSize *
@@ -88,8 +83,9 @@ AICORE inline void CopyDiagonalFractalsL1ToL0(SrcL1TileT src, DstL0TileT dst)
     constexpr bool is_left = std::is_same_v<DstL0TileT, TileLeft<InputT, MatrixSize, MatrixSize>>;
     constexpr TileType LeftOrRight = is_left ? TileType::Left : TileType::Right;
     constexpr SLayout InnerLayout = is_left ? SLayout::RowMajor : SLayout::ColMajor;
+    constexpr BLayout OuterLayout = mega_kernel_utils::GetOuterLayout(is_left);
 
-    Tile<LeftOrRight, InputT, FractalSize, FractalSize, BLayout::RowMajor, FractalSize, FractalSize, InnerLayout,
+    Tile<LeftOrRight, InputT, FractalSize, FractalSize, OuterLayout, FractalSize, FractalSize, InnerLayout,
          TileConfig::fractalABSize>
         fractals[NumFractals];
     const std::uintptr_t starting_address = reinterpret_cast<std::uintptr_t>(dst.data());
@@ -99,7 +95,7 @@ AICORE inline void CopyDiagonalFractalsL1ToL0(SrcL1TileT src, DstL0TileT dst)
     }
 }
 
-/*
+/**
  * @brief: Takes as input two matrices of size MatrixSize * MatrixSize each,
  * and an integer block_size. The src matrix lies in L1, while the dst matrix
  * either in L0A or L0B. This method copies some of the diagonal blocks from the
@@ -118,6 +114,10 @@ AICORE inline void CopyDiagonalFractalsL1ToL0(SrcL1TileT src, DstL0TileT dst)
  * @param src Tile in L1 memory.
  * @param dst Tile in L0A or L0B memory.
  * @param block_size Size of diagonal blocks. Needs: block_size >= FractalSize.
+ * @param swap_parity If true, then the parity of copied blocks is swapped: left
+ * tile gets odd blocks, while right tile gets even blocks. This is used in the
+ * unrolled recursion part of the algorithm, where we need to copy alternating
+ * blocks of X in each iteration.
  */
 template <typename InputT, uint32_t FractalSize, uint32_t MatrixSize, typename SrcL1TileT, typename DstL0TileT>
 AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst, uint32_t block_size,
@@ -126,7 +126,9 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst, uin
     constexpr bool is_left = std::is_same_v<DstL0TileT, TileLeft<InputT, MatrixSize, MatrixSize>>;
     constexpr TileType LeftOrRight = is_left ? TileType::Left : TileType::Right;
     constexpr SLayout InnerLayout = is_left ? SLayout::RowMajor : SLayout::ColMajor;
-
+    constexpr BLayout OuterLayout = mega_kernel_utils::GetOuterLayout(is_left);
+    // For left: copy even blocks 0, 2, 4, ... (starting_block=0)
+    // For right: copy odd blocks 1, 3, 5, ... (starting_block=1)
     // Default: left→even(0), right→odd(1). swap_parity flips this.
     const uint32_t starting_block_index = (is_left ? 0u : 1u) ^ (swap_parity ? 1u : 0u);
 
@@ -134,7 +136,7 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst, uin
     const uint32_t num_fractals_per_block = block_size / FractalSize;
 
     // might need fewer fractals if block_size < FractalSize
-    Tile<LeftOrRight, InputT, FractalSize, FractalSize, BLayout::RowMajor, FractalSize, FractalSize, InnerLayout,
+    Tile<LeftOrRight, InputT, FractalSize, FractalSize, OuterLayout, FractalSize, FractalSize, InnerLayout,
          TileConfig::fractalABSize>
         fractals[MatrixSize / FractalSize];
 
@@ -142,9 +144,16 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst, uin
     for (uint32_t i = 0; i < num_fractals_per_block; ++i) {
         for (uint32_t j = 0; j < num_fractals_per_block; ++j) {
             for (uint32_t b = starting_block_index; b < num_blocks; b += 2) {
+#ifdef __DAV_C310__
+                const uint32_t row_stride = is_left ? FractalSize : MatrixSize;
+                const uint32_t col_stride = is_left ? MatrixSize : FractalSize;
+#else
+                const uint32_t row_stride = MatrixSize;
+                const uint32_t col_stride = FractalSize;
+#endif
                 const uint32_t offset = b * (MatrixSize + FractalSize) * block_size /* block_offset */ +
-                                        i * MatrixSize * FractalSize /* col_fractal_offset */ +
-                                        j * FractalSize * FractalSize /* row_fractal_offset */;
+                                        j * col_stride * FractalSize /* col_fractal_offset */ +
+                                        i * row_stride * FractalSize /* row_fractal_offset */;
                 TASSIGN(fractals[b], starting_address + offset * sizeof(InputT));
                 TEXTRACT(fractals[b], src, b * block_size + i * FractalSize, b * block_size + j * FractalSize);
             }
@@ -152,7 +161,7 @@ AICORE inline void CopyOddOrEvenBlocksL1ToL0(SrcL1TileT src, DstL0TileT dst, uin
     }
 }
 
-/*
+/**
  * @brief: Prepares Identity and Zeros matrix.
  *
  * @tparam TileL1AB The type of the input tiles in L1.
@@ -198,7 +207,7 @@ AICORE inline void PrepareAuxiliaryMatrices(TileL1AB I_neg_l1_tile, TileL1AB Zer
     wait_flag(PIPE_FIX, PIPE_MTE1, static_cast<event_t>(0));
 }
 
-/*
+/**
  * @brief: Inverts a single matrix / tile of the global tensor.
  * The first part of the algorithm inverts the FractalSize * FractalSize
  * diagonal blocks of the input matrix (inv_trick part). The second phase
@@ -224,6 +233,10 @@ AICORE inline void PrepareAuxiliaryMatrices(TileL1AB I_neg_l1_tile, TileL1AB Zer
  * @param b_l0_tile* Array of two tiles in L0B (for double-buffering).
  * @param c_l0_tile* Tile in L0C for matmuls.
  * @param tile_id Index of the current tile (used for sync).
+ * @param swap_parity If true, then the parity of copied blocks is swapped: left
+ * tile gets odd blocks, while right tile gets even blocks. This is used in the
+ * unrolled recursion part of the algorithm, where we need to copy alternating
+ * blocks of X in each iteration.
  */
 template <typename InputT, typename TileL1AB, typename TileL0A, typename TileL0B, typename TileL0C, uint32_t MatrixSize,
           uint32_t FractalSize, uint32_t NumTilesPerCubeIter>
@@ -366,6 +379,15 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile, Tile
 
     /*
      * Unrolled recursion part:
+     * block_size = FractalSize
+     * while block_size < MatrixSize:
+     *     LX = even_blocks(X, block_size)
+     *     RX = odd_blocks(X, block_size)
+     *     Y = LX @ (-M) + I
+     *     X = Y @ RX + LX
+     *     block_size *= 2
+     *
+     * Comments:
      * Upper-tri (swap_parity=false):
      *   LX = even_blocks(X), RX = odd_blocks(X)
      *   Y = LX @ (-M) + I, X = Y @ RX + LX
@@ -415,7 +437,8 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile, Tile
         set_flag(PIPE_FIX, PIPE_MTE1, event_0);
         set_flag(PIPE_FIX, PIPE_M, event_0);
 
-        /* Load complementary blocks of X in L0B */
+        /* Load complementary blocks of X in L0B. If swap_parity = false, "Load Odd
+         * Blocks Of X In L0B" */
         wait_flag(PIPE_M, PIPE_MTE1, event_1);
         TMOV(b_l0_tile[0], Zero_l1_tile);
         CopyOddOrEvenBlocksL1ToL0<InputT, FractalSize, MatrixSize>(X_l1_tile, b_l0_tile[0], block_size,
@@ -445,10 +468,10 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile, Tile
     wait_flag(PIPE_FIX, PIPE_MTE1, event_1);  // Write c_l0[1] to X_l1
 }
 
-/*
+/**
  * @brief: Runs the main kernel (inverts all matrices in the tensor)
  *
- * @tparam InputT The type of the input elements.
+ * @tparam InputT The type of the input elements. Supports fp16 and bf16.
  * @tparam OutputT The type of the output elements.
  * @tparam MatrixSize Size of the entire input/output matrices.
  * @tparam NumTilesPerCubeIter How many matrices to load and invert in a single
@@ -466,16 +489,20 @@ AICORE inline void InvertSingleTile(TileL1AB X_l1_tile, TileL1AB I_l1_tile, Tile
  * @param I_neg Pointer to global memory that contains the negative identity.
  * @param total_tiles The total number of matrices to invert.
  * @param num_bsnd_heads The number of heads, only for BSND format.
+ * @param is_lower If input matrices are lower-triangular (is_lower == 1) or
+ * upper-triangular (is_lower == 0). Default is upper triangular.
+ * @param num_bsnd_heads The number of heads, only for BSND format.
  */
-template <typename InputT, typename OutputT, uint32_t MatrixSize, uint32_t NumTilesPerCubeIter, bool IsBSND,
-          typename StoreT = OutputT>
-AICORE inline void TriInvRecUnrollKernel(__gm__ StoreT *M_inv, __gm__ InputT *M, __gm__ InputT *I_neg,
-                                         uint32_t total_tiles, uint32_t num_bsnd_heads = 0,
-                                         __gm__ int32_t *cu_seqlens = nullptr, uint32_t is_lower = 0)
+template <typename InputT, typename OutputT, uint32_t MatrixSize, uint32_t NumTilesPerCubeIter, bool IsBSND>
+AICORE inline void TriInvRecUnrollKernel(__gm__ OutputT *M_inv, __gm__ InputT *M, __gm__ InputT *I_neg,
+                                         uint32_t total_tiles, uint32_t num_bsnd_heads = 0, uint32_t is_lower = 0,
+                                         __gm__ int32_t *cu_seqlens = nullptr)
 {
+    using pto::Stride;
+
     /* Initializations */
     constexpr uint32_t TileLen = MatrixSize * MatrixSize;
-    constexpr uint32_t FractalSize = 16;  // fractal size for half
+    constexpr uint32_t FractalSize = 16;  // fractal size for half /bf16
     constexpr uint32_t NumFractalsRowWise = MatrixSize / FractalSize;
     constexpr uint32_t NumL0Buffers = 2;
 
@@ -486,20 +513,20 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ StoreT *M_inv, __gm__ InputT *M,
     using GlobalTileShapeIn = TileShape2D<InputT, MatrixSize, MatrixSize, Layout::ND>;
     using GlobalTileStridesIn =
         typename std::conditional<!IsBSND, BaseShape2D<InputT, MatrixSize, MatrixSize, Layout::ND>,
-                                  Stride<1, 1, 1, -1, 1>>::type;
+                                  pto::Stride<1, 1, 1, -1, 1>>::type;
     using GlobalTileIn = GlobalTensor<InputT, GlobalTileShapeIn, GlobalTileStridesIn, Layout::ND>;
     using GlobalTileDynamicShape = Shape<1, 1, 1, DYNAMIC, DYNAMIC>;
-    using GlobalTileDynamicStride = Stride<1, 1, 1, DYNAMIC, 1>;
+    using GlobalTileDynamicStride = pto::Stride<1, 1, 1, DYNAMIC, 1>;
     using GlobalTileDynamicIn = GlobalTensor<InputT, GlobalTileDynamicShape, GlobalTileDynamicStride, Layout::ND>;
     using GlobalTileStridesINeg = BaseShape2D<InputT, MatrixSize, MatrixSize, Layout::ND>;
     using GlobalTileINeg = GlobalTensor<InputT, GlobalTileShapeIn, GlobalTileStridesINeg, Layout::ND>;
 
-    using GlobalTileShapeOut = TileShape2D<StoreT, MatrixSize, MatrixSize, Layout::ND>;
+    using GlobalTileShapeOut = TileShape2D<OutputT, MatrixSize, MatrixSize, Layout::ND>;
     using GlobalTileStridesOut =
-        typename std::conditional<!IsBSND, BaseShape2D<StoreT, MatrixSize, MatrixSize, Layout::ND>,
-                                  Stride<1, 1, 1, -1, 1>>::type;
-    using GlobalTileOut = GlobalTensor<StoreT, GlobalTileShapeOut, GlobalTileStridesOut, Layout::ND>;
-    using GlobalTileDynamicOut = GlobalTensor<StoreT, GlobalTileDynamicShape, GlobalTileDynamicStride, Layout::ND>;
+        typename std::conditional<!IsBSND, BaseShape2D<OutputT, MatrixSize, MatrixSize, Layout::ND>,
+                                  pto::Stride<1, 1, 1, -1, 1>>::type;
+    using GlobalTileOut = GlobalTensor<OutputT, GlobalTileShapeOut, GlobalTileStridesOut, Layout::ND>;
+    using GlobalTileDynamicOut = GlobalTensor<OutputT, GlobalTileDynamicShape, GlobalTileDynamicStride, Layout::ND>;
     using TileL1AB = Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor, MatrixSize, MatrixSize,
                           SLayout::RowMajor, 512>;
     using TileL1ABDynamic = Tile<TileType::Mat, InputT, MatrixSize, MatrixSize, BLayout::ColMajor, DYNAMIC, DYNAMIC,
@@ -508,8 +535,8 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ StoreT *M_inv, __gm__ InputT *M,
     // L0 Memory
     using TileL0A = TileLeft<InputT, MatrixSize, MatrixSize>;
     using TileL0B = TileRight<InputT, MatrixSize, MatrixSize>;
-    using TileL0C = TileAcc<OutputT, MatrixSize, MatrixSize>;
-    using TileL0CDynamic = TileAcc<OutputT, MatrixSize, MatrixSize, DYNAMIC, DYNAMIC>;
+    using TileL0C = TileAcc<float, MatrixSize, MatrixSize>;
+    using TileL0CDynamic = TileAcc<float, MatrixSize, MatrixSize, DYNAMIC, DYNAMIC>;
 
     GlobalTileINeg I_neg_global_in(I_neg);
 
@@ -536,7 +563,7 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ StoreT *M_inv, __gm__ InputT *M,
     for (uint32_t buffer_num = 0; buffer_num < NumL0Buffers; ++buffer_num) {
         TASSIGN(a_l0_tile[buffer_num], 0x0 + buffer_num * TileLen * sizeof(InputT));
         TASSIGN(b_l0_tile[buffer_num], 0x0 + buffer_num * TileLen * sizeof(InputT));
-        TASSIGN(c_l0_tile[buffer_num], 0x0 + buffer_num * TileLen * sizeof(OutputT));
+        TASSIGN(c_l0_tile[buffer_num], 0x0 + buffer_num * TileLen * sizeof(float));
     }
     TLOAD(I_neg_l1_tile, I_neg_global_in);
     set_flag(PIPE_MTE2, PIPE_MTE1, static_cast<event_t>(0));
@@ -622,7 +649,7 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ StoreT *M_inv, __gm__ InputT *M,
                 const int row_stride = static_cast<int>(MatrixSize * num_bsnd_heads);
                 if (valid_size < MatrixSize) {
                     TileL0CDynamic c_l0_tail_tile(valid_size, valid_size);
-                    TASSIGN(c_l0_tail_tile, 0x0 + final_c_buffer_index * TileLen * sizeof(OutputT));
+                    TASSIGN(c_l0_tail_tile, 0x0 + final_c_buffer_index * TileLen * sizeof(float));
                     GlobalTileDynamicOut M_inv_global_out_dyn(
                         M_inv + bsnd_offset, {1, 1, 1, static_cast<int>(valid_size), static_cast<int>(valid_size)},
                         {1, 1, 1, row_stride, 1});
@@ -648,43 +675,93 @@ AICORE inline void TriInvRecUnrollKernel(__gm__ StoreT *M_inv, __gm__ InputT *M,
 /*
  * @brief: Computes the inverses of the blocks of tensor M
  */
-template <typename InputT, typename OutputT, uint32_t MatrixSize, uint32_t NumTilesPerCubeIter, bool IsBSND,
-          typename StoreT = OutputT>
-AICORE void runKernelTriInvRecUnroll(__gm__ StoreT *M_inv, __gm__ InputT *M, __gm__ InputT *I_neg, uint32_t total_tiles,
-                                     uint32_t num_bsnd_heads = 0, __gm__ int32_t *cu_seqlens = nullptr,
-                                     uint32_t is_lower = 0)
+template <typename InputT, typename OutputT, uint32_t MatrixSize, uint32_t NumTilesPerCubeIter, bool IsBSND>
+AICORE void runKernelTriInvRecUnroll(__gm__ OutputT *M_inv, __gm__ InputT *M, __gm__ InputT *I_neg,
+                                     uint32_t total_tiles, uint32_t num_bsnd_heads = 0, uint32_t is_lower = 0,
+                                     __gm__ int32_t *cu_seqlens = nullptr)
 {
-#if (__CHECK_FEATURE_AT_PRECOMPILE) || (__CCE_AICORE__ == 220 && defined(__DAV_C220_CUBE__))  // Cube compilation
+#if defined(__DAV_CUBE__)  // Cube compilation
 
-    TriInvRecUnrollKernel<InputT, OutputT, MatrixSize, NumTilesPerCubeIter, IsBSND, StoreT>(
-        M_inv, M, I_neg, total_tiles, num_bsnd_heads, cu_seqlens, is_lower);
+    TriInvRecUnrollKernel<InputT, OutputT, MatrixSize, NumTilesPerCubeIter, IsBSND>(
+        M_inv, M, I_neg, total_tiles, num_bsnd_heads, is_lower, cu_seqlens);
 #else
 // Nothing to do on AIV
 #endif
 }
 
-template <typename InputT, uint32_t NumTilesPerCubeIter, bool IsBSND>
-AICORE void run_tri_inv_rec_unroll(__gm__ float *tensor_out, __gm__ InputT *tensor_in, __gm__ InputT *minus_identity_in,
+template <typename InputT, typename OutputT, uint32_t NumTilesPerCubeIter, bool IsBSND>
+AICORE void run_tri_inv_rec_unroll(__gm__ OutputT *tensor_out, __gm__ InputT *tensor_in, __gm__ InputT *minus_eye_in,
                                    uint32_t matrix_size, uint32_t num_matrices, uint32_t num_bsnd_heads,
-                                   __gm__ int32_t *cu_seqlens = nullptr, uint32_t is_lower = 0)
+                                   uint32_t is_lower = 0, __gm__ int32_t *cu_seqlens = nullptr)
 {
-    static_assert(std::is_same_v<InputT, half>, "tri_inv_rec_unroll supports only fp16.");
+    static_assert(std::is_same_v<InputT, half> or std::is_same_v<InputT, bfloat16_t>,
+                  "tri_inv_rec_unroll supports only fp16 or bf16.");
+
+    static_assert(std::is_same_v<OutputT, float> or std::is_same_v<OutputT, bfloat16_t>,
+                  "tri_inv_rec_unroll supports only fp32 or bf16.");
     switch (matrix_size) {
         case 16:
-            runKernelTriInvRecUnroll<InputT, float, 16, NumTilesPerCubeIter, IsBSND>(
-                tensor_out, tensor_in, minus_identity_in, num_matrices, num_bsnd_heads, cu_seqlens, is_lower);
+            runKernelTriInvRecUnroll<InputT, OutputT, 16, NumTilesPerCubeIter, IsBSND>(
+                tensor_out, tensor_in, minus_eye_in, num_matrices, num_bsnd_heads, is_lower, cu_seqlens);
             break;
         case 32:
-            runKernelTriInvRecUnroll<InputT, float, 32, NumTilesPerCubeIter, IsBSND>(
-                tensor_out, tensor_in, minus_identity_in, num_matrices, num_bsnd_heads, cu_seqlens, is_lower);
+            runKernelTriInvRecUnroll<InputT, OutputT, 32, NumTilesPerCubeIter, IsBSND>(
+                tensor_out, tensor_in, minus_eye_in, num_matrices, num_bsnd_heads, is_lower, cu_seqlens);
             break;
         case 64:
-            runKernelTriInvRecUnroll<InputT, float, 64, NumTilesPerCubeIter, IsBSND>(
-                tensor_out, tensor_in, minus_identity_in, num_matrices, num_bsnd_heads, cu_seqlens, is_lower);
+            runKernelTriInvRecUnroll<InputT, OutputT, 64, NumTilesPerCubeIter, IsBSND>(
+                tensor_out, tensor_in, minus_eye_in, num_matrices, num_bsnd_heads, is_lower, cu_seqlens);
             break;
         case 128:
-            runKernelTriInvRecUnroll<InputT, float, 128, NumTilesPerCubeIter, IsBSND>(
-                tensor_out, tensor_in, minus_identity_in, num_matrices, num_bsnd_heads, cu_seqlens, is_lower);
+            runKernelTriInvRecUnroll<InputT, OutputT, 128, NumTilesPerCubeIter, IsBSND>(
+                tensor_out, tensor_in, minus_eye_in, num_matrices, num_bsnd_heads, is_lower, cu_seqlens);
             break;
+    }
+}
+
+/*
+ * @brief: Wrapper for the kernel supporting fp16 and bfloat16 types.
+ *
+ * @param tensor_out pointer to the global memory to store the final inverse.
+ * @param tensor_in Pointer to the global tensor matrix in global memory.
+ * @param minus_eye_in Pointer to the global tensor matrix containing the
+ * negative identity matrix.
+ * @param matrix_size The size if each individual matrix / tile. Can take
+ * values: {16, 32, 64, 128}.
+ * @param num_matrices The total number of matrices / tiles in the global
+ * tensor.
+ * @param num_bsnd_heads The number of heads, which is only greater than zero
+ * if the matrix is in BSND format, that is, the tiles need to be loaded with
+ * strided accesses. If each tile is stored consecutively (and row-wise) in
+ * memory, then num_bsnd_heads=0.
+ */
+template <typename InputT, typename OutputT, uint32_t NumTilesPerCubeIter>
+AICORE void run_tri_inv_rec_unroll_per_num_matrices(__gm__ OutputT *tensor_out, __gm__ InputT *tensor_in,
+                                                    __gm__ InputT *minus_eye_in, uint32_t matrix_size,
+                                                    uint32_t num_matrices, uint32_t num_bsnd_heads,
+                                                    uint32_t is_lower = 0, __gm__ int32_t *cu_seqlens = nullptr)
+{
+    if (num_bsnd_heads == 0) {
+        if (num_matrices <= get_block_num()) {
+            run_tri_inv_rec_unroll<InputT, OutputT, 1 /* NumTilesPerCubeIter */, false /* IsBSND */>(
+                tensor_out, tensor_in, minus_eye_in, matrix_size, num_matrices, num_bsnd_heads, is_lower, cu_seqlens);
+        } else if (num_matrices <= 2 * get_block_num()) {
+            run_tri_inv_rec_unroll<InputT, OutputT, 2 /* NumTilesPerCubeIter */, false /* IsBSND */>(
+                tensor_out, tensor_in, minus_eye_in, matrix_size, num_matrices, num_bsnd_heads, is_lower, cu_seqlens);
+        } else {
+            run_tri_inv_rec_unroll<InputT, OutputT, 4 /* NumTilesPerCubeIter */, false /* IsBSND */>(
+                tensor_out, tensor_in, minus_eye_in, matrix_size, num_matrices, num_bsnd_heads, is_lower, cu_seqlens);
+        }
+    } else {
+        if (num_matrices <= get_block_num()) {
+            run_tri_inv_rec_unroll<InputT, OutputT, 1 /* NumTilesPerCubeIter */, true /* IsBSND */>(
+                tensor_out, tensor_in, minus_eye_in, matrix_size, num_matrices, num_bsnd_heads, is_lower, cu_seqlens);
+        } else if (num_matrices <= 2 * get_block_num()) {
+            run_tri_inv_rec_unroll<InputT, OutputT, 2 /* NumTilesPerCubeIter */, true /* IsBSND */>(
+                tensor_out, tensor_in, minus_eye_in, matrix_size, num_matrices, num_bsnd_heads, is_lower, cu_seqlens);
+        } else {
+            run_tri_inv_rec_unroll<InputT, OutputT, 4 /* NumTilesPerCubeIter */, true /* IsBSND */>(
+                tensor_out, tensor_in, minus_eye_in, matrix_size, num_matrices, num_bsnd_heads, is_lower, cu_seqlens);
+        }
     }
 }

--- a/csrc/mega_chunk_gdn/op_kernel/wy_fast.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/wy_fast.cpp
@@ -244,7 +244,7 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                            __gm__ float *G_handle, __gm__ half *A_handle, __gm__ half *workspace_a1_handle,
                            __gm__ half *workspace_a2_handle, __gm__ half *W_handle, __gm__ half *U_handle,
                            __gm__ int32_t *cu_seqlens, int64_t batch_size, int64_t seq_len, int64_t total_tokens,
-                           uint32_t num_heads, uint32_t num_key_heads, uint64_t ffts_addr)
+                           uint32_t num_heads, uint32_t num_key_heads)
 {
     // WY recompute materializes two diagonal reweightings of the same A tile:
     //   A2[:, j] = A[:, j] * beta_j
@@ -296,7 +296,6 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
     constexpr int32_t WsA1Size = ChunkSize * ChunkSize;
     constexpr int32_t WsA2Size = ChunkSize * ChunkSize;
 
-    set_ffts_base_addr(ffts_addr);
     auto cid = get_block_idx();
     auto block_num = get_block_num();
     auto vid = get_subblockid();

--- a/csrc/mega_chunk_gdn/op_kernel/wy_fast.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/wy_fast.cpp
@@ -37,24 +37,28 @@
 //   Cube core: wait for workspace → load A2/A1 + K/V → GEMM → store U,W
 //
 // Key PTO APIs (with numpy/torch equivalents):
-//   TLOAD(ub_tile, gm)      — ub_tile = gm[...]          (DMA: GM→UB, async MTE2)
-//   TSTORE(gm, ub_tile)     — gm[...] = ub_tile          (DMA: UB→GM, async MTE3)
-//   TCVT(dst, src, mode)    — dst = src.float() or .half() (type conversion)
-//   TMOV(dst, src)          — dst = src.clone()
-//   TMUL(d, a, b)           — d = a * b                   (element-wise)
-//   TEXP(d, s)              — d = torch.exp(s)
-//   TCOLEXPAND(2d, row)     — 2d[i,j] = row[j]  (broadcast row across all rows)
-//   TEXTRACT(l0, l1, r, c)  — L1 sub-block → L0A/L0B     (MTE1 for Cube GEMM)
-//   TMATMUL(C, A, B)        — C = A @ B in Cube engine    (fp16→fp32 accumulate)
-//   set_flag / wait_flag    — sync between pipes on SAME core
-//   ffts_cross_core_sync    — signal ACROSS Cube↔Vec cores
+//   TLOAD(ub_tile, gm)      — ub_tile = gm[...]          (DMA: GM→UB, async
+//   MTE2) TSTORE(gm, ub_tile)     — gm[...] = ub_tile          (DMA: UB→GM,
+//   async MTE3) TCVT(dst, src, mode)    — dst = src.float() or .half() (type
+//   conversion) TMOV(dst, src)          — dst = src.clone() TMUL(d, a, b) — d =
+//   a * b                   (element-wise) TEXP(d, s)              — d =
+//   torch.exp(s) TCOLEXPAND(2d, row)     — 2d[i,j] = row[j]  (broadcast row
+//   across all rows) TEXTRACT(l0, l1, r, c)  — L1 sub-block → L0A/L0B     (MTE1
+//   for Cube GEMM) TMATMUL(C, A, B)        — C = A @ B in Cube engine
+//   (fp16→fp32 accumulate) set_flag / wait_flag    — sync between pipes on SAME
+//   core ffts_cross_core_sync    — signal ACROSS Cube↔Vec cores
 //   wait_flag_dev(flag)     — wait for cross-core signal
 // ============================================================================
 
+#include <runtime/rt_ffts.h>
+
 #include <pto/pto-inst.hpp>
-#include "acl/acl.h"
 #include <type_traits>
+
+#include "acl/acl.h"
+#include "mega_kernel_utils.h"
 using namespace pto;
+using namespace mega_kernel_utils;
 
 #ifndef GDN_D
 #define GDN_D 128
@@ -77,12 +81,12 @@ using TileMatL1ZN = pto::Tile<pto::TileType::Mat, T, Rows, Cols, pto::BLayout::R
                               pto::SLayout::ColMajor, 512, pto::PadValue::Zero>;
 
 template <typename T, int Rows, int Cols, int RowValid = Rows, int ColValid = Cols>
-using TileMatL0A = pto::Tile<pto::TileType::Left, T, Rows, Cols, pto::BLayout::RowMajor, RowValid, ColValid,
-                             pto::SLayout::RowMajor, 512, pto::PadValue::Zero>;
+using TileMatL0A = pto::Tile<pto::TileType::Left, T, Rows, Cols, mega_kernel_utils::GetOuterLayout(/*is_left=*/true),
+                             RowValid, ColValid, pto::SLayout::RowMajor, 512, pto::PadValue::Zero>;
 
 template <typename T, int Rows, int Cols, int RowValid = Rows, int ColValid = Cols>
-using TileMatL0B = pto::Tile<pto::TileType::Right, T, Rows, Cols, pto::BLayout::RowMajor, RowValid, ColValid,
-                             pto::SLayout::ColMajor, 512, pto::PadValue::Zero>;
+using TileMatL0B = pto::Tile<pto::TileType::Right, T, Rows, Cols, mega_kernel_utils::GetOuterLayout(/*is_left=*/false),
+                             RowValid, ColValid, pto::SLayout::ColMajor, 512, pto::PadValue::Zero>;
 
 template <typename T, int Rows, int Cols, int RowValid = Rows, int ColValid = Cols,
           pto::PadValue PadVal = pto::PadValue::Null>
@@ -112,7 +116,8 @@ template <typename T, int32_t Rows, int32_t Cols>
 using DynAccTile = pto::TileAcc<T, Rows, Cols, pto::DYNAMIC, pto::DYNAMIC>;
 
 // PTO cheat sheet for readers coming from PyTorch / NumPy:
-//   - `GlobalTensor<T>` is a GM tensor view with explicit shape/stride metadata.
+//   - `GlobalTensor<T>` is a GM tensor view with explicit shape/stride
+//   metadata.
 //   - `Tile<..., Mat, ...>` is an on-chip matrix tile used by Cube kernels.
 //   - `Tile<..., Vec, ...>` is an on-chip UB tile used by SIMD vector kernels.
 //   - `TileAcc<T, ...>` is the matmul accumulator tile.
@@ -234,12 +239,12 @@ gemm_v0(std::conditional_t<transpose_A, TileMatL1<T1, K, M, validK, validM>, Til
 
 #endif
 
-template <int32_t NumHeads, int32_t HiddenSize, int32_t ChunkSize>
+template <int32_t HiddenSize, int32_t ChunkSize>
 AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ half *Beta_handle,
                            __gm__ float *G_handle, __gm__ half *A_handle, __gm__ half *workspace_a1_handle,
                            __gm__ half *workspace_a2_handle, __gm__ half *W_handle, __gm__ half *U_handle,
                            __gm__ int32_t *cu_seqlens, int64_t batch_size, int64_t seq_len, int64_t total_tokens,
-                           uint32_t num_key_heads)
+                           uint32_t num_heads, uint32_t num_key_heads, uint64_t ffts_addr)
 {
     // WY recompute materializes two diagonal reweightings of the same A tile:
     //   A2[:, j] = A[:, j] * beta_j
@@ -265,15 +270,12 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
     constexpr int32_t HalfChunk = ChunkSize / 2;
     constexpr uint32_t KTail = (HiddenSize % 128 == 0) ? 128 : (HiddenSize % 128);
 
-    constexpr int32_t H = NumHeads;
+    const int32_t H = static_cast<int32_t>(num_heads);
     const int32_t Hg = static_cast<int32_t>(num_key_heads);
-    if (Hg <= 0 || (H % Hg) != 0) return;
+    if (H <= 0 || Hg <= 0 || (H % Hg) != 0) return;
     const int32_t GROUP = H / Hg;
-    constexpr int32_t BSND_V_STRIDE = H * HiddenSize;
+    const int32_t BSND_V_STRIDE = H * HiddenSize;
     const int32_t BSND_QK_STRIDE = Hg * HiddenSize;
-
-    constexpr int32_t GHeadTileCols = ((NumHeads + 7) / 8) * 8;
-    constexpr int32_t BetaHeadTileCols = ((NumHeads + 15) / 16) * 16;
 
     constexpr int32_t BetaHalfUbAddr = 0;
     constexpr int32_t A1HalfUbAddr = 256;
@@ -294,6 +296,7 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
     constexpr int32_t WsA1Size = ChunkSize * ChunkSize;
     constexpr int32_t WsA2Size = ChunkSize * ChunkSize;
 
+    set_ffts_base_addr(ffts_addr);
     auto cid = get_block_idx();
     auto block_num = get_block_num();
     auto vid = get_subblockid();
@@ -341,10 +344,10 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
     int64_t total_work = 0;
     if (cu_seqlens == nullptr) {
         int64_t chunks_per_seq = (seq_len + ChunkSize - 1) / ChunkSize;
-        total_work = num_seqs * chunks_per_seq * NumHeads;
+        total_work = num_seqs * chunks_per_seq * H;
     }
 
-#if defined(__DAV_C220_VEC__)
+#if defined(__DAV_VEC__)
     set_mask_norm();
     set_vector_mask(-1, -1);
 
@@ -359,7 +362,7 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
             int64_t nc = (slen + ChunkSize - 1) / ChunkSize;
 
             for (int64_t ci = 0; ci < nc; ++ci) {
-                for (int32_t head_idx = 0; head_idx < NumHeads; ++head_idx) {
+                for (int32_t head_idx = 0; head_idx < H; ++head_idx) {
                     if (gi % static_cast<int64_t>(block_num) == static_cast<int64_t>(cid)) {
                         int64_t chunk_start = ci * ChunkSize;
                         int64_t remaining = slen - chunk_start;
@@ -392,13 +395,14 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                         // Load only the live rows for this sub-block, then zero-pad the
                         // remainder of the HalfChunk tile.  The Cube phase always consumes
                         // a full [HalfChunk, ChunkSize] workspace tile, so stale rows here
-                        // would leak garbage into ragged tails and cross-sequence boundaries.
+                        // would leak garbage into ragged tails and cross-sequence
+                        // boundaries.
                         if (local_rows > 0) {
                             int64_t a_gm_offset =
-                                ((chunk_token_start + static_cast<int64_t>(vid) * HalfChunk) * NumHeads + head_idx) *
+                                ((chunk_token_start + static_cast<int64_t>(vid) * HalfChunk) * H + head_idx) *
                                 static_cast<int64_t>(ChunkSize);
                             GmShape2D a_shape(local_rows, ChunkSize);
-                            GmStride2D a_stride(NumHeads * ChunkSize);
+                            GmStride2D a_stride(H * ChunkSize);
                             GmTensor2D<half> a_global(A_handle + a_gm_offset, a_shape, a_stride);
                             DynVecTile<half, HalfChunk, ChunkSize, pto::PadValue::Zero> a_load(local_rows, ChunkSize);
                             TASSIGN(a_load, A1HalfUbAddr);
@@ -407,10 +411,11 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                                 TFILLPAD_INPLACE(a1_ub_half, a_load);
                             }
                         } else {
-                            // Fully empty lower-half tail: materialize an all-zero tile so the
-                            // workspace still looks like a correctly padded HalfChunk block.
+                            // Fully empty lower-half tail: materialize an all-zero tile so
+                            // the workspace still looks like a correctly padded HalfChunk
+                            // block.
                             TEXPANDS(a1_ub, 0.0f);
-                            pipe_barrier(PIPE_V);
+                            PipeBarrierVec();
                             TCVT(a1_ub_half, a1_ub, pto::RoundMode::CAST_NONE);
                         }
 
@@ -418,21 +423,31 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
                         TCVT(beta_ub, beta_ub_half, pto::RoundMode::CAST_NONE);
-                        pipe_barrier(PIPE_V);
+                        PipeBarrierVec();
                         TMOV(beta_r_ub, beta_ub);
-                        pipe_barrier(PIPE_V);
-                        // Replicate beta_j across rows so every column j of A gets the same beta.
-                        // PyTorch-like:
+                        PipeBarrierVec();
+                        // Replicate beta_j across rows so every column j of A gets the same
+                        // beta. PyTorch-like:
                         //   beta_2d = beta[None, :].expand(HalfChunk, ChunkSize)
                         TCOLEXPAND(beta_2d_ub, beta_r_ub);
 
                         TCVT(a1_ub, a1_ub_half, pto::RoundMode::CAST_NONE);
-                        // Form the beta-scaled tile that the later U = A2 * V matmul consumes.
+                        // Form the beta-scaled tile that the later U = A2 * V matmul
+                        // consumes.
                         //   a2_ub = a1_ub * beta_2d_ub
                         TMUL(a2_ub, a1_ub, beta_2d_ub);
                         TCVT(a2_ub_half, a2_ub, pto::RoundMode::CAST_NONE);
 
-                        if (!first_iter) wait_flag_dev(3);
+                        // Wait Cube: A2 slot free (flag 3).
+                        // A2: Cube is a separate core → FFTS cross-core flag.
+                        // A5: Cube shares the core → intra-block flag.
+                        if (!first_iter) {
+#if __CCE_AICORE__ == 220
+                            wait_flag_dev(3);
+#else
+                            wait_intra_block(PIPE_MTE3, 3);
+#endif
+                        }
                         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
                         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
                         {
@@ -445,7 +460,13 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                             TSTORE(workspace_a2_global, a2_ub_half);
                         }
                         pipe_barrier(PIPE_ALL);
-                        ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (2 << 8));
+                        // Signal Cube: A2 workspace ready (flag 2)
+                        // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (2 << 8));
+#if __CCE_AICORE__ == 220
+                        SetCrossFlag<PIPE_MTE3>(2);
+#else
+                        set_intra_block(PIPE_MTE3, 2);
+#endif
 
                         // G is pre-transposed to [H, total_tokens] for contiguous loads.
                         {
@@ -465,22 +486,30 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
                         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
-                        // Build the g-based column weights before forming the W = A1 * K branch.
-                        // Torch-like:
+                        // Build the g-based column weights before forming the W = A1 * K
+                        // branch. Torch-like:
                         //   g_weight = exp(g) * beta
                         TEXP(g_ub, g_ub);
-                        pipe_barrier(PIPE_V);
+                        PipeBarrierVec();
                         TMUL(g_ub, g_ub, beta_ub);
-                        pipe_barrier(PIPE_V);
+                        PipeBarrierVec();
                         TMOV(g_r_ub, g_ub);
-                        pipe_barrier(PIPE_V);
+                        PipeBarrierVec();
                         TCOLEXPAND(g_2d_ub, g_r_ub);
-                        // A1 keeps the same A columns but multiplies each one by exp(g_j) * beta_j.
+                        // A1 keeps the same A columns but multiplies each one by exp(g_j) *
+                        // beta_j.
                         //   a1_ub = a1_ub * g_weight[None, :]
                         TMUL(a1_ub, a1_ub, g_2d_ub);
                         TCVT(a1_ub_half, a1_ub, pto::RoundMode::CAST_NONE);
 
-                        if (!first_iter) wait_flag_dev(4);
+                        // Wait Cube: A1 slot free (flag 4).
+                        if (!first_iter) {
+#if __CCE_AICORE__ == 220
+                            wait_flag_dev(4);
+#else
+                            wait_intra_block(PIPE_MTE3, 4);
+#endif
+                        }
                         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
                         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
                         {
@@ -493,7 +522,13 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                             TSTORE(workspace_a1_global, a1_ub_half);
                         }
                         pipe_barrier(PIPE_ALL);
-                        ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+                        // Signal Cube: A1 workspace ready (flag 1)
+                        // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+#if __CCE_AICORE__ == 220
+                        SetCrossFlag<PIPE_MTE3>(1);
+#else
+                        set_intra_block(PIPE_MTE3, 1);
+#endif
                         first_iter = false;
                     }
                     gi++;
@@ -501,7 +536,8 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
             }
         }
     } else {
-        // Same WY math as above; only the work enumeration changes for varlen input.
+        // Same WY math as above; only the work enumeration changes for varlen
+        // input.
         int64_t gi = 0;
         bool first_iter_v = true;
         for (int64_t si = 0; si < num_seqs; ++si) {
@@ -511,7 +547,7 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
             int64_t nc = (slen + ChunkSize - 1) / ChunkSize;
 
             for (int64_t ci = 0; ci < nc; ++ci) {
-                for (int32_t h = 0; h < NumHeads; ++h) {
+                for (int32_t h = 0; h < H; ++h) {
                     if (gi % static_cast<int64_t>(block_num) == static_cast<int64_t>(cid)) {
                         int64_t chunk_start = ci * ChunkSize;
                         int64_t remaining = slen - chunk_start;
@@ -540,15 +576,16 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                             }
                         }
 
-                        // Tail-safe A loading is especially important in varlen mode because
-                        // the final chunk of one sequence may be immediately followed by the
-                        // first chunk of the next sequence in packed storage.
+                        // Tail-safe A loading is especially important in varlen mode
+                        // because the final chunk of one sequence may be immediately
+                        // followed by the first chunk of the next sequence in packed
+                        // storage.
                         if (local_rows > 0) {
                             int64_t a_gm_offset =
-                                ((chunk_token_start + static_cast<int64_t>(vid) * HalfChunk) * NumHeads + head_idx) *
+                                ((chunk_token_start + static_cast<int64_t>(vid) * HalfChunk) * H + head_idx) *
                                 static_cast<int64_t>(ChunkSize);
                             GmShape2D a_shape(local_rows, ChunkSize);
-                            GmStride2D a_stride(NumHeads * ChunkSize);
+                            GmStride2D a_stride(H * ChunkSize);
                             GmTensor2D<half> a_global(A_handle + a_gm_offset, a_shape, a_stride);
                             DynVecTile<half, HalfChunk, ChunkSize, pto::PadValue::Zero> a_load(local_rows, ChunkSize);
                             TASSIGN(a_load, A1HalfUbAddr);
@@ -558,9 +595,10 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                             }
                         } else {
                             // Empty stripe for this sub-block: write zeros so the downstream
-                            // full-tile Cube GEMM sees valid padding rather than old workspace.
+                            // full-tile Cube GEMM sees valid padding rather than old
+                            // workspace.
                             TEXPANDS(a1_ub, 0.0f);
-                            pipe_barrier(PIPE_V);
+                            PipeBarrierVec();
                             TCVT(a1_ub_half, a1_ub, pto::RoundMode::CAST_NONE);
                         }
 
@@ -568,17 +606,25 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
                         TCVT(beta_ub, beta_ub_half, pto::RoundMode::CAST_NONE);
-                        pipe_barrier(PIPE_V);
+                        PipeBarrierVec();
                         TMOV(beta_r_ub, beta_ub);
-                        pipe_barrier(PIPE_V);
+                        PipeBarrierVec();
                         TCOLEXPAND(beta_2d_ub, beta_r_ub);
 
                         TCVT(a1_ub, a1_ub_half, pto::RoundMode::CAST_NONE);
-                        // Form the beta-scaled tile that the later U = A2 * V matmul consumes.
+                        // Form the beta-scaled tile that the later U = A2 * V matmul
+                        // consumes.
                         TMUL(a2_ub, a1_ub, beta_2d_ub);
                         TCVT(a2_ub_half, a2_ub, pto::RoundMode::CAST_NONE);
 
-                        if (!first_iter_v) wait_flag_dev(3);
+                        // Wait Cube: A2 slot free (flag 3).
+                        if (!first_iter_v) {
+#if __CCE_AICORE__ == 220
+                            wait_flag_dev(3);
+#else
+                            wait_intra_block(PIPE_MTE3, 3);
+#endif
+                        }
                         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
                         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
                         {
@@ -591,7 +637,13 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                             TSTORE(workspace_a2_global, a2_ub_half);
                         }
                         pipe_barrier(PIPE_ALL);
-                        ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (2 << 8));
+                        // Signal Cube: A2 workspace ready (flag 2)
+                        // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (2 << 8));
+#if __CCE_AICORE__ == 220
+                        SetCrossFlag<PIPE_MTE3>(2);
+#else
+                        set_intra_block(PIPE_MTE3, 2);
+#endif
 
                         // G is pre-transposed to [H, total_tokens] for contiguous loads.
                         {
@@ -611,18 +663,26 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                         set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
                         wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 
-                        // Build the g-based column weights before forming the W = A1 * K branch.
+                        // Build the g-based column weights before forming the W = A1 * K
+                        // branch.
                         TEXP(g_ub, g_ub);
-                        pipe_barrier(PIPE_V);
+                        PipeBarrierVec();
                         TMUL(g_ub, g_ub, beta_ub);
-                        pipe_barrier(PIPE_V);
+                        PipeBarrierVec();
                         TMOV(g_r_ub, g_ub);
-                        pipe_barrier(PIPE_V);
+                        PipeBarrierVec();
                         TCOLEXPAND(g_2d_ub, g_r_ub);
                         TMUL(a1_ub, a1_ub, g_2d_ub);
                         TCVT(a1_ub_half, a1_ub, pto::RoundMode::CAST_NONE);
 
-                        if (!first_iter_v) wait_flag_dev(4);
+                        // Wait Cube: A1 slot free (flag 4).
+                        if (!first_iter_v) {
+#if __CCE_AICORE__ == 220
+                            wait_flag_dev(4);
+#else
+                            wait_intra_block(PIPE_MTE3, 4);
+#endif
+                        }
                         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
                         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
                         {
@@ -635,7 +695,13 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                             TSTORE(workspace_a1_global, a1_ub_half);
                         }
                         pipe_barrier(PIPE_ALL);
-                        ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+                        // Signal Cube: A1 workspace ready (flag 1)
+                        // ffts_cross_core_sync(PIPE_MTE3, 1 | (2 << 4) | (1 << 8));
+#if __CCE_AICORE__ == 220
+                        SetCrossFlag<PIPE_MTE3>(1);
+#else
+                        set_intra_block(PIPE_MTE3, 1);
+#endif
                         first_iter_v = false;
                     }
                     gi++;
@@ -645,7 +711,7 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
     }
 #endif
 
-#if defined(__DAV_C220_CUBE__)
+#if defined(__DAV_CUBE__)
     // Cube consumes the two Vec-generated workspaces and turns them into the
     // branch outputs U and W.
     if (cu_seqlens == nullptr) {
@@ -656,7 +722,7 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
             int64_t nc = (slen + ChunkSize - 1) / ChunkSize;
 
             for (int64_t ci = 0; ci < nc; ++ci) {
-                for (int32_t head_idx = 0; head_idx < NumHeads; ++head_idx) {
+                for (int32_t head_idx = 0; head_idx < H; ++head_idx) {
                     if (gi % static_cast<int64_t>(block_num) == static_cast<int64_t>(cid)) {
                         int64_t chunk_start = ci * ChunkSize;
                         int64_t remaining = slen - chunk_start;
@@ -692,7 +758,14 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                             }
                         }
 
+                        // Cube waits Vec: A2 ready (flag 2), then GEMM U = A2 @ V.
+                        // The wait must block MTE2: the consuming op is the GM->L1 TLOAD.
+#if __CCE_AICORE__ == 220
                         wait_flag_dev(2);
+#else
+                        WaitBothVecOnA5<PIPE_MTE2>(2);
+                        pipe_barrier(PIPE_ALL);
+#endif
                         {
                             GmShape2D a2_shape(ChunkSize, ChunkSize);
                             GmStride2D a2_stride(ChunkSize);
@@ -705,7 +778,8 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
 
                         set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
                         wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
-                        // U = A2 * V keeps the beta-scaled path separate from the K-side update.
+                        // U = A2 * V keeps the beta-scaled path separate from the K-side
+                        // update.
                         gemm_v0<half, float, ChunkSize, HiddenSize, ChunkSize, ChunkSize, HiddenSize, ChunkSize, KTail,
                                 false, false>(a2_l1, v_l1, u_l0, true);
 
@@ -715,13 +789,26 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                             GmTensor2D<half> u_global(U_handle + v_off, u_shape, u_stride);
                             DynAccTile<float, ChunkSize, HiddenSize> u_store(valid_rows, HiddenSize);
                             TASSIGN(u_store, 0);
-                            // Store only the valid token rows even though the accumulator tile is
-                            // physically ChunkSize x HiddenSize.
+                            // Store only the valid token rows even though the accumulator
+                            // tile is physically ChunkSize x HiddenSize.
                             TSTORE(u_global, u_store);
                         }
-                        ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (3 << 8));
+                        // Cube signals Vec: A2 slot free (flag 3)
+                        // ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (3 << 8));
+#if __CCE_AICORE__ == 220
+                        SetCrossFlag<PIPE_FIX>(3);
+#else
+                        SignalBothVecOnA5<PIPE_FIX>(3);
+#endif
 
+                        // Cube waits Vec: A1 ready (flag 1), then GEMM W = A1 @ K.
+                        // The wait must block MTE2: the consuming op is the GM->L1 TLOAD.
+#if __CCE_AICORE__ == 220
                         wait_flag_dev(1);
+#else
+                        WaitBothVecOnA5<PIPE_MTE2>(1);
+                        pipe_barrier(PIPE_ALL);
+#endif
                         {
                             GmShape2D a1_shape(ChunkSize, ChunkSize);
                             GmStride2D a1_stride(ChunkSize);
@@ -734,7 +821,8 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
 
                         set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
                         wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
-                        // W = A1 * K uses the g-reweighted path for the complementary WY factor.
+                        // W = A1 * K uses the g-reweighted path for the complementary WY
+                        // factor.
                         gemm_v0<half, float, ChunkSize, HiddenSize, ChunkSize, ChunkSize, HiddenSize, ChunkSize, KTail,
                                 false, false>(a1_l1, k_l1, w_l0, true);
 
@@ -746,7 +834,13 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                             TASSIGN(w_store, 65536);
                             TSTORE(w_global, w_store);
                         }
-                        ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (4 << 8));
+                        // Cube signals Vec: A1 slot free (flag 4)
+                        // ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (4 << 8));
+#if __CCE_AICORE__ == 220
+                        SetCrossFlag<PIPE_FIX>(4);
+#else
+                        SignalBothVecOnA5<PIPE_FIX>(4);
+#endif
                     }
                     gi++;
                 }
@@ -761,7 +855,7 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
             int64_t nc = (slen + ChunkSize - 1) / ChunkSize;
 
             for (int64_t ci = 0; ci < nc; ++ci) {
-                for (int32_t h = 0; h < NumHeads; ++h) {
+                for (int32_t h = 0; h < H; ++h) {
                     if (gi % static_cast<int64_t>(block_num) == static_cast<int64_t>(cid)) {
                         int64_t chunk_start = ci * ChunkSize;
                         int64_t remaining = slen - chunk_start;
@@ -798,7 +892,14 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                             }
                         }
 
+                        // Cube waits Vec: A2 ready (flag 2), then GEMM U = A2 @ V.
+                        // The wait must block MTE2: the consuming op is the GM->L1 TLOAD.
+#if __CCE_AICORE__ == 220
                         wait_flag_dev(2);
+#else
+                        WaitBothVecOnA5<PIPE_MTE2>(2);
+                        pipe_barrier(PIPE_ALL);
+#endif
                         {
                             GmShape2D a2_shape(ChunkSize, ChunkSize);
                             GmStride2D a2_stride(ChunkSize);
@@ -809,7 +910,8 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
 
                         set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
                         wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
-                        // U = A2 * V keeps the beta-scaled path separate from the K-side update.
+                        // U = A2 * V keeps the beta-scaled path separate from the K-side
+                        // update.
                         gemm_v0<half, float, ChunkSize, HiddenSize, ChunkSize, ChunkSize, HiddenSize, ChunkSize, KTail,
                                 false, false>(a2_l1, v_l1, u_l0, true);
 
@@ -821,9 +923,22 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                             TASSIGN(u_store, 0);
                             TSTORE(u_global, u_store);
                         }
-                        ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (3 << 8));
+                        // Cube signals Vec: A2 slot free (flag 3)
+                        // ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (3 << 8));
+#if __CCE_AICORE__ == 220
+                        SetCrossFlag<PIPE_FIX>(3);
+#else
+                        SignalBothVecOnA5<PIPE_FIX>(3);
+#endif
 
+                        // Cube waits Vec: A1 ready (flag 1), then GEMM W = A1 @ K.
+                        // The wait must block MTE2: the consuming op is the GM->L1 TLOAD.
+#if __CCE_AICORE__ == 220
                         wait_flag_dev(1);
+#else
+                        WaitBothVecOnA5<PIPE_MTE2>(1);
+                        pipe_barrier(PIPE_ALL);
+#endif
                         {
                             GmShape2D a1_shape(ChunkSize, ChunkSize);
                             GmStride2D a1_stride(ChunkSize);
@@ -834,7 +949,8 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
 
                         set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
                         wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
-                        // W = A1 * K uses the g-reweighted path for the complementary WY factor.
+                        // W = A1 * K uses the g-reweighted path for the complementary WY
+                        // factor.
                         gemm_v0<half, float, ChunkSize, HiddenSize, ChunkSize, ChunkSize, HiddenSize, ChunkSize, KTail,
                                 false, false>(a1_l1, k_l1, w_l0, true);
 
@@ -846,7 +962,13 @@ AICORE void wy_fast_kernel(__gm__ half *K_handle, __gm__ half *V_handle, __gm__ 
                             TASSIGN(w_store, 65536);
                             TSTORE(w_global, w_store);
                         }
-                        ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (4 << 8));
+                        // Cube signals Vec: A1 slot free (flag 4)
+                        // ffts_cross_core_sync(PIPE_FIX, 1 | (2 << 4) | (4 << 8));
+#if __CCE_AICORE__ == 220
+                        SetCrossFlag<PIPE_FIX>(4);
+#else
+                        SignalBothVecOnA5<PIPE_FIX>(4);
+#endif
                     }
                     gi++;
                 }


### PR DESCRIPTION
Following https://github.com/huawei-csl/megagdn-pto/pull/51 , upstream the GDN kernel that adds support for both A2A3 and A5.

## Changelog
* Remove macros since number of head (H) now is dynamic, see https://github.com/huawei-csl/megagdn-pto/pull/29
* Introduce `mega_kernel_utils.h` with the mega kernel utils, copied from https://github.com/huawei-csl/pto-kernels


### Status

- [x] Kernels compile using `bash build.sh -a kernels` 
- [ ] Unit tests `pytest tests/python/sgl_kernel_npu/test_chunk_gdn_pto.py`
- [ ] Run E2E tests

To verify compilation passes (backwards compatibility, a2a3)

```
docker run -ti quay.io/ascend/cann:9.1.0-910b-ubuntu22.04-py3.12 /bin/bash
# Install CI dependencies (yaml,numpy,pybind11, etc)
pip install --force-reinstall torch-npu==2.10.0 --extra-index-url https://download.pytorch.org/whl/cpu
bash build.sh -a kernels
```