### PR TITLE
Migrate some fusion operator test cases to A3-560T and remove redundant environment variables

### DIFF
--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -558,7 +558,7 @@ jobs:
           HCCL_BUFFSIZE: 3000
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-topk=1 --num-experts=4
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-experts=384
+          # python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-experts=384
 
   test-build-deepep-a2:
     needs: get-changed-files

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -121,9 +121,6 @@ jobs:
             rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
             bash scripts/prepare_deepep_in_container.sh
           fi
-      - name: Set CANN 9.0.0 env
-        if: matrix.cann_version == '9.0.0'
-        run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
       - name: Run test intranode
         timeout-minutes: 10
         env:
@@ -354,9 +351,6 @@ jobs:
             rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
             bash scripts/prepare_deepep_in_container.sh
           fi
-      - name: Set CANN 9.0.0 env
-        if: matrix.cann_version == '9.0.0'
-        run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
       - name: Run test fused deepep moe for little processes
         timeout-minutes: 10
         env:
@@ -499,9 +493,6 @@ jobs:
             rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
             bash scripts/prepare_deepep_in_container.sh
           fi
-      - name: Set CANN 9.0.0 env
-        if: matrix.cann_version == '9.0.0'
-        run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
       - name: Run test base fused deep moe
         timeout-minutes: 10
         env:
@@ -629,9 +620,6 @@ jobs:
             rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
             bash scripts/prepare_deepep_in_container.sh
           fi
-      - name: Set CANN 9.0.0 env
-        if: matrix.cann_version == '9.0.0'
-        run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
       - name: Run test fused deepep moe for experts
         timeout-minutes: 10
         env:
@@ -709,9 +697,6 @@ jobs:
             rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
             bash scripts/prepare_deepep_in_container.sh -a deepep2
           fi
-      - name: Set CANN 9.0.0 env
-        if: matrix.cann_version == '9.0.0'
-        run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
       - name: Run test intranode
         timeout-minutes: 10
         env:

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -51,7 +51,385 @@ jobs:
               - scripts/**
               - .github/workflows/pr-test-deepep-npu.yml
 
-  test-all-build-core:
+#  test-all-build-core:
+#    needs: get-changed-files
+#    if: |
+#      github.event_name == 'workflow_dispatch' ||
+#      github.event_name == 'workflow_call' || (
+#        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
+#        github.event.pull_request.draft == false &&
+#        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
+#      )
+#    runs-on: linux-aarch64-a3-16
+#    container:
+#      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
+#    env:
+#      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+#      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+#      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+#      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+#    strategy:
+#      matrix:
+#        cann_version: [8.5.0, 9.0.0]
+#    steps:
+#      - name: Clean git config
+#        run: |
+#          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
+#          git config --global --unset "$CONFIG_KEY" || true
+#      - name: Clean workspace
+#        run: |
+#          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
+#      - name: Checkout code
+#        uses: actions/checkout@v4
+#        with:
+#          clean: true
+#          submodules: recursive
+#      - name: Get build hash
+#        id: get_build_hash
+#        run: |
+#          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
+#            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+#          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+#          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+#          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+#          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+#          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+#      - name: Restore build cache
+#        id: cache-build
+#        uses: runs-on/cache@v4
+#        with:
+#          path: output
+#          key: sgl-kernel-npu-build-v3-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+#      - name: Install dependencies
+#        run: |
+#          # speed up by using infra cache services
+#          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+#          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+#          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+#          pip config set global.trusted-host ${CACHING_URL}
+#          pip install uv
+#          bash scripts/npu_ci_install_dependency.sh
+#      - name: Prepare Deepep
+#        # - cache hit: install cached wheel only (skip build via -s flag)
+#        # - cache miss: clear stale wheels + build + install
+#        run: |
+#          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+#            echo "Cache hit, installing cached wheel only"
+#            bash scripts/prepare_deepep_in_container.sh -s
+#          else
+#            echo "Cache miss, building and installing"
+#            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+#            bash scripts/prepare_deepep_in_container.sh
+#          fi
+#      - name: Set CANN 9.0.0 env
+#        if: matrix.cann_version == '9.0.0'
+#        run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
+#      - name: Run test intranode
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
+#      - name: Run test intranode for little bs
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 4065
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=4
+#      - name: Run test intranode for big bs
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 4065
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=8192
+#      - name: Run test multi-round intranode
+#        timeout-minutes: 10
+#        env:
+#          DEEPEP_NORMAL_LONG_SEQ_ROUND: 5
+#          DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS: 512
+#          HCCL_BUFFSIZE: 1000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2122
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2048
+#      - name: Run test little processes intranode
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2241
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2
+#      - name: Run test hidden intranode
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=2048
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=4096
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=6144
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=7168
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=8192
+#      - name: Run test topk num intranode
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 4065
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=1
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=16
+#      - name: Run test experts num intranode
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2 --num-topk=1 --num-experts=2
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=512 --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=1024 --num-processes=16
+#      - name: Run test intranode for active ranks
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --active-ranks="0,1,3"
+#      - name: Run test intranode for DeepXtrace
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-diagnose
+#      - name: Run test intranode for int8 quant
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --quant-type=int8
+#
+#      - name: Run test intranode for output parameters of different types
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#          MOE_EXPERT_TOKEN_NUMS_TYPE: 0
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
+#      - name: Run test intranode for dynamic tokens
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-dynamic-tokens
+#      - name: Run test low latency
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1913
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=1
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=2
+#      - name: Run test low latency for big bs
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3825
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=512
+#      - name: Run test low latency for little num processes
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1913
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2
+#      - name: Run test low latency for hidden
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2200
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=2048
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=4096
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=6144
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=7168
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=8192
+#      - name: Run test low latency for topk
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1969
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=4
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=16
+#      - name: Run test low latency for experts
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 7481
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-experts=1024
+#      - name: Run test low latency for drop percent
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1913
+#          MOE_ENABLE_TOPK_NEG_ONE: 1
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --drop-percent=0.3
+#      - name: Run test low latency for dynamic tokens
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --enable-dynamic-tokens
+#      - name: Run test generalization of fused deep moe
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2048
+#        run: bash scripts/generalization_test_fused_deep_moe.sh
+#      - name: Run test combine only
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3900
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --test-type="low_latency"
+#
+#  test-all-build-moe:
+#    needs: get-changed-files
+#    if: |
+#      github.event_name == 'workflow_dispatch' ||
+#      github.event_name == 'workflow_call' || (
+#        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
+#        github.event.pull_request.draft == false &&
+#        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
+#      )
+#    runs-on: ["linux-aarch64-a3-16", "a3-752t"]
+#    container:
+#      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
+#    env:
+#      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+#      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+#      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+#      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+#    strategy:
+#      matrix:
+#        cann_version: [8.5.0, 9.0.0]
+#    steps:
+#      - name: Clean git config
+#        run: |
+#          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
+#          git config --global --unset "$CONFIG_KEY" || true
+#      - name: Clean workspace
+#        run: |
+#          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
+#      - name: Checkout code
+#        uses: actions/checkout@v4
+#        with:
+#          clean: true
+#          submodules: recursive
+#      - name: Get build hash
+#        id: get_build_hash
+#        run: |
+#          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
+#            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+#          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+#          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+#          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+#          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+#          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+#      - name: Restore build cache
+#        id: cache-build
+#        uses: runs-on/cache@v4
+#        with:
+#          path: output
+#          key: sgl-kernel-npu-build-v3-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+#      - name: Install dependencies
+#        run: |
+#          # speed up by using infra cache services
+#          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+#          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+#          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+#          pip config set global.trusted-host ${CACHING_URL}
+#          pip install uv
+#          bash scripts/npu_ci_install_dependency.sh
+#      - name: Prepare Deepep
+#        # - cache hit: install cached wheel only (skip build via -s flag)
+#        # - cache miss: clear stale wheels + build + install
+#        run: |
+#          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+#            echo "Cache hit, installing cached wheel only"
+#            bash scripts/prepare_deepep_in_container.sh -s
+#          else
+#            echo "Cache miss, building and installing"
+#            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+#            bash scripts/prepare_deepep_in_container.sh
+#          fi
+#      - name: Set CANN 9.0.0 env
+#        if: matrix.cann_version == '9.0.0'
+#        run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
+#      - name: Run test fused deepep moe for little processes
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-experts=24
+#      - name: Run test mixed running
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py
+#      - name: Run test mixed running for little processes
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2241
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --test-loop=100
+#      - name: Run test mixed running for bs
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 4065
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=1 --low-latency-num-tokens=1 --test-loop=100
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=8192 --low-latency-num-tokens=512 --test-loop=100
+#      - name: Run test mixed running for hidden
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=2048 --test-loop=100
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=4096 --test-loop=100
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=6144 --test-loop=100
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=7168 --test-loop=100
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=8192 --test-loop=100
+#      - name: Run test mixed running for experts
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 7500
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2 --test-loop=100
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=512 --test-loop=100 --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=1024 --test-loop=100 --num-processes=16
+#      - name: Run test mixed running for topk
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 4065
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=1 --test-loop=100
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=16 --test-loop=100
+#      - name: Run test mixed running for dynamic tokens
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3769
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --test-loop=100 --enable-dynamic-tokens
+#      - name: Run test fused deep moe for fuse_mode.DISPATCH_FFN_COMBINE
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2048
+#        run: python3 $GITHUB_WORKSPACE/tests/python/deepep/test_dispatch_ffn_combine.py
+#      - name: Run test alltoall mode for both normal and low_latency
+#        if: matrix.cann_version == '9.0.0'
+#        timeout-minutes: 10
+#        env:
+#          DEEP_MOE_MODE: alltoall
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type int8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type int8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type bf16
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type bf16
+
+  test-all-build-moe-fused-deep-moe:
     needs: get-changed-files
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -60,240 +438,7 @@ jobs:
         github.event.pull_request.draft == false &&
         (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
       )
-    runs-on: linux-aarch64-a3-16
-    container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
-    env:
-      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
-      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
-      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
-      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-    strategy:
-      matrix:
-        cann_version: [8.5.0, 9.0.0]
-    steps:
-      - name: Clean git config
-        run: |
-          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
-          git config --global --unset "$CONFIG_KEY" || true
-      - name: Clean workspace
-        run: |
-          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          clean: true
-          submodules: recursive
-      - name: Get build hash
-        id: get_build_hash
-        run: |
-          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
-            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
-          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
-          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
-          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
-          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
-          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
-      - name: Restore build cache
-        id: cache-build
-        uses: runs-on/cache@v4
-        with:
-          path: output
-          key: sgl-kernel-npu-build-v3-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
-      - name: Install dependencies
-        run: |
-          # speed up by using infra cache services
-          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
-          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
-          pip config set global.index-url http://${CACHING_URL}/pypi/simple
-          pip config set global.trusted-host ${CACHING_URL}
-          pip install uv
-          bash scripts/npu_ci_install_dependency.sh
-      - name: Prepare Deepep
-        # - cache hit: install cached wheel only (skip build via -s flag)
-        # - cache miss: clear stale wheels + build + install
-        run: |
-          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
-            echo "Cache hit, installing cached wheel only"
-            bash scripts/prepare_deepep_in_container.sh -s
-          else
-            echo "Cache miss, building and installing"
-            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
-            bash scripts/prepare_deepep_in_container.sh
-          fi
-      - name: Set CANN 9.0.0 env
-        if: matrix.cann_version == '9.0.0'
-        run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
-      - name: Run test intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
-      - name: Run test intranode for little bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 4065
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=4
-      - name: Run test intranode for big bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 4065
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=8192
-      - name: Run test multi-round intranode
-        timeout-minutes: 10
-        env:
-          DEEPEP_NORMAL_LONG_SEQ_ROUND: 5
-          DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS: 512
-          HCCL_BUFFSIZE: 1000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2122
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2048
-      - name: Run test little processes intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2241
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2
-      - name: Run test hidden intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=2048
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=4096
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=6144
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=7168
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=8192
-      - name: Run test topk num intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 4065
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=1
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=16
-      - name: Run test experts num intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2 --num-topk=1 --num-experts=2
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=512 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=1024 --num-processes=16
-      - name: Run test intranode for active ranks
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --active-ranks="0,1,3"
-      - name: Run test intranode for DeepXtrace
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-diagnose
-      - name: Run test intranode for int8 quant
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --quant-type=int8
-
-      - name: Run test intranode for output parameters of different types
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-          MOE_EXPERT_TOKEN_NUMS_TYPE: 0
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
-      - name: Run test intranode for dynamic tokens
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-dynamic-tokens
-      - name: Run test low latency
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1913
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=1
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=2
-      - name: Run test low latency for big bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3825
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=512
-      - name: Run test low latency for little num processes
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1913
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2
-      - name: Run test low latency for hidden
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2200
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=2048
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=4096
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=6144
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=7168
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=8192
-      - name: Run test low latency for topk
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1969
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=4
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=16
-      - name: Run test low latency for experts
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 7481
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-experts=1024
-      - name: Run test low latency for drop percent
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1913
-          MOE_ENABLE_TOPK_NEG_ONE: 1
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --drop-percent=0.3
-      - name: Run test low latency for dynamic tokens
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --enable-dynamic-tokens
-      - name: Run test generalization of fused deep moe
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2048
-        run: bash scripts/generalization_test_fused_deep_moe.sh
-      - name: Run test combine only
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3900
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --test-type="low_latency"
-
-  test-all-build-moe:
-    needs: get-changed-files
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call' || (
-        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
-        github.event.pull_request.draft == false &&
-        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
-      )
-    runs-on: ["linux-aarch64-a3-16", "a3-752t"]
+    runs-on: ["linux-aarch64-a3-16", "a3-560t"]
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
     env:
@@ -387,12 +532,6 @@ jobs:
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 2
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 3 --num-experts 16
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 4 --topk-drop-col 1 --num-experts 32
-      - name: Run test fused deepep moe for little processes
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-experts=24
       - name: Run test fused deepep moe for bs
         timeout-minutes: 10
         env:
@@ -420,71 +559,6 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-topk=1 --num-experts=4
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-experts=384
-      - name: Run test mixed running
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py
-      - name: Run test mixed running for little processes
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2241
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --test-loop=100
-      - name: Run test mixed running for bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 4065
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=1 --low-latency-num-tokens=1 --test-loop=100
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=8192 --low-latency-num-tokens=512 --test-loop=100
-      - name: Run test mixed running for hidden
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=2048 --test-loop=100
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=4096 --test-loop=100
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=6144 --test-loop=100
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=7168 --test-loop=100
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=8192 --test-loop=100
-      - name: Run test mixed running for experts
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 7500
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2 --test-loop=100
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=512 --test-loop=100 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=1024 --test-loop=100 --num-processes=16
-      - name: Run test mixed running for topk
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 4065
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=1 --test-loop=100
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=16 --test-loop=100
-      - name: Run test mixed running for dynamic tokens
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3769
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --test-loop=100 --enable-dynamic-tokens
-      - name: Run test fused deep moe for fuse_mode.DISPATCH_FFN_COMBINE
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2048
-        run: python3 $GITHUB_WORKSPACE/tests/python/deepep/test_dispatch_ffn_combine.py
-      - name: Run test alltoall mode for both normal and low_latency
-        if: matrix.cann_version == '9.0.0'
-        timeout-minutes: 10
-        env:
-          DEEP_MOE_MODE: alltoall
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type int8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type int8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type bf16
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type bf16
 
   test-build-deepep-a2:
     needs: get-changed-files
@@ -760,8 +834,9 @@ jobs:
   finish:
     if: always()
     needs:
-      - test-all-build-core
-      - test-all-build-moe
+#      - test-all-build-core
+#      - test-all-build-moe
+      - test-all-build-moe-fused-deep-moe
       - test-build-deepep-a2
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -429,7 +429,137 @@ jobs:
 #          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type bf16
 #          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type bf16
 
-  test-all-build-moe-fused-deep-moe:
+#  test-all-build-moe-fused-deep-moe-a3-560t:
+#    needs: get-changed-files
+#    if: |
+#      github.event_name == 'workflow_dispatch' ||
+#      github.event_name == 'workflow_call' || (
+#        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
+#        github.event.pull_request.draft == false &&
+#        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
+#      )
+#    runs-on: ["linux-aarch64-a3-16", "a3-560t"]
+#    container:
+#      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
+#    env:
+#      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+#      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+#      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+#      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+#    strategy:
+#      matrix:
+#        cann_version: [8.5.0, 9.0.0]
+#    steps:
+#      - name: Clean git config
+#        run: |
+#          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
+#          git config --global --unset "$CONFIG_KEY" || true
+#      - name: Clean workspace
+#        run: |
+#          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
+#      - name: Checkout code
+#        uses: actions/checkout@v4
+#        with:
+#          clean: true
+#          submodules: recursive
+#      - name: Get build hash
+#        id: get_build_hash
+#        run: |
+#          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
+#            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+#          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+#          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+#          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+#          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+#          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+#      - name: Restore build cache
+#        id: cache-build
+#        uses: runs-on/cache@v4
+#        with:
+#          path: output
+#          key: sgl-kernel-npu-build-v3-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+#      - name: Install dependencies
+#        run: |
+#          # speed up by using infra cache services
+#          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+#          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+#          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+#          pip config set global.trusted-host ${CACHING_URL}
+#          pip install uv
+#          bash scripts/npu_ci_install_dependency.sh
+#      - name: Prepare Deepep
+#        # - cache hit: install cached wheel only (skip build via -s flag)
+#        # - cache miss: clear stale wheels + build + install
+#        run: |
+#          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+#            echo "Cache hit, installing cached wheel only"
+#            bash scripts/prepare_deepep_in_container.sh -s
+#          else
+#            echo "Cache miss, building and installing"
+#            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+#            bash scripts/prepare_deepep_in_container.sh
+#          fi
+#      - name: Set CANN 9.0.0 env
+#        if: matrix.cann_version == '9.0.0'
+#        run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
+#      - name: Run test base fused deep moe
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 256
+#      - name: Run test muti-model for fused deep moe
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256 --hidden 6144 --moe-intermediate-size 2048
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128 --hidden 6144 --moe-intermediate-size 2048
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256 --hidden 4096 --moe-intermediate-size 1536
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 256 --hidden 4096 --moe-intermediate-size 1536
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128 --hidden 4096 --moe-intermediate-size 1536
+#      - name: Run test fused deepep moe eplb
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --topk-drop-col 3
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --topk-drop-prob 0.3
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 2
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 3 --num-experts 16
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 4 --topk-drop-col 1 --num-experts 32
+#      - name: Run test fused deepep moe for bs
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1913
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens=256
+#      - name: Run test fused deepep moe for hidden
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1913
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --hidden=2048
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --hidden=7168
+#      - name: Run test fused deepep moe for topk
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-topk=1
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-topk=12
+#      - name: Run test fused deepep moe for experts
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-topk=1 --num-experts=4
+
+  test-all-build-moe-fused-deep-moe-a3-752t:
     needs: get-changed-files
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -438,7 +568,7 @@ jobs:
         github.event.pull_request.draft == false &&
         (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
       )
-    runs-on: ["linux-aarch64-a3-16", "a3-560t"]
+    runs-on: ["linux-aarch64-a3-16", "a3-752t"]
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
     env:
@@ -502,63 +632,12 @@ jobs:
       - name: Set CANN 9.0.0 env
         if: matrix.cann_version == '9.0.0'
         run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
-      - name: Run test base fused deep moe
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 256
-      - name: Run test muti-model for fused deep moe
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256 --hidden 6144 --moe-intermediate-size 2048
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128 --hidden 6144 --moe-intermediate-size 2048
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256 --hidden 4096 --moe-intermediate-size 1536
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 256 --hidden 4096 --moe-intermediate-size 1536
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128 --hidden 4096 --moe-intermediate-size 1536
-      - name: Run test fused deepep moe eplb
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --topk-drop-col 3
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --topk-drop-prob 0.3
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 2
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 3 --num-experts 16
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 4 --topk-drop-col 1 --num-experts 32
-      - name: Run test fused deepep moe for bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1913
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens=256
-      - name: Run test fused deepep moe for hidden
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1913
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --hidden=2048
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --hidden=7168
-      - name: Run test fused deepep moe for topk
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-topk=1
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-topk=12
       - name: Run test fused deepep moe for experts
         timeout-minutes: 10
         env:
           HCCL_BUFFSIZE: 3000
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-topk=1 --num-experts=4
-          # python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-experts=384
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-experts=384
 
   test-build-deepep-a2:
     needs: get-changed-files
@@ -836,7 +915,8 @@ jobs:
     needs:
 #      - test-all-build-core
 #      - test-all-build-moe
-      - test-all-build-moe-fused-deep-moe
+#      - test-all-build-moe-fused-deep-moe-a3-560t
+      - test-all-build-moe-fused-deep-moe-a3-752t
       - test-build-deepep-a2
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -51,513 +51,513 @@ jobs:
               - scripts/**
               - .github/workflows/pr-test-deepep-npu.yml
 
-#  test-all-build-core:
-#    needs: get-changed-files
-#    if: |
-#      github.event_name == 'workflow_dispatch' ||
-#      github.event_name == 'workflow_call' || (
-#        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
-#        github.event.pull_request.draft == false &&
-#        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
-#      )
-#    runs-on: linux-aarch64-a3-16
-#    container:
-#      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
-#    env:
-#      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
-#      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
-#      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
-#      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-#    strategy:
-#      matrix:
-#        cann_version: [8.5.0, 9.0.0]
-#    steps:
-#      - name: Clean git config
-#        run: |
-#          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
-#          git config --global --unset "$CONFIG_KEY" || true
-#      - name: Clean workspace
-#        run: |
-#          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
-#      - name: Checkout code
-#        uses: actions/checkout@v4
-#        with:
-#          clean: true
-#          submodules: recursive
-#      - name: Get build hash
-#        id: get_build_hash
-#        run: |
-#          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
-#            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
-#          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
-#          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
-#          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
-#          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
-#          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
-#      - name: Restore build cache
-#        id: cache-build
-#        uses: runs-on/cache@v4
-#        with:
-#          path: output
-#          key: sgl-kernel-npu-build-v3-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
-#      - name: Install dependencies
-#        run: |
-#          # speed up by using infra cache services
-#          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
-#          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
-#          pip config set global.index-url http://${CACHING_URL}/pypi/simple
-#          pip config set global.trusted-host ${CACHING_URL}
-#          pip install uv
-#          bash scripts/npu_ci_install_dependency.sh
-#      - name: Prepare Deepep
-#        # - cache hit: install cached wheel only (skip build via -s flag)
-#        # - cache miss: clear stale wheels + build + install
-#        run: |
-#          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
-#            echo "Cache hit, installing cached wheel only"
-#            bash scripts/prepare_deepep_in_container.sh -s
-#          else
-#            echo "Cache miss, building and installing"
-#            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
-#            bash scripts/prepare_deepep_in_container.sh
-#          fi
-#      - name: Set CANN 9.0.0 env
-#        if: matrix.cann_version == '9.0.0'
-#        run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
-#      - name: Run test intranode
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
-#      - name: Run test intranode for little bs
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 4065
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=4
-#      - name: Run test intranode for big bs
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 4065
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=8192
-#      - name: Run test multi-round intranode
-#        timeout-minutes: 10
-#        env:
-#          DEEPEP_NORMAL_LONG_SEQ_ROUND: 5
-#          DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS: 512
-#          HCCL_BUFFSIZE: 1000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2122
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2048
-#      - name: Run test little processes intranode
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2241
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2
-#      - name: Run test hidden intranode
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=2048
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=4096
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=6144
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=7168
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=8192
-#      - name: Run test topk num intranode
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 4065
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=1
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=16
-#      - name: Run test experts num intranode
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2 --num-topk=1 --num-experts=2
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=512 --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=1024 --num-processes=16
-#      - name: Run test intranode for active ranks
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --active-ranks="0,1,3"
-#      - name: Run test intranode for DeepXtrace
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-diagnose
-#      - name: Run test intranode for int8 quant
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --quant-type=int8
-#
-#      - name: Run test intranode for output parameters of different types
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#          MOE_EXPERT_TOKEN_NUMS_TYPE: 0
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
-#      - name: Run test intranode for dynamic tokens
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-dynamic-tokens
-#      - name: Run test low latency
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1913
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=1
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=2
-#      - name: Run test low latency for big bs
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3825
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=512
-#      - name: Run test low latency for little num processes
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1913
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2
-#      - name: Run test low latency for hidden
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2200
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=2048
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=4096
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=6144
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=7168
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=8192
-#      - name: Run test low latency for topk
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1969
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=4
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=16
-#      - name: Run test low latency for experts
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 7481
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-experts=1024
-#      - name: Run test low latency for drop percent
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1913
-#          MOE_ENABLE_TOPK_NEG_ONE: 1
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --drop-percent=0.3
-#      - name: Run test low latency for dynamic tokens
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --enable-dynamic-tokens
-#      - name: Run test generalization of fused deep moe
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2048
-#        run: bash scripts/generalization_test_fused_deep_moe.sh
-#      - name: Run test combine only
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3900
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --test-type="low_latency"
-#
-#  test-all-build-moe:
-#    needs: get-changed-files
-#    if: |
-#      github.event_name == 'workflow_dispatch' ||
-#      github.event_name == 'workflow_call' || (
-#        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
-#        github.event.pull_request.draft == false &&
-#        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
-#      )
-#    runs-on: ["linux-aarch64-a3-16", "a3-752t"]
-#    container:
-#      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
-#    env:
-#      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
-#      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
-#      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
-#      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-#    strategy:
-#      matrix:
-#        cann_version: [8.5.0, 9.0.0]
-#    steps:
-#      - name: Clean git config
-#        run: |
-#          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
-#          git config --global --unset "$CONFIG_KEY" || true
-#      - name: Clean workspace
-#        run: |
-#          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
-#      - name: Checkout code
-#        uses: actions/checkout@v4
-#        with:
-#          clean: true
-#          submodules: recursive
-#      - name: Get build hash
-#        id: get_build_hash
-#        run: |
-#          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
-#            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
-#          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
-#          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
-#          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
-#          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
-#          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
-#      - name: Restore build cache
-#        id: cache-build
-#        uses: runs-on/cache@v4
-#        with:
-#          path: output
-#          key: sgl-kernel-npu-build-v3-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
-#      - name: Install dependencies
-#        run: |
-#          # speed up by using infra cache services
-#          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
-#          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
-#          pip config set global.index-url http://${CACHING_URL}/pypi/simple
-#          pip config set global.trusted-host ${CACHING_URL}
-#          pip install uv
-#          bash scripts/npu_ci_install_dependency.sh
-#      - name: Prepare Deepep
-#        # - cache hit: install cached wheel only (skip build via -s flag)
-#        # - cache miss: clear stale wheels + build + install
-#        run: |
-#          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
-#            echo "Cache hit, installing cached wheel only"
-#            bash scripts/prepare_deepep_in_container.sh -s
-#          else
-#            echo "Cache miss, building and installing"
-#            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
-#            bash scripts/prepare_deepep_in_container.sh
-#          fi
-#      - name: Set CANN 9.0.0 env
-#        if: matrix.cann_version == '9.0.0'
-#        run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
-#      - name: Run test fused deepep moe for little processes
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-experts=24
-#      - name: Run test mixed running
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py
-#      - name: Run test mixed running for little processes
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2241
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --test-loop=100
-#      - name: Run test mixed running for bs
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 4065
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=1 --low-latency-num-tokens=1 --test-loop=100
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=8192 --low-latency-num-tokens=512 --test-loop=100
-#      - name: Run test mixed running for hidden
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=2048 --test-loop=100
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=4096 --test-loop=100
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=6144 --test-loop=100
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=7168 --test-loop=100
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=8192 --test-loop=100
-#      - name: Run test mixed running for experts
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 7500
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2 --test-loop=100
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=512 --test-loop=100 --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=1024 --test-loop=100 --num-processes=16
-#      - name: Run test mixed running for topk
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 4065
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=1 --test-loop=100
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=16 --test-loop=100
-#      - name: Run test mixed running for dynamic tokens
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3769
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --test-loop=100 --enable-dynamic-tokens
-#      - name: Run test fused deep moe for fuse_mode.DISPATCH_FFN_COMBINE
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2048
-#        run: python3 $GITHUB_WORKSPACE/tests/python/deepep/test_dispatch_ffn_combine.py
-#      - name: Run test alltoall mode for both normal and low_latency
-#        if: matrix.cann_version == '9.0.0'
-#        timeout-minutes: 10
-#        env:
-#          DEEP_MOE_MODE: alltoall
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type int8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type int8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type bf16
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type bf16
+  test-all-build-core:
+    needs: get-changed-files
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call' || (
+        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
+        github.event.pull_request.draft == false &&
+        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
+      )
+    runs-on: linux-aarch64-a3-16
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
+    env:
+      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+    strategy:
+      matrix:
+        cann_version: [8.5.0, 9.0.0]
+    steps:
+      - name: Clean git config
+        run: |
+          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
+          git config --global --unset "$CONFIG_KEY" || true
+      - name: Clean workspace
+        run: |
+          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          clean: true
+          submodules: recursive
+      - name: Get build hash
+        id: get_build_hash
+        run: |
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
+            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+      - name: Restore build cache
+        id: cache-build
+        uses: runs-on/cache@v4
+        with:
+          path: output
+          key: sgl-kernel-npu-build-v3-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+      - name: Install dependencies
+        run: |
+          # speed up by using infra cache services
+          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+          pip config set global.trusted-host ${CACHING_URL}
+          pip install uv
+          bash scripts/npu_ci_install_dependency.sh
+      - name: Prepare Deepep
+        # - cache hit: install cached wheel only (skip build via -s flag)
+        # - cache miss: clear stale wheels + build + install
+        run: |
+          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+            echo "Cache hit, installing cached wheel only"
+            bash scripts/prepare_deepep_in_container.sh -s
+          else
+            echo "Cache miss, building and installing"
+            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+            bash scripts/prepare_deepep_in_container.sh
+          fi
+      - name: Set CANN 9.0.0 env
+        if: matrix.cann_version == '9.0.0'
+        run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
+      - name: Run test intranode
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
+      - name: Run test intranode for little bs
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 4065
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=4
+      - name: Run test intranode for big bs
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 4065
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=8192
+      - name: Run test multi-round intranode
+        timeout-minutes: 10
+        env:
+          DEEPEP_NORMAL_LONG_SEQ_ROUND: 5
+          DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS: 512
+          HCCL_BUFFSIZE: 1000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2122
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2048
+      - name: Run test little processes intranode
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2241
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2
+      - name: Run test hidden intranode
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=2048
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=4096
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=6144
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=7168
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=8192
+      - name: Run test topk num intranode
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 4065
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=1
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=16
+      - name: Run test experts num intranode
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2 --num-topk=1 --num-experts=2
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=512 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=1024 --num-processes=16
+      - name: Run test intranode for active ranks
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --active-ranks="0,1,3"
+      - name: Run test intranode for DeepXtrace
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-diagnose
+      - name: Run test intranode for int8 quant
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --quant-type=int8
 
-#  test-all-build-moe-fused-deep-moe-a3-560t:
-#    needs: get-changed-files
-#    if: |
-#      github.event_name == 'workflow_dispatch' ||
-#      github.event_name == 'workflow_call' || (
-#        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
-#        github.event.pull_request.draft == false &&
-#        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
-#      )
-#    runs-on: ["linux-aarch64-a3-16", "a3-560t"]
-#    container:
-#      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
-#    env:
-#      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
-#      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
-#      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
-#      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-#    strategy:
-#      matrix:
-#        cann_version: [8.5.0, 9.0.0]
-#    steps:
-#      - name: Clean git config
-#        run: |
-#          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
-#          git config --global --unset "$CONFIG_KEY" || true
-#      - name: Clean workspace
-#        run: |
-#          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
-#      - name: Checkout code
-#        uses: actions/checkout@v4
-#        with:
-#          clean: true
-#          submodules: recursive
-#      - name: Get build hash
-#        id: get_build_hash
-#        run: |
-#          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
-#            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
-#          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
-#          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
-#          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
-#          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
-#          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
-#      - name: Restore build cache
-#        id: cache-build
-#        uses: runs-on/cache@v4
-#        with:
-#          path: output
-#          key: sgl-kernel-npu-build-v3-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
-#      - name: Install dependencies
-#        run: |
-#          # speed up by using infra cache services
-#          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
-#          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
-#          pip config set global.index-url http://${CACHING_URL}/pypi/simple
-#          pip config set global.trusted-host ${CACHING_URL}
-#          pip install uv
-#          bash scripts/npu_ci_install_dependency.sh
-#      - name: Prepare Deepep
-#        # - cache hit: install cached wheel only (skip build via -s flag)
-#        # - cache miss: clear stale wheels + build + install
-#        run: |
-#          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
-#            echo "Cache hit, installing cached wheel only"
-#            bash scripts/prepare_deepep_in_container.sh -s
-#          else
-#            echo "Cache miss, building and installing"
-#            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
-#            bash scripts/prepare_deepep_in_container.sh
-#          fi
-#      - name: Set CANN 9.0.0 env
-#        if: matrix.cann_version == '9.0.0'
-#        run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
-#      - name: Run test base fused deep moe
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 256
-#      - name: Run test muti-model for fused deep moe
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256 --hidden 6144 --moe-intermediate-size 2048
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128 --hidden 6144 --moe-intermediate-size 2048
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256 --hidden 4096 --moe-intermediate-size 1536
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 256 --hidden 4096 --moe-intermediate-size 1536
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128 --hidden 4096 --moe-intermediate-size 1536
-#      - name: Run test fused deepep moe eplb
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --topk-drop-col 3
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --topk-drop-prob 0.3
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 2
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 3 --num-experts 16
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 4 --topk-drop-col 1 --num-experts 32
-#      - name: Run test fused deepep moe for bs
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1913
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens=256
-#      - name: Run test fused deepep moe for hidden
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1913
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --hidden=2048
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --hidden=7168
-#      - name: Run test fused deepep moe for topk
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-topk=1
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-topk=12
-#      - name: Run test fused deepep moe for experts
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-topk=1 --num-experts=4
+      - name: Run test intranode for output parameters of different types
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+          MOE_EXPERT_TOKEN_NUMS_TYPE: 0
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
+      - name: Run test intranode for dynamic tokens
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-dynamic-tokens
+      - name: Run test low latency
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1913
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=1
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=2
+      - name: Run test low latency for big bs
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3825
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=512
+      - name: Run test low latency for little num processes
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1913
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2
+      - name: Run test low latency for hidden
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2200
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=2048
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=4096
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=6144
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=7168
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=8192
+      - name: Run test low latency for topk
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1969
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=4
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=16
+      - name: Run test low latency for experts
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 7481
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-experts=1024
+      - name: Run test low latency for drop percent
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1913
+          MOE_ENABLE_TOPK_NEG_ONE: 1
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --drop-percent=0.3
+      - name: Run test low latency for dynamic tokens
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --enable-dynamic-tokens
+      - name: Run test generalization of fused deep moe
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2048
+        run: bash scripts/generalization_test_fused_deep_moe.sh
+      - name: Run test combine only
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3900
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --test-type="low_latency"
+
+  test-all-build-moe:
+    needs: get-changed-files
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call' || (
+        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
+        github.event.pull_request.draft == false &&
+        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
+      )
+    runs-on: ["linux-aarch64-a3-16", "a3-752t"]
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
+    env:
+      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+    strategy:
+      matrix:
+        cann_version: [8.5.0, 9.0.0]
+    steps:
+      - name: Clean git config
+        run: |
+          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
+          git config --global --unset "$CONFIG_KEY" || true
+      - name: Clean workspace
+        run: |
+          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          clean: true
+          submodules: recursive
+      - name: Get build hash
+        id: get_build_hash
+        run: |
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
+            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+      - name: Restore build cache
+        id: cache-build
+        uses: runs-on/cache@v4
+        with:
+          path: output
+          key: sgl-kernel-npu-build-v3-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+      - name: Install dependencies
+        run: |
+          # speed up by using infra cache services
+          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+          pip config set global.trusted-host ${CACHING_URL}
+          pip install uv
+          bash scripts/npu_ci_install_dependency.sh
+      - name: Prepare Deepep
+        # - cache hit: install cached wheel only (skip build via -s flag)
+        # - cache miss: clear stale wheels + build + install
+        run: |
+          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+            echo "Cache hit, installing cached wheel only"
+            bash scripts/prepare_deepep_in_container.sh -s
+          else
+            echo "Cache miss, building and installing"
+            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+            bash scripts/prepare_deepep_in_container.sh
+          fi
+      - name: Set CANN 9.0.0 env
+        if: matrix.cann_version == '9.0.0'
+        run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
+      - name: Run test fused deepep moe for little processes
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-experts=24
+      - name: Run test mixed running
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py
+      - name: Run test mixed running for little processes
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2241
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --test-loop=100
+      - name: Run test mixed running for bs
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 4065
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=1 --low-latency-num-tokens=1 --test-loop=100
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=8192 --low-latency-num-tokens=512 --test-loop=100
+      - name: Run test mixed running for hidden
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=2048 --test-loop=100
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=4096 --test-loop=100
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=6144 --test-loop=100
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=7168 --test-loop=100
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=8192 --test-loop=100
+      - name: Run test mixed running for experts
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 7500
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2 --test-loop=100
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=512 --test-loop=100 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=1024 --test-loop=100 --num-processes=16
+      - name: Run test mixed running for topk
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 4065
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=1 --test-loop=100
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=16 --test-loop=100
+      - name: Run test mixed running for dynamic tokens
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3769
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --test-loop=100 --enable-dynamic-tokens
+      - name: Run test fused deep moe for fuse_mode.DISPATCH_FFN_COMBINE
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2048
+        run: python3 $GITHUB_WORKSPACE/tests/python/deepep/test_dispatch_ffn_combine.py
+      - name: Run test alltoall mode for both normal and low_latency
+        if: matrix.cann_version == '9.0.0'
+        timeout-minutes: 10
+        env:
+          DEEP_MOE_MODE: alltoall
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type int8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type int8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type bf16
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type bf16
+
+  test-all-build-moe-fused-deep-moe-a3-560t:
+    needs: get-changed-files
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call' || (
+        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
+        github.event.pull_request.draft == false &&
+        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
+      )
+    runs-on: ["linux-aarch64-a3-16", "a3-560t"]
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py3.11
+    env:
+      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+    strategy:
+      matrix:
+        cann_version: [8.5.0, 9.0.0]
+    steps:
+      - name: Clean git config
+        run: |
+          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
+          git config --global --unset "$CONFIG_KEY" || true
+      - name: Clean workspace
+        run: |
+          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          clean: true
+          submodules: recursive
+      - name: Get build hash
+        id: get_build_hash
+        run: |
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
+            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+      - name: Restore build cache
+        id: cache-build
+        uses: runs-on/cache@v4
+        with:
+          path: output
+          key: sgl-kernel-npu-build-v3-${{ runner.os }}-a3-cann${{ steps.get_build_hash.outputs.CANN_VERSION }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+      - name: Install dependencies
+        run: |
+          # speed up by using infra cache services
+          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+          pip config set global.trusted-host ${CACHING_URL}
+          pip install uv
+          bash scripts/npu_ci_install_dependency.sh
+      - name: Prepare Deepep
+        # - cache hit: install cached wheel only (skip build via -s flag)
+        # - cache miss: clear stale wheels + build + install
+        run: |
+          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+            echo "Cache hit, installing cached wheel only"
+            bash scripts/prepare_deepep_in_container.sh -s
+          else
+            echo "Cache miss, building and installing"
+            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+            bash scripts/prepare_deepep_in_container.sh
+          fi
+      - name: Set CANN 9.0.0 env
+        if: matrix.cann_version == '9.0.0'
+        run: echo "MOE_ENABLE_CCU=0" >> $GITHUB_ENV
+      - name: Run test base fused deep moe
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 256
+      - name: Run test muti-model for fused deep moe
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256 --hidden 6144 --moe-intermediate-size 2048
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128 --hidden 6144 --moe-intermediate-size 2048
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256 --hidden 4096 --moe-intermediate-size 1536
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 256 --hidden 4096 --moe-intermediate-size 1536
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128 --hidden 4096 --moe-intermediate-size 1536
+      - name: Run test fused deepep moe eplb
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --topk-drop-col 3
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --topk-drop-prob 0.3
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 2
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 3 --num-experts 16
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 4 --topk-drop-col 1 --num-experts 32
+      - name: Run test fused deepep moe for bs
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1913
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens=256
+      - name: Run test fused deepep moe for hidden
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1913
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --hidden=2048
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --hidden=7168
+      - name: Run test fused deepep moe for topk
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-topk=1
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-topk=12
+      - name: Run test fused deepep moe for experts
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-topk=1 --num-experts=4
 
   test-all-build-moe-fused-deep-moe-a3-752t:
     needs: get-changed-files
@@ -913,9 +913,9 @@ jobs:
   finish:
     if: always()
     needs:
-#      - test-all-build-core
-#      - test-all-build-moe
-#      - test-all-build-moe-fused-deep-moe-a3-560t
+      - test-all-build-core
+      - test-all-build-moe
+      - test-all-build-moe-fused-deep-moe-a3-560t
       - test-all-build-moe-fused-deep-moe-a3-752t
       - test-build-deepep-a2
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

1.Migrate some fusion operator test cases to A3-560T
2.Remove redundant environment variables: MOE_ENABLE_CCU=0

## Changes

Updated file: .github/workflows/pr-test-deepep-npu.yml, 

