### PR TITLE
[feat] add quant_mode['mx_fp8_e4m3','mx_fp8_e5m2','mx_fp4_e2m1'] in alltoall mode

### DIFF
--- a/python/deep_ep/deep_ep/strategies/normal_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/normal_strategy.py
@@ -610,11 +610,6 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
         num_experts = layout["num_experts"]
         topk_idx_int = topk_idx.to(torch.int32)
 
-        # Determine quant type from quant_mode
-        VALID_QUANT_MODES = {
-            "bf16",
-            "int8",
-        }
         if quant_mode is None:
             quant_mode = "bf16"
         if quant_mode not in VALID_QUANT_MODES:
@@ -625,16 +620,33 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
             )
         hidden_shape = x.shape
 
-        use_quant = 1 if quant_mode == "int8" else -1
+        use_quant = {
+            "bf16": -1,
+            "int8": 1,
+            "mx_fp8_e4m3": 3,
+            "mx_fp8_e5m2": 2,
+            "pertoken_fp8_e4m3": 8,
+            "mx_fp4_e2m1": 9,
+        }[quant_mode]
+
+        use_quant_type = {
+            "bf16": torch.bfloat16,
+            "int8": torch.int8,
+            "mx_fp8_e4m3": torch.float8_e4m3fn,
+            "mx_fp8_e5m2": torch.float8_e5m2,
+            "pertoken_fp8_e4m3": torch.float8_e4m3fn,
+            "mx_fp4_e2m1": torch.float4_e2m1fn_x2,
+        }[quant_mode]
+
         is_quant_env = os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT")
         if is_quant_env is not None and quant_mode is None:
             use_quant = 1 if is_quant_env == "1" else -1
 
-        (permutated_tokens, reversed_local_mapping, _, dynamic_scale) = (
+        (permutated_tokens, reversed_local_mapping, _, _) = (
             torch_npu.npu_moe_init_routing_v2(
                 x,
                 topk_idx_int,
-                quant_mode=use_quant,
+                quant_mode=-1,
                 expert_num=num_experts,
                 expert_tokens_num_type=1,
                 expert_tokens_num_flag=True,
@@ -643,13 +655,6 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
             )
         )
 
-        if use_quant == 1:
-            _, dynamic_scale_after_all2all, scale_handle = self._async_all_to_all(
-                dynamic_scale, output_splits, input_splits, self.group
-            )
-            scale_handle.wait()
-            dynamic_scale.untyped_storage().resize_(0)
-
         _, global_input_tokens, handle_a2a = self._async_all_to_all(
             permutated_tokens,
             output_splits,
@@ -657,36 +662,16 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
             self.group,
         )
         handle_a2a.wait()
-        permutated_tokens.untyped_storage().resize_(0)
 
         if num_local_experts > 1:
             global_tokens_indices = global_tokens_indices.reshape(
                 global_tokens_indices.size(0), 1
             )
-            if use_quant == 1:
-                dynamic_scale_after_all2all = dynamic_scale_after_all2all.reshape(
-                    dynamic_scale_after_all2all.size(0), 1
-                )
-                (dynamic_scale_after_routing, reversed_global_mapping, _, _) = (
-                    torch_npu.npu_moe_init_routing_v2(
-                        dynamic_scale_after_all2all,
-                        global_tokens_indices,
-                        quant_mode=-1,
-                        expert_num=num_local_experts,
-                        expert_tokens_num_type=1,
-                        expert_tokens_num_flag=True,
-                        row_idx_type=0,
-                        active_expert_range=[0, num_local_experts],
-                    )
-                )
-                dynamic_scale_after_routing = dynamic_scale_after_routing.reshape(
-                    dynamic_scale_after_routing.size(0)
-                )
-            (dispatch_out, reversed_global_mapping, _, _) = (
+            (dispatch_out, reversed_global_mapping, _, dynamic_scale_after_routing) = (
                 torch_npu.npu_moe_init_routing_v2(
                     global_input_tokens,
                     global_tokens_indices,
-                    quant_mode=-1,
+                    quant_mode=use_quant,
                     expert_num=num_local_experts,
                     expert_tokens_num_type=1,
                     expert_tokens_num_flag=True,
@@ -713,8 +698,8 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
             "num_local_experts": num_local_experts,
         }
         recv_x = (
-            (dispatch_out, dynamic_scale_after_routing)
-            if use_quant == 1
+            (dispatch_out.view(use_quant_type), dynamic_scale_after_routing)
+            if use_quant != -1
             else dispatch_out
         )
 

--- a/python/deep_ep/deep_ep/strategies/normal_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/normal_strategy.py
@@ -615,8 +615,8 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
         if quant_mode not in VALID_QUANT_MODES:
             raise NotImplementedError(
                 f"quant_mode '{quant_mode}' is not supported by the alltoall strategy. "
-                f"Only 'bf16' and 'int8' are supported; use the default strategy for "
-                f"FP8/FP4 modes."
+                f"Only 'bf16','int8','mx_fp8_e4m3','mx_fp8_e5m2','mx_fp4_e2m1' are supported; "
+                f"use the default strategy for FP8/FP4 modes."
             )
         hidden_shape = x.shape
 
@@ -625,7 +625,6 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
             "int8": 1,
             "mx_fp8_e4m3": 3,
             "mx_fp8_e5m2": 2,
-            "pertoken_fp8_e4m3": 8,
             "mx_fp4_e2m1": 9,
         }[quant_mode]
 
@@ -634,7 +633,6 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
             "int8": torch.int8,
             "mx_fp8_e4m3": torch.float8_e4m3fn,
             "mx_fp8_e5m2": torch.float8_e5m2,
-            "pertoken_fp8_e4m3": torch.float8_e4m3fn,
             "mx_fp4_e2m1": torch.float4_e2m1fn_x2,
         }[quant_mode]
 

--- a/tests/python/deepep/test_normal_alltoall.py
+++ b/tests/python/deepep/test_normal_alltoall.py
@@ -14,10 +14,10 @@ from utils import (
     bench,
     calc_diff,
     diagnose_matrix,
+    get_diff_threshold,
     init_dist,
     inplace_unique,
     per_token_cast_back,
-    get_diff_threshold,
 )
 
 # 设置环境变量
@@ -307,7 +307,6 @@ def test_main(
         else:
             raise ValueError(f"Unsupported quant_type: {quant_type}")
         recv_bytes = data_bytes + scale_bytes
-        #fp8_recv_bytes = quant_data_bytes + quant_scale_bytes
         return recv_bytes
 
     config = deep_ep.Config(24, 8, buffer_size)

--- a/tests/python/deepep/test_normal_alltoall.py
+++ b/tests/python/deepep/test_normal_alltoall.py
@@ -425,7 +425,7 @@ if __name__ == "__main__":
         dest="quant_type",
         type=str,
         default="bf16",
-        help="quant type: bf16, int8, mx_fp8_e4m3, mx_fp8_e5m2, pertoken_fp8_e4m3, mx_fp4_e2m1",
+        help="quant type: bf16, int8, mx_fp8_e4m3, mx_fp8_e5m2, mx_fp4_e2m1",
     )
     args = parser.parse_args()
 

--- a/tests/python/deepep/test_normal_alltoall.py
+++ b/tests/python/deepep/test_normal_alltoall.py
@@ -17,6 +17,7 @@ from utils import (
     init_dist,
     inplace_unique,
     per_token_cast_back,
+    get_diff_threshold,
 )
 
 # 设置环境变量
@@ -266,7 +267,8 @@ def test_main(
 
         avg_diff = torch.mean(torch.abs(check_x - golden) / golden_nozero).item()
         print(f"{rank=}, {avg_diff=:.5f}, {max_diff=:.5f}, cosine_diff={diff:.5f}")
-        assert diff < 5e-5, f"Assertion diff failed on {rank=}"
+        diff_threshold = get_diff_threshold(quant_type)
+        assert diff < diff_threshold, f"Assertion diff failed on {rank=}"
 
         # For later tuning
         dispatch_bf16_recv_bytes = recv_x.numel() * 2
@@ -282,19 +284,30 @@ def test_main(
         hidden_dim = hidden
         bs = dispatch_bf16_recv_bytes / 2 / hidden_dim
         num_values = bs * hidden_dim
-
+        num_recv_tokens = dispatch_bf16_recv_bytes // (hidden * 2)
+        scale_bytes = 0
         if quant_type == "bf16":
             # No quantization, use original BF16 communication
-            recv_bytes = dispatch_bf16_recv_bytes
+            data_bytes = dispatch_bf16_recv_bytes
         elif quant_type == "int8":
             # INT8 per-token quantization:
             # - Data: num_values * 1 byte (INT8)
             # - Scale: x tokens * 2 bytes each (BF16)
             data_bytes = num_values * 1
             scale_bytes = bs * 2
-            recv_bytes = data_bytes + scale_bytes
+        elif quant_type.startswith("pertoken_fp8"):
+            data_bytes = num_values * 1
+            scale_bytes = num_recv_tokens * 4
+        elif quant_type.startswith("mx_fp8"):
+            data_bytes = num_values * 1
+            scale_bytes = num_recv_tokens * hidden // 32
+        elif quant_type.startswith("mx_fp4"):
+            data_bytes = num_values // 2
+            scale_bytes = num_recv_tokens * hidden // 32
         else:
             raise ValueError(f"Unsupported quant_type: {quant_type}")
+        recv_bytes = data_bytes + scale_bytes
+        #fp8_recv_bytes = quant_data_bytes + quant_scale_bytes
         return recv_bytes
 
     config = deep_ep.Config(24, 8, buffer_size)
@@ -412,7 +425,7 @@ if __name__ == "__main__":
         dest="quant_type",
         type=str,
         default="bf16",
-        help="quant type: bf16, int8",
+        help="quant type: bf16, int8, mx_fp8_e4m3, mx_fp8_e5m2, pertoken_fp8_e4m3, mx_fp4_e2m1",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Motivation

Quantization mode be added to the AlltoAll mode to be aligned with the A5 mode. fix #691 

## Modifications

- **`normal_strategy.py`**:Added Quantitative Type.
- **`test_normal_alltoall.py`**:Provide quantitative parameters

## Testing

python test_normal_alltoall.py --num-processes 2 --quant-type mx_fp8_e4m3
python test_normal_alltoall.py --num-processes 2 --quant-type mx_fp8_e5m2
python test_normal_alltoall.py --num-processes 2 --quant-type mx_fp4_e2m1

## Benchmarking and Profiling

[testing] Running with BF16, with top-k 8 ...
rank=1, avg_diff=0.00001, max_diff=1.00000, cosine_diff=0.00038
rank=0, avg_diff=0.00001, max_diff=1.00000, cosine_diff=0.00038
[test] passed, dispatch_bf16_recv_bytes=469762048
[tuning] Dispatch (quant_type='mx_fp8_e4m3') 30.16 GB/s (HCCS), avg_t: 8031.22 us
[tuning] Combine 67.56 GB/s (HCCS), avg_t: 6953.37 us


[testing] Running with BF16, with top-k 8 ...
rank=1, avg_diff=0.00000, max_diff=0.00000, cosine_diff=0.00000
rank=1, avg_diff=0.00002, max_diff=0.12488, cosine_diff=0.00130
rank=0, avg_diff=0.00000, max_diff=0.12493, cosine_diff=0.00130
[test] passed, dispatch_bf16_recv_bytes=469762048
[tuning] Dispatch (quant_type='mx_fp8_e5m2') 31.95 GB/s (HCCS), avg_t: 7582.43 us
[tuning] Combine 69.34 GB/s (HCCS), avg_t: 6775.12 us


[testing] Running with BF16, with top-k 8 ...
rank=0, avg_diff=-0.00006, max_diff=1.98828, cosine_diff=0.00701
[test] passed, dispatch_bf16_recv_bytes=469762048
rank=1, avg_diff=0.00005, max_diff=1.98827, cosine_diff=0.00703
[tuning] Dispatch (quant_type='mx_fp4_e2m1') 17.14 GB/s (HCCS), avg_t: 7279.56 us
[tuning] Combine 69.56 GB/s (HCCS), avg_t: 6753.12 us

## Checklist

- [ ] Format your code.
- [ ] Add unit tests.
- [ ] Update documentation.
- [ ] Provide accuracy and speed benchmark results.