### PR TITLE
[perf] mega_chunk_gdn: cache workspaces and drop per-layer allocations for long prefill

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/chunk.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/chunk.py
@@ -214,8 +214,12 @@ def chunk_gated_delta_rule_fwd(
     cu_seqlens: Optional[torch.LongTensor] = None,
 ):
     if _use_mega_gdn():
+        # At default SUPPRESS_LEVEL the serving stack keeps only o/final_state/h,
+        # so skip the A_inv/w/v_new casts inside the wrapper (~1.5 GB/layer
+        # copies at 128k tokens).
         g, o, A, final_state, w, h, v_new = run_mega_chunk_gdn(
-            q, k, v, g, beta, scale, initial_state, output_final_state, cu_seqlens
+            q, k, v, g, beta, scale, initial_state, output_final_state, cu_seqlens,
+            return_internals=SUPPRESS_LEVEL >= 3,
         )
         if SUPPRESS_LEVEL < 3:
             return g, o, A, final_state, None, h, None

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/mega_chunk_gdn.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/mega_chunk_gdn.py
@@ -1,10 +1,45 @@
+import os
+from collections import OrderedDict
 from functools import lru_cache
 from typing import Optional
 
 import torch
+from sgl_kernel_npu.fla.utils import (
+    _lru_get,
+    _lru_put,
+    cached_cu_lens_cpu,
+    is_gdn_meta_cache_enabled,
+)
 
 HEAD_DIM = 128
 CHUNK_SIZE = 128
+
+
+# Grow-only token slab for kernel-internal + caller-discarded tensors. The
+# AscendC kernel addresses them as h*total_tokens+t and the op host never
+# validates their shapes, so an oversized contiguous buffer is safe: buffers
+# grow to the longest prefill seen and are reused across layers and steps.
+_POOL_OUTPUTS = os.getenv("SGLANG_NPU_GDN_POOL_OUTPUTS", "1") != "0"
+# The kernel fully covers every element it consumes: kkt writes all valid rows
+# of A; solve_tril loads only the valid_size triangle and TFILLPADs the rest;
+# chunk_h stores S/final_state stripes unconditionally. Zero-init is therefore
+# unnecessary (verified against csrc/mega_chunk_gdn kernels).
+_SKIP_OUTPUT_ZERO = os.getenv("SGLANG_NPU_GDN_SKIP_OUTPUT_ZERO", "1") != "0"
+
+# Cross-layer mega scratch / cu32 (shape or content keyed). Not returned to callers.
+_MEGA_CU32_CACHE: "OrderedDict[tuple, torch.Tensor]" = OrderedDict()
+_MEGA_NUM_CHUNKS_CACHE: "OrderedDict[tuple, int]" = OrderedDict()
+_MEGA_SCRATCH_CACHE: "OrderedDict[tuple, dict]" = OrderedDict()
+_MEGA_SLAB_CACHE: "OrderedDict[tuple, dict]" = OrderedDict()
+_DUMMY_F32_CACHE: "OrderedDict[tuple, torch.Tensor]" = OrderedDict()
+
+
+def clear_mega_workspace_cache() -> None:
+    _MEGA_CU32_CACHE.clear()
+    _MEGA_NUM_CHUNKS_CACHE.clear()
+    _MEGA_SCRATCH_CACHE.clear()
+    _MEGA_SLAB_CACHE.clear()
+    _DUMMY_F32_CACHE.clear()
 
 
 def _device_key(device: torch.device) -> tuple[str, int]:
@@ -37,12 +72,29 @@ def _minus_identity(device_type: str, device_index: int) -> torch.Tensor:
     return minus_identity
 
 
-def _total_chunks(cu_seqlens: torch.Tensor) -> int:
-    cu = cu_seqlens.cpu().tolist()
+def _dummy_f32(device_type: str, device_index: int) -> torch.Tensor:
+    """Placeholder for the op's a_inv_f32 argument: the kernel signature takes
+    it but never reads it (the fp32->fp16 cast stage was removed). Saves a
+    full T*H*C fp32 allocation + memset per layer."""
+    key = (device_type, device_index)
+    dummy = _DUMMY_F32_CACHE.get(key)
+    if dummy is None:
+        dummy = torch.zeros(1, device=_device_from_key(device_type, device_index),
+                            dtype=torch.float32)
+        _DUMMY_F32_CACHE[key] = dummy
+    return dummy
+
+
+def _total_chunks_from_cpu(cu: list[int]) -> int:
     total = 0
     for start, end in zip(cu, cu[1:]):
         total += (end - start + CHUNK_SIZE - 1) // CHUNK_SIZE
     return total
+
+
+def _total_chunks(cu_seqlens: torch.Tensor) -> int:
+    _, cu = cached_cu_lens_cpu(cu_seqlens)
+    return _total_chunks_from_cpu(cu)
 
 
 def _block_dim(device: torch.device) -> int:
@@ -51,6 +103,121 @@ def _block_dim(device: torch.device) -> int:
         return max(1, int(getattr(props, "cube_core_num", 24)))
     except (RuntimeError, AttributeError, AssertionError):
         return 24
+
+
+def _get_cu32_and_chunks(
+    cu_seqlens: Optional[torch.Tensor],
+    total_tokens: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, int, int]:
+    """Return (cu32, num_sequences, num_chunks), caching cu32 by content across layers."""
+    if cu_seqlens is None:
+        cu_cpu = [0, total_tokens]
+        num_chunks = _total_chunks_from_cpu(cu_cpu)
+        if not is_gdn_meta_cache_enabled():
+            cu32 = torch.tensor(cu_cpu, dtype=torch.int32, device=device)
+            return cu32, 1, num_chunks
+        key = (tuple(cu_cpu), _device_key(device))
+        cached = _lru_get(_MEGA_CU32_CACHE, key)
+        if cached is not None:
+            return cached, 1, num_chunks
+        cu32 = torch.tensor(cu_cpu, dtype=torch.int32, device=device)
+        _lru_put(_MEGA_CU32_CACHE, key, cu32)
+        return cu32, 1, num_chunks
+
+    content_key, cu_cpu = cached_cu_lens_cpu(cu_seqlens)
+    num_sequences = len(cu_cpu) - 1
+    if is_gdn_meta_cache_enabled():
+        nkey = (content_key, CHUNK_SIZE)
+        num_chunks = _lru_get(_MEGA_NUM_CHUNKS_CACHE, nkey)
+        if num_chunks is None:
+            num_chunks = _total_chunks_from_cpu(cu_cpu)
+            _lru_put(_MEGA_NUM_CHUNKS_CACHE, nkey, num_chunks)
+        ckey = (content_key, _device_key(device))
+        cu32 = _lru_get(_MEGA_CU32_CACHE, ckey)
+        if cu32 is None:
+            cu32 = cu_seqlens.to(torch.int32)
+            _lru_put(_MEGA_CU32_CACHE, ckey, cu32)
+        return cu32, num_sequences, num_chunks
+
+    cu32 = cu_seqlens.to(torch.int32)
+    return cu32, num_sequences, _total_chunks_from_cpu(cu_cpu)
+
+
+def _get_mega_scratch(block_dim: int, head_dim: int, device: torch.device, dtype: torch.dtype) -> dict:
+    """Scratch buffers rewritten each launch; safe to reuse across GDN layers."""
+    if not is_gdn_meta_cache_enabled():
+        return _alloc_mega_scratch(block_dim, head_dim, device, dtype)
+
+    key = (int(block_dim), int(head_dim), str(dtype), _device_key(device))
+    cached = _lru_get(_MEGA_SCRATCH_CACHE, key)
+    if cached is not None:
+        return cached
+    pack = _alloc_mega_scratch(block_dim, head_dim, device, dtype)
+    return _lru_put(_MEGA_SCRATCH_CACHE, key, pack)
+
+
+def _alloc_mega_scratch(block_dim: int, head_dim: int, device: torch.device, dtype: torch.dtype) -> dict:
+    wy_a1 = torch.zeros(
+        block_dim, CHUNK_SIZE, CHUNK_SIZE, device=device, dtype=dtype
+    )
+    o_qk = torch.zeros(
+        block_dim, CHUNK_SIZE, CHUNK_SIZE, device=device, dtype=dtype
+    )
+    return {
+        "kkt": torch.zeros(
+            block_dim * 2, CHUNK_SIZE, CHUNK_SIZE, device=device, dtype=dtype
+        ),
+        "wy_a1": wy_a1,
+        "wy_a2": torch.zeros_like(wy_a1),
+        "h": torch.zeros(
+            block_dim * 4, head_dim, head_dim, device=device, dtype=dtype
+        ),
+        "o_qk": o_qk,
+        "o_qs": torch.zeros(
+            block_dim, CHUNK_SIZE, head_dim, device=device, dtype=dtype
+        ),
+        "o_gated": torch.zeros_like(o_qk),
+    }
+
+
+def _alloc_slab(
+    cap: int, num_value_heads: int, head_dim: int, device: torch.device, dtype: torch.dtype
+) -> dict:
+    """Token-scaled buffers sized to `cap` >= total_tokens. The kernel only
+    touches elements below total_tokens, so oversizing is safe."""
+    z = torch.zeros if not _SKIP_OUTPUT_ZERO else torch.empty
+    A = z(1, cap, num_value_heads, CHUNK_SIZE, device=device, dtype=dtype)
+    return {
+        "cap": cap,
+        "g_sum": torch.empty(1, cap, num_value_heads, device=device, dtype=torch.float32),
+        "g_t": torch.empty(num_value_heads, cap, device=device, dtype=torch.float32),
+        "beta_t": torch.empty(num_value_heads, cap, device=device, dtype=dtype),
+        "A": A,
+        # Returned by the wrapper but discarded by every caller in the serving
+        # stack (chunk_gated_delta_rule_npu keeps only o/final_state/h).
+        "A_inv": z(1, cap, num_value_heads, CHUNK_SIZE, device=device, dtype=dtype),
+        "w": torch.empty(1, cap, num_value_heads, head_dim, device=device, dtype=dtype),
+        "u": torch.empty(1, cap, num_value_heads, head_dim, device=device, dtype=dtype),
+        "v_new": torch.empty(1, cap, num_value_heads, head_dim, device=device, dtype=dtype),
+    }
+
+
+def _get_mega_slab(
+    total_tokens: int,
+    num_value_heads: int,
+    head_dim: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> dict:
+    key = (int(num_value_heads), int(head_dim), str(dtype), _device_key(device))
+    slab = _MEGA_SLAB_CACHE.get(key)
+    if slab is not None and slab["cap"] >= total_tokens:
+        return slab
+    cap = total_tokens if slab is None else max(total_tokens, slab["cap"])
+    slab = _alloc_slab(cap, num_value_heads, head_dim, device, dtype)
+    _MEGA_SLAB_CACHE[key] = slab
+    return slab
 
 
 def run_mega_chunk_gdn(
@@ -63,6 +230,7 @@ def run_mega_chunk_gdn(
     initial_state: Optional[torch.Tensor],
     output_final_state: bool,
     cu_seqlens: Optional[torch.Tensor],
+    return_internals: bool = True,
 ) -> tuple[
     torch.Tensor,
     torch.Tensor,
@@ -81,76 +249,68 @@ def run_mega_chunk_gdn(
     _, total_tokens, _, head_dim = q.shape
     num_value_heads = v.shape[-2]
     device_type, device_index = _device_key(q.device)
-    if cu_seqlens is None:
-        cu32 = torch.tensor([0, total_tokens], dtype=torch.int32, device=q.device)
-    else:
-        cu32 = cu_seqlens.to(torch.int32)
 
-    num_sequences = cu32.numel() - 1
-    num_chunks = _total_chunks(cu32)
+    cu32, num_sequences, num_chunks = _get_cu32_and_chunks(
+        cu_seqlens, total_tokens, q.device
+    )
     num_matrices = num_chunks * num_value_heads
 
     mask_lower, mask_full = _masks(device_type, device_index)
     minus_identity = _minus_identity(device_type, device_index)
+    a_inv_f32 = _dummy_f32(device_type, device_index)
 
-    g_sum = torch.empty_like(g, dtype=torch.float32)
-    g_t = torch.empty(
-        num_value_heads, total_tokens, device=q.device, dtype=torch.float32
-    )
-    beta_t = torch.empty(
-        num_value_heads, total_tokens, device=q.device, dtype=torch.float16
-    )
-
-    A = torch.zeros(
-        1,
-        total_tokens,
-        num_value_heads,
-        CHUNK_SIZE,
-        device=q.device,
-        dtype=torch.float16,
-    )
-    A_inv_f32 = torch.zeros_like(A, dtype=torch.float32)
-    A_inv = torch.zeros_like(A)
-
-    w = torch.empty_like(v)
-    u = torch.empty_like(v)
-    h = torch.zeros(
+    # Outputs / states that escape this call — allocate fresh every layer.
+    z = torch.zeros if not _SKIP_OUTPUT_ZERO else torch.empty
+    h = z(
         num_chunks * num_value_heads,
         head_dim,
         head_dim,
         device=q.device,
         dtype=torch.float16,
     )
-    v_new = torch.empty_like(v)
-    final_state = torch.zeros(
+    final_state = z(
         num_sequences * num_value_heads,
         head_dim,
         head_dim,
         device=q.device,
         dtype=torch.float16,
     )
+    out = torch.empty_like(v)
+
+    cache_on = is_gdn_meta_cache_enabled()
+    if cache_on and _POOL_OUTPUTS:
+        slab = _get_mega_slab(total_tokens, num_value_heads, head_dim, q.device, torch.float16)
+        g_sum = slab["g_sum"]
+        A_inv = slab["A_inv"]
+        w = slab["w"]
+        u = slab["u"]
+        v_new = slab["v_new"]
+        g_t = slab["g_t"]
+        beta_t = slab["beta_t"]
+        A = slab["A"]
+    else:
+        g_sum = torch.empty_like(g, dtype=torch.float32)
+        A_inv = z(
+            1, total_tokens, num_value_heads, CHUNK_SIZE,
+            device=q.device, dtype=torch.float16,
+        )
+        w = torch.empty_like(v)
+        u = torch.empty_like(v)
+        v_new = torch.empty_like(v)
+        g_t = torch.empty(num_value_heads, total_tokens, device=q.device, dtype=torch.float32)
+        beta_t = torch.empty(num_value_heads, total_tokens, device=q.device, dtype=torch.float16)
+        A = z(
+            1, total_tokens, num_value_heads, CHUNK_SIZE,
+            device=q.device, dtype=torch.float16,
+        )
+
     has_initial_state = initial_state is not None
-    initial_state = initial_state.half() if has_initial_state else final_state
+    initial_state = (
+        initial_state.to(torch.float16) if has_initial_state else final_state
+    )
 
     block_dim = _block_dim(q.device)
-    kkt_workspace = torch.zeros(
-        block_dim * 2, CHUNK_SIZE, CHUNK_SIZE, device=q.device, dtype=torch.float16
-    )
-    wy_workspace_a1 = torch.zeros(
-        block_dim, CHUNK_SIZE, CHUNK_SIZE, device=q.device, dtype=torch.float16
-    )
-    wy_workspace_a2 = torch.zeros_like(wy_workspace_a1)
-    h_workspace = torch.zeros(
-        block_dim * 4, head_dim, head_dim, device=q.device, dtype=torch.float16
-    )
-    o_workspace_qk = torch.zeros(
-        block_dim, CHUNK_SIZE, CHUNK_SIZE, device=q.device, dtype=torch.float16
-    )
-    o_workspace_qs = torch.zeros(
-        block_dim, CHUNK_SIZE, head_dim, device=q.device, dtype=torch.float16
-    )
-    o_workspace_gated = torch.zeros_like(o_workspace_qk)
-    out = torch.empty_like(v)
+    scratch = _get_mega_scratch(block_dim, head_dim, q.device, torch.float16)
 
     torch.ops.npu.mega_chunk_gdn(
         q,
@@ -167,7 +327,7 @@ def run_mega_chunk_gdn(
         g_t,
         beta_t,
         A,
-        A_inv_f32,
+        a_inv_f32,
         A_inv,
         w,
         u,
@@ -176,13 +336,13 @@ def run_mega_chunk_gdn(
         final_state,
         initial_state,
         has_initial_state,
-        kkt_workspace,
-        wy_workspace_a1,
-        wy_workspace_a2,
-        h_workspace,
-        o_workspace_qk,
-        o_workspace_qs,
-        o_workspace_gated,
+        scratch["kkt"],
+        scratch["wy_a1"],
+        scratch["wy_a2"],
+        scratch["h"],
+        scratch["o_qk"],
+        scratch["o_qs"],
+        scratch["o_gated"],
         block_dim,
         num_sequences,
         total_tokens,
@@ -197,12 +357,27 @@ def run_mega_chunk_gdn(
         ).to(torch.float32)
     else:
         final_state_out = None
+    # Slab buffers may be oversized (cap >= total_tokens); the kernel only
+    # writes below total_tokens, so slice the escaped tensors back to size.
+    T = total_tokens
+    if not return_internals:
+        # chunk_gated_delta_rule_fwd discards A_inv/w/v_new at default
+        # SUPPRESS_LEVEL: skip the .to() casts (~1.5 GB/layer copies at 128k).
+        return (
+            g_sum[:, :T],
+            (out * scale).to(q_dtype),
+            None,
+            final_state_out,
+            None,
+            h,
+            None,
+        )
     return (
-        g_sum,
+        g_sum[:, :T],
         (out * scale).to(q_dtype),
-        A_inv.to(k_dtype),
+        A_inv[:, :T].to(k_dtype),
         final_state_out,
-        w.to(k_dtype),
+        w[:, :T].to(k_dtype),
         h.to(k_dtype),
-        v_new.to(v_dtype),
+        v_new[:, :T].to(v_dtype),
     )

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
@@ -5,7 +5,8 @@
 import contextlib
 import functools
 import os
-from typing import Any, Callable, Dict, Optional, Tuple
+from collections import OrderedDict
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import torch
 import triton
@@ -14,6 +15,9 @@ import triton.language.extra.libdevice as tldevice
 
 is_gather_supported = hasattr(triton.language, "gather")
 SUPPRESS_LEVEL = int(os.getenv("GDN_RECOMPUTE_SUPPRESS_LEVEL", "0"))
+# Cross-layer GDN chunk meta / prepare_* cache. Content-keyed (not data_ptr).
+_GDN_META_CACHE = os.getenv("SGLANG_NPU_GDN_META_CACHE", "1") != "0"
+_GDN_META_CACHE_SIZE = max(1, int(os.getenv("SGLANG_NPU_GDN_META_CACHE_SIZE", "16")))
 
 if os.environ.get("FLA_USE_FAST_OPS", "0") == "1":
     exp = tldevice.fast_expf
@@ -145,32 +149,211 @@ def tensor_cache(fn: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]
     return wrapper
 
 
-@tensor_cache
-def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
-    cu_seqlens_i64 = cu_seqlens.to(torch.int64)
-    return cu_seqlens_i64[1:] - cu_seqlens_i64[:-1]
+# ---------------------------------------------------------------------------
+# Cross-layer GDN prepare_* caches (content key; not data_ptr).
+# Same cu_seqlens values across GDN layers reuse indices/offsets / CPU lens.
+# ---------------------------------------------------------------------------
+_CU_LENS_SESSION: Dict[str, Any] = {
+    "tensor": None,
+    "key": None,
+    "cpu": None,
+}
+_CU_LENS_CPU_CACHE: "OrderedDict[Tuple[int, ...], List[int]]" = OrderedDict()
+_PREPARE_LENS_CACHE: "OrderedDict[Tuple, torch.Tensor]" = OrderedDict()
+_CHUNK_INDICES_CACHE: "OrderedDict[Tuple, torch.Tensor]" = OrderedDict()
+_CHUNK_OFFSETS_CACHE: "OrderedDict[Tuple, torch.Tensor]" = OrderedDict()
+_AD_WORKSPACE_CACHE: "OrderedDict[Tuple, torch.Tensor]" = OrderedDict()
 
 
-@tensor_cache
-def prepare_chunk_indices(
-    cu_seqlens: torch.LongTensor, chunk_size: int
+def _lru_get(cache: OrderedDict, key: Tuple) -> Any:
+    value = cache.get(key)
+    if value is not None:
+        cache.move_to_end(key)
+    return value
+
+
+def _lru_put(cache: OrderedDict, key: Tuple, value: Any) -> Any:
+    cache[key] = value
+    cache.move_to_end(key)
+    while len(cache) > _GDN_META_CACHE_SIZE:
+        cache.popitem(last=False)
+    return value
+
+
+def _device_key(device: torch.device) -> Tuple[str, int]:
+    index = device.index if device.index is not None else -1
+    return device.type, index
+
+
+def cached_cu_lens_cpu(cu_seqlens: torch.Tensor) -> Tuple[Tuple[int, ...], List[int]]:
+    """D2H once per distinct cu_seqlens content; same Python object hits session."""
+    if (
+        _GDN_META_CACHE
+        and _CU_LENS_SESSION["tensor"] is cu_seqlens
+        and _CU_LENS_SESSION["key"] is not None
+    ):
+        return _CU_LENS_SESSION["key"], _CU_LENS_SESSION["cpu"]
+
+    cpu = [int(x) for x in cu_seqlens.detach().cpu().tolist()]
+    key = tuple(cpu)
+
+    if _GDN_META_CACHE:
+        cached = _lru_get(_CU_LENS_CPU_CACHE, key)
+        if cached is not None:
+            cpu = cached
+        else:
+            _lru_put(_CU_LENS_CPU_CACHE, key, cpu)
+        _CU_LENS_SESSION["tensor"] = cu_seqlens
+        _CU_LENS_SESSION["key"] = key
+        _CU_LENS_SESSION["cpu"] = cpu
+
+    return key, cpu
+
+
+def _prepare_lens_uncached(
+    cu_seqlens: torch.LongTensor, cpu: Optional[List[int]] = None
 ) -> torch.LongTensor:
-    indices = torch.cat(
-        [
-            torch.arange(n)
-            for n in triton.cdiv(prepare_lens(cu_seqlens), chunk_size).tolist()
+    if cpu is None:
+        cu_seqlens_i64 = cu_seqlens.to(torch.int64)
+        return cu_seqlens_i64[1:] - cu_seqlens_i64[:-1]
+    lens = [cpu[i + 1] - cpu[i] for i in range(len(cpu) - 1)]
+    return torch.tensor(lens, dtype=torch.int64, device=cu_seqlens.device)
+
+
+def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
+    if not _GDN_META_CACHE:
+        return _prepare_lens_uncached(cu_seqlens)
+
+    content_key, cpu = cached_cu_lens_cpu(cu_seqlens)
+    cache_key = (content_key, _device_key(cu_seqlens.device))
+    cached = _lru_get(_PREPARE_LENS_CACHE, cache_key)
+    if cached is not None:
+        return cached
+    result = _prepare_lens_uncached(cu_seqlens, cpu=cpu)
+    return _lru_put(_PREPARE_LENS_CACHE, cache_key, result)
+
+
+def _prepare_chunk_indices_uncached(
+    cu_seqlens: torch.LongTensor,
+    chunk_size: int,
+    cpu: Optional[List[int]] = None,
+) -> torch.LongTensor:
+    if cpu is None:
+        n_chunks = triton.cdiv(prepare_lens(cu_seqlens), chunk_size).tolist()
+    else:
+        n_chunks = [
+            triton.cdiv(cpu[i + 1] - cpu[i], chunk_size) for i in range(len(cpu) - 1)
         ]
-    )
+    indices = torch.cat([torch.arange(n) for n in n_chunks])
     return torch.stack([indices.eq(0).cumsum(0) - 1, indices], 1).to(cu_seqlens)
 
 
-@tensor_cache
+def prepare_chunk_indices(
+    cu_seqlens: torch.LongTensor, chunk_size: int
+) -> torch.LongTensor:
+    if not _GDN_META_CACHE:
+        return _prepare_chunk_indices_uncached(cu_seqlens, chunk_size)
+
+    content_key, cpu = cached_cu_lens_cpu(cu_seqlens)
+    cache_key = (
+        content_key,
+        int(chunk_size),
+        _device_key(cu_seqlens.device),
+        cu_seqlens.dtype,
+    )
+    cached = _lru_get(_CHUNK_INDICES_CACHE, cache_key)
+    if cached is not None:
+        return cached
+    result = _prepare_chunk_indices_uncached(cu_seqlens, chunk_size, cpu=cpu)
+    return _lru_put(_CHUNK_INDICES_CACHE, cache_key, result)
+
+
+def _prepare_chunk_offsets_uncached(
+    cu_seqlens: torch.LongTensor,
+    chunk_size: int,
+    cpu: Optional[List[int]] = None,
+) -> torch.LongTensor:
+    if cpu is None:
+        return torch.cat(
+            [
+                cu_seqlens.new_tensor([0]),
+                triton.cdiv(prepare_lens(cu_seqlens), chunk_size),
+            ]
+        ).cumsum(-1)
+    n_chunks = [
+        triton.cdiv(cpu[i + 1] - cpu[i], chunk_size) for i in range(len(cpu) - 1)
+    ]
+    n_chunks_t = torch.tensor(n_chunks, dtype=torch.int64, device=cu_seqlens.device)
+    return torch.cat([cu_seqlens.new_tensor([0]), n_chunks_t]).cumsum(-1)
+
+
 def prepare_chunk_offsets(
     cu_seqlens: torch.LongTensor, chunk_size: int
 ) -> torch.LongTensor:
-    return torch.cat(
-        [cu_seqlens.new_tensor([0]), triton.cdiv(prepare_lens(cu_seqlens), chunk_size)]
-    ).cumsum(-1)
+    if not _GDN_META_CACHE:
+        return _prepare_chunk_offsets_uncached(cu_seqlens, chunk_size)
+
+    content_key, cpu = cached_cu_lens_cpu(cu_seqlens)
+    cache_key = (
+        content_key,
+        int(chunk_size),
+        _device_key(cu_seqlens.device),
+        cu_seqlens.dtype,
+    )
+    cached = _lru_get(_CHUNK_OFFSETS_CACHE, cache_key)
+    if cached is not None:
+        return cached
+    result = _prepare_chunk_offsets_uncached(cu_seqlens, chunk_size, cpu=cpu)
+    return _lru_put(_CHUNK_OFFSETS_CACHE, cache_key, result)
+
+
+def get_gdn_ad_workspace(
+    B: int,
+    T: int,
+    H: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Reuse Ad scratch across GDN layers when shape matches; content is rewritten."""
+    if not _GDN_META_CACHE:
+        return torch.empty(B, T, H, 16, device=device, dtype=dtype)
+
+    cache_key = (int(B), int(T), int(H), _device_key(device), dtype)
+    cached = _lru_get(_AD_WORKSPACE_CACHE, cache_key)
+    if cached is not None and cached.numel() == B * T * H * 16:
+        return cached
+    Ad = torch.empty(B, T, H, 16, device=device, dtype=dtype)
+    return _lru_put(_AD_WORKSPACE_CACHE, cache_key, Ad)
+
+
+def clear_gdn_meta_cache() -> None:
+    """Drop all cross-layer GDN meta / prepare_* / mega scratch cache entries."""
+    _CU_LENS_SESSION["tensor"] = None
+    _CU_LENS_SESSION["key"] = None
+    _CU_LENS_SESSION["cpu"] = None
+    _CU_LENS_CPU_CACHE.clear()
+    _PREPARE_LENS_CACHE.clear()
+    _CHUNK_INDICES_CACHE.clear()
+    _CHUNK_OFFSETS_CACHE.clear()
+    _AD_WORKSPACE_CACHE.clear()
+    try:
+        from sgl_kernel_npu.fla.mega_chunk_gdn import clear_mega_workspace_cache
+
+        clear_mega_workspace_cache()
+    except ImportError:
+        pass
+
+
+def set_gdn_meta_cache(enabled: bool) -> None:
+    """Runtime toggle for profilers / A-B tests (overrides env for this process)."""
+    global _GDN_META_CACHE
+    _GDN_META_CACHE = bool(enabled)
+    if not _GDN_META_CACHE:
+        clear_gdn_meta_cache()
+
+
+def is_gdn_meta_cache_enabled() -> bool:
+    return bool(_GDN_META_CACHE)
 
 
 @tensor_cache

--- a/scripts/bench_mega_meta_cache.py
+++ b/scripts/bench_mega_meta_cache.py
@@ -1,0 +1,551 @@
+#!/usr/bin/env python3
+"""A/B benchmark for mega_chunk_gdn wrapper overhead on Ascend NPU.
+
+Variant A "upstream": per-call allocation logic of the ORIGINAL wrapper
+(every buffer fresh per layer, ~4 GB/layer at 128k tokens incl. a dead 1 GB
+fp32 A_inv_f32, plus a cu_seqlens D2H sync).
+
+Variant B "optimized": the patched sgl_kernel_npu.fla.mega_chunk_gdn wrapper
+  - cross-layer scratch cache (kkt/wy/h/o workspaces, keyed by shape)
+  - grow-only token slab reused across layers AND forward steps
+    (g_sum/g_t/beta_t/A/A_inv/w/u/v_new), SGLANG_NPU_GDN_POOL_OUTPUTS
+  - dropped dead op argument A_inv_f32 (kernel never reads it; dummy scalar)
+  - zeros -> empty where the kernel provably covers every element
+  - cu32 / num_chunks cached by content, one D2H per distinct cu_seqlens
+
+Both variants call the SAME AscendC op torch.ops.npu.mega_chunk_gdn, so the
+wall delta isolates wrapper overhead (alloc / memset / D2H / launch churn).
+
+Run on an Ascend host (sgl_kernel_npu installed):
+
+  python scripts/bench_mega_meta_cache.py
+  python scripts/bench_mega_meta_cache.py --seq 16384,65536,131072 --layers 30
+  python scripts/bench_mega_meta_cache.py --num-seqs 4            # packed batch
+  python scripts/bench_mega_meta_cache.py --clone-cu              # fresh cu object/layer
+
+Notes:
+  - With pooling ON, buffers that escape the call but are discarded by every
+    caller in the serving stack (A_inv/w/v_new; u is not even returned) are
+    served from the shared slab. Disable via SGLANG_NPU_GDN_POOL_OUTPUTS=0.
+  - Do not name this file profile.py (cProfile stdlib clash).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import time
+from typing import Callable, Dict, List
+
+import torch
+import torch.nn.functional as F
+
+HEAD_DIM = 128
+CHUNK_SIZE = 128
+GB = 1024**3
+
+ZEROS_UPSTREAM = ("A", "A_inv_f32", "A_inv", "h", "final_state", "kkt",
+                  "wy_a1", "wy_a2", "h_ws", "o_qk", "o_qs", "o_gated")
+
+
+def sync() -> None:
+    torch.npu.synchronize()
+
+
+def fmt_us(us: float) -> str:
+    if us >= 1e6:
+        return f"{us / 1e6:.3f} s"
+    if us >= 1e3:
+        return f"{us / 1e3:.3f} ms"
+    return f"{us:.1f} us"
+
+
+def parse_ints(s: str) -> List[int]:
+    return [int(x) for x in s.split(",") if x.strip()]
+
+
+def build_gdn_inputs(total_tokens, num_seqs, qh, vh, dim, device, dtype):
+    assert total_tokens % num_seqs == 0, "tokens must be divisible by num_seqs"
+    seg = total_tokens // num_seqs
+    cu = None
+    if num_seqs > 1:
+        cu = torch.arange(0, total_tokens + 1, seg, device=device, dtype=torch.int64)
+    q = torch.randn(1, total_tokens, qh, dim, device=device, dtype=dtype)
+    k = F.normalize(
+        torch.randn(1, total_tokens, qh, dim, device=device, dtype=torch.float32),
+        p=2, dim=-1,
+    ).to(dtype)
+    v = torch.randn(1, total_tokens, vh, dim, device=device, dtype=dtype)
+    g = F.logsigmoid(torch.rand(1, total_tokens, vh, device=device, dtype=torch.float32))
+    beta = torch.rand(1, total_tokens, vh, device=device, dtype=dtype).sigmoid()
+    h0 = torch.randn(num_seqs, vh, dim, dim, device=device, dtype=dtype)
+    return dict(q=q, k=k, v=v, g=g, beta=beta, h0=h0, cu=cu, scale=dim**-0.5)
+
+
+# ---------------------------------------------------------------------------
+# Variant A: original upstream wrapper, verbatim allocation logic
+# ---------------------------------------------------------------------------
+
+def run_upstream(inp):
+    q = inp["q"].half()
+    k = inp["k"].half()
+    v = inp["v"].half()
+    beta = inp["beta"].half()
+    g = inp["g"]
+    initial_state = inp["h0"]
+    cu_seqlens = inp["cu"]
+
+    _, total_tokens, _, head_dim = q.shape
+    num_value_heads = v.shape[-2]
+    device = q.device
+
+    if cu_seqlens is None:
+        cu32 = torch.tensor([0, total_tokens], dtype=torch.int32, device=device)
+        num_sequences, num_chunks = 1, -(-total_tokens // CHUNK_SIZE)
+    else:
+        cu32 = cu_seqlens.to(torch.int32)
+        cu = cu_seqlens.cpu().tolist()  # D2H sync every call (upstream behavior)
+        num_sequences = len(cu) - 1
+        num_chunks = sum(-(-(b - a) // CHUNK_SIZE) for a, b in zip(cu, cu[1:]))
+    num_matrices = num_chunks * num_value_heads
+
+    from sgl_kernel_npu.fla.mega_chunk_gdn import (
+        _block_dim, _masks, _minus_identity,
+    )
+
+    device_type, device_index = (device.type, 0 if device.index is None else device.index)
+    mask_lower, mask_full = _masks(device_type, device_index)
+    minus_identity = _minus_identity(device_type, device_index)
+
+    g_sum = torch.empty_like(g, dtype=torch.float32)
+    g_t = torch.empty(num_value_heads, total_tokens, device=device, dtype=torch.float32)
+    beta_t = torch.empty(num_value_heads, total_tokens, device=device, dtype=torch.float16)
+    A = torch.zeros(1, total_tokens, num_value_heads, CHUNK_SIZE, device=device,
+                    dtype=torch.float16)
+    A_inv_f32 = torch.zeros_like(A, dtype=torch.float32)  # dead op argument
+    A_inv = torch.zeros_like(A)
+    w = torch.empty_like(v)
+    u = torch.empty_like(v)
+    h = torch.zeros(num_chunks * num_value_heads, head_dim, head_dim, device=device,
+                    dtype=torch.float16)
+    v_new = torch.empty_like(v)
+    final_state = torch.zeros(num_sequences * num_value_heads, head_dim, head_dim,
+                              device=device, dtype=torch.float16)
+    has_initial_state = initial_state is not None
+    initial_state = initial_state.half() if has_initial_state else final_state
+    out = torch.empty_like(v)
+
+    block_dim = _block_dim(device)
+    kkt = torch.zeros(block_dim * 2, CHUNK_SIZE, CHUNK_SIZE, device=device, dtype=torch.float16)
+    wy_a1 = torch.zeros(block_dim, CHUNK_SIZE, CHUNK_SIZE, device=device, dtype=torch.float16)
+    wy_a2 = torch.zeros_like(wy_a1)
+    h_ws = torch.zeros(block_dim * 4, head_dim, head_dim, device=device, dtype=torch.float16)
+    o_qk = torch.zeros(block_dim, CHUNK_SIZE, CHUNK_SIZE, device=device, dtype=torch.float16)
+    o_qs = torch.zeros(block_dim, CHUNK_SIZE, head_dim, device=device, dtype=torch.float16)
+    o_gated = torch.zeros_like(o_qk)
+
+    torch.ops.npu.mega_chunk_gdn(
+        q, k, v, g, beta, mask_lower, mask_full, minus_identity, cu32,
+        out, g_sum, g_t, beta_t, A, A_inv_f32, A_inv, w, u, h, v_new,
+        final_state, initial_state, has_initial_state,
+        kkt, wy_a1, wy_a2, h_ws, o_qk, o_qs, o_gated,
+        block_dim, num_sequences, total_tokens, total_tokens, num_matrices,
+    )
+
+    # Same post-processing as the ORIGINAL wrapper so the A/B comparison is
+    # apples-to-apples: upstream casts A_inv/w/v_new/h back to the model dtype
+    # on return (they are dead outputs at default SUPPRESS_LEVEL, but the
+    # upstream wrapper still pays for the copies).
+    scale = inp["scale"]
+    model_dtype = inp["q"].dtype
+    A_inv = A_inv.to(model_dtype)
+    w = w.to(model_dtype)
+    v_new = v_new.to(model_dtype)
+    h = h.view(1, num_chunks, num_value_heads, head_dim, head_dim).to(model_dtype)
+    final_state = final_state.view(
+        num_sequences, num_value_heads, head_dim, head_dim
+    ).to(torch.float32)
+    return (out * scale).to(model_dtype), final_state, h
+
+
+# ---------------------------------------------------------------------------
+# Variant B: patched wrapper from the installed package
+# ---------------------------------------------------------------------------
+
+def _wrapper_supports_return_internals():
+    import inspect
+    from sgl_kernel_npu.fla.mega_chunk_gdn import run_mega_chunk_gdn
+    try:
+        return "return_internals" in inspect.signature(run_mega_chunk_gdn).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+def make_run_optimized(clone_cu: bool, return_internals: bool):
+    from sgl_kernel_npu.fla.mega_chunk_gdn import run_mega_chunk_gdn
+
+    # Older installs of the wrapper have no cast-skip optimization, so passing
+    # return_internals would raise TypeError; detect and fall back to the
+    # full-return call (which is exactly what those servers run).
+    supports = _wrapper_supports_return_internals()
+
+    def _run(inp):
+        cur = inp
+        if clone_cu and inp["cu"] is not None:
+            cur = dict(inp)
+            cur["cu"] = inp["cu"].clone()
+        if supports:
+            g_sum, o, A_inv, final_state, w, h, v_new = run_mega_chunk_gdn(
+                inp["q"], inp["k"], inp["v"], inp["g"], inp["beta"],
+                inp["scale"], inp["h0"], True, cur["cu"],
+                return_internals=return_internals,
+            )
+        else:
+            g_sum, o, A_inv, final_state, w, h, v_new = run_mega_chunk_gdn(
+                inp["q"], inp["k"], inp["v"], inp["g"], inp["beta"],
+                inp["scale"], inp["h0"], True, cur["cu"],
+            )
+        return o, final_state, h
+
+    return _run
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+def memory_model(total_tokens, vh, num_seqs, block_dim):
+    fp16, fp32 = 2, 4
+    # Packed sequences chunk independently: ceil per segment, not over the total.
+    seg = total_tokens // num_seqs
+    chunks = num_seqs * (-(-seg // CHUNK_SIZE))
+    per_tensor = {
+        "out": total_tokens * vh * HEAD_DIM * fp16,
+        "g_sum": total_tokens * vh * fp32,
+        "g_t": vh * total_tokens * fp32,
+        "beta_t": vh * total_tokens * fp16,
+        "A": total_tokens * vh * CHUNK_SIZE * fp16,
+        "A_inv_f32": total_tokens * vh * CHUNK_SIZE * fp32,
+        "A_inv": total_tokens * vh * CHUNK_SIZE * fp16,
+        "w": total_tokens * vh * HEAD_DIM * fp16,
+        "u": total_tokens * vh * HEAD_DIM * fp16,
+        "h": chunks * vh * HEAD_DIM * HEAD_DIM * fp16,
+        "v_new": total_tokens * vh * HEAD_DIM * fp16,
+        "final_state": num_seqs * vh * HEAD_DIM * HEAD_DIM * fp16,
+        "kkt": block_dim * 2 * CHUNK_SIZE * CHUNK_SIZE * fp16,
+        "wy_a1": block_dim * CHUNK_SIZE * CHUNK_SIZE * fp16,
+        "wy_a2": block_dim * CHUNK_SIZE * CHUNK_SIZE * fp16,
+        "h_ws": block_dim * 4 * HEAD_DIM * HEAD_DIM * fp16,
+        "o_qk": block_dim * CHUNK_SIZE * CHUNK_SIZE * fp16,
+        "o_qs": block_dim * CHUNK_SIZE * HEAD_DIM * fp16,
+        "o_gated": block_dim * CHUNK_SIZE * CHUNK_SIZE * fp16,
+    }
+    total_up = sum(per_tensor.values())
+    zeros_up = sum(per_tensor[n] for n in ZEROS_UPSTREAM)
+    # optimized steady state: only out + h + final_state escape per layer
+    per_call_opt = per_tensor["out"] + per_tensor["h"] + per_tensor["final_state"]
+    return per_tensor, total_up, zeros_up, per_call_opt
+
+
+def make_multilayer_fn(run_fn: Callable, inp: dict, n_layers: int):
+    """Run n_layers forward passes; only the last layer's outputs stay alive,
+    like the serving stack where each layer's outputs are consumed/freed."""
+
+    def _fn():
+        last = None
+        for _ in range(n_layers):
+            last = run_fn(inp)
+        return last
+
+    return _fn
+
+
+def bench_host(fn: Callable, n_layers: int, iters: int) -> float:
+    """Host-side time per layer (no sync inside: exposes alloc/memset/D2H/launch)."""
+    fn()
+    sync()
+    best = float("inf")
+    for _ in range(max(3, iters)):
+        t0 = time.perf_counter()
+        fn()
+        host_us = (time.perf_counter() - t0) * 1e6
+        sync()
+        best = min(best, host_us)
+    return best / n_layers
+
+
+def bench_wall(fn: Callable, warmup: int, active: int) -> Dict[str, float]:
+    for _ in range(warmup):
+        fn()
+    sync()
+    times = []
+    for _ in range(active):
+        t0 = time.perf_counter()
+        fn()
+        sync()
+        times.append((time.perf_counter() - t0) * 1e6)
+    return {"mean_us": statistics.mean(times), "p50_us": statistics.median(times),
+            "min_us": min(times)}
+
+
+def bench_memory(fn: Callable, iters: int = 2) -> Dict[str, float]:
+    """Allocator-level HBM accounting around repeated multi-layer forwards.
+
+    churn/forward counts every byte the caching allocator hands out across one
+    whole forward (fn call) — the traffic this PR removes. Peak allocated/
+    reserved show the footprint kept around. Input tensors live through both
+    variants' windows, so they cancel out in the base-vs-opt delta.
+    """
+    fn()
+    sync()  # one-time slab/cache build happens here, outside the window
+    torch.npu.empty_cache()
+    try:
+        torch.npu.reset_peak_memory_stats()
+    except Exception:
+        pass
+    try:
+        stats0 = torch.npu.memory_stats()
+    except Exception:
+        stats0 = None
+
+    for _ in range(iters):
+        fn()
+        sync()
+
+    result = {
+        "peak_alloc_gb": torch.npu.max_memory_allocated() / GB,
+        "peak_res_gb": torch.npu.max_memory_reserved() / GB,
+        "churn_gb": None,
+        "allocs": None,
+    }
+    if stats0 is not None:
+        try:
+            stats1 = torch.npu.memory_stats()
+
+            def delta(key):
+                return stats1.get(key, 0) - stats0.get(key, 0)
+
+            result["churn_gb"] = delta("allocated_bytes.all.allocated") / iters / GB
+            result["allocs"] = delta("allocation.all.allocated") / iters
+        except Exception:
+            pass
+    return result
+
+
+def check_outputs(up, opt) -> List[str]:
+    errs = []
+    for name, a, b in zip(("o", "final_state", "h"), up, opt):
+        if (a is None) != (b is None):
+            errs.append(f"{name}: None-ness mismatch")
+            continue
+        if a is None:
+            continue
+        if a.shape != b.shape or a.dtype != b.dtype:
+            errs.append(f"{name}: shape/dtype {tuple(a.shape)}/{a.dtype} "
+                        f"vs {tuple(b.shape)}/{b.dtype}")
+            continue
+        if torch.equal(a, b):
+            print(f"    {name:<12} bit-equal")
+            continue
+        a32, b32 = a.float(), b.float()
+        diff = (a32 - b32).abs()
+        max_abs = diff.max().item()
+        # allclose-style threshold; both variants call the same op with the
+        # same inputs, so any real divergence here is a wrapper bug.
+        ok = torch.allclose(a32, b32, rtol=1e-3, atol=1e-3)
+        print(f"    {name:<12} maxdiff={max_abs:.3e} allclose={'yes' if ok else 'NO'}")
+        if not ok:
+            errs.append(f"{name}: maxdiff={max_abs:.3e}")
+    return errs
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--seq", type=str, default="8192,32768,131072",
+                        help="packed total tokens per scenario")
+    parser.add_argument("--num-seqs", type=int, default=1,
+                        help="sequences packed in the request (1 = single long seq)")
+    parser.add_argument("--layers", type=int, default=30,
+                        help="GDN layers per forward (Qwen3.6-35B-A3B: 30)")
+    parser.add_argument("--q-heads", type=int, default=8, help="key/query heads (TP=2)")
+    parser.add_argument("--v-heads", type=int, default=16, help="value heads (TP=2)")
+    parser.add_argument("--dtype", type=str, default="bf16", choices=["bf16", "fp16"])
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--active", type=int, default=5)
+    parser.add_argument("--clone-cu", action="store_true",
+                        help="clone cu_seqlens each layer (content-keyed cache still hits)")
+    parser.add_argument("--suppress-level", type=int, default=0,
+                        help="GDN_RECOMPUTE_SUPPRESS_LEVEL as used by the serving "
+                             "stack; >=3 keeps A_inv/w/v_new (wrapper casts them), "
+                             "0-2 discards them (wrapper skips the casts)")
+    parser.add_argument("--skip-correctness", action="store_true")
+    args = parser.parse_args()
+
+    import torch_npu  # noqa: F401  # registers the npu device on torch
+    import sgl_kernel_npu  # noqa: F401  # loads libsgl_kernel_npu, registers ops
+
+    if not torch.npu.is_available():
+        raise RuntimeError("NPU not available; run this script on an Ascend host.")
+    if not hasattr(torch.ops.npu, "mega_chunk_gdn"):
+        raise RuntimeError(
+            "torch.ops.npu.mega_chunk_gdn missing; rebuild sgl_kernel_npu with the "
+            "mega_chunk_gdn kernel enabled."
+        )
+
+    from sgl_kernel_npu.fla.mega_chunk_gdn import _block_dim
+    from sgl_kernel_npu.fla.utils import (
+        clear_gdn_meta_cache, is_gdn_meta_cache_enabled, set_gdn_meta_cache,
+    )
+
+    device = torch.device("npu")
+    dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float16
+    block_dim = _block_dim(device)
+    seqs = parse_ints(args.seq)
+
+    print("=" * 78)
+    print("mega_chunk_gdn wrapper A/B: upstream alloc vs optimized (meta cache + slab)")
+    print(f"  device={device} cube_block_dim={block_dim} H_qk={args.q_heads} "
+          f"H_v={args.v_heads} D={HEAD_DIM} CHUNK={CHUNK_SIZE} dtype={args.dtype}")
+    print(f"  layers={args.layers} num_seqs={args.num_seqs} clone_cu={args.clone_cu} "
+          f"pool_outputs={os.getenv('SGLANG_NPU_GDN_POOL_OUTPUTS', '1')}")
+    if _wrapper_supports_return_internals():
+        mode = "serving path (A_inv/w/v_new cast-skip)" if args.suppress_level < 3 \
+            else "full-return path"
+        print(f"  wrapper cast-skip: supported, running {mode}")
+    else:
+        print("  wrapper cast-skip: NOT installed (old build); both arms use the")
+        print("  full-return path, i.e. A_inv/w/v_new/h casts are still paid.")
+    print("=" * 78)
+
+    rows: List[dict] = []
+    for seq in seqs:
+        if seq % args.num_seqs != 0:
+            print(f"\n[skip] seq={seq} not divisible by num_seqs={args.num_seqs}")
+            continue
+        per_tensor, total_up, zeros_up, per_call_opt = memory_model(
+            seq, args.v_heads, args.num_seqs, block_dim)
+        free_b, _ = torch.npu.mem_get_info()
+        # Peak ~= inputs + one layer's allocations (outputs freed per layer),
+        # so upstream and optimized differ by roughly total_up - slab.
+        print(f"\n{'=' * 78}")
+        print(f"tokens={seq}")
+        print(f"  upstream alloc/layer : {total_up / GB:6.2f} GB  "
+              f"(zeros: {zeros_up / GB:5.2f} GB, x{args.layers} = "
+              f"{total_up * args.layers / GB:.1f} GB churn/forward)")
+        print(f"  optimized alloc/layer: {per_call_opt / GB:6.2f} GB steady-state "
+              f"(out+h+final_state; slab buffers reused)")
+        if total_up + per_call_opt + 2 * GB > free_b:
+            print("  [warn] tight free memory; reduce --seq")
+            continue
+
+        inp = build_gdn_inputs(seq, args.num_seqs, args.q_heads, args.v_heads,
+                               HEAD_DIM, device, dtype)
+        # Match the serving stack: chunk.py passes return_internals=
+        # SUPPRESS_LEVEL >= 3 (False by default), so A_inv/w/v_new casts are
+        # skipped. Use --suppress-level 3 to benchmark the full-return path.
+        return_internals = args.suppress_level >= 3
+        run_opt = make_run_optimized(args.clone_cu, return_internals)
+
+        if not args.skip_correctness:
+            # Verify via the full-return path so dtypes/shapes match upstream
+            # exactly; the serving path (return_internals=False) only skips
+            # casts of dead outputs and cannot change numerics.
+            print("  correctness (upstream vs optimized, full-return path):")
+            clear_gdn_meta_cache()
+            up = run_upstream(inp)
+            sync()
+            clear_gdn_meta_cache()
+            set_gdn_meta_cache(True)
+            run_opt_full = make_run_optimized(args.clone_cu, True)
+            opt = run_opt_full(inp)
+            sync()
+            errs = check_outputs(up, opt)
+            del up, opt, run_opt_full
+            if errs:
+                raise AssertionError("optimized diverged:\n" + "\n".join(errs))
+
+        # host-only overhead per layer
+        fn_up = make_multilayer_fn(run_upstream, inp, args.layers)
+        host_up = bench_host(fn_up, args.layers, args.active)
+
+        clear_gdn_meta_cache()
+        set_gdn_meta_cache(True)
+        fn_opt = make_multilayer_fn(run_opt, inp, args.layers)
+        fn_opt()  # fill slab + caches before timing
+        sync()
+        host_opt = bench_host(fn_opt, args.layers, args.active)
+
+        # full xL wall (kernel included, one sync per xL)
+        wall_up = bench_wall(fn_up, args.warmup, args.active)
+        wall_opt = bench_wall(fn_opt, args.warmup, args.active)
+        assert is_gdn_meta_cache_enabled()
+
+        # allocator-level HBM accounting: churn = bytes the caching allocator
+        # hands out across ONE whole forward (all layers), i.e. the traffic
+        # this change removes. Input tensors are live for both windows, so the
+        # base-vs-opt delta is unaffected by them.
+        mem_up = bench_memory(fn_up)
+        mem_opt = bench_memory(fn_opt)
+
+        print(f"  {'host/layer':<24} upstream={fmt_us(host_up):>10}  "
+              f"optimized={fmt_us(host_opt):>10}  saved={fmt_us(host_up - host_opt)}  "
+              f"({host_up / max(host_opt, 1e-9):.2f}x)")
+        print(f"  {'xL wall (kernel incl.)':<24} upstream={fmt_us(wall_up['mean_us']):>10}  "
+              f"optimized={fmt_us(wall_opt['mean_us']):>10}  "
+              f"saved={fmt_us(wall_up['mean_us'] - wall_opt['mean_us'])}  "
+              f"({wall_up['mean_us'] / max(wall_opt['mean_us'], 1e-9):.2f}x)  "
+              f"[min: {fmt_us(wall_up['min_us'])} / {fmt_us(wall_opt['min_us'])}]")
+        if mem_up["churn_gb"] is not None:
+            print(f"  {'churn/forward (meas.)':<24} upstream={mem_up['churn_gb']:>8.2f} GB  "
+                  f"optimized={mem_opt['churn_gb']:>8.2f} GB  "
+                  f"saved={mem_up['churn_gb'] - mem_opt['churn_gb']:.2f} GB  "
+                  f"(allocs: {mem_up['allocs']:.0f} -> {mem_opt['allocs']:.0f}/forward)")
+        print(f"  {'peak allocated':<24} upstream={mem_up['peak_alloc_gb']:>8.2f} GB  "
+              f"optimized={mem_opt['peak_alloc_gb']:>8.2f} GB")
+        print(f"  {'peak reserved':<24} upstream={mem_up['peak_res_gb']:>8.2f} GB  "
+              f"optimized={mem_opt['peak_res_gb']:>8.2f} GB")
+        rows.append({"tokens": seq, "host_us_up": host_up, "host_us_opt": host_opt,
+                     "wall_us_up": wall_up["mean_us"], "wall_us_opt": wall_opt["mean_us"],
+                     "alloc_gb_up": total_up / GB, "alloc_gb_opt": per_call_opt / GB,
+                     "mem_up": mem_up, "mem_opt": mem_opt})
+
+        del inp
+        clear_gdn_meta_cache()
+
+    if rows:
+        print(f"\n{'=' * 78}\nsummary")
+        for r in rows:
+            print(f"  tokens={r['tokens']:>7}  alloc/layer {r['alloc_gb_up']:.2f} GB -> "
+                  f"{r['alloc_gb_opt']:.2f} GB  host/layer {fmt_us(r['host_us_up']):>9} -> "
+                  f"{fmt_us(r['host_us_opt']):>9}  xL wall {fmt_us(r['wall_us_up']):>9} -> "
+                  f"{fmt_us(r['wall_us_opt']):>9}")
+        if all(r["mem_up"]["churn_gb"] is not None for r in rows):
+            print(f"\n{'=' * 78}\nPR-ready HBM table (allocator-measured):\n")
+            print("| tokens/forward | churn upstream | churn optimized | saved | "
+                  "peak alloc up/opt | peak reserved up/opt |")
+            print("| ---: | ---: | ---: | ---: | ---: | ---: |")
+            for r in rows:
+                mu, mo = r["mem_up"], r["mem_opt"]
+                print(f"| {r['tokens']} | {mu['churn_gb']:.1f} GB | "
+                      f"{mo['churn_gb']:.1f} GB | "
+                      f"{mu['churn_gb'] - mo['churn_gb']:.1f} GB | "
+                      f"{mu['peak_alloc_gb']:.2f} / {mo['peak_alloc_gb']:.2f} GB | "
+                      f"{mu['peak_res_gb']:.2f} / {mo['peak_res_gb']:.2f} GB |")
+    print(
+        """
+How to read:
+  - host/layer: allocator churn + torch.zeros memsets + D2H + launch churn.
+    The optimized variant should collapse to ~constant (cache hits).
+  - xL wall includes the AscendC kernel; on long sequences the kernel dilutes
+    the host saving, so compare wall at small tokens and host at large tokens.
+  - env toggles: SGLANG_NPU_GDN_META_CACHE=0, SGLANG_NPU_GDN_POOL_OUTPUTS=0,
+    SGLANG_NPU_GDN_SKIP_OUTPUT_ZERO=0 (restore zero-init for isolation).
+"""
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/sgl_kernel_npu/test_mega_chunk_gdn_meta_cache.py
+++ b/tests/python/sgl_kernel_npu/test_mega_chunk_gdn_meta_cache.py
@@ -1,0 +1,498 @@
+"""Tests for the meta-cache / workspace-pool paths in ``run_mega_chunk_gdn``.
+
+The optimized wrapper keeps a grow-only token slab, content-keyed cu_seqlens
+caches and per-shape scratch buffers so that repeated prefill calls (across
+GDN layers and across iterations) do not re-allocate or re-initialize
+intermediates. These tests pin the contracts that make those caches safe:
+
+* slab grow/shrink across calls keeps outputs correct (slab reuse + slicing);
+* toggling the meta cache at runtime does not change numerics;
+* repeated calls with identical ``cu_seqlens`` content (fresh tensor objects
+  each call, i.e. the content-keyed D2H cache path) stay correct;
+* ``return_internals=False`` keeps the documented dtype/shape contract;
+* ``clear_mega_workspace_cache()`` does not break subsequent calls.
+
+A regression gate is included but gated behind ``SGLANG_NPU_RUN_META_CACHE_PERF=1``
+because it is timing sensitive: it re-runs the same AscendC kernel under the
+upstream per-call allocation pattern and the cached wrapper and asserts the
+cached path is not slower end-to-end. Run it manually before merging, not on
+every CI cycle.
+"""
+
+import os
+import time
+
+import pytest
+import torch
+import torch.nn.functional as F
+from sgl_kernel_npu.fla.chunk import chunk_gated_delta_rule_native
+from sgl_kernel_npu.fla.mega_chunk_gdn import (
+    clear_mega_workspace_cache,
+    run_mega_chunk_gdn,
+)
+from sgl_kernel_npu.fla.utils import is_gdn_meta_cache_enabled, set_gdn_meta_cache
+
+
+def _has_npu() -> bool:
+    return hasattr(torch, "npu") and torch.npu.is_available()
+
+
+pytestmark = pytest.mark.skipif(not _has_npu(), reason="NPU is required")
+
+CHUNK_SIZE = 128
+
+
+def _op_registered() -> bool:
+    return hasattr(torch.ops.npu, "mega_chunk_gdn")
+
+
+def _assert_close(name: str, actual: torch.Tensor, expected: torch.Tensor) -> None:
+    diff = (actual.float().cpu() - expected.float()).abs()
+    max_abs = diff.max().item()
+    if max_abs <= 1e-2:
+        return
+
+    rmse = torch.sqrt((diff.flatten() ** 2).mean()).item()
+    base = torch.sqrt((expected.float().flatten() ** 2).mean()).item()
+    ratio = rmse / max(base, 1e-8)
+    assert ratio < 0.05, f"{name} max_abs={max_abs:.6f} rmse_ratio={ratio:.6f}"
+
+
+def _native_reference(
+    q, k, v, g, beta, cu_seqlens, initial_state=None, output_final_state=True
+):
+    if q.shape[2] != v.shape[2]:
+        assert v.shape[2] % q.shape[2] == 0
+        group_size = v.shape[2] // q.shape[2]
+        q = q.repeat_interleave(group_size, dim=2)
+        k = k.repeat_interleave(group_size, dim=2)
+
+    outs = []
+    final_states = []
+    for seq_idx, (start, end) in enumerate(zip(cu_seqlens, cu_seqlens[1:])):
+        cur_initial_state = (
+            None if initial_state is None else initial_state[seq_idx : seq_idx + 1]
+        )
+        out, final_state = chunk_gated_delta_rule_native(
+            query=q[:, start:end],
+            key=k[:, start:end],
+            value=v[:, start:end],
+            g=g[:, start:end],
+            beta=beta[:, start:end],
+            chunk_size=CHUNK_SIZE,
+            initial_state=cur_initial_state,
+            output_final_state=output_final_state,
+        )
+        outs.append(out)
+        if output_final_state:
+            final_states.append(final_state)
+    return torch.cat(outs, dim=1), (
+        torch.cat(final_states, dim=0) if output_final_state else None
+    )
+
+
+def _make_inputs(total_tokens, cu_list, H, Hg, D, seed=0):
+    gen = torch.Generator().manual_seed(seed)
+    q = F.normalize(
+        torch.randn(1, total_tokens, Hg, D, generator=gen), p=2, dim=-1
+    ).to(torch.float16)
+    k = F.normalize(
+        torch.randn(1, total_tokens, Hg, D, generator=gen), p=2, dim=-1
+    ).to(torch.float16)
+    v = torch.randn(1, total_tokens, H, D, dtype=torch.float16, generator=gen)
+    g = F.logsigmoid(
+        torch.randn(1, total_tokens, H, dtype=torch.float32, generator=gen)
+    )
+    beta = torch.rand(1, total_tokens, H, dtype=torch.float16, generator=gen)
+    h0 = (0.05 * torch.randn(len(cu_list) - 1, H, D, D, generator=gen)).to(
+        torch.float16
+    )
+    return {"q": q, "k": k, "v": v, "g": g, "beta": beta, "h0": h0, "scale": D**-0.5}
+
+
+def _run_and_check(inputs, cu_list, label, device=None, check_h_boundaries=False):
+    """Run the wrapper once and verify o / final_state / h against native.
+
+    ``h[c]`` stores the recurrent state before chunk ``c`` (i.e. after
+    processing chunks ``0..c-1``), while ``final_state`` is the state after
+    the last chunk of each sequence. The h-boundary check re-runs the native
+    reference on every chunk prefix, so it is opt-in to keep runtime bounded.
+    """
+    device = device or torch.device("npu")
+    total_tokens = cu_list[-1]
+
+    def to_npu(t):
+        return t.to(device)
+
+    cu = torch.tensor(cu_list, dtype=torch.long, device=device)
+    g_sum, o, a_inv, final_state, w, h, v_new = run_mega_chunk_gdn(
+        q=to_npu(inputs["q"]),
+        k=to_npu(inputs["k"]),
+        v=to_npu(inputs["v"]),
+        g=to_npu(inputs["g"]),
+        beta=to_npu(inputs["beta"]),
+        scale=inputs["scale"],
+        initial_state=to_npu(inputs["h0"]),
+        output_final_state=True,
+        cu_seqlens=cu,
+        return_internals=True,
+    )
+    torch.npu.synchronize()
+
+    assert g_sum.shape[1] == total_tokens
+    assert o.shape[1] == total_tokens
+    assert a_inv.shape[1] == total_tokens
+    assert w.shape[1] == total_tokens
+    assert v_new.shape[1] == total_tokens
+    assert h.dim() == 5 and h.shape[0] == 1
+
+    expected_o, expected_states = _native_reference(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["g"],
+        inputs["beta"],
+        cu_list,
+        initial_state=inputs["h0"],
+        output_final_state=True,
+    )
+    _assert_close(f"{label}/o", o, expected_o)
+    _assert_close(f"{label}/final_state", final_state, expected_states)
+
+    # h[c] stores the recurrent state BEFORE chunk c (post-chunk c-1), so
+    # h[chunk_offset + c] for c >= 1 must equal the final state of the native
+    # reference run on the prefix ending at that chunk boundary.
+    if not check_h_boundaries:
+        return
+    chunk_offset = 0
+    for seq_idx, (start, end) in enumerate(zip(cu_list, cu_list[1:])):
+        seg = end - start
+        n_chunks = -(-seg // CHUNK_SIZE)
+        for c in range(1, n_chunks):
+            boundary = start + c * CHUNK_SIZE
+            _, prefix_state = _native_reference(
+                inputs["q"][:, :boundary],
+                inputs["k"][:, :boundary],
+                inputs["v"][:, :boundary],
+                inputs["g"][:, :boundary],
+                inputs["beta"][:, :boundary],
+                cu_list[: seq_idx + 1] + [boundary],
+                initial_state=inputs["h0"][: seq_idx + 1],
+                output_final_state=True,
+            )
+            _assert_close(
+                f"{label}/h_boundary_seq{seq_idx}_chunk{c}",
+                h[0, chunk_offset + c],
+                prefix_state[seq_idx],
+            )
+        chunk_offset += n_chunks
+
+
+def test_slab_grow_and_shrink_keep_correctness():
+    if not _op_registered():
+        pytest.skip("mega_chunk_gdn op is not registered")
+
+    H, Hg, D = 16, 4, 128
+    # Grow the slab (256 -> 1024), then shrink (1024 -> 384): the slab must
+    # grow exactly once and every later call must slice [:, :total_tokens].
+    # The 1024-token shape also exercises the h-boundary check, which re-runs
+    # the native reference on every chunk prefix (kept small on purpose).
+    shapes = [(256, "grow1", False), (1024, "grow2", True), (384, "shrink", False)]
+    for total_tokens, name, check_h in shapes:
+        cu_list = [0, total_tokens // 4, total_tokens]
+        inputs = _make_inputs(total_tokens, cu_list, H, Hg, D, seed=total_tokens)
+        _run_and_check(
+            inputs, cu_list, f"slab_{name}", check_h_boundaries=check_h
+        )
+
+
+def test_meta_cache_toggle_keeps_outputs_identical():
+    if not _op_registered():
+        pytest.skip("mega_chunk_gdn op is not registered")
+
+    H, Hg, D = 16, 4, 128
+    total_tokens = 1024
+    cu_list = [0, 512, 1024]
+    inputs = _make_inputs(total_tokens, cu_list, H, Hg, D, seed=7)
+    device = torch.device("npu")
+    cu = torch.tensor(cu_list, dtype=torch.long, device=device)
+
+    kwargs = dict(
+        q=inputs["q"].to(device),
+        k=inputs["k"].to(device),
+        v=inputs["v"].to(device),
+        g=inputs["g"].to(device),
+        beta=inputs["beta"].to(device),
+        scale=inputs["scale"],
+        initial_state=inputs["h0"].to(device),
+        output_final_state=True,
+        return_internals=True,
+    )
+
+    try:
+        set_gdn_meta_cache(False)
+        _, o_off, _, fs_off, _, _, _ = run_mega_chunk_gdn(cu_seqlens=cu, **kwargs)
+        torch.npu.synchronize()
+
+        set_gdn_meta_cache(True)
+        _, o_on, _, fs_on, _, _, _ = run_mega_chunk_gdn(cu_seqlens=cu, **kwargs)
+        torch.npu.synchronize()
+    finally:
+        set_gdn_meta_cache(True)
+
+    assert torch.equal(o_off, o_on), "o differs with meta cache toggled"
+    assert torch.equal(fs_off, fs_on), (
+        "final_state differs with meta cache toggled"
+    )
+
+
+def test_repeated_identical_cu_seqlens_content():
+    if not _op_registered():
+        pytest.skip("mega_chunk_gdn op is not registered")
+
+    # Same cu_seqlens content but a fresh device tensor each call: exercises
+    # the content-keyed cu_seqlens D2H cache and the slab hit path.
+    H, Hg, D = 16, 4, 128
+    total_tokens = 1536
+    cu_list = [0, 400, 900, 1536]
+    inputs = _make_inputs(total_tokens, cu_list, H, Hg, D, seed=11)
+    device = torch.device("npu")
+
+    first = None
+    for i in range(3):
+        cu = torch.tensor(cu_list, dtype=torch.long, device=device)
+        _, o, _, final_state, _, _, _ = run_mega_chunk_gdn(
+            q=inputs["q"].to(device),
+            k=inputs["k"].to(device),
+            v=inputs["v"].to(device),
+            g=inputs["g"].to(device),
+            beta=inputs["beta"].to(device),
+            scale=inputs["scale"],
+            initial_state=inputs["h0"].to(device),
+            output_final_state=True,
+            cu_seqlens=cu,
+            return_internals=True,
+        )
+        torch.npu.synchronize()
+        if first is None:
+            first = (o.clone(), final_state.clone())
+        else:
+            assert torch.equal(first[0], o), f"o drifted on call {i}"
+            assert torch.equal(first[1], final_state), (
+                f"final_state drifted on call {i}"
+            )
+
+    expected_o, _ = _native_reference(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["g"],
+        inputs["beta"],
+        cu_list,
+        initial_state=inputs["h0"],
+    )
+    _assert_close("repeated_cu/o", first[0], expected_o)
+
+
+def test_return_internals_false_contract():
+    if not _op_registered():
+        pytest.skip("mega_chunk_gdn op is not registered")
+
+    H, Hg, D = 16, 4, 128
+    total_tokens = 777  # not a multiple of CHUNK_SIZE: exercises the tail
+    cu_list = [0, total_tokens]
+    inputs = _make_inputs(total_tokens, cu_list, H, Hg, D, seed=3)
+    device = torch.device("npu")
+    cu = torch.tensor(cu_list, dtype=torch.long, device=device)
+
+    g_sum, o, a_inv, final_state, w, h, v_new = run_mega_chunk_gdn(
+        q=inputs["q"].to(device),
+        k=inputs["k"].to(device),
+        v=inputs["v"].to(device),
+        g=inputs["g"].to(device),
+        beta=inputs["beta"].to(device),
+        scale=inputs["scale"],
+        initial_state=inputs["h0"].to(device),
+        output_final_state=True,
+        cu_seqlens=cu,
+        return_internals=False,
+    )
+    torch.npu.synchronize()
+
+    # Contract of return_internals=False: A_inv / w / v_new are None (their
+    # fp16->fp16 casts are skipped) while o / final_state / h stay usable.
+    assert a_inv is None and w is None and v_new is None
+    assert g_sum.dtype == torch.float32 and g_sum.shape[1] == total_tokens
+    assert o.dtype == torch.float16 and o.shape[1] == total_tokens
+    assert final_state.dtype == torch.float32
+    assert h.dtype == torch.float16
+
+    expected_o, _ = _native_reference(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["g"],
+        inputs["beta"],
+        cu_list,
+        initial_state=inputs["h0"],
+    )
+    _assert_close("return_internals_false/o", o, expected_o)
+
+
+def test_clear_workspace_cache_then_call():
+    if not _op_registered():
+        pytest.skip("mega_chunk_gdn op is not registered")
+
+    H, Hg, D = 16, 4, 128
+    total_tokens = 640
+    cu_list = [0, 256, 640]
+
+    for phase in ("before_clear", "after_clear"):
+        inputs = _make_inputs(total_tokens, cu_list, H, Hg, D, seed=5)
+        _run_and_check(inputs, cu_list, f"clear_{phase}")
+        clear_mega_workspace_cache()
+        torch.npu.empty_cache()
+
+
+def test_host_overhead_not_regressed():
+    """End-to-end gate: the cached wrapper must not be slower than upstream.
+
+    Runs the SAME AscendC kernel under two wrapper variants (upstream-style
+    per-call allocations vs. the cached wrapper) and compares end-to-end wall
+    time, so kernel cost cancels out and any wrapper overhead delta shows.
+    Gated behind an env flag because it is timing sensitive.
+    """
+    if os.environ.get("SGLANG_NPU_RUN_META_CACHE_PERF", "0") != "1":
+        pytest.skip("set SGLANG_NPU_RUN_META_CACHE_PERF=1 to run the perf gate")
+    if not _op_registered():
+        pytest.skip("mega_chunk_gdn op is not registered")
+
+    from sgl_kernel_npu.fla.mega_chunk_gdn import (
+        _block_dim,
+        _masks,
+        _minus_identity,
+    )
+
+    H, Hg, D = 16, 4, 128
+    total_tokens = 8192
+    cu_list = [0, total_tokens // 2, total_tokens]
+    device = torch.device("npu")
+    num_value_heads = H
+    num_seqs = len(cu_list) - 1
+    num_chunks = sum(-(-(b - a) // CHUNK_SIZE) for a, b in zip(cu_list, cu_list[1:]))
+
+    inputs = _make_inputs(total_tokens, cu_list, H, Hg, D, seed=1)
+    q = inputs["q"].to(device)
+    k = inputs["k"].to(device)
+    v = inputs["v"].to(device)
+    g = inputs["g"].to(device)
+    beta = inputs["beta"].to(device)
+    h0 = inputs["h0"].to(device)
+    cu = torch.tensor(cu_list, dtype=torch.long, device=device)
+    scale = inputs["scale"]
+
+    device_type, device_index = device.type, 0 if device.index is None else device.index
+    mask_lower, mask_full = _masks(device_type, device_index)
+    minus_identity = _minus_identity(device_type, device_index)
+    block_dim = _block_dim(device)
+
+    def upstream_call():
+        """Verbatim upstream per-call allocation pattern + same kernel launch."""
+        cu32 = cu.to(torch.int32)
+        _ = cu.cpu().tolist()  # D2H sync every call (upstream behavior)
+        num_matrices = num_chunks * num_value_heads
+
+        g_sum = torch.empty_like(g, dtype=torch.float32)
+        g_t = torch.empty(num_value_heads, total_tokens, device=device, dtype=torch.float32)
+        beta_t = torch.empty(num_value_heads, total_tokens, device=device, dtype=torch.float16)
+        A = torch.zeros(1, total_tokens, num_value_heads, CHUNK_SIZE, device=device, dtype=torch.float16)
+        A_inv_f32 = torch.zeros(1, total_tokens, num_value_heads, CHUNK_SIZE, device=device, dtype=torch.float32)
+        A_inv = torch.zeros_like(A)
+        w = torch.empty_like(v)
+        u = torch.empty_like(v)
+        h = torch.zeros(num_chunks * num_value_heads, D, D, device=device, dtype=torch.float16)
+        v_new = torch.empty_like(v)
+        final_state = torch.zeros(num_seqs * num_value_heads, D, D, device=device, dtype=torch.float16)
+        out = torch.empty_like(v)
+
+        kkt = torch.zeros(block_dim * 2, CHUNK_SIZE, CHUNK_SIZE, device=device, dtype=torch.float16)
+        wy_a1 = torch.zeros(block_dim, CHUNK_SIZE, CHUNK_SIZE, device=device, dtype=torch.float16)
+        wy_a2 = torch.zeros_like(wy_a1)
+        h_ws = torch.zeros(block_dim * 4, D, D, device=device, dtype=torch.float16)
+        o_qk = torch.zeros(block_dim, CHUNK_SIZE, CHUNK_SIZE, device=device, dtype=torch.float16)
+        o_qs = torch.zeros(block_dim, CHUNK_SIZE, D, device=device, dtype=torch.float16)
+        o_gated = torch.zeros_like(o_qk)
+
+        torch.ops.npu.mega_chunk_gdn(
+            q, k, v, g, beta, mask_lower, mask_full, minus_identity, cu32,
+            out, g_sum, g_t, beta_t, A, A_inv_f32, A_inv, w, u, h, v_new,
+            final_state, h0, True,
+            kkt, wy_a1, wy_a2, h_ws, o_qk, o_qs, o_gated,
+            block_dim, num_seqs, total_tokens, total_tokens, num_matrices,
+        )
+        return out
+
+    def cached_call():
+        _, o, _, _, _, _, _ = run_mega_chunk_gdn(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=h0,
+            output_final_state=True,
+            cu_seqlens=cu,
+            return_internals=False,
+        )
+        return o
+
+    def wall_time(fn, iters=5):
+        fn()
+        torch.npu.synchronize()
+        start = time.perf_counter()
+        for _ in range(iters):
+            fn()
+        torch.npu.synchronize()
+        return (time.perf_counter() - start) / iters * 1e3
+
+    upstream_ms = wall_time(upstream_call)
+    cached_ms = wall_time(cached_call)
+
+    # Sanity: the upstream replica must be wired identically to the wrapper.
+    _, o_cached, _, _, _, _, _ = run_mega_chunk_gdn(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=h0,
+        output_final_state=True,
+        cu_seqlens=cu,
+        return_internals=False,
+    )
+    out_upstream = upstream_call()
+    torch.npu.synchronize()
+    assert torch.allclose(out_upstream * scale, o_cached, atol=1e-2), (
+        "upstream replica diverged from the cached wrapper in the perf gate"
+    )
+
+    print(f"\nwall/call upstream={upstream_ms:.3f} ms cached={cached_ms:.3f} ms")
+    # End-to-end the cached wrapper must not regress beyond run-to-run noise.
+    assert cached_ms < upstream_ms * 1.10, (
+        f"cached wrapper regressed end-to-end: {cached_ms:.3f} ms "
+        f">= 1.10x upstream {upstream_ms:.3f} ms"
+    )
+
+
+def test_env_toggle_consistent_with_runtime_toggle():
+    """set_gdn_meta_cache must agree with the module-level enabled flag."""
+    previous = is_gdn_meta_cache_enabled()
+    try:
+        set_gdn_meta_cache(False)
+        assert not is_gdn_meta_cache_enabled()
+        set_gdn_meta_cache(True)
+        assert is_gdn_meta_cache_enabled()
+    finally:
+        set_gdn_meta_cache(previous)


### PR DESCRIPTION
## Motivation

`mega_chunk_gdn` wrapper(GDN prefill,`GDN_USE_MEGA_GDN=1`)在每个 GDN 层都会重复执行以下开销:

1. **重复分配与清零中间张量**:每次调用重新分配并 zero-init 约 0.3~4.5 GB 的中间结果(`A`、`A_inv`、`g_sum`、`w`、`u`、`v_new`、`g_t`、`beta_t` 及 7 个 kernel scratch);
2. **重复计算 chunk meta**:每层重做 `cu_seqlens.cpu()`(D2H 同步)、`prepare_lens`、`prepare_chunk_indices`、`prepare_chunk_offsets` 等,内容在各层间完全相同;
3. **死参数分配**:op 签名中的 `A_inv_f32` kernel 从不读取,却每层分配一个完整的 T*H*C fp32 张量并 memset;
4. **死输出 cast**:默认 `GDN_RECOMPUTE_SUPPRESS_LEVEL=0` 下,`chunk.py` 直接丢弃 `A_inv/w/v_new`,但 wrapper 仍每层执行 `.to()` 拷贝(128k tokens 时约 1.5 GB/层)。

在 131k tokens 下单次 forward 累计约 256 GB allocator churn、每层约 39 ms host 开销,并额外占用数 GB HBM,挤占 KV cache 余量。

## Change

纯 Python 侧改动(`sgl_kernel_npu/fla/` 下的 `utils.py`、`mega_chunk_gdn.py`、`chunk.py`),无 AscendC/C++ kernel 改动。全部通过环境变量控制、默认开启,且可独立回退:

1. **Meta cache**(`SGLANG_NPU_GDN_META_CACHE`,默认开启):为 `cu_seqlens.cpu()`、`prepare_lens`、`prepare_chunk_indices`、`prepare_chunk_offsets` 以及 mega kernel 的 cu32/num_chunks/scratch 建立 content-keyed LRU 缓存。key 基于张量内容而非 data_ptr,因此即使输入张量被重新分配也能跨层命中。`SGLANG_NPU_GDN_META_CACHE_SIZE` 控制 LRU 容量。
2. **输出 slab 池**(`SGLANG_NPU_GDN_POOL_OUTPUTS`,默认开启):为 kernel 中间量(`g_sum/A/A_inv/w/u/v_new/g_t/beta_t`)使用 grow-only slab,只增不减,跨层、跨 step 复用;仅会逃逸出调用的 `o/h/final_state` 仍每层新分配。kernel 按 `h*total_tokens+t` 寻址且 op host 不校验这些 buffer 形状,因此超尺寸连续缓冲区是安全的(已在 csrc 中验证)。
3. **去掉冗余 zero-init**(`SGLANG_NPU_GDN_SKIP_OUTPUT_ZERO`,默认开启):kernel 会完整覆盖所有被读取的元素(kkt 写 A 的全部有效行、solve_tril 只读 valid_size 三角区、chunk_h 无条件写 S/final_state),因此用 `torch.empty` 替代 `torch.zeros`,省去 memset(已对照 `csrc/mega_chunk_gdn` 各 kernel 验证)。
4. **死输出 cast 跳过 + 死参数占位**:`chunk.py` 传 `return_internals=SUPPRESS_LEVEL >= 3`;当调用方丢弃 `A_inv/w/v_new` 时,wrapper 返回 `None` 并跳过拷贝。同时用单元素占位张量替代死参数 `A_inv_f32` 的每层完整分配。

## Measurements

环境:单卡 Ascend 910C,`H_qk=8 H_v=16 D=128 CHUNK=128`,bf16,30 层,`num_seqs=1`。A/B 对比:上游分配逻辑逐字复刻 vs 本 PR wrapper,每个 size 均验证 bit-equal。

| tokens | host/layer | wall (30L) | 加速 | churn/forward | peak reserved |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 8k | 2.76 ms → 0.19 ms | 83.6 → 67.0 ms | **1.25x** | 16.3 → 5.7 GB (−65%) | 0.76 → 0.52 GB (−32%) |
| 32k | 10.2 ms → 0.19 ms | 309.0 → 264.7 ms | **1.17x** | 64.3 → 22.6 GB (−65%) | 2.87 → 1.98 GB (−31%) |
| 131k | 39.0 ms → 0.20 ms | 1.225 → 1.063 s | **1.15x** | 256.0 → 90.2 GB (−65%) | 11.12 → 7.60 GB (−32%) |

(allocs/forward: 960 → 330)

端到端(Qwen3.6,910C,`GDN_USE_MEGA_GDN=1`,REPS=5):

| input tokens | conc | base TTFT | opt TTFT | saved |
| ---: | ---: | ---: | ---: | ---: |
| 10k | 1 | 327 ms | 318 ms | **−9 ms (−2.8%)** |
| 32k | 1 | 847 ms | 823 ms | **−24 ms (−2.8%)** |

conc=1 下 TTFT 有一致方向的小幅提升(约 3%);提升有限是因为单请求 prefill 是 kernel-bound,host 侧节省只有部分体现在 TTFT 上(测量抖动:10k ±27/±40 ms,32k ±126/±87 ms)。主要收益在 allocator churn(−65%)与 peak HBM(−32%),为 KV cache 与并发 prefill 释放显存余量。

## Accuracy

在 8k/32k/131k tokens(单序列与多序列)下,输出 `o`、`final_state`、`h` 与上游 **bit-equal**。改动仅影响缓存/分配/拷贝路径,不改变任何数值计算。

## Tests

- 新增 `tests/python/sgl_kernel_npu/test_mega_chunk_gdn_meta_cache.py`:slab 增长/收缩正确性、meta cache 运行时开关数值一致性、相同 `cu_seqlens` 内容重复调用、`return_internals=False` 契约、`clear_mega_workspace_cache` 后调用;perf gate 由 `SGLANG_NPU_RUN_META_CACHE_PERF=1` 手动触发。
- 新增 `scripts/bench_mega_meta_cache.py`:A/B 微基准(上游逐字复刻 vs 优化 wrapper),含正确性、host/层、wall、churn、peak 测量。
- 环境变量矩阵已验证:`SGLANG_NPU_GDN_META_CACHE=0`、`SGLANG_NPU_GDN_POOL_OUTPUTS=0`、`SGLANG_NPU_GDN_SKIP_OUTPUT_ZERO=0` 各自回退到与上游等价的行为,组合使用仍 bit-equal。

## CI

无 CI 变更;纯 Python diff,受 lint + 现有 kernel UT 覆盖。

## 相关 Issue

死参数 `A_inv_f32` 的 op 签名清理涉及 op_host/op_kernel 变更,超出本 PR 范围,已立 issue 跟踪:#696。本 PR 在 Python 侧以单元素占位张量规避每层分配,与 issue 中的清理建议互补。

