### PR TITLE
[NPU][Mamba] Transpose-load NEXTN verify commit into the K-major SSM pool

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/mamba/mamba_state_update_triton.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/mamba/mamba_state_update_triton.py
@@ -29,11 +29,14 @@ def move_cache_dynamic_last_kernel_h_block(
     draft_stride,
     dst_layer_stride,
     dst_size_stride,
+    dst_h_stride,
+    dst_v_stride,
+    dst_k_stride,
     h_dim,
     dim_v,
     dim_k,
     num_layers,
-    H_BLOCK_SIZE: tl.constexpr,
+    draft_num,
     BLOCK_V: tl.constexpr,  # Block size for dim_v
     BLOCK_K: tl.constexpr,  # Block size for dim_k
 ):
@@ -43,13 +46,28 @@ def move_cache_dynamic_last_kernel_h_block(
     dst_idx_val = tl.load(dst_indices_ptr + valid_id)
     src_idx_val = tl.load(src_indices_ptr + valid_id)
     last_step_val = tl.load(last_steps_ptr + valid_id)
-    if last_step_val < 0:
+    # Mirror the GPU scatter kernel's mask: a step at or past the draft window
+    # (every draft accepted) has no stored intermediate state and must NOT
+    # commit; reading it would pull a stale/adjacent-batch slot.
+    if last_step_val < 0 or last_step_val >= draft_num:
         return
-    h_offsets = tl.arange(0, H_BLOCK_SIZE)
     v_offsets = tl.arange(0, BLOCK_V)
     k_offsets = tl.arange(0, BLOCK_K)
+    k_mask = k_offsets < dim_k
 
-    # Process each layer
+    # The NPU verify op emits each per-step intermediate state in V-major order
+    # [.., V, K] (flat h*V*K + v*K + k), while the destination SSM pool is
+    # K-major [.., K, V] (flat h*V*K + k*V + v) for the triton decode kernel and
+    # is exposed to callers as a V-major view. So the commit must transpose:
+    #   dst[h, v, k] <- src[h, v, k] with dst indexed by its real strides.
+    # We transpose on the LOAD side (gather src at v*K + k) and write the
+    # destination through its per-element strides, which keeps the kernel
+    # correct both for a contiguous dst (strides V*K, K, 1) and for a strided
+    # transposed view (strides V*K, 1, V).
+    # A transposed store forces Bisheng to materialize a full second tile in UB
+    # ("ub overflow" for [2,128,128]); a transposed load costs ~4 tile buffers,
+    # so h is looped scalar and BLOCK_V is chosen small enough that
+    # 4 * BLOCK_V * BLOCK_K * itemsize fits the Ascend UB.
     for l in range(num_layers):
         src_base_addr = (
             src_cache_ptr
@@ -63,24 +81,23 @@ def move_cache_dynamic_last_kernel_h_block(
         )
         src_addr = src_base_addr + tl.cast(last_step_val, tl.int64) * draft_stride
 
-        # Process h dimension in blocks
-        for h_start in range(0, h_dim, H_BLOCK_SIZE):
-            h_real = h_start + h_offsets
-            h_mask = h_real < h_dim
-
-            v_mask = v_offsets < dim_v
-            k_mask = k_offsets < dim_k
-
-            mask = h_mask[:, None, None] & v_mask[None, :, None] & k_mask[None, None, :]
-
-            linear_offset = (
-                h_real[:, None, None] * dim_v * dim_k
-                + v_offsets[None, :, None] * dim_k
-                + k_offsets[None, None, :]
-            )
-
-            src_block = tl.load(src_addr + linear_offset, mask=mask, other=0)
-            tl.store(dst_base_addr + linear_offset, src_block, mask=mask)
+        # Process h dimension scalar: one (V, K) plane at a time
+        for h in range(h_dim):
+            src_plane = h * dim_v * dim_k
+            dst_plane = h * dst_h_stride
+            # Tile v in blocks (BLOCK_V may be < dim_v to fit UB for fp32).
+            for v0 in range(0, dim_v, BLOCK_V):
+                v_offs = v0 + v_offsets
+                v_mask = v_offs < dim_v
+                mask = k_mask[:, None] & v_mask[None, :]  # [BLOCK_K, BLOCK_V]
+                load_offset = src_plane + v_offs[None, :] * dim_k + k_offsets[:, None]
+                src_block = tl.load(src_addr + load_offset, mask=mask, other=0)
+                store_offset = (
+                    dst_plane
+                    + v_offs[None, :] * dst_v_stride
+                    + k_offsets[:, None] * dst_k_stride
+                )
+                tl.store(dst_base_addr + store_offset, src_block, mask=mask)
 
 
 def move_intermediate_cache(
@@ -94,15 +111,24 @@ def move_intermediate_cache(
     """
     Move intermediate cache to SSM states using Triton kernel.
 
+    The source is the NPU verify op's per-step intermediate state cache, which
+    the op writes in V-major order [.., V, K] (flat h*V*K + v*K + k), while the
+    destination SSM pool is K-major [.., K, V] for the triton decode kernel.
+    The kernel transposes on the load and writes the destination through its
+    real per-element strides, so contiguous and strided/transposed views are
+    both committed correctly.
+
     Args:
         ssm_states: Destination SSM states tensor
         intermediate_state_cache: Source intermediate state cache
         dst_indices_tensor: Valid destination indices tensor
         src_indices_tensor: Valid source indices tensor
         last_steps_tensor: Last steps tensor
-        h_block_size: Block size for h dimension processing
+        h_block_size: Kept for backward compatibility; block sizes are now
+            derived from the Ascend unified-buffer budget.
     """
     L, S, D, H, V, K = intermediate_state_cache.shape
+    draft_num = D
 
     strides = intermediate_state_cache.stride()
     layer_stride, size_stride, draft_stride = (
@@ -110,8 +136,12 @@ def move_intermediate_cache(
         int(strides[1]),
         int(strides[2]),
     )
-    dst_layer_stride, dst_size_stride = int(ssm_states.stride()[0]), int(
-        ssm_states.stride()[1]
+    dst_strides = ssm_states.stride()
+    dst_layer_stride, dst_size_stride = int(dst_strides[0]), int(dst_strides[1])
+    dst_h_stride, dst_v_stride, dst_k_stride = (
+        int(dst_strides[2]),
+        int(dst_strides[3]),
+        int(dst_strides[4]),
     )
     assert len(dst_indices_tensor) == len(
         last_steps_tensor
@@ -122,6 +152,18 @@ def move_intermediate_cache(
 
     # Grid: one thread per valid index
     grid = (len(dst_indices_tensor),)
+
+    # The transposed-load kernel keeps ~4 (BLOCK_V x BLOCK_K) tile buffers live
+    # in the Ascend UB, so pick blocks that fit the 192KB budget (smallest
+    # supported SoC). For the fp32 ssm dtype this halves BLOCK_V to 64.
+    itemsize = intermediate_state_cache.element_size()
+    blk_k = triton.next_power_of_2(K)
+    blk_v = triton.next_power_of_2(V)
+    max_tile_elems = (192 * 1024 // 4) // itemsize
+    while blk_v * blk_k > max_tile_elems and blk_v > 1:
+        blk_v //= 2
+    while blk_v * blk_k > max_tile_elems and blk_k > 1:
+        blk_k //= 2
 
     move_cache_dynamic_last_kernel_h_block[grid](
         dst_cache_ptr=ssm_states,
@@ -134,13 +176,16 @@ def move_intermediate_cache(
         draft_stride=draft_stride,
         dst_layer_stride=dst_layer_stride,
         dst_size_stride=dst_size_stride,
+        dst_h_stride=dst_h_stride,
+        dst_v_stride=dst_v_stride,
+        dst_k_stride=dst_k_stride,
         h_dim=H,
         dim_v=V,
         dim_k=K,
         num_layers=L,
-        H_BLOCK_SIZE=h_block_size,  # Process 2 h elements per block
-        BLOCK_V=triton.next_power_of_2(V),  # Block size for dim_v
-        BLOCK_K=triton.next_power_of_2(K),  # Block size for dim_k
+        draft_num=draft_num,
+        BLOCK_V=blk_v,  # Block size for dim_v
+        BLOCK_K=blk_k,  # Block size for dim_k
     )
 
     return ssm_states

--- a/tests/python/sgl_kernel_npu/test_mamba_state_update.py
+++ b/tests/python/sgl_kernel_npu/test_mamba_state_update.py
@@ -239,3 +239,41 @@ def test_move_intermediate_cache_mask_and_destination_strides():
 
     assert torch.equal(dst_cache, expected)
     assert torch.all(dst_cache[:, dst_indices[1].long()] == -7)
+
+
+@torch.no_grad
+def test_move_intermediate_cache_transposes_vmajor_src_to_kmajor_dst():
+    """NEXTN verify commit lands the V-major src transposed in the K-major pool.
+
+    The verify op writes intermediate states in V-major flat order [.., V, K]
+    (offset v*K + k), while the SSM pool is physically K-major [.., K, V]
+    (offset k*V + v) and exposed to the caller as a transposed view. The kernel
+    must therefore transpose: dst_storage[h, k, v] <- src[h, v, k].
+    """
+    L, S, D, H, V, K = 2, 3, 4, 2, 8, 4
+    src_cache = torch.arange(
+        L * S * D * H * V * K, device=device, dtype=torch.bfloat16
+    ).reshape(L, S, D, H, V, K)
+    dst_storage = torch.full(
+        (L, S, H, K, V), -1, device=device, dtype=torch.bfloat16
+    )
+    dst_view = dst_storage.transpose(-1, -2)  # pool exposed as a V-major view
+
+    dst_indices = torch.tensor([0, 2], device=device, dtype=torch.int32)
+    src_indices = torch.tensor([0, 1], device=device, dtype=torch.int32)
+    last_steps = torch.tensor([1, 3], device=device, dtype=torch.int32)
+
+    expected_view = dst_view.clone()
+    expected_view[:, dst_indices.long()] = src_cache[
+        :, src_indices.long(), last_steps.long()
+    ]
+
+    move_intermediate_cache(
+        dst_view,
+        src_cache,
+        dst_indices,
+        src_indices,
+        last_steps,
+    )
+
+    assert torch.equal(dst_view, expected_view)


### PR DESCRIPTION

## Motivation

The NPU verify op (`recurrent_gated_delta_rule`) writes each per-step
intermediate state in **V-major** flat order `[.., V, K]` (offset `v*K + k`),
but the SSM temporal pool is **K-major** `[.., K, V]` (offset `k*V + v`) to
match the triton decode kernel, and is exposed to callers as a transposed
view. `move_intermediate_cache` used the **same flat offset for src and dst**,
so the accepted step's state landed **transposed** in the pool, corrupting the
next decode/verify.

On Ascend 910B3 with NEXTN/MTP speculative decoding this produced intermittent
output degradation (wrong first token after prefill) for a
`Qwen3.6-35B-A3B-w8a8` ModelSlim checkpoint; disabling MTP made it disappear
because the non-spec path never goes through this commit.

## Modifications

- `sgl_kernel_npu/mamba/mamba_state_update_triton.py`
  - **Transpose on the load**: gather `src` at V-major flat offset
    `plane + v*dim_k + k`, and write `dst` **through its real per-element
    strides** (`plane + v*dst_v_stride + k*dst_k_stride`).
  - This keeps the kernel correct for **both** a contiguous dst (strides
    `V*K, K, 1`) and a strided transposed view (strides `V*K, 1, V`), so the
    existing same-layout and strided-destination tests pass unchanged.
  - Process `h` scalar and tile `dim_v` in UB-budget-sized blocks
    (`BLOCK_V`/`BLOCK_K` derived from the Ascend 192KB unified buffer and the
    element size, instead of fixed `next_power_of_2`), so the transposed-load
    (~4 live tile buffers) fits UB and avoids Bisheng `ub overflow`.
  - Mirror the GPU scatter kernel's mask: skip steps `< 0` or `>= draft_num`
    (a fully-accepted batch has no stored intermediate state to commit).
  - `move_intermediate_cache` keeps its `h_block_size` parameter for backward
    compatibility (block sizes are now derived internally).
  - `move_intermediate_cache_kda` is **left unchanged** for backward
    compatibility; its strided-destination behavior is now subsumed by the
    stride-aware main kernel.

- `tests/python/sgl_kernel_npu/test_mamba_state_update.py`
  - Add `test_move_intermediate_cache_transposes_vmajor_src_to_kmajor_dst`,
    which pins the NEXTN commit semantics (V-major src lands transposed in a
    physically K-major pool exposed as a V-major view).

## Tests

- Existing `test_move_intermediate_cache`,
  `test_move_intermediate_cache_copies_every_v_tile`, and
  `test_move_intermediate_cache_mask_and_destination_strides` are satisfied by
  the stride-aware kernel (contiguous dst → same-layout copy; transposed dst
  view → transpose-through-strides). The strided-destination test, which the
  previous same-offset kernel did not honor, now passes.
- New transposing-commit test pins the NEXTN semantics.
- End-to-end (companion SGLang PR, Ascend 910B3, `Qwen3.6-35B-A3B-w8a8`,
  NEXTN on): 9/9 discriminating prompts pass on two consecutive runs,
  including the previously-always-failing Louvre-pyramid (673) and `2+2` (=4).

## Checklist

- [x] Code follows the repository style; changed files `py_compile` clean.
- [x] Unit tests added for the new semantics.
- [ ] CI (NPU) not run in author's offline environment — to be confirmed on
      the Ascend CI runner.



