### PR TITLE
add sparse_attn_sharedkv_metadata ops for dsv4 spark

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -38,6 +38,7 @@ set(OP_SRCS
     ${PROJECT_OP_SRC_BASE}/lora/op_host/tiling/sgemmc_tiling.cpp
     ${PROJECT_OP_SRC_BASE}/causal_conv1d_update/op_host/causal_conv1d_update.cpp
     ${PROJECT_OP_SRC_BASE}/apply_token_bitmask/op_host/apply_token_bitmask.cpp
+    ${PROJECT_OP_SRC_BASE}/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.cpp
     ${PROJECT_OP_SRC_BASE}/sparse_attention_score/op_host/sparse_attention_score.cpp
     ${PROJECT_OP_SRC_BASE}/sparse_attention_score/op_host/tiling/sparse_attention_score_tiling.cpp
     )
@@ -189,6 +190,10 @@ target_link_directories(${OP_PLUGIN_NAME} PRIVATE
         ${TORCH_DIR}/lib
         ${TORCH_NPU_DIR}/lib
 )
+
+# Enable OpenMP for the pure-host metadata scheduler (parallel per-row cache build).
+target_compile_options(${OP_PLUGIN_NAME} PRIVATE -fopenmp)
+target_link_libraries(${OP_PLUGIN_NAME} PRIVATE gomp)
 
 target_include_directories(${OP_PLUGIN_NAME} PRIVATE
         ${PROJECT_OP_SRC_BASE}/utils

--- a/csrc/pytorch_extensions.cpp
+++ b/csrc/pytorch_extensions.cpp
@@ -18,7 +18,7 @@
 #include "causal_conv1d_update/op_host/causal_conv1d_update.h"
 #ifdef SGL_KERNEL_ENABLE_A3_ONLY_OPS
 #include "causal_conv1d/op_host/causal_conv1d.h"
-#endif
+#include "sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.h"
 
 namespace {
 TORCH_LIBRARY_FRAGMENT(npu, m)
@@ -150,6 +150,17 @@ TORCH_LIBRARY_FRAGMENT(npu, m)
         "Tensor? query_start_loc=None, Tensor? cache_indices=None, Tensor? has_initial_state=None, "
         "Tensor? num_accepted_tokens=None, int activation_mode=0, int pad_slot_id=-1, "
         "int run_mode=0) -> Tensor");
+
+    m.def(
+        "sparse_attn_sharedkv_metadata_host("
+        "int num_heads_q, int num_heads_kv, int head_dim, "
+        "int aic_core_num, int aiv_core_num, "
+        "str soc_version, str layout_q, str layout_kv, "
+        "Tensor? cu_seqlens_q=None, Tensor? seqused_kv=None, "
+        "int batch_size=0, int cmp_topk=0, int cmp_ratio=-1, "
+        "int ori_mask_mode=4, int cmp_mask_mode=3, "
+        "int ori_win_left=127, int ori_win_right=0, "
+        "bool has_ori_kv=True, bool has_cmp_kv=True) -> Tensor");
 #endif
 
 #ifdef BUILD_CATLASS_MODULE
@@ -264,5 +275,13 @@ TORCH_LIBRARY_IMPL(npu, PrivateUse1, m)
     m.impl("softfp8_w8a16_grouped_matmul", TORCH_FN(sglang::npu_kernel::softfp8_w8a16_grouped_matmul));
 #endif
 #endif
+}
+}  // namespace
+
+namespace {
+// CPU dispatch key: this op takes CPU input tensors and returns a device tensor.
+TORCH_LIBRARY_IMPL(npu, CPU, m)
+{
+    m.impl("sparse_attn_sharedkv_metadata_host", TORCH_FN(sgl_kernel_npu::sparse_attn_sharedkv_metadata_host));
 }
 }  // namespace

--- a/csrc/pytorch_extensions.cpp
+++ b/csrc/pytorch_extensions.cpp
@@ -18,7 +18,7 @@
 #include "causal_conv1d_update/op_host/causal_conv1d_update.h"
 #ifdef SGL_KERNEL_ENABLE_A3_ONLY_OPS
 #include "causal_conv1d/op_host/causal_conv1d.h"
-#include "sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.h"
+#endif
 
 namespace {
 TORCH_LIBRARY_FRAGMENT(npu, m)
@@ -281,6 +281,6 @@ namespace {
 // CPU dispatch key: this op takes CPU input tensors and returns a device tensor.
 TORCH_LIBRARY_IMPL(npu, CPU, m)
 {
-    m.impl("sparse_attn_sharedkv_metadata_host", TORCH_FN(sgl_kernel_npu::sparse_attn_sharedkv_metadata_host));
+    m.impl("sparse_attn_sharedkv_metadata_host", TORCH_FN(sglang::npu_kernel::sparse_attn_sharedkv_metadata_host));
 }
 }  // namespace

--- a/csrc/pytorch_extensions.cpp
+++ b/csrc/pytorch_extensions.cpp
@@ -154,8 +154,7 @@ TORCH_LIBRARY_FRAGMENT(npu, m)
     m.def(
         "sparse_attn_sharedkv_metadata_host("
         "int num_heads_q, int num_heads_kv, int head_dim, "
-        "int aic_core_num, int aiv_core_num, "
-        "str soc_version, str layout_q, str layout_kv, "
+        "str layout_q, str layout_kv, "
         "Tensor? cu_seqlens_q=None, Tensor? seqused_kv=None, "
         "int batch_size=0, int cmp_topk=0, int cmp_ratio=-1, "
         "int ori_mask_mode=4, int cmp_mask_mode=3, "

--- a/csrc/sparse_attn_sharedkv_metadata/README.md
+++ b/csrc/sparse_attn_sharedkv_metadata/README.md
@@ -57,6 +57,27 @@ is needed — sglang already keeps the seq-lens on the host. The device topology
 core counts + SoC name) is queried inside the op via ACL and cached after the first call,
 so callers never pass or know about it.
 
+### Async H2D (stream-ordered result, zero host sync)
+
+The internal 4 KB H2D is a **pinned + `non_blocking` copy enqueued on the caller's current
+stream**. The host returns as soon as the copy is enqueued (~µs) and is never blocked by
+in-flight stream work — the same async-enqueue contract as the AICPU op. Consequences for
+callers:
+
+- **Same-stream consumers need nothing**: any kernel enqueued after the op on the same
+  stream (attention forward, `.copy_()` into graph-capture buffers) reads the completed
+  table by stream order.
+- **Cross-stream readers need an explicit event** (record on the producing stream, wait on
+  the consuming stream) — exactly as they would for the AICPU op's output.
+- The staging buffer is allocated with `pinned_memory(true)` through the caching host
+  allocator, whose event tracking guarantees the block is not reused until the async copy
+  has completed (validated by a 2,000-iteration allocate/copy/destroy stress loop with
+  interleaved device load: zero corruption). A pageable staging buffer must not be
+  substituted: with pageable memory torch_npu silently falls back to a host-synchronous
+  copy that additionally drains all prior work on the current stream (measured: pinned
+  ~0.4 ms vs pageable ~249 ms with ~250 ms of kernels in flight), which would serialize
+  overlapped host-side metadata preparation with the running forward.
+
 ### Usage
 
 ```python
@@ -72,7 +93,7 @@ metadata = torch.ops.npu.sparse_attn_sharedkv_metadata_host(
     ori_mask_mode=4, cmp_mask_mode=3,
     ori_win_left=127, ori_win_right=0,
     has_ori_kv=True, has_cmp_kv=has_cmp_kv,
-)                                             # already a device tensor; the 4 KB H2D ran inside
+)                                             # device tensor; 4 KB H2D enqueued async on the current stream
 ```
 
 ## Output Layout
@@ -100,6 +121,13 @@ fork/join overhead dominate and must not be used.
 Output is verified byte-identical to the AICPU op both against the original algorithm source
 (compiled unchanged against a framework shim) and against the live AICPU op, across c1a / c4a /
 c128a paths, batch sizes 1–32, and context lengths up to 100k.
+
+Async behavior is validated on top: same-stream consumers read the completed table after the
+non-blocking copy; a 2,000-iteration allocate→async-copy→destroy stress loop (pinned staging
+dropped immediately, heavy device load interleaved) shows zero corruption, confirming the
+caching-host-allocator event protection; and host wall-time of the op stays ~µs while ~250 ms
+of kernels are in flight on the current stream (pageable staging, by contrast, blocks the host
+for the full drain).
 
 ### Performance (time-to-device-ready, vs the live AICPU op)
 

--- a/csrc/sparse_attn_sharedkv_metadata/README.md
+++ b/csrc/sparse_attn_sharedkv_metadata/README.md
@@ -27,9 +27,6 @@ torch.ops.npu.sparse_attn_sharedkv_metadata_host(
     num_heads_q: int,          # required, e.g. 64
     num_heads_kv: int,         # required, must be 1 (MQA)
     head_dim: int,             # required, e.g. 512
-    aic_core_num: int,         # required, cube-core count (from torch.npu.get_device_properties)
-    aiv_core_num: int,         # required, vector-core count (from torch.npu.get_device_properties)
-    soc_version: str,          # required, e.g. "Ascend910_9362" (only Ascend950 is special-cased)
     layout_q: str,             # required, "TND"
     layout_kv: str,            # required, "PA_ND"
     cu_seqlens_q: Tensor|None, # optional, CPU int32 [B+1]; required for layout_q TND
@@ -49,7 +46,9 @@ torch.ops.npu.sparse_attn_sharedkv_metadata_host(
 Inputs are **CPU `int32` tensors**; the result is a **device (NPU) `int32[1024]`** tensor.
 The op performs the 4 KB H2D internally, so it is functionally equivalent to the AICPU op
 (which writes device memory directly) and needs no `.npu()` at the call site. No input D2H
-is needed — sglang already keeps the seq-lens on the host.
+is needed — sglang already keeps the seq-lens on the host. The device topology (cube/vector
+core counts + SoC name) is queried inside the op via ACL and cached after the first call,
+so callers never pass or know about it.
 
 ### Usage
 
@@ -57,14 +56,9 @@ is needed — sglang already keeps the seq-lens on the host.
 import torch
 import sgl_kernel_npu
 
-# Query the target chip's topology once at init (cube/vector core counts + SoC name).
-props = torch.npu.get_device_properties(0)
-aic, aiv, soc = int(props.cube_core_num), int(props.vector_core_num), str(props.name)
-
 # cu_seqlens_q / seqused_kv built from sglang's CPU seq-lens (int32, on CPU)
 metadata = torch.ops.npu.sparse_attn_sharedkv_metadata_host(
     num_heads_q=64, num_heads_kv=1, head_dim=512,
-    aic_core_num=aic, aiv_core_num=aiv, soc_version=soc,
     layout_q="TND", layout_kv="PA_ND",
     cu_seqlens_q=cu_seqlens_q_cpu, seqused_kv=seqused_kv_cpu,
     batch_size=B, cmp_topk=cmp_topk, cmp_ratio=cmp_ratio,

--- a/csrc/sparse_attn_sharedkv_metadata/README.md
+++ b/csrc/sparse_attn_sharedkv_metadata/README.md
@@ -1,0 +1,113 @@
+# torch.ops.npu.sparse_attn_sharedkv_metadata_host
+
+## Function Description
+
+Host-side (CPU) reimplementation of the `npu_sparse_attn_sharedkv_metadata` load-balancer.
+
+The original op is an AICPU kernel that turns seq-lens and attention config into a fixed
+`int32[1024]` core-distribution table (`SasMetaData`), consumed by the
+`npu_sparse_attn_sharedkv` AICore kernel. The scheduler is pure integer logic (base-block
+tiling → cost model → greedy core assignment), so it is rehosted on the server CPU. This
+drops the CANN AICPU/dspark build dependency while producing **byte-identical** output to
+the AICPU op.
+
+The algorithm is ported from the AICPU kernel unchanged; only the I/O shim
+(`CpuKernelContext`/`Tensor`/`GetAttrValue`) is replaced by plain pointers + `at::Tensor`.
+Performance is improved by computing each row's cost state once in a parallel build pass
+and reading it by reference thereafter (no redundant recompute, no copy).
+
+## Interface Prototype
+
+### Python Binding Definition
+
+```python
+import sgl_kernel_npu
+
+torch.ops.npu.sparse_attn_sharedkv_metadata_host(
+    num_heads_q: int,          # required, e.g. 64
+    num_heads_kv: int,         # required, must be 1 (MQA)
+    head_dim: int,             # required, e.g. 512
+    aic_core_num: int,         # required, cube-core count (from torch.npu.get_device_properties)
+    aiv_core_num: int,         # required, vector-core count (from torch.npu.get_device_properties)
+    soc_version: str,          # required, e.g. "Ascend910_9362" (only Ascend950 is special-cased)
+    layout_q: str,             # required, "TND"
+    layout_kv: str,            # required, "PA_ND"
+    cu_seqlens_q: Tensor|None, # optional, CPU int32 [B+1]; required for layout_q TND
+    seqused_kv:  Tensor|None,  # optional, CPU int32 [B];   required for layout_kv PA_ND
+    batch_size: int = 0,
+    cmp_topk: int = 0,         # 0 / 512 / 1024 (only when has_cmp_kv)
+    cmp_ratio: int = -1,       # 4 or 128 (only when has_cmp_kv)
+    ori_mask_mode: int = 4,    # 0 (default) / 3 (right-down causal) / 4 (band)
+    cmp_mask_mode: int = 3,
+    ori_win_left: int = 127,
+    ori_win_right: int = 0,
+    has_ori_kv: bool = True,
+    has_cmp_kv: bool = True,
+) -> Tensor                    # device (NPU) int32 [1024]
+```
+
+Inputs are **CPU `int32` tensors**; the result is a **device (NPU) `int32[1024]`** tensor.
+The op performs the 4 KB H2D internally, so it is functionally equivalent to the AICPU op
+(which writes device memory directly) and needs no `.npu()` at the call site. No input D2H
+is needed — sglang already keeps the seq-lens on the host.
+
+### Usage
+
+```python
+import torch
+import sgl_kernel_npu
+
+# Query the target chip's topology once at init (cube/vector core counts + SoC name).
+props = torch.npu.get_device_properties(0)
+aic, aiv, soc = int(props.cube_core_num), int(props.vector_core_num), str(props.name)
+
+# cu_seqlens_q / seqused_kv built from sglang's CPU seq-lens (int32, on CPU)
+metadata = torch.ops.npu.sparse_attn_sharedkv_metadata_host(
+    num_heads_q=64, num_heads_kv=1, head_dim=512,
+    aic_core_num=aic, aiv_core_num=aiv, soc_version=soc,
+    layout_q="TND", layout_kv="PA_ND",
+    cu_seqlens_q=cu_seqlens_q_cpu, seqused_kv=seqused_kv_cpu,
+    batch_size=B, cmp_topk=cmp_topk, cmp_ratio=cmp_ratio,
+    ori_mask_mode=4, cmp_mask_mode=3,
+    ori_win_left=127, ori_win_right=0,
+    has_ori_kv=True, has_cmp_kv=has_cmp_kv,
+)                                             # already a device tensor; the 4 KB H2D ran inside
+```
+
+## Output Layout
+
+The `int32[1024]` buffer is a flattened `SasMetaData`:
+
+- `faMetadata[36][8]` — per AIC (cube) core: `[core_enable, bn2_start, m_start, s2_start,
+  bn2_end, m_end, s2_end, first_fd_data_workspace_idx]`. Only `[0, aic_core_num)` entries are
+  filled; the rest are zero. `core_enable == 0` marks inactive cores.
+- `fdMetadata[72][8]` — per AIV (vector) core: the FlashDecode reduction plan (inert while
+  `supportFd` is disabled, as in the upstream AICPU build).
+
+The 36 / 72 dimensions are fixed buffer capacity (the consumer indexes with these strides);
+the runtime `aic_core_num` / `aiv_core_num` only bound how many entries are enabled.
+
+## Build
+
+No CANN AICPU toolchain is needed — the op is plain host C++ compiled into `libsgl_kernel_npu.so`.
+OpenMP is enabled (`-fopenmp`) for the parallel per-row build. The OpenMP team is **capped at 16
+threads** (`ROW_PARALLEL_MAX_THREADS`); on high-core-count hosts the default `nproc` team makes the
+fork/join overhead dominate and must not be used.
+
+## Validation
+
+Output is verified byte-identical to the AICPU op both against the original algorithm source
+(compiled unchanged against a framework shim) and against the live AICPU op, across c1a / c4a /
+c128a paths, batch sizes 1–32, and context lengths up to 100k.
+
+### Performance (time-to-device-ready, vs the live AICPU op)
+
+| scenario | AICPU | host | speedup |
+| --- | --- | --- | --- |
+| decode B256 | ~300 µs | ~108 µs | ~2.6× |
+| prefill T8k | ~358 µs | ~310 µs | ~1.15× |
+| prefill T32k | ~889 µs | ~852 µs | ~1.04× |
+| c4a prefill T8k | ~969 µs | ~339 µs | ~2.86× |
+
+The host op wins or ties across decode and all prefill sizes, and is amortized once per batch
+across all attention layers.

--- a/csrc/sparse_attn_sharedkv_metadata/README.md
+++ b/csrc/sparse_attn_sharedkv_metadata/README.md
@@ -1,5 +1,12 @@
 # torch.ops.npu.sparse_attn_sharedkv_metadata_host
 
+## Attribution
+
+Reimplemented on the host CPU with reference to the vllm-ascend AICPU op
+`SparseAttnSharedkvMetadata` (`vllm-ascend/csrc/attention/sparse_attn_sharedkv_metadata`,
+Copyright (c) Huawei Technologies Co., Ltd., CANN Open Software License Version 2.0).
+The scheduling algorithm is ported unchanged; the output is byte-identical.
+
 ## Function Description
 
 Host-side (CPU) reimplementation of the `npu_sparse_attn_sharedkv_metadata` load-balancer.

--- a/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.cpp
+++ b/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.cpp
@@ -809,7 +809,10 @@ bool SparseAttnSharedkvMetadataHost::GenMetaData(SplitResult &splitRes)
     return true;
 }
 
-// ---- at::Tensor entry point ------------------------------------------------
+}  // namespace sgl_kernel_npu
+
+namespace sglang {
+namespace npu_kernel {
 namespace {
 struct HostTopology {
     uint32_t aicCoreNum;
@@ -870,7 +873,7 @@ at::Tensor sparse_attn_sharedkv_metadata_host(int64_t num_heads_q, int64_t num_h
     }
 
     const HostTopology &topo = ResolveHostTopology();
-    SparseAttnSharedkvMetadataHost scheduler;
+    sgl_kernel_npu::SparseAttnSharedkvMetadataHost scheduler;
     bool ok =
         scheduler.Run(cuQPtr, seqKvPtr, static_cast<int32_t>(batch_size), static_cast<int32_t>(num_heads_q),
                       static_cast<int32_t>(num_heads_kv), static_cast<int32_t>(head_dim), topo.aicCoreNum,
@@ -882,4 +885,5 @@ at::Tensor sparse_attn_sharedkv_metadata_host(int64_t num_heads_q, int64_t num_h
     return metaDataHost.to(at::Device("npu"));
 }
 
-}  // namespace sgl_kernel_npu
+}  // namespace npu_kernel
+}  // namespace sglang

--- a/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.cpp
+++ b/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.cpp
@@ -1,13 +1,12 @@
-// Pure-host scheduler implementation (optimized: per-row cache + parallel build).
-// See the header for provenance. The algorithm is byte-identical to the AICPU kernel;
-// only the data-access plumbing changed: every row's S1GCache is computed once in a
-// parallel build pass, then the cost-model and assignment passes read it by const-ref
-// (no recompute, no copy). The per-row typeCost scratch is passed in (thread-local).
-
 #include "sparse_attn_sharedkv_metadata.h"
 
 #include <algorithm>
+#include <cctype>
 #include <climits>
+#include <string>
+#include <vector>
+
+#include "acl/acl.h"
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -15,10 +14,7 @@
 
 namespace sgl_kernel_npu {
 
-// Threshold below which OpenMP fork/join overhead isn't worth it (decode-sized batches).
 constexpr int64_t ROW_PARALLEL_THRESHOLD = 4096;
-// Cap the OpenMP team: this op's per-row work is tiny, so a small bounded team beats the
-// default (nproc, e.g. 320) — spawning hundreds of threads costs more than the work itself.
 constexpr int ROW_PARALLEL_MAX_THREADS = 16;
 
 bool SparseAttnSharedkvMetadataHost::Run(const int32_t *cuSeqLenQ, const int32_t *seqUsedKv, int32_t batchSize,
@@ -53,8 +49,7 @@ bool SparseAttnSharedkvMetadataHost::Run(const int32_t *cuSeqLenQ, const int32_t
     if (aicCoreNum_ == 0U || aivCoreNum_ == 0U || metaData_ == nullptr) {
         return false;
     }
-    // Match the AICPU op's input contract (CheckSingleParam / CheckFeature): silent
-    // rejection of unsupported configs would otherwise produce wrong schedules.
+    // Match the AICPU op's input contract (CheckSingleParam / CheckFeature).
     if (kvHeadNum != 1) {
         return false;
     }
@@ -75,8 +70,13 @@ bool SparseAttnSharedkvMetadataHost::Run(const int32_t *cuSeqLenQ, const int32_t
 
 ValidSocVersion SparseAttnSharedkvMetadataHost::ProcessSocVersion()
 {
-    const std::string ascend950 = "Ascend950";
-    if (socVersion_.find(ascend950) != std::string::npos) {
+    // Case-insensitive: aclrtGetSocName() casing is not guaranteed stable across SoCs.
+    std::string lower;
+    lower.reserve(socVersion_.size());
+    for (char c : socVersion_) {
+        lower.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+    }
+    if (lower.find("ascend950") != std::string::npos) {
         return ValidSocVersion::ASCEND950;
     }
     return ValidSocVersion::ASCEND910;
@@ -360,7 +360,7 @@ void SparseAttnSharedkvMetadataHost::GatherWinAndCmpCache(S1GCache &s1GCache)
     s1GCache.s1GCost = s1GCache.winS1GCost + s1GCache.cmpS1GCost;
 }
 
-// Exact body of the original CalcS1GCache, using a caller-provided typeCost scratch.
+// Compute one row's cost state with a caller-provided typeCost scratch.
 void SparseAttnSharedkvMetadataHost::ComputeS1GCache(uint32_t s1GIdx, const SplitContext &splitContext,
                                                      const BatchCache &batchCache, BlockCost<int64_t> &typeCost,
                                                      S1GCache &out)
@@ -403,7 +403,7 @@ void SparseAttnSharedkvMetadataHost::BuildRowCache(const SplitContext &splitCont
     for (int b = 0; b < batchSize_; b++) {
         CalcBatchCache(static_cast<uint32_t>(b), splitContext, batchCacheArr_[b]);
     }
-    // slot -> batch lookup (sequential, O(total); cheap vs the per-row compute)
+    // slot -> batch lookup
     std::vector<uint32_t> slotB(total);
     for (int b = 0; b < batchSize_; b++) {
         for (uint32_t g = rowOffset_[b]; g < rowOffset_[b + 1]; g++)
@@ -417,7 +417,7 @@ void SparseAttnSharedkvMetadataHost::BuildRowCache(const SplitContext &splitCont
         ComputeS1GCache(j, splitContext, batchCacheArr_[b], tc, rowCache_[g]);
     };
     if (total >= ROW_PARALLEL_THRESHOLD) {
-        int nt = static_cast<int>(total) / 512;  // >=512 rows/thread to amortize fork/join
+        int nt = static_cast<int>(total) / 512;
         if (nt < 1) {
             nt = 1;
         }
@@ -762,7 +762,7 @@ bool SparseAttnSharedkvMetadataHost::BalanceSchedule(SplitResult &splitRes)
         splitRes.s2End[0] = 0U;
         return true;
     }
-    BuildRowCache(splitContext);  // compute every row once (parallel), then read by-ref
+    BuildRowCache(splitContext);
     CalcCostInfo(splitContext);
     splitRes.maxCost = INT64_MAX;
     splitRes.usedCoreNum = 1U;
@@ -809,13 +809,47 @@ bool SparseAttnSharedkvMetadataHost::GenMetaData(SplitResult &splitRes)
     return true;
 }
 
-// ---- at::Tensor entry point -------------------------------------------------
-at::Tensor sparse_attn_sharedkv_metadata_host(
-    int64_t num_heads_q, int64_t num_heads_kv, int64_t head_dim, int64_t aic_core_num, int64_t aiv_core_num,
-    const std::string &soc_version, const std::string &layout_q, const std::string &layout_kv,
-    const c10::optional<at::Tensor> &cu_seqlens_q, const c10::optional<at::Tensor> &seqused_kv, int64_t batch_size,
-    int64_t cmp_topk, int64_t cmp_ratio, int64_t ori_mask_mode, int64_t cmp_mask_mode, int64_t ori_win_left,
-    int64_t ori_win_right, bool has_ori_kv, bool has_cmp_kv)
+// ---- at::Tensor entry point ------------------------------------------------
+namespace {
+struct HostTopology {
+    uint32_t aicCoreNum;
+    uint32_t aivCoreNum;
+    std::string socVersion;
+};
+
+// Query core counts and the SoC name from the current device via ACL.
+const HostTopology &ResolveHostTopology()
+{
+    static const HostTopology cached = [] {
+        int32_t device = 0;
+        if (aclrtGetDevice(&device) != ACL_SUCCESS) {
+            device = 0;  // fall back to device 0
+        }
+        int64_t aic = 0;
+        int64_t aiv = 0;
+        TORCH_CHECK(aclGetDeviceCapability(device, ACL_DEVICE_INFO_AI_CORE_NUM, &aic) == ACL_SUCCESS,
+                    "sparse_attn_sharedkv_metadata_host: aclGetDeviceCapability(AI_CORE_NUM) failed");
+        TORCH_CHECK(aclGetDeviceCapability(device, ACL_DEVICE_INFO_VECTOR_CORE_NUM, &aiv) == ACL_SUCCESS,
+                    "sparse_attn_sharedkv_metadata_host: aclGetDeviceCapability(VECTOR_CORE_NUM) failed");
+        TORCH_CHECK(aic > 0 && aiv > 0,
+                    "sparse_attn_sharedkv_metadata_host: invalid device core counts "
+                    "(aic=",
+                    aic, ", aiv=", aiv, ")");
+        const char *soc = aclrtGetSocName();
+        return HostTopology{static_cast<uint32_t>(aic), static_cast<uint32_t>(aiv),
+                            (soc != nullptr) ? std::string(soc) : std::string()};
+    }();
+    return cached;
+}
+}  // namespace
+
+at::Tensor sparse_attn_sharedkv_metadata_host(int64_t num_heads_q, int64_t num_heads_kv, int64_t head_dim,
+                                              const std::string &layout_q, const std::string &layout_kv,
+                                              const c10::optional<at::Tensor> &cu_seqlens_q,
+                                              const c10::optional<at::Tensor> &seqused_kv, int64_t batch_size,
+                                              int64_t cmp_topk, int64_t cmp_ratio, int64_t ori_mask_mode,
+                                              int64_t cmp_mask_mode, int64_t ori_win_left, int64_t ori_win_right,
+                                              bool has_ori_kv, bool has_cmp_kv)
 {
     auto opts = at::TensorOptions().dtype(at::kInt).device(at::kCPU);
     at::Tensor metaDataHost = at::zeros({static_cast<int64_t>(optiling::SAS_META_SIZE)}, opts);
@@ -835,17 +869,16 @@ at::Tensor sparse_attn_sharedkv_metadata_host(
         seqKvPtr = static_cast<const int32_t *>(t.const_data_ptr());
     }
 
+    const HostTopology &topo = ResolveHostTopology();
     SparseAttnSharedkvMetadataHost scheduler;
-    bool ok = scheduler.Run(
-        cuQPtr, seqKvPtr, static_cast<int32_t>(batch_size), static_cast<int32_t>(num_heads_q),
-        static_cast<int32_t>(num_heads_kv), static_cast<int32_t>(head_dim), static_cast<uint32_t>(aic_core_num),
-        static_cast<uint32_t>(aiv_core_num), soc_version, static_cast<int32_t>(cmp_topk),
-        static_cast<int32_t>(cmp_ratio), static_cast<int32_t>(ori_mask_mode), static_cast<int32_t>(cmp_mask_mode),
-        ori_win_left, ori_win_right, layout_q, layout_kv, has_ori_kv, has_cmp_kv, metaDataHost.data_ptr<int32_t>());
+    bool ok =
+        scheduler.Run(cuQPtr, seqKvPtr, static_cast<int32_t>(batch_size), static_cast<int32_t>(num_heads_q),
+                      static_cast<int32_t>(num_heads_kv), static_cast<int32_t>(head_dim), topo.aicCoreNum,
+                      topo.aivCoreNum, topo.socVersion, static_cast<int32_t>(cmp_topk), static_cast<int32_t>(cmp_ratio),
+                      static_cast<int32_t>(ori_mask_mode), static_cast<int32_t>(cmp_mask_mode), ori_win_left,
+                      ori_win_right, layout_q, layout_kv, has_ori_kv, has_cmp_kv, metaDataHost.data_ptr<int32_t>());
     TORCH_CHECK(ok, "sparse_attn_sharedkv_metadata_host: scheduling failed (invalid params)");
-    // H2D the result so the op is functionally equivalent to the AICPU version, which
-    // writes device memory directly. Inputs stay on the host (no D2H: sglang already has
-    // the seq-lens on CPU). The 4 KB H2D is the only device traffic on this path.
+    // Return the table on device, matching the AICPU op's output placement.
     return metaDataHost.to(at::Device("npu"));
 }
 

--- a/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.cpp
+++ b/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.cpp
@@ -876,7 +876,8 @@ at::Tensor sparse_attn_sharedkv_metadata_host(int64_t num_heads_q, int64_t num_h
                                               int64_t cmp_mask_mode, int64_t ori_win_left, int64_t ori_win_right,
                                               bool has_ori_kv, bool has_cmp_kv)
 {
-    auto opts = at::TensorOptions().dtype(at::kInt).device(at::kCPU);
+    // Pinned staging so the final H2D can be enqueued asynchronously (see below).
+    auto opts = at::TensorOptions().dtype(at::kInt).device(at::kCPU).pinned_memory(true);
     at::Tensor metaDataHost = at::zeros({static_cast<int64_t>(optiling::SAS_META_SIZE)}, opts);
 
     const int32_t *cuQPtr = nullptr;
@@ -904,7 +905,7 @@ at::Tensor sparse_attn_sharedkv_metadata_host(int64_t num_heads_q, int64_t num_h
                       ori_win_right, layout_q, layout_kv, has_ori_kv, has_cmp_kv, metaDataHost.data_ptr<int32_t>());
     TORCH_CHECK(ok, "sparse_attn_sharedkv_metadata_host: scheduling failed (invalid params)");
     // Return the table on device, matching the AICPU op's output placement.
-    return metaDataHost.to(at::Device("npu"));
+    return metaDataHost.to(at::Device("npu"), /*non_blocking=*/true);
 }
 
 }  // namespace npu_kernel

--- a/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.cpp
+++ b/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.cpp
@@ -1,3 +1,25 @@
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. See LICENSE in the root of
+ * the software repository for the full text of the License.
+ *
+ * Reimplemented on the host CPU with reference to the vllm-ascend AICPU op
+ * `SparseAttnSharedkvMetadata` (csrc/attention/sparse_attn_sharedkv_metadata).
+ */
+
+/*!
+ * \file sparse_attn_sharedkv_metadata.cpp
+ * \brief Core-distribution scheduler: base-block tiling, cost model, and greedy
+ * core assignment, ported from the vllm-ascend AICPU kernel unchanged; only the
+ * I/O shim (CpuKernelContext/Tensor/GetAttrValue) is replaced by plain pointers
+ * plus at::Tensor allocation.
+ */
+
 #include "sparse_attn_sharedkv_metadata.h"
 
 #include <algorithm>

--- a/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.cpp
+++ b/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.cpp
@@ -1,0 +1,852 @@
+// Pure-host scheduler implementation (optimized: per-row cache + parallel build).
+// See the header for provenance. The algorithm is byte-identical to the AICPU kernel;
+// only the data-access plumbing changed: every row's S1GCache is computed once in a
+// parallel build pass, then the cost-model and assignment passes read it by const-ref
+// (no recompute, no copy). The per-row typeCost scratch is passed in (thread-local).
+
+#include "sparse_attn_sharedkv_metadata.h"
+
+#include <algorithm>
+#include <climits>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace sgl_kernel_npu {
+
+// Threshold below which OpenMP fork/join overhead isn't worth it (decode-sized batches).
+constexpr int64_t ROW_PARALLEL_THRESHOLD = 4096;
+// Cap the OpenMP team: this op's per-row work is tiny, so a small bounded team beats the
+// default (nproc, e.g. 320) — spawning hundreds of threads costs more than the work itself.
+constexpr int ROW_PARALLEL_MAX_THREADS = 16;
+
+bool SparseAttnSharedkvMetadataHost::Run(const int32_t *cuSeqLenQ, const int32_t *seqUsedKv, int32_t batchSize,
+                                         int32_t queryHeadNum, int32_t kvHeadNum, int32_t headDim, uint32_t aicCoreNum,
+                                         uint32_t aivCoreNum, const std::string &socVersion, int32_t cmpTopK,
+                                         int32_t cmpRatio, int32_t oriMaskMode, int32_t cmpMaskMode, int64_t winLeft,
+                                         int64_t winRight, const std::string &layoutQuery, const std::string &layoutKv,
+                                         bool hasOriKv, bool hasCmpKv, int32_t *metaData)
+{
+    cacheReady_ = false;
+    actSeqLenQ_ = cuSeqLenQ;
+    seqUsedKv_ = seqUsedKv;
+    batchSize_ = batchSize;
+    queryHeadNum_ = queryHeadNum;
+    kvHeadNum_ = kvHeadNum;
+    headDim_ = headDim;
+    aicCoreNum_ = aicCoreNum;
+    aivCoreNum_ = aivCoreNum;
+    socVersion_ = socVersion;
+    cmpTopK_ = cmpTopK;
+    cmpRatio_ = cmpRatio;
+    oriMaskMode_ = oriMaskMode;
+    cmpMaskMode_ = cmpMaskMode;
+    winLeft_ = winLeft;
+    winRight_ = winRight;
+    layoutQuery_ = layoutQuery;
+    layoutKv_ = layoutKv;
+    hasOriKv_ = hasOriKv;
+    hasCmpKv_ = hasCmpKv;
+    metaData_ = metaData;
+
+    if (aicCoreNum_ == 0U || aivCoreNum_ == 0U || metaData_ == nullptr) {
+        return false;
+    }
+    // Match the AICPU op's input contract (CheckSingleParam / CheckFeature): silent
+    // rejection of unsupported configs would otherwise produce wrong schedules.
+    if (kvHeadNum != 1) {
+        return false;
+    }
+    if (hasCmpKv) {
+        if (cmpTopK != 0 && cmpTopK != 512 && cmpTopK != 1024) {
+            return false;
+        }
+        if (cmpRatio != 4 && cmpRatio != 128) {
+            return false;
+        }
+    }
+    if (!ParamsInit()) {
+        return false;
+    }
+    SplitResult splitRes{aicCoreNum_, aivCoreNum_};
+    return BalanceSchedule(splitRes) && GenMetaData(splitRes);
+}
+
+ValidSocVersion SparseAttnSharedkvMetadataHost::ProcessSocVersion()
+{
+    const std::string ascend950 = "Ascend950";
+    if (socVersion_.find(ascend950) != std::string::npos) {
+        return ValidSocVersion::ASCEND950;
+    }
+    return ValidSocVersion::ASCEND910;
+}
+
+bool SparseAttnSharedkvMetadataHost::ParamsInit()
+{
+    auto mode = static_cast<SparseMode>(oriMaskMode_);
+    if (mode == SparseMode::DEFAULT_MASK) {
+        preToken_ = INT64_MAX;
+        nextToken_ = INT64_MAX;
+        attentionMode_ = 0;
+    } else if (mode == SparseMode::RIGHT_DOWN_CAUSAL) {
+        preToken_ = INT64_MAX;
+        nextToken_ = 0;
+        attentionMode_ = 1;
+    } else {  // SparseMode = 4 (BAND)
+        preToken_ = (winLeft_ > -1) ? winLeft_ : INT64_MAX;
+        nextToken_ = (winRight_ > -1) ? winRight_ : INT64_MAX;
+        attentionMode_ = 1;
+    }
+    isS1G_ = (layoutQuery_ == "BSND" || layoutQuery_ == "BSH" || layoutQuery_ == "TND");
+    groupSize_ = queryHeadNum_ / kvHeadNum_;
+    if (hasCmpKv_) {
+        if (cmpTopK_ > 0) {
+            isSCFA_ = true;
+        } else {
+            isCFA_ = true;
+        }
+    }
+    ValidSocVersion validSocVersion = ProcessSocVersion();
+    if (validSocVersion == ValidSocVersion::ASCEND910) {
+        mBaseSize_ = groupSize_;
+        s2BaseSize_ = 512U;
+    } else if (validSocVersion == ValidSocVersion::ASCEND950) {
+        mBaseSize_ = 64U;
+        s2BaseSize_ = 128U;
+    }
+    return true;
+}
+
+uint32_t SparseAttnSharedkvMetadataHost::GetS1SeqSize(uint32_t bIdx)
+{
+    if (layoutQuery_ == "TND" && actSeqLenQ_ != nullptr) {
+        return static_cast<uint32_t>(actSeqLenQ_[bIdx + 1U] - actSeqLenQ_[bIdx]);
+    }
+    return 0U;  // layout_q BSND fallback; the op requires cu_seqlens_q (TND)
+}
+
+uint32_t SparseAttnSharedkvMetadataHost::GetS2SeqSize(uint32_t bIdx)
+{
+    if (seqUsedKv_ != nullptr) {
+        return static_cast<uint32_t>(seqUsedKv_[bIdx]);
+    }
+    return 0U;  // layout_kv TND fallback; the op requires seqused_kv (PA_ND)
+}
+
+void SparseAttnSharedkvMetadataHost::CalcSplitInfo(SplitContext &splitContext)
+{
+    SplitInfo &splitInfo = splitContext.splitInfo;
+    for (uint32_t bIdx = 0; bIdx < static_cast<uint32_t>(batchSize_); bIdx++) {
+        uint32_t s1Size = GetS1SeqSize(bIdx);
+        uint32_t s2Size = GetS2SeqSize(bIdx);
+        splitInfo.s1GBaseNum[bIdx] = (s1Size * groupSize_ + (mBaseSize_ - 1U)) / mBaseSize_;
+        splitInfo.s1GTailSize[bIdx] = (s1Size * groupSize_) % mBaseSize_;
+        splitInfo.s2BaseNum[bIdx] = (s2Size + s2BaseSize_ - 1U) / s2BaseSize_;
+        splitInfo.s2TailSize[bIdx] = s2Size % s2BaseSize_;
+        if (splitInfo.s1GBaseNum[bIdx] != 0U && splitInfo.s2BaseNum[bIdx] != 0U) {
+            splitInfo.isKvSeqAllZero = false;
+        }
+    }
+}
+
+int64_t SparseAttnSharedkvMetadataHost::CalcPreTokenLeftUp(uint32_t s1Size, uint32_t s2Size)
+{
+    auto mode = static_cast<SparseMode>(oriMaskMode_);
+    if (mode == SparseMode::BAND) {
+        return static_cast<int64_t>(s1Size) - static_cast<int64_t>(s2Size) + preToken_;
+    }
+    return preToken_;
+}
+
+int64_t SparseAttnSharedkvMetadataHost::CalcNextTokenLeftUp(uint32_t s1Size, uint32_t s2Size)
+{
+    auto mode = static_cast<SparseMode>(oriMaskMode_);
+    switch (mode) {
+        case SparseMode::DEFAULT_MASK:
+        case SparseMode::ALL_MASK:
+        case SparseMode::LEFT_UP_CAUSAL:
+            return nextToken_;
+        case SparseMode::RIGHT_DOWN_CAUSAL:
+            return static_cast<int64_t>(s2Size) - static_cast<int64_t>(s1Size);
+        case SparseMode::BAND:
+            return static_cast<int64_t>(s2Size) - static_cast<int64_t>(s1Size) + nextToken_;
+        default:
+            return nextToken_;
+    }
+}
+
+int64_t SparseAttnSharedkvMetadataHost::WinCalcCost(uint32_t basicM, uint32_t basicS2)
+{
+    uint32_t winAlignCoefM = 16U;
+    uint32_t winAlignCoefS2 = 64U;
+    uint32_t winAlignBasicM = (basicM + winAlignCoefM - 1U) >> 4U;
+    uint32_t winAlignBasicS2 = (basicS2 + winAlignCoefS2 - 1U) >> 6U;
+    return static_cast<int64_t>(6U * winAlignBasicM + 10U * winAlignBasicS2);
+}
+
+int64_t SparseAttnSharedkvMetadataHost::CmpCalcCost(uint32_t basicM, uint32_t basicS2)
+{
+    uint32_t cmpAlignCoefM = 16U;
+    uint32_t cmpAlignCoefS2 = 64U;
+    uint32_t cmpAlignBasicM = (basicM + cmpAlignCoefM - 1U) >> 4U;
+    uint32_t cmpAlignBasicS2 = (basicS2 + cmpAlignCoefS2 - 1U) >> 6U;
+    return static_cast<int64_t>(6U * cmpAlignBasicM + 10U * cmpAlignBasicS2);
+}
+
+void SparseAttnSharedkvMetadataHost::CalcCostTable(uint32_t s1NormalSize, uint32_t s2NormalSize, uint32_t s1GTailSize,
+                                                   uint32_t winS2TailSize, uint32_t cmpS2TailSize,
+                                                   BlockCost<int64_t> &typeCost)
+{
+    typeCost[WIN_NORMAL_BLOCK][WIN_NORMAL_BLOCK] = WinCalcCost(s1NormalSize, s2NormalSize);
+    typeCost[WIN_TAIL_BLOCK][WIN_NORMAL_BLOCK] = (s1GTailSize == 0U) ? 0U : WinCalcCost(s1GTailSize, s2NormalSize);
+    typeCost[WIN_NORMAL_BLOCK][WIN_TAIL_BLOCK] = (winS2TailSize == 0U) ? 0U : WinCalcCost(s1NormalSize, winS2TailSize);
+    typeCost[WIN_TAIL_BLOCK][WIN_TAIL_BLOCK] =
+        (s1GTailSize == 0U || winS2TailSize == 0U) ? 0U : WinCalcCost(s1GTailSize, winS2TailSize);
+    if (hasCmpKv_) {
+        typeCost[CMP_NORMAL_BLOCK][CMP_NORMAL_BLOCK] = CmpCalcCost(s1NormalSize, s2NormalSize);
+        typeCost[CMP_TAIL_BLOCK][CMP_NORMAL_BLOCK] = (s1GTailSize == 0U) ? 0U : CmpCalcCost(s1GTailSize, s2NormalSize);
+        typeCost[CMP_NORMAL_BLOCK][CMP_TAIL_BLOCK] =
+            (cmpS2TailSize == 0U) ? 0U : CmpCalcCost(s1NormalSize, cmpS2TailSize);
+        typeCost[CMP_TAIL_BLOCK][CMP_TAIL_BLOCK] =
+            (s1GTailSize == 0U || cmpS2TailSize == 0U) ? 0U : CmpCalcCost(s1GTailSize, cmpS2TailSize);
+    }
+}
+
+Range<int64_t> SparseAttnSharedkvMetadataHost::CalcS2TokenRange(uint32_t s1GIdx, const BatchCache &batchCache)
+{
+    if (batchCache.s1Size == 0U || batchCache.s2Size == 0U) {
+        return std::make_pair(0, 0);
+    }
+    if (!attentionMode_) {
+        return std::make_pair(0, static_cast<int64_t>(batchCache.s2Size) - 1);
+    }
+    int64_t s1GFirstToken = static_cast<int64_t>(s1GIdx) * static_cast<int64_t>(mBaseSize_);
+    int64_t s1GLastToken = std::min(s1GFirstToken + static_cast<int64_t>(mBaseSize_),
+                                    static_cast<int64_t>(batchCache.s1Size) * static_cast<int64_t>(groupSize_)) -
+                           1;
+    int64_t s1FirstToken = 0;
+    int64_t s1LastToken = 0;
+    if (isS1G_) {
+        s1FirstToken = s1GFirstToken / static_cast<int64_t>(groupSize_);
+        s1LastToken = s1GLastToken / static_cast<int64_t>(groupSize_);
+    } else {
+        if (s1GFirstToken / batchCache.s1Size == s1GLastToken / batchCache.s1Size) {
+            s1FirstToken = s1GFirstToken % static_cast<int64_t>(batchCache.s1Size);
+            s1LastToken = s1GLastToken % static_cast<int64_t>(batchCache.s1Size);
+        } else {
+            s1FirstToken = 0;
+            s1LastToken = batchCache.s1Size;
+        }
+    }
+    int64_t s2FirstToken = s1FirstToken - batchCache.preTokenLeftUp;
+    int64_t s2LastToken = s1LastToken + batchCache.nextTokenLeftUp;
+    return std::make_pair(s2FirstToken, s2LastToken);
+}
+
+void SparseAttnSharedkvMetadataHost::CalcBatchCache(uint32_t bIdx, const SplitContext &splitContext,
+                                                    BatchCache &batchCache)
+{
+    (void)splitContext;
+    batchCache.bIdx = bIdx;
+    batchCache.s1Size = GetS1SeqSize(bIdx);
+    batchCache.s2Size = GetS2SeqSize(bIdx);
+    batchCache.preTokenLeftUp = CalcPreTokenLeftUp(batchCache.s1Size, batchCache.s2Size);
+    batchCache.nextTokenLeftUp = CalcNextTokenLeftUp(batchCache.s1Size, batchCache.s2Size);
+}
+
+void SparseAttnSharedkvMetadataHost::CalcWinS1GCache(S1GCache &s1GCache, const SplitInfo &splitInfo,
+                                                     const BlockCost<int64_t> &typeCost)
+{
+    if (s1GCache.winS2Start >= s1GCache.winS2End) {
+        s1GCache.winS1GBlock = 0;
+        s1GCache.winS1GCost = 0;
+        s1GCache.winS1GLastBlockCost = 0;
+        s1GCache.winS1GNormalBlockCost = 0;
+    } else {
+        s1GCache.winS1GBlock = s1GCache.winS2End - s1GCache.winS2Start;
+        uint32_t curWinTailS2Num = (s1GCache.winS2TailSize != 0U) ? 1U : 0U;
+        uint32_t curWinNormalS2Num = s1GCache.winS1GBlock - curWinTailS2Num;
+        if (s1GCache.s1GIdx == (splitInfo.s1GBaseNum[s1GCache.bIdx] - 1U) &&
+            splitInfo.s1GTailSize[s1GCache.bIdx] != 0U) {
+            s1GCache.winS1GCost = typeCost[WIN_TAIL_BLOCK][WIN_NORMAL_BLOCK] * curWinNormalS2Num +
+                                  typeCost[WIN_TAIL_BLOCK][WIN_TAIL_BLOCK] * curWinTailS2Num;
+            s1GCache.winS1GLastBlockCost = curWinTailS2Num > 0U ? typeCost[WIN_TAIL_BLOCK][WIN_TAIL_BLOCK]
+                                                                : typeCost[WIN_TAIL_BLOCK][WIN_NORMAL_BLOCK];
+            s1GCache.winS1GNormalBlockCost = typeCost[WIN_TAIL_BLOCK][WIN_NORMAL_BLOCK];
+        } else {
+            s1GCache.winS1GCost = typeCost[WIN_NORMAL_BLOCK][WIN_NORMAL_BLOCK] * curWinNormalS2Num +
+                                  typeCost[WIN_NORMAL_BLOCK][WIN_TAIL_BLOCK] * curWinTailS2Num;
+            s1GCache.winS1GLastBlockCost = curWinTailS2Num > 0U ? typeCost[WIN_NORMAL_BLOCK][WIN_TAIL_BLOCK]
+                                                                : typeCost[WIN_NORMAL_BLOCK][WIN_NORMAL_BLOCK];
+            s1GCache.winS1GNormalBlockCost = typeCost[WIN_NORMAL_BLOCK][WIN_NORMAL_BLOCK];
+        }
+    }
+}
+
+void SparseAttnSharedkvMetadataHost::CalcCmpS1GCache(S1GCache &s1GCache, const SplitInfo &splitInfo,
+                                                     const BlockCost<int64_t> &typeCost)
+{
+    if (s1GCache.cmpS2Start >= s1GCache.cmpS2End) {
+        s1GCache.cmpS1GBlock = 0;
+        s1GCache.cmpS1GCost = 0;
+        s1GCache.cmpS1GLastBlockCost = 0;
+        s1GCache.cmpS1GNormalBlockCost = 0;
+    } else {
+        s1GCache.cmpS1GBlock = s1GCache.cmpS2End - s1GCache.cmpS2Start;
+        uint32_t curCmpTailS2Num = (s1GCache.cmpS2TailSize != 0U) ? 1U : 0U;
+        uint32_t curCmpNormalS2Num = s1GCache.cmpS1GBlock - curCmpTailS2Num;
+        if (s1GCache.s1GIdx == (splitInfo.s1GBaseNum[s1GCache.bIdx] - 1U) &&
+            splitInfo.s1GTailSize[s1GCache.bIdx] != 0U) {
+            s1GCache.cmpS1GCost = typeCost[CMP_TAIL_BLOCK][CMP_NORMAL_BLOCK] * curCmpNormalS2Num +
+                                  typeCost[CMP_TAIL_BLOCK][CMP_TAIL_BLOCK] * curCmpTailS2Num;
+            s1GCache.cmpS1GLastBlockCost = curCmpTailS2Num > 0U ? typeCost[CMP_TAIL_BLOCK][CMP_TAIL_BLOCK]
+                                                                : typeCost[CMP_TAIL_BLOCK][CMP_NORMAL_BLOCK];
+            s1GCache.cmpS1GNormalBlockCost = typeCost[CMP_TAIL_BLOCK][CMP_NORMAL_BLOCK];
+        } else {
+            s1GCache.cmpS1GCost = typeCost[CMP_NORMAL_BLOCK][CMP_NORMAL_BLOCK] * curCmpNormalS2Num +
+                                  typeCost[CMP_NORMAL_BLOCK][CMP_TAIL_BLOCK] * curCmpTailS2Num;
+            s1GCache.cmpS1GLastBlockCost = curCmpTailS2Num > 0U ? typeCost[CMP_NORMAL_BLOCK][CMP_TAIL_BLOCK]
+                                                                : typeCost[CMP_NORMAL_BLOCK][CMP_NORMAL_BLOCK];
+            s1GCache.cmpS1GNormalBlockCost = typeCost[CMP_NORMAL_BLOCK][CMP_NORMAL_BLOCK];
+        }
+    }
+}
+
+void SparseAttnSharedkvMetadataHost::CalcBlockRangeAndTailSize(Range<int64_t> &oriS2TokenRange,
+                                                               const BatchCache &batchCache, S1GCache &s1GCache)
+{
+    int64_t oriS2FirstToken = oriS2TokenRange.first;
+    int64_t oriS2LastToken = oriS2TokenRange.second;
+    if (oriS2FirstToken >= static_cast<int64_t>(batchCache.s2Size) || oriS2LastToken < 0 ||
+        oriS2LastToken < oriS2FirstToken) {
+        oriS2FirstToken = 0;
+        oriS2LastToken = 0;
+        s1GCache.winS2Start = 0;
+        s1GCache.winS2End = 0;
+        s1GCache.winS2TailSize = 0;
+    } else {
+        oriS2FirstToken = Clip(oriS2FirstToken, static_cast<int64_t>(0), static_cast<int64_t>(batchCache.s2Size - 1U));
+        oriS2LastToken = Clip(oriS2LastToken, static_cast<int64_t>(0), static_cast<int64_t>(batchCache.s2Size - 1U));
+        s1GCache.winS2Start = 0;
+        s1GCache.winS2End = (oriS2LastToken - oriS2FirstToken) / s2BaseSize_ + 1U;
+        s1GCache.winS2TailSize = (oriS2LastToken - oriS2FirstToken + 1) % s2BaseSize_;
+    }
+    s1GCache.cmpS2Start = s1GCache.winS2End;
+    uint32_t cmpS2LastTokenSize = hasCmpKv_ ? (oriS2LastToken + 1) / cmpRatio_ : 0;
+    uint32_t actCmpS2LastTokenSize = 0;
+    if (isCFA_) {
+        actCmpS2LastTokenSize = cmpS2LastTokenSize;
+    } else if (isSCFA_) {
+        actCmpS2LastTokenSize = std::min(cmpS2LastTokenSize, static_cast<uint32_t>(cmpTopK_));
+    }
+    s1GCache.cmpS2End = (actCmpS2LastTokenSize == 0)
+                            ? s1GCache.cmpS2Start
+                            : s1GCache.cmpS2Start + (actCmpS2LastTokenSize - 1) / s2BaseSize_ + 1U;
+    s1GCache.cmpS2TailSize = actCmpS2LastTokenSize % s2BaseSize_;
+}
+
+void SparseAttnSharedkvMetadataHost::GatherWinAndCmpCache(S1GCache &s1GCache)
+{
+    s1GCache.s2Start = (s1GCache.winS1GBlock > 0) ? s1GCache.winS2Start : s1GCache.cmpS2Start;
+    if (s1GCache.cmpS1GBlock > 0) {
+        s1GCache.s1GLastBlockCost = s1GCache.cmpS1GLastBlockCost;
+        s1GCache.s2End = s1GCache.cmpS2End;
+    } else {
+        s1GCache.s1GLastBlockCost = s1GCache.winS1GLastBlockCost;
+        s1GCache.s2End = s1GCache.winS2End;
+    }
+    s1GCache.s1GBlock = s1GCache.winS1GBlock + s1GCache.cmpS1GBlock;
+    s1GCache.s1GCost = s1GCache.winS1GCost + s1GCache.cmpS1GCost;
+}
+
+// Exact body of the original CalcS1GCache, using a caller-provided typeCost scratch.
+void SparseAttnSharedkvMetadataHost::ComputeS1GCache(uint32_t s1GIdx, const SplitContext &splitContext,
+                                                     const BatchCache &batchCache, BlockCost<int64_t> &typeCost,
+                                                     S1GCache &out)
+{
+    const SplitInfo &splitInfo = splitContext.splitInfo;
+    if (splitInfo.s1GBaseNum[batchCache.bIdx] == 0) {
+        out.s1GCost = 0;
+        out.s1GLastBlockCost = 0;
+        out.winS1GNormalBlockCost = 0;
+        out.winS1GLastBlockCost = 0;
+        out.cmpS1GNormalBlockCost = 0;
+        out.cmpS1GLastBlockCost = 0;
+        out.s1GBlock = 0;
+        out.s2Start = 0;
+        out.cmpS2Start = 0;
+        out.s2End = 0;
+        return;
+    }
+    out.bIdx = batchCache.bIdx;
+    out.s1GIdx = s1GIdx;
+    auto oriS2TokenRange = CalcS2TokenRange(s1GIdx, batchCache);
+    CalcBlockRangeAndTailSize(oriS2TokenRange, batchCache, out);
+    CalcCostTable(mBaseSize_, s2BaseSize_, splitInfo.s1GTailSize[out.bIdx], out.winS2TailSize, out.cmpS2TailSize,
+                  typeCost);
+    CalcWinS1GCache(out, splitInfo, typeCost);
+    CalcCmpS1GCache(out, splitInfo, typeCost);
+    GatherWinAndCmpCache(out);
+}
+
+void SparseAttnSharedkvMetadataHost::BuildRowCache(const SplitContext &splitContext)
+{
+    const SplitInfo &si = splitContext.splitInfo;
+    rowOffset_.assign(static_cast<size_t>(batchSize_) + 1, 0U);
+    for (int b = 0; b < batchSize_; b++) {
+        rowOffset_[b + 1] = rowOffset_[b] + si.s1GBaseNum[b] + 1U;  // +1 phantom slot per batch
+    }
+    uint32_t total = rowOffset_[batchSize_];
+    rowCache_.assign(total, S1GCache{});
+    batchCacheArr_.assign(batchSize_, BatchCache{});
+    for (int b = 0; b < batchSize_; b++) {
+        CalcBatchCache(static_cast<uint32_t>(b), splitContext, batchCacheArr_[b]);
+    }
+    // slot -> batch lookup (sequential, O(total); cheap vs the per-row compute)
+    std::vector<uint32_t> slotB(total);
+    for (int b = 0; b < batchSize_; b++) {
+        for (uint32_t g = rowOffset_[b]; g < rowOffset_[b + 1]; g++)
+            slotB[g] = static_cast<uint32_t>(b);
+    }
+    cacheReady_ = true;
+    auto worker = [&](int g) {
+        uint32_t b = slotB[g];
+        uint32_t j = static_cast<uint32_t>(g) - rowOffset_[b];
+        BlockCost<int64_t> tc;  // per-iteration scratch -> thread-safe
+        ComputeS1GCache(j, splitContext, batchCacheArr_[b], tc, rowCache_[g]);
+    };
+    if (total >= ROW_PARALLEL_THRESHOLD) {
+        int nt = static_cast<int>(total) / 512;  // >=512 rows/thread to amortize fork/join
+        if (nt < 1) {
+            nt = 1;
+        }
+        if (nt > ROW_PARALLEL_MAX_THREADS) {
+            nt = ROW_PARALLEL_MAX_THREADS;
+        }
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static) num_threads(nt)
+#endif
+        for (int g = 0; g < static_cast<int>(total); g++)
+            worker(g);
+    } else {
+        for (uint32_t g = 0; g < total; g++)
+            worker(static_cast<int>(g));
+    }
+}
+
+const S1GCache &SparseAttnSharedkvMetadataHost::GetS1GCache(uint32_t s1GIdx, const BatchCache &batchCache)
+{
+    uint32_t base = rowCache_.empty() ? 0U : (rowOffset_[batchCache.bIdx + 1] - rowOffset_[batchCache.bIdx] - 1U);
+    uint32_t idx = rowOffset_[batchCache.bIdx] + (s1GIdx < base ? s1GIdx : base);
+    return rowCache_[idx];
+}
+
+void SparseAttnSharedkvMetadataHost::CalcBatchCost(uint32_t bIdx, const SplitContext &splitContext, CostInfo &costInfo)
+{
+    const SplitInfo &splitInfo = splitContext.splitInfo;
+    costInfo.bN2CostOfEachBatch[bIdx] = 0;
+    costInfo.bN2BlockOfEachBatch[bIdx] = 0U;
+    costInfo.bN2LastBlockCostOfEachBatch[bIdx] = 0U;
+    if (GetS1SeqSize(bIdx) == 0U || GetS2SeqSize(bIdx) == 0U) {
+        return;
+    }
+    for (uint32_t s1GIdx = 0; s1GIdx < splitInfo.s1GBaseNum[bIdx]; s1GIdx++) {
+        const S1GCache &r = rowCache_[rowOffset_[bIdx] + s1GIdx];
+        costInfo.bN2CostOfEachBatch[bIdx] += r.s1GCost;
+        costInfo.bN2BlockOfEachBatch[bIdx] += r.s1GBlock;
+        if (r.s1GCost > costInfo.maxS1GCost) {
+            costInfo.maxS1GCost = r.s1GCost;
+        }
+        if (r.s1GBlock > 0) {
+            costInfo.bN2LastBlockCostOfEachBatch[bIdx] = r.s1GLastBlockCost;
+        }
+    }
+}
+
+void SparseAttnSharedkvMetadataHost::CalcCostInfo(SplitContext &splitContext)
+{
+    CostInfo &costInfo = splitContext.costInfo;
+    const SplitInfo &splitInfo = splitContext.splitInfo;
+    if (splitInfo.isKvSeqAllZero) {
+        costInfo.totalCost = 0;
+        costInfo.totalBlockNum = 0U;
+        return;
+    }
+    for (uint32_t bIdx = 0; bIdx < static_cast<uint32_t>(batchSize_); bIdx++) {
+        CalcBatchCost(bIdx, splitContext, costInfo);
+        costInfo.totalCost += costInfo.bN2CostOfEachBatch[bIdx] * kvHeadNum_;
+        costInfo.totalBlockNum += costInfo.bN2BlockOfEachBatch[bIdx] * kvHeadNum_;
+    }
+}
+
+void SparseAttnSharedkvMetadataHost::AssignByBatch(const SplitContext &splitContext, AssignContext &assignContext)
+{
+    if (assignContext.isFinished) {
+        return;
+    }
+    const CostInfo &costInfo = splitContext.costInfo;
+    while (assignContext.bN2Cost == 0 ||
+           IsWithinTolerance(assignContext.coreCache.costLimit,
+                             costInfo.bN2LastBlockCostOfEachBatch[assignContext.curBIdx] / FA_TOLERANCE_RATIO,
+                             assignContext.coreCache.cost + assignContext.bN2Cost)) {
+        assignContext.coreCache.cost += assignContext.bN2Cost;
+        assignContext.coreCache.block += assignContext.bN2Block;
+        assignContext.curBN2Idx++;
+        if (assignContext.curBN2Idx == static_cast<uint32_t>(batchSize_) * kvHeadNum_) {
+            assignContext.curS1GIdx = 0U;
+            assignContext.curS2Idx = 0U;
+            assignContext.isFinished = true;
+            return;
+        }
+        if (assignContext.curBN2Idx / kvHeadNum_ != assignContext.curBIdx) {
+            assignContext.curBIdx = assignContext.curBN2Idx / kvHeadNum_;
+            CalcBatchCache(assignContext.curBIdx, splitContext, assignContext.batchCache);
+        }
+        assignContext.bN2Cost = costInfo.bN2CostOfEachBatch[assignContext.curBIdx];
+        assignContext.bN2Block = costInfo.bN2BlockOfEachBatch[assignContext.curBIdx];
+        assignContext.curS1GIdx = 0U;
+        assignContext.s1GPtr = &GetS1GCache(assignContext.curS1GIdx, assignContext.batchCache);
+        assignContext.curS2Idx = assignContext.s1GPtr->s2Start;
+    }
+}
+
+void SparseAttnSharedkvMetadataHost::AssignByRow(const SplitContext &splitContext, AssignContext &assignContext)
+{
+    if (assignContext.isFinished) {
+        return;
+    }
+    while (IsWithinTolerance(assignContext.coreCache.costLimit,
+                             assignContext.s1GPtr->s1GLastBlockCost / FA_TOLERANCE_RATIO,
+                             assignContext.coreCache.cost + assignContext.s1GPtr->s1GCost)) {
+        assignContext.coreCache.cost += assignContext.s1GPtr->s1GCost;
+        assignContext.coreCache.block += assignContext.s1GPtr->s1GBlock;
+        assignContext.bN2Cost = assignContext.bN2Cost > assignContext.s1GPtr->s1GCost
+                                    ? assignContext.bN2Cost - assignContext.s1GPtr->s1GCost
+                                    : 0;
+        assignContext.bN2Block = assignContext.bN2Block > assignContext.s1GPtr->s1GBlock
+                                     ? assignContext.bN2Block - assignContext.s1GPtr->s1GBlock
+                                     : 0U;
+        do {
+            assignContext.curS1GIdx++;
+            assignContext.s1GPtr = &GetS1GCache(assignContext.curS1GIdx, assignContext.batchCache);
+        } while (assignContext.s1GPtr->s1GBlock == 0);
+        assignContext.curS2Idx = assignContext.s1GPtr->s2Start;
+    }
+}
+
+int64_t SparseAttnSharedkvMetadataHost::CalcCurBlockCost(AssignContext &assignContext)
+{
+    int64_t curCost = 0;
+    if (assignContext.curS2Idx < assignContext.s1GPtr->cmpS2Start) {
+        curCost = assignContext.s1GPtr->winS1GNormalBlockCost;
+        if (assignContext.curS2Idx == (assignContext.s1GPtr->cmpS2Start - 1U)) {
+            curCost = assignContext.s1GPtr->winS1GLastBlockCost;
+        }
+    } else {
+        curCost = assignContext.s1GPtr->cmpS1GNormalBlockCost;
+        if (assignContext.curS2Idx == (assignContext.s1GPtr->s2End - 1U)) {
+            curCost = assignContext.s1GPtr->cmpS1GLastBlockCost;
+        }
+    }
+    return curCost;
+}
+
+void SparseAttnSharedkvMetadataHost::AssignByBlock(const SplitContext &splitContext, AssignContext &assignContext)
+{
+    if (assignContext.isFinished || !supportFd_) {
+        return;
+    }
+    // supportFd path (inert: supportFd_ is always false). Operate on a local mutable copy.
+    S1GCache sc = (assignContext.s1GPtr != nullptr) ? *assignContext.s1GPtr : S1GCache{};
+    int64_t curCost = CalcCurBlockCost(assignContext);
+    while (IsWithinTolerance(assignContext.coreCache.costLimit, curCost / FA_TOLERANCE_RATIO,
+                             assignContext.coreCache.cost + curCost)) {
+        assignContext.coreCache.cost += curCost;
+        assignContext.coreCache.block++;
+        assignContext.curS2Idx++;
+        assignContext.bN2Cost = assignContext.bN2Cost - curCost;
+        sc.s1GCost = sc.s1GCost - curCost;
+        assignContext.bN2Block--;
+        sc.s1GBlock--;
+        curCost = CalcCurBlockCost(assignContext);
+    }
+    (void)sc;
+}
+
+bool SparseAttnSharedkvMetadataHost::IsNeedRecordFDInfo(const AssignContext &assignContext, const SplitResult &splitRes)
+{
+    if (assignContext.curCoreIdx == 0U) {
+        return false;
+    }
+    if (assignContext.curKvSplitPart <= 1U) {
+        return false;
+    }
+    if (assignContext.curBN2Idx == splitRes.bN2End[assignContext.curCoreIdx - 1U] &&
+        assignContext.curS1GIdx == splitRes.gS1End[assignContext.curCoreIdx - 1U]) {
+        return false;
+    }
+    return true;
+}
+
+void SparseAttnSharedkvMetadataHost::RecordFDInfo(const SplitContext &splitContext, const AssignContext &assignContext,
+                                                  SplitResult &result)
+{
+    const SplitInfo &splitInfo = splitContext.splitInfo;
+    uint32_t splitBIdx = result.bN2End[assignContext.curCoreIdx - 1U] / kvHeadNum_;
+    uint32_t splitS1GIdx = result.gS1End[assignContext.curCoreIdx - 1U];
+    uint32_t s1Size = GetS1SeqSize(splitBIdx);
+    uint32_t curFdS1gSize = (splitS1GIdx == splitInfo.s1GBaseNum[splitBIdx] - 1U)
+                                ? (s1Size * groupSize_ - splitS1GIdx * mBaseSize_)
+                                : mBaseSize_;
+    result.maxS2SplitNum = std::max(result.maxS2SplitNum, assignContext.curKvSplitPart);
+    result.fdRes.fdBN2Idx[result.numOfFdHead] = result.bN2End[assignContext.curCoreIdx - 1U];
+    result.fdRes.fdMIdx[result.numOfFdHead] = result.gS1End[assignContext.curCoreIdx - 1U];
+    result.fdRes.fdWorkspaceIdx[result.numOfFdHead] = assignContext.curFdDataNum - assignContext.curKvSplitPart;
+    result.fdRes.fdS2SplitNum[result.numOfFdHead] = assignContext.curKvSplitPart;
+    result.fdRes.fdMSize[result.numOfFdHead] = curFdS1gSize;
+    result.numOfFdHead++;
+}
+
+void SparseAttnSharedkvMetadataHost::UpdateCursor(const SplitContext &splitContext, AssignContext &assignContext)
+{
+    const SplitInfo &splitInfo = splitContext.splitInfo;
+    const CostInfo &costInfo = splitContext.costInfo;
+    bool UpdateS1G = false;
+    bool UpdateBatch = false;
+    if (assignContext.curS2Idx >= assignContext.s1GPtr->s2End) {
+        assignContext.curS2Idx = 0U;
+        assignContext.curS1GIdx++;
+        UpdateS1G = true;
+    }
+    if (assignContext.curS1GIdx >= splitInfo.s1GBaseNum[assignContext.curBIdx]) {
+        assignContext.curS1GIdx = 0U;
+        assignContext.curBN2Idx++;
+    }
+    if (assignContext.curBN2Idx == static_cast<uint32_t>(batchSize_) * kvHeadNum_) {
+        assignContext.curS1GIdx = 0U;
+        assignContext.curS2Idx = 0U;
+        assignContext.isFinished = true;
+        return;
+    }
+    if (assignContext.curBN2Idx / kvHeadNum_ != assignContext.curBIdx) {
+        assignContext.curBIdx = assignContext.curBN2Idx / kvHeadNum_;
+        assignContext.curS1GIdx = 0U;
+        UpdateBatch = true;
+        UpdateS1G = true;
+    }
+    if (UpdateBatch) {
+        CalcBatchCache(assignContext.curBIdx, splitContext, assignContext.batchCache);
+        assignContext.bN2Cost = costInfo.bN2CostOfEachBatch[assignContext.curBIdx];
+        assignContext.bN2Block = costInfo.bN2BlockOfEachBatch[assignContext.curBIdx];
+    }
+    if (UpdateS1G) {
+        assignContext.s1GPtr = &GetS1GCache(assignContext.curS1GIdx, assignContext.batchCache);
+        assignContext.curS2Idx = (supportFd_) ? assignContext.s1GPtr->winS2Start : 0;
+    }
+}
+
+void SparseAttnSharedkvMetadataHost::ForceAssign(const SplitContext &splitContext, AssignContext &assignContext)
+{
+    if (assignContext.isFinished) {
+        return;
+    }
+    int64_t curCost = CalcCurBlockCost(assignContext);
+    assignContext.coreCache.cost += curCost;
+    assignContext.coreCache.block++;
+    assignContext.curS2Idx++;
+    assignContext.bN2Cost = assignContext.bN2Cost - curCost;
+    assignContext.bN2Block--;
+    if (assignContext.s1GPtr != nullptr) {
+        S1GCache sc = *assignContext.s1GPtr;
+        sc.s1GCost = sc.s1GCost - curCost;
+        sc.s1GBlock--;
+        (void)sc;
+    }
+    UpdateCursor(splitContext, assignContext);
+}
+
+void SparseAttnSharedkvMetadataHost::AssignBlocksToCore(const SplitContext &splitContext, AssignContext &assignContext,
+                                                        SplitResult &result)
+{
+    const CostInfo &costInfo = splitContext.costInfo;
+    int64_t avgCost = assignContext.unassignedCost / (aicCoreNum_ - assignContext.curCoreIdx);
+    assignContext.coreCache = {};
+    if (!supportFd_) {
+        assignContext.coreCache.costLimit = std::max(avgCost, costInfo.maxS1GCost);
+    } else {
+        assignContext.coreCache.costLimit = avgCost;
+    }
+    AssignByBatch(splitContext, assignContext);
+    AssignByRow(splitContext, assignContext);
+    AssignByBlock(splitContext, assignContext);
+    if (assignContext.coreCache.block == 0 && supportFd_) {
+        ForceAssign(splitContext, assignContext);
+    }
+    result.bN2End[assignContext.curCoreIdx] = assignContext.curBN2Idx;
+    result.gS1End[assignContext.curCoreIdx] = assignContext.curS1GIdx;
+    result.s2End[assignContext.curCoreIdx] = assignContext.curS2Idx;
+    result.maxCost = std::max(result.maxCost, assignContext.coreCache.cost);
+    assignContext.unassignedCost -= assignContext.coreCache.cost;
+    if (IsNeedRecordFDInfo(assignContext, result)) {
+        RecordFDInfo(splitContext, assignContext, result);
+        assignContext.curKvSplitPart = 1U;
+    }
+    if (assignContext.curS2Idx > assignContext.s1GPtr->s2Start &&
+        assignContext.curS2Idx <= assignContext.s1GPtr->s2End) {
+        assignContext.curKvSplitPart++;
+    }
+}
+
+void SparseAttnSharedkvMetadataHost::CalcSplitPlan(int64_t costLimit, const SplitContext &splitContext,
+                                                   SplitResult &result)
+{
+    const CostInfo &costInfo = splitContext.costInfo;
+    if (aicCoreNum_ == 0U) {
+        return;
+    }
+    result.maxCost = 0U;
+    result.usedCoreNum = 0U;
+    AssignContext assignContext{};
+    assignContext.curBIdx = 0U;
+    assignContext.curS1GIdx = 0U;
+    assignContext.unassignedCost = costInfo.totalCost;
+    assignContext.bN2Cost = costInfo.bN2CostOfEachBatch[assignContext.curBIdx];
+    assignContext.bN2Block = costInfo.bN2BlockOfEachBatch[assignContext.curBIdx];
+    CalcBatchCache(assignContext.curBIdx, splitContext, assignContext.batchCache);
+    assignContext.s1GPtr = &GetS1GCache(assignContext.curS1GIdx, assignContext.batchCache);
+    assignContext.curS2Idx = assignContext.s1GPtr->s2Start;
+    for (uint32_t i = 0; i < aicCoreNum_; ++i) {
+        if (result.maxCost > costLimit) {
+            return;
+        }
+        if (assignContext.isFinished || assignContext.unassignedCost <= 0) {
+            break;
+        }
+        assignContext.curCoreIdx = i;
+        AssignBlocksToCore(splitContext, assignContext, result);
+    }
+    result.usedCoreNum = assignContext.curCoreIdx + 1;
+}
+
+void SparseAttnSharedkvMetadataHost::SplitFD(SplitResult &splitRes)
+{
+    uint64_t totalFDLoad = 0;
+    for (uint32_t i = 0; i < splitRes.numOfFdHead; i++) {
+        totalFDLoad += splitRes.fdRes.fdS2SplitNum[i] * splitRes.fdRes.fdMSize[i];
+    }
+    uint64_t averageLoad = totalFDLoad / aivCoreNum_;
+    uint32_t curCoreIndex = 0;
+    for (uint32_t i = 0; i < splitRes.numOfFdHead; i++) {
+        uint32_t curFDVectorNum = splitRes.fdRes.fdS2SplitNum[i] * splitRes.fdRes.fdMSize[i] / averageLoad;
+        uint32_t curAveMSize = splitRes.fdRes.fdMSize[i] / curFDVectorNum;
+        for (uint32_t vid = 0; vid < curFDVectorNum; vid++) {
+            splitRes.fdRes.fdIdx[curCoreIndex] = i;
+            splitRes.fdRes.fdMStart[curCoreIndex] = vid * curAveMSize;
+            splitRes.fdRes.fdMNum[curCoreIndex] =
+                (vid < curFDVectorNum - 1) ? curAveMSize : (splitRes.fdRes.fdMSize[i] - vid * curAveMSize);
+            curCoreIndex++;
+        }
+    }
+    splitRes.fdRes.fdUsedVecNum = curCoreIndex;
+}
+
+bool SparseAttnSharedkvMetadataHost::BalanceSchedule(SplitResult &splitRes)
+{
+    SplitContext splitContext(static_cast<uint32_t>(batchSize_));
+    CalcSplitInfo(splitContext);
+    if (splitContext.splitInfo.isKvSeqAllZero) {
+        splitRes.usedCoreNum = 1U;
+        splitRes.bN2End[0] = static_cast<uint32_t>(batchSize_) * kvHeadNum_;
+        splitRes.gS1End[0] = 0U;
+        splitRes.s2End[0] = 0U;
+        return true;
+    }
+    BuildRowCache(splitContext);  // compute every row once (parallel), then read by-ref
+    CalcCostInfo(splitContext);
+    splitRes.maxCost = INT64_MAX;
+    splitRes.usedCoreNum = 1U;
+    CalcSplitPlan(splitRes.maxCost, splitContext, splitRes);
+    if (splitRes.numOfFdHead > 0U) {
+        SplitFD(splitRes);
+    }
+    splitRes.usedCoreNum = std::max(splitRes.usedCoreNum, 1U);
+    return true;
+}
+
+bool SparseAttnSharedkvMetadataHost::GenMetaData(SplitResult &splitRes)
+{
+    optiling::detail::SasMetaData *metaDataPtr = reinterpret_cast<optiling::detail::SasMetaData *>(metaData_);
+    for (size_t i = 0; i < aicCoreNum_; ++i) {
+        if (i >= splitRes.usedCoreNum) {
+            metaDataPtr->faMetadata[i][optiling::FA_CORE_ENABLE_INDEX] = 0;
+            continue;
+        }
+        metaDataPtr->faMetadata[i][optiling::FA_CORE_ENABLE_INDEX] = 1;
+        metaDataPtr->faMetadata[i][optiling::FA_BN2_START_INDEX] = (i == 0) ? 0 : splitRes.bN2End[i - 1];
+        metaDataPtr->faMetadata[i][optiling::FA_M_START_INDEX] = (i == 0) ? 0 : splitRes.gS1End[i - 1];
+        metaDataPtr->faMetadata[i][optiling::FA_S2_START_INDEX] = (i == 0) ? 0 : splitRes.s2End[i - 1];
+        metaDataPtr->faMetadata[i][optiling::FA_BN2_END_INDEX] = splitRes.bN2End[i];
+        metaDataPtr->faMetadata[i][optiling::FA_M_END_INDEX] = splitRes.gS1End[i];
+        metaDataPtr->faMetadata[i][optiling::FA_S2_END_INDEX] = splitRes.s2End[i];
+        metaDataPtr->faMetadata[i][optiling::FA_FIRST_FD_DATA_WORKSPACE_IDX_INDEX] =
+            splitRes.firstFdDataWorkspaceIdx[i];
+    }
+    for (size_t i = 0; i < aivCoreNum_; ++i) {
+        if (i >= splitRes.fdRes.fdUsedVecNum) {
+            metaDataPtr->fdMetadata[i][optiling::FD_CORE_ENABLE_INDEX] = 0;
+            continue;
+        }
+        metaDataPtr->fdMetadata[i][optiling::FD_CORE_ENABLE_INDEX] = 1;
+        uint32_t curFdIdx = splitRes.fdRes.fdIdx[i];
+        metaDataPtr->fdMetadata[i][optiling::FD_BN2_IDX_INDEX] = splitRes.fdRes.fdBN2Idx[curFdIdx];
+        metaDataPtr->fdMetadata[i][optiling::FD_M_IDX_INDEX] = splitRes.fdRes.fdMIdx[curFdIdx];
+        metaDataPtr->fdMetadata[i][optiling::FD_WORKSPACE_IDX_INDEX] = splitRes.fdRes.fdWorkspaceIdx[curFdIdx];
+        metaDataPtr->fdMetadata[i][optiling::FD_WORKSPACE_NUM_INDEX] = splitRes.fdRes.fdS2SplitNum[curFdIdx];
+        metaDataPtr->fdMetadata[i][optiling::FD_M_START_INDEX] = splitRes.fdRes.fdMStart[i];
+        metaDataPtr->fdMetadata[i][optiling::FD_M_NUM_INDEX] = splitRes.fdRes.fdMNum[i];
+    }
+    return true;
+}
+
+// ---- at::Tensor entry point -------------------------------------------------
+at::Tensor sparse_attn_sharedkv_metadata_host(
+    int64_t num_heads_q, int64_t num_heads_kv, int64_t head_dim, int64_t aic_core_num, int64_t aiv_core_num,
+    const std::string &soc_version, const std::string &layout_q, const std::string &layout_kv,
+    const c10::optional<at::Tensor> &cu_seqlens_q, const c10::optional<at::Tensor> &seqused_kv, int64_t batch_size,
+    int64_t cmp_topk, int64_t cmp_ratio, int64_t ori_mask_mode, int64_t cmp_mask_mode, int64_t ori_win_left,
+    int64_t ori_win_right, bool has_ori_kv, bool has_cmp_kv)
+{
+    auto opts = at::TensorOptions().dtype(at::kInt).device(at::kCPU);
+    at::Tensor metaDataHost = at::zeros({static_cast<int64_t>(optiling::SAS_META_SIZE)}, opts);
+
+    const int32_t *cuQPtr = nullptr;
+    if (cu_seqlens_q.has_value()) {
+        const at::Tensor &t = *cu_seqlens_q;
+        TORCH_CHECK(t.scalar_type() == at::kInt, "cu_seqlens_q must be int32");
+        TORCH_CHECK(t.device().is_cpu(), "cu_seqlens_q must be a CPU tensor (host metadata path)");
+        cuQPtr = static_cast<const int32_t *>(t.const_data_ptr());
+    }
+    const int32_t *seqKvPtr = nullptr;
+    if (seqused_kv.has_value()) {
+        const at::Tensor &t = *seqused_kv;
+        TORCH_CHECK(t.scalar_type() == at::kInt, "seqused_kv must be int32");
+        TORCH_CHECK(t.device().is_cpu(), "seqused_kv must be a CPU tensor (host metadata path)");
+        seqKvPtr = static_cast<const int32_t *>(t.const_data_ptr());
+    }
+
+    SparseAttnSharedkvMetadataHost scheduler;
+    bool ok = scheduler.Run(
+        cuQPtr, seqKvPtr, static_cast<int32_t>(batch_size), static_cast<int32_t>(num_heads_q),
+        static_cast<int32_t>(num_heads_kv), static_cast<int32_t>(head_dim), static_cast<uint32_t>(aic_core_num),
+        static_cast<uint32_t>(aiv_core_num), soc_version, static_cast<int32_t>(cmp_topk),
+        static_cast<int32_t>(cmp_ratio), static_cast<int32_t>(ori_mask_mode), static_cast<int32_t>(cmp_mask_mode),
+        ori_win_left, ori_win_right, layout_q, layout_kv, has_ori_kv, has_cmp_kv, metaDataHost.data_ptr<int32_t>());
+    TORCH_CHECK(ok, "sparse_attn_sharedkv_metadata_host: scheduling failed (invalid params)");
+    // H2D the result so the op is functionally equivalent to the AICPU version, which
+    // writes device memory directly. Inputs stay on the host (no D2H: sglang already has
+    // the seq-lens on CPU). The 4 KB H2D is the only device traffic on this path.
+    return metaDataHost.to(at::Device("npu"));
+}
+
+}  // namespace sgl_kernel_npu

--- a/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.h
+++ b/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.h
@@ -1,4 +1,21 @@
-// Host-side (CPU) implementation of the npu_sparse_attn_sharedkv_metadata scheduler.
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. See LICENSE in the root of
+ * the software repository for the full text of the License.
+ *
+ * Reimplemented on the host CPU with reference to the vllm-ascend AICPU op
+ * `SparseAttnSharedkvMetadata` (csrc/attention/sparse_attn_sharedkv_metadata).
+ */
+
+/*!
+ * \file sparse_attn_sharedkv_metadata.h
+ * \brief Host-side (CPU) implementation of the npu_sparse_attn_sharedkv_metadata scheduler.
+ */
 
 #ifndef SPARSE_ATTN_SHAREDKV_METADATA_HOST_H
 #define SPARSE_ATTN_SHAREDKV_METADATA_HOST_H

--- a/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.h
+++ b/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.h
@@ -336,16 +336,6 @@ private:
     bool cacheReady_{false};
 };
 
-// Build the sparse-attention core-distribution table on the host CPU; the result is
-// returned as a device int32[1024] tensor.
-at::Tensor sparse_attn_sharedkv_metadata_host(int64_t num_heads_q, int64_t num_heads_kv, int64_t head_dim,
-                                              const std::string &layout_q, const std::string &layout_kv,
-                                              const c10::optional<at::Tensor> &cu_seqlens_q,
-                                              const c10::optional<at::Tensor> &seqused_kv, int64_t batch_size,
-                                              int64_t cmp_topk, int64_t cmp_ratio, int64_t ori_mask_mode,
-                                              int64_t cmp_mask_mode, int64_t ori_win_left, int64_t ori_win_right,
-                                              bool has_ori_kv, bool has_cmp_kv);
-
 }  // namespace sgl_kernel_npu
 
 #endif  // SPARSE_ATTN_SHAREDKV_METADATA_HOST_H

--- a/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.h
+++ b/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.h
@@ -1,0 +1,367 @@
+// Host-side reimplementation of the AICPU load-balancer
+// `SparseAttnSharedkvMetadata[Dspark]` (a.k.a. npu_sparse_attn_sharedkv_metadata).
+//
+// The scheduler is pure integer logic (tiling -> cost model -> greedy core assignment),
+// so it is rehosted on the server CPU to drop the CANN AICPU/dspark build dependency.
+// Output is byte-identical to the AICPU op. See README.md for usage and performance.
+
+#ifndef SPARSE_ATTN_SHAREDKV_METADATA_HOST_H
+#define SPARSE_ATTN_SHAREDKV_METADATA_HOST_H
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <ATen/ATen.h>
+
+// Fixed output buffer layout. The consumer AICore kernel indexes the flat int32[1024]
+// buffer with these exact strides (GetAttrAbsIndex), so they must not change.
+namespace optiling {
+constexpr uint32_t AIC_CORE_NUM = 36;  // FA (cube-core) slot capacity
+constexpr uint32_t AIV_CORE_NUM = 72;  // FD (vector-core) slot capacity
+constexpr uint32_t SAS_META_SIZE = 1024;
+using SAS_METADATA_T = int32_t;
+
+constexpr uint32_t FA_METADATA_SIZE = 8;
+constexpr uint32_t FD_METADATA_SIZE = 8;
+
+// FA (Flash-Attention / cube side): 8 ints per AIC core.
+constexpr uint32_t FA_CORE_ENABLE_INDEX = 0;
+constexpr uint32_t FA_BN2_START_INDEX = 1;
+constexpr uint32_t FA_M_START_INDEX = 2;
+constexpr uint32_t FA_S2_START_INDEX = 3;
+constexpr uint32_t FA_BN2_END_INDEX = 4;
+constexpr uint32_t FA_M_END_INDEX = 5;
+constexpr uint32_t FA_S2_END_INDEX = 6;
+constexpr uint32_t FA_FIRST_FD_DATA_WORKSPACE_IDX_INDEX = 7;
+
+// FD (Flash-Decode / vector reduction side): 7 used ints per AIV core.
+constexpr uint32_t FD_CORE_ENABLE_INDEX = 0;
+constexpr uint32_t FD_BN2_IDX_INDEX = 1;
+constexpr uint32_t FD_M_IDX_INDEX = 2;
+constexpr uint32_t FD_WORKSPACE_IDX_INDEX = 3;
+constexpr uint32_t FD_WORKSPACE_NUM_INDEX = 4;
+constexpr uint32_t FD_M_START_INDEX = 5;
+constexpr uint32_t FD_M_NUM_INDEX = 6;
+
+namespace detail {
+struct SasMetaData {
+    uint32_t faMetadata[AIC_CORE_NUM][FA_METADATA_SIZE];
+    uint32_t fdMetadata[AIV_CORE_NUM][FD_METADATA_SIZE];
+};
+}  // namespace detail
+static_assert(SAS_META_SIZE * sizeof(SAS_METADATA_T) >= sizeof(detail::SasMetaData),
+              "metadata buffer must hold the full SasMetaData layout");
+}  // namespace optiling
+
+namespace sgl_kernel_npu {
+
+constexpr int64_t FA_TOLERANCE_RATIO = 2;
+
+enum BlockType : uint32_t { WIN_NORMAL_BLOCK = 0, WIN_TAIL_BLOCK, CMP_NORMAL_BLOCK, CMP_TAIL_BLOCK, BLOCK_MAX_TYPE };
+
+enum class SparseMode : uint8_t {
+    DEFAULT_MASK = 0,
+    ALL_MASK,
+    LEFT_UP_CAUSAL,
+    RIGHT_DOWN_CAUSAL,
+    BAND,
+    SPARSE_BUTT,
+};
+
+enum class ValidSocVersion { ASCEND910 = 0, ASCEND950, RESERVED_VERSION = 99999 };
+
+template <class T>
+using Range = std::pair<T, T>;
+
+template <class T>
+using BlockCost = std::array<std::array<T, static_cast<size_t>(BLOCK_MAX_TYPE)>, static_cast<size_t>(BLOCK_MAX_TYPE)>;
+
+template <typename T>
+T Clip(T value, T minValue, T maxValue)
+{
+    if (value < minValue) {
+        return minValue;
+    }
+    if (value > maxValue) {
+        return maxValue;
+    }
+    return value;
+}
+
+template <typename T>
+inline bool IsWithinTolerance(T limit, T tolerance, T value)
+{
+    return limit + tolerance >= value;
+}
+
+// FD (FlashDecode) reduction info: indices of cross-core partial results and their
+// per-vector split.
+struct FlashDecodeResult {
+    uint32_t fdUsedVecNum{0U};
+    std::vector<uint32_t> fdBN2Idx{};
+    std::vector<uint32_t> fdMIdx{};
+    std::vector<uint32_t> fdWorkspaceIdx{};
+    std::vector<uint32_t> fdS2SplitNum{};
+    std::vector<uint32_t> fdMSize{};
+    std::vector<uint32_t> fdIdx{};
+    std::vector<uint32_t> fdMStart{};
+    std::vector<uint32_t> fdMNum{};
+
+    FlashDecodeResult(uint32_t aicNum, uint32_t aivNum)
+        : fdBN2Idx(aicNum),
+          fdMIdx(aicNum),
+          fdWorkspaceIdx(aicNum),
+          fdS2SplitNum(aicNum),
+          fdMSize(aicNum),
+          fdIdx(aivNum),
+          fdMStart(aivNum),
+          fdMNum(aivNum)
+    {}
+};
+
+// FA (Flash-Attention) per-cube-core split endpoints.
+struct SplitResult {
+    uint32_t usedCoreNum{0U};
+    std::vector<uint32_t> bN2End{};
+    std::vector<uint32_t> gS1End{};
+    std::vector<uint32_t> s2End{};
+    std::vector<uint32_t> firstFdDataWorkspaceIdx{};
+    int64_t maxCost{0};
+    uint32_t numOfFdHead{0U};
+    uint32_t maxS2SplitNum{0U};
+    FlashDecodeResult fdRes{0U, 0U};
+
+    SplitResult(uint32_t aicNum, uint32_t aivNum)
+        : bN2End(aicNum), gS1End(aicNum), s2End(aicNum), firstFdDataWorkspaceIdx(aicNum), fdRes(aicNum, aivNum)
+    {}
+};
+
+// Per-batch base-block tiling info.
+struct SplitInfo {
+    std::vector<uint32_t> s1GBaseNum{};
+    std::vector<uint32_t> s2BaseNum{};
+    std::vector<uint32_t> s1GTailSize{};
+    std::vector<uint32_t> s2TailSize{};
+    bool isKvSeqAllZero{true};
+
+    explicit SplitInfo(uint32_t batchSize)
+        : s1GBaseNum(batchSize), s2BaseNum(batchSize), s1GTailSize(batchSize), s2TailSize(batchSize)
+    {}
+};
+
+struct CostInfo {
+    std::vector<int64_t> bN2CostOfEachBatch{};
+    std::vector<uint32_t> bN2BlockOfEachBatch{};
+    std::vector<int64_t> bN2LastBlockCostOfEachBatch{};
+    uint32_t totalBlockNum{0U};
+    int64_t totalCost{0};
+    int64_t maxS1GCost{0};
+
+    explicit CostInfo(uint32_t batchSize)
+        : bN2CostOfEachBatch(batchSize), bN2BlockOfEachBatch(batchSize), bN2LastBlockCostOfEachBatch(batchSize)
+    {}
+};
+
+struct SplitContext {
+    SplitInfo splitInfo{0U};
+    CostInfo costInfo{0U};
+
+    explicit SplitContext(uint32_t batchSize) : splitInfo(batchSize), costInfo(batchSize) {}
+};
+
+// Per-batch constants derived from seq lens and mask mode.
+struct BatchCache {
+    uint32_t bIdx{0U};
+    uint32_t s1Size{0U};
+    uint32_t s2Size{0U};
+    int64_t preTokenLeftUp{0};
+    int64_t nextTokenLeftUp{0};
+};
+
+// Per-S1G-row (M-axis block) computed cost / range state. Cached once, read by reference.
+struct S1GCache {
+    uint32_t bIdx{0U};
+    uint32_t s1GIdx{0U};
+    uint32_t s2Start{0U};
+    uint32_t s2End{0U};
+    uint32_t winS2Start{0U};
+    uint32_t winS2End{0U};
+    uint32_t cmpS2Start{0U};
+    uint32_t cmpS2End{0U};
+    int64_t s1GCost{0};
+    int64_t s1GLastBlockCost{0};
+    uint32_t s1GBlock{0U};
+    int64_t s1GNormalBlockCost{0};
+    uint32_t winS1GBlock{0U};
+    int64_t winS1GCost{0};
+    int64_t winS1GLastBlockCost{0};
+    int64_t winS1GNormalBlockCost{0};
+    uint32_t cmpS1GBlock{0U};
+    int64_t cmpS1GCost{0};
+    int64_t cmpS1GLastBlockCost{0};
+    int64_t cmpS1GNormalBlockCost{0};
+    int64_t cmpS2TailSize{0};
+    int64_t winS2TailSize{0};
+};
+
+struct CoreCache {
+    int64_t costLimit{0};
+    int64_t cost{0};
+    uint32_t block{0U};
+};
+
+// Walk state for the greedy core-assignment pass.
+struct AssignContext {
+    uint32_t curBIdx{0U};
+    uint32_t curBN2Idx{0U};
+    uint32_t curS1GIdx{0U};
+    uint32_t curS2Idx{0U};
+    uint32_t curCoreIdx{0U};
+    int64_t unassignedCost{0};
+    uint32_t usedCoreNum{0U};
+    uint32_t curKvSplitPart{1U};
+    uint32_t curFdDataNum{1U};
+
+    int64_t bN2Cost{0};
+    uint32_t bN2Block{0U};
+    bool isFinished{false};
+    BatchCache batchCache{};
+    const S1GCache *s1GPtr{nullptr};  // points into rowCache_ (stable, no copy)
+    CoreCache coreCache{};
+};
+
+// Pure-host core-distribution scheduler. Inputs are CPU int32 arrays; output is written
+// into the caller-provided int32[1024] buffer (zero-initialized).
+class SparseAttnSharedkvMetadataHost
+{
+public:
+    SparseAttnSharedkvMetadataHost() = default;
+    ~SparseAttnSharedkvMetadataHost() = default;
+
+    bool Run(const int32_t *cuSeqLenQ,  // cu_seqlens_q (len B+1); required for layout_q TND
+             const int32_t *seqUsedKv,  // seqused_kv  (len B);  required for layout_kv PA_ND
+             int32_t batchSize, int32_t queryHeadNum, int32_t kvHeadNum, int32_t headDim, uint32_t aicCoreNum,
+             uint32_t aivCoreNum, const std::string &socVersion, int32_t cmpTopK, int32_t cmpRatio, int32_t oriMaskMode,
+             int32_t cmpMaskMode, int64_t winLeft, int64_t winRight, const std::string &layoutQuery,
+             const std::string &layoutKv, bool hasOriKv, bool hasCmpKv, int32_t *metaData);
+
+private:
+    bool ParamsInit();
+    ValidSocVersion ProcessSocVersion();
+    bool BalanceSchedule(SplitResult &splitRes);
+    bool GenMetaData(SplitResult &splitRes);
+
+    uint32_t GetS1SeqSize(uint32_t bIdx);
+    uint32_t GetS2SeqSize(uint32_t bIdx);
+    int64_t CalcPreTokenLeftUp(uint32_t s1Size, uint32_t s2Size);
+    int64_t CalcNextTokenLeftUp(uint32_t s1Size, uint32_t s2Size);
+    Range<int64_t> CalcS2TokenRange(uint32_t s1GIdx, const BatchCache &batchCache);
+    int64_t WinCalcCost(uint32_t basicM, uint32_t basicS2);
+    int64_t CmpCalcCost(uint32_t basicM, uint32_t basicS2);
+    void CalcCostTable(uint32_t s1NormalSize, uint32_t s2NormalSize, uint32_t s1GTailSize, uint32_t winS2TailSize,
+                       uint32_t cmpS2TailSize, BlockCost<int64_t> &typeCost);
+
+    void CalcBatchCache(uint32_t bIdx, const SplitContext &splitContext, BatchCache &batchCache);
+    void CalcBlockRangeAndTailSize(Range<int64_t> &oriS2TokenRange, const BatchCache &batchCache, S1GCache &s1GCache);
+    void CalcWinS1GCache(S1GCache &s1GCache, const SplitInfo &splitInfo, const BlockCost<int64_t> &typeCost);
+    void CalcCmpS1GCache(S1GCache &s1GCache, const SplitInfo &splitInfo, const BlockCost<int64_t> &typeCost);
+    void GatherWinAndCmpCache(S1GCache &s1GCache);
+    // Compute one row's S1GCache into `out` with a caller-provided typeCost scratch
+    // (thread-safe: reads only members, writes only `out`/`typeCost`).
+    void ComputeS1GCache(uint32_t s1GIdx, const SplitContext &splitContext, const BatchCache &batchCache,
+                         BlockCost<int64_t> &typeCost, S1GCache &out);
+    // Build rowCache_ for every (batch, s1GIdx) plus one boundary phantom per batch
+    // (matches the original on-demand compute for s1GIdx == s1GBaseNum). Parallelized.
+    void BuildRowCache(const SplitContext &splitContext);
+    // O(1) cache lookup returning a stable const ref (clamps s1GIdx to [0, s1GBaseNum]).
+    const S1GCache &GetS1GCache(uint32_t s1GIdx, const BatchCache &batchCache);
+
+    void CalcSplitInfo(SplitContext &splitContext);
+    void CalcBatchCost(uint32_t bIdx, const SplitContext &splitContext, CostInfo &costInfo);
+    void CalcCostInfo(SplitContext &splitContext);
+
+    void UpdateCursor(const SplitContext &splitContext, AssignContext &assignContext);
+    void AssignByBatch(const SplitContext &splitContext, AssignContext &assignContext);
+    void AssignByRow(const SplitContext &splitContext, AssignContext &assignContext);
+    int64_t CalcCurBlockCost(AssignContext &assignContext);
+    void AssignByBlock(const SplitContext &splitContext, AssignContext &assignContext);
+    void ForceAssign(const SplitContext &splitContext, AssignContext &assignContext);
+    void AssignBlocksToCore(const SplitContext &splitContext, AssignContext &assignContext, SplitResult &result);
+
+    bool IsNeedRecordFDInfo(const AssignContext &assignContext, const SplitResult &splitRes);
+    void RecordFDInfo(const SplitContext &splitContext, const AssignContext &assignContext, SplitResult &result);
+
+    void SplitFD(SplitResult &splitRes);
+    void CalcSplitPlan(int64_t costLimit, const SplitContext &splitContext, SplitResult &result);
+
+    // Inputs (raw CPU pointers; null when the optional tensor was not provided).
+    const int32_t *actSeqLenQ_{nullptr};
+    const int32_t *seqUsedKv_{nullptr};
+
+    int32_t *metaData_{nullptr};  // output
+
+    // Attributes.
+    int32_t batchSize_{0};
+    int32_t queryHeadNum_{0};
+    int32_t kvHeadNum_{0};
+    int32_t headDim_{0};
+    int32_t cmpTopK_{0};
+    int32_t cmpRatio_{-1};
+    int32_t oriMaskMode_{4};
+    int32_t cmpMaskMode_{3};
+    int64_t winLeft_{127};
+    int64_t winRight_{0};
+    std::string layoutQuery_{"BSND"};
+    std::string layoutKv_{"PA_ND"};
+    bool hasOriKv_{true};
+    bool hasCmpKv_{true};
+    uint32_t aicCoreNum_{24U};
+    uint32_t aivCoreNum_{48U};
+
+    std::string socVersion_{"ascend910B"};
+    int64_t preToken_{0};
+    int64_t nextToken_{0};
+    uint32_t groupSize_{0};
+    uint32_t mBaseSize_{0};
+    uint32_t s2BaseSize_{0};
+    bool isS1G_{true};
+    bool isCFA_{false};
+    bool isSCFA_{false};
+    bool supportFd_{false};  // inert (upstream AICPU build never enables it)
+    uint32_t attentionMode_{1};
+
+    // Per-row cache: filled once in BuildRowCache (parallel), then read by const-ref by
+    // the cost-model and assignment passes (no recompute, no copy).
+    std::vector<S1GCache> rowCache_;         // total = sum_b (s1GBaseNum[b] + 1)
+    std::vector<uint32_t> rowOffset_;        // rowOffset_[b] = first slot of batch b
+    std::vector<BatchCache> batchCacheArr_;  // per-batch BatchCache (read-only in parallel)
+    bool cacheReady_{false};
+};
+
+/**
+ * @brief Compute the sparse-attention shared-KV core-distribution metadata on the host CPU.
+ *
+ * A drop-in host replacement for `npu_sparse_attn_sharedkv_metadata` (AICPU): turns the
+ * seq-lens and attention config into a fixed int32[1024] schedule consumed by the
+ * `npu_sparse_attn_sharedkv` AICore kernel. Inputs are CPU int32 tensors; the result is a
+ * device (NPU) int32[1024] tensor — the op performs the 4 KB H2D internally, so it is
+ * functionally equivalent to the AICPU op (which writes device memory directly). No input
+ * D2H is needed: sglang already keeps the seq-lens on the host.
+ *
+ * @param aic_core_num/aiv_core_num/soc_version target topology (e.g. from
+ *        `torch.npu.get_device_properties(0)`); only the Ascend950 vs other branch matters.
+ */
+at::Tensor sparse_attn_sharedkv_metadata_host(
+    int64_t num_heads_q, int64_t num_heads_kv, int64_t head_dim, int64_t aic_core_num, int64_t aiv_core_num,
+    const std::string &soc_version, const std::string &layout_q, const std::string &layout_kv,
+    const c10::optional<at::Tensor> &cu_seqlens_q, const c10::optional<at::Tensor> &seqused_kv, int64_t batch_size,
+    int64_t cmp_topk, int64_t cmp_ratio, int64_t ori_mask_mode, int64_t cmp_mask_mode, int64_t ori_win_left,
+    int64_t ori_win_right, bool has_ori_kv, bool has_cmp_kv);
+
+}  // namespace sgl_kernel_npu
+
+#endif  // SPARSE_ATTN_SHAREDKV_METADATA_HOST_H

--- a/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.h
+++ b/csrc/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.h
@@ -1,9 +1,4 @@
-// Host-side reimplementation of the AICPU load-balancer
-// `SparseAttnSharedkvMetadata[Dspark]` (a.k.a. npu_sparse_attn_sharedkv_metadata).
-//
-// The scheduler is pure integer logic (tiling -> cost model -> greedy core assignment),
-// so it is rehosted on the server CPU to drop the CANN AICPU/dspark build dependency.
-// Output is byte-identical to the AICPU op. See README.md for usage and performance.
+// Host-side (CPU) implementation of the npu_sparse_attn_sharedkv_metadata scheduler.
 
 #ifndef SPARSE_ATTN_SHAREDKV_METADATA_HOST_H
 #define SPARSE_ATTN_SHAREDKV_METADATA_HOST_H
@@ -274,8 +269,7 @@ private:
     // (thread-safe: reads only members, writes only `out`/`typeCost`).
     void ComputeS1GCache(uint32_t s1GIdx, const SplitContext &splitContext, const BatchCache &batchCache,
                          BlockCost<int64_t> &typeCost, S1GCache &out);
-    // Build rowCache_ for every (batch, s1GIdx) plus one boundary phantom per batch
-    // (matches the original on-demand compute for s1GIdx == s1GBaseNum). Parallelized.
+    // Build rowCache_ for every (batch, s1GIdx) plus one boundary phantom per batch.
     void BuildRowCache(const SplitContext &splitContext);
     // O(1) cache lookup returning a stable const ref (clamps s1GIdx to [0, s1GBaseNum]).
     const S1GCache &GetS1GCache(uint32_t s1GIdx, const BatchCache &batchCache);
@@ -331,7 +325,7 @@ private:
     bool isS1G_{true};
     bool isCFA_{false};
     bool isSCFA_{false};
-    bool supportFd_{false};  // inert (upstream AICPU build never enables it)
+    bool supportFd_{false};  // inert (never enabled)
     uint32_t attentionMode_{1};
 
     // Per-row cache: filled once in BuildRowCache (parallel), then read by const-ref by
@@ -342,25 +336,15 @@ private:
     bool cacheReady_{false};
 };
 
-/**
- * @brief Compute the sparse-attention shared-KV core-distribution metadata on the host CPU.
- *
- * A drop-in host replacement for `npu_sparse_attn_sharedkv_metadata` (AICPU): turns the
- * seq-lens and attention config into a fixed int32[1024] schedule consumed by the
- * `npu_sparse_attn_sharedkv` AICore kernel. Inputs are CPU int32 tensors; the result is a
- * device (NPU) int32[1024] tensor — the op performs the 4 KB H2D internally, so it is
- * functionally equivalent to the AICPU op (which writes device memory directly). No input
- * D2H is needed: sglang already keeps the seq-lens on the host.
- *
- * @param aic_core_num/aiv_core_num/soc_version target topology (e.g. from
- *        `torch.npu.get_device_properties(0)`); only the Ascend950 vs other branch matters.
- */
-at::Tensor sparse_attn_sharedkv_metadata_host(
-    int64_t num_heads_q, int64_t num_heads_kv, int64_t head_dim, int64_t aic_core_num, int64_t aiv_core_num,
-    const std::string &soc_version, const std::string &layout_q, const std::string &layout_kv,
-    const c10::optional<at::Tensor> &cu_seqlens_q, const c10::optional<at::Tensor> &seqused_kv, int64_t batch_size,
-    int64_t cmp_topk, int64_t cmp_ratio, int64_t ori_mask_mode, int64_t cmp_mask_mode, int64_t ori_win_left,
-    int64_t ori_win_right, bool has_ori_kv, bool has_cmp_kv);
+// Build the sparse-attention core-distribution table on the host CPU; the result is
+// returned as a device int32[1024] tensor.
+at::Tensor sparse_attn_sharedkv_metadata_host(int64_t num_heads_q, int64_t num_heads_kv, int64_t head_dim,
+                                              const std::string &layout_q, const std::string &layout_kv,
+                                              const c10::optional<at::Tensor> &cu_seqlens_q,
+                                              const c10::optional<at::Tensor> &seqused_kv, int64_t batch_size,
+                                              int64_t cmp_topk, int64_t cmp_ratio, int64_t ori_mask_mode,
+                                              int64_t cmp_mask_mode, int64_t ori_win_left, int64_t ori_win_right,
+                                              bool has_ori_kv, bool has_cmp_kv);
 
 }  // namespace sgl_kernel_npu
 

--- a/include/sgl_kenel_npu_ops.h
+++ b/include/sgl_kenel_npu_ops.h
@@ -185,6 +185,15 @@ at::Tensor sparse_attention_score(
     int64_t num_key_value_heads, double scale_value, int64_t block_size,
     int64_t top_k, int64_t inner_precise);
 
+at::Tensor sparse_attn_sharedkv_metadata_host(
+    int64_t num_heads_q, int64_t num_heads_kv, int64_t head_dim,
+    const std::string &layout_q, const std::string &layout_kv,
+    const c10::optional<at::Tensor> &cu_seqlens_q,
+    const c10::optional<at::Tensor> &seqused_kv, int64_t batch_size,
+    int64_t cmp_topk, int64_t cmp_ratio, int64_t ori_mask_mode,
+    int64_t cmp_mask_mode, int64_t ori_win_left, int64_t ori_win_right,
+    bool has_ori_kv, bool has_cmp_kv);
+
 } // namespace npu_kernel
 
 } // namespace sglang

--- a/tests/python/sgl_kernel_npu/test_sparse_attn_sharedkv_metadata_host.py
+++ b/tests/python/sgl_kernel_npu/test_sparse_attn_sharedkv_metadata_host.py
@@ -1,0 +1,242 @@
+"""Functional + validity tests for the host-side sparse_attn_sharedkv_metadata op.
+
+Covers:
+  * output contract (device int32[1024], enabled-core counts within hardware limits),
+  * schedule validity (the FA cores form a contiguous partition that covers all batches),
+  * input-contract rejection (invalid cmp_topk / cmp_ratio),
+  * (optional) byte-identical to the live AICPU op on decode — only when the custom_ops
+    vendor env is loaded; decode is version-insensitive so it matches regardless of which
+    AICPU build is deployed.
+
+Run:
+    python tests/python/sgl_kernel_npu/test_sparse_attn_sharedkv_metadata_host.py
+"""
+
+import unittest
+
+import sgl_kernel_npu  # noqa: F401  (loads libsgl_kernel_npu.so -> registers torch.ops.npu.*)
+import torch
+import torch_npu
+
+HOST = torch.ops.npu.sparse_attn_sharedkv_metadata_host
+
+_PROPS = torch.npu.get_device_properties(0)
+AIC = int(_PROPS.cube_core_num)
+AIV = int(_PROPS.vector_core_num)
+SOC = str(_PROPS.name)
+
+# Buffer capacity (consumer strides). Runtime aic/aiv only bound enabled-entry counts.
+FA_SLOTS = 36  # AIC_CORE_NUM
+FD_SLOTS = 72  # AIV_CORE_NUM
+
+# Optional live AICPU op (needs the custom_ops package + vendor aclnn env). Only used for
+# the decode byte-identical cross-check.
+try:
+    import custom_ops  # noqa: F401
+
+    _AICPU_OP = torch.ops.custom.npu_sparse_attn_sharedkv_metadata
+except Exception:  # pragma: no cover - env dependent
+    _AICPU_OP = None
+
+
+def _topology():
+    return AIC, AIV, SOC
+
+
+def host_call(cu, skv, cmp_ratio, has_cmp, cmp_topk=0):
+    return HOST(
+        64,
+        1,
+        512,
+        AIC,
+        AIV,
+        SOC,
+        "TND",
+        "PA_ND",
+        cu,
+        skv,
+        int(skv.numel()),
+        int(cmp_topk),
+        int(cmp_ratio),
+        4,
+        3,
+        127,
+        0,
+        True,
+        bool(has_cmp),
+    )
+
+
+def aicpu_call(cu, skv, cmp_ratio, has_cmp, cmp_topk=0):
+    return _AICPU_OP(
+        num_heads_q=64,
+        num_heads_kv=1,
+        head_dim=512,
+        cu_seqlens_q=cu.npu(),
+        seqused_kv=skv.npu(),
+        batch_size=int(skv.numel()),
+        cmp_topk=int(cmp_topk),
+        cmp_ratio=int(cmp_ratio),
+        ori_mask_mode=4,
+        cmp_mask_mode=3,
+        ori_win_left=127,
+        ori_win_right=0,
+        layout_q="TND",
+        layout_kv="PA_ND",
+        has_ori_kv=True,
+        has_cmp_kv=bool(has_cmp),
+        device="npu",
+    )
+
+
+def _fa_fd(meta):
+    m = meta.view(-1)
+    return m[: FA_SLOTS * 8].view(FA_SLOTS, 8), m[
+        FA_SLOTS * 8 : FA_SLOTS * 8 + FD_SLOTS * 8
+    ].view(FD_SLOTS, 8)
+
+
+def _enabled_fa(fa):
+    return int((fa[:AIC, 0] == 1).sum())
+
+
+_AICPU_OK_CACHE = None
+
+
+def _aicpu_ok():
+    """True iff the live AICPU op is actually runnable in this env (import + aclnn)."""
+    global _AICPU_OK_CACHE
+    if _AICPU_OK_CACHE is not None:
+        return _AICPU_OK_CACHE
+    if _AICPU_OP is None:
+        _AICPU_OK_CACHE = False
+        return False
+    try:
+        aicpu_call(
+            torch.arange(2, dtype=torch.int32),
+            torch.tensor([8], dtype=torch.int32),
+            1,
+            False,
+        )
+        _AICPU_OK_CACHE = True
+    except Exception:
+        _AICPU_OK_CACHE = False
+    return _AICPU_OK_CACHE
+
+
+class TestSparseAttnSharedkvMetadataHost(unittest.TestCase):
+    def _assert_contract(self, o):
+        self.assertEqual(tuple(o.shape), (1024,))
+        self.assertEqual(o.dtype, torch.int32)
+        self.assertEqual(o.device.type, "npu")
+
+    def _assert_valid_schedule(self, o, batch):
+        """Enabled FA cores must (1) be a contiguous prefix, (2) stay within the hardware
+        cube-core count, (3) cover every batch (last enabled core's bn2_end == batch).
+        """
+        fa, fd = _fa_fd(o.cpu())
+        enabled = _enabled_fa(fa)
+        self.assertGreaterEqual(enabled, 1)
+        self.assertLessEqual(enabled, AIC)
+        # contiguous enabled prefix: core_enable==1 for [0, enabled), 0 after (within AIC)
+        for i in range(enabled):
+            self.assertEqual(int(fa[i, 0]), 1, f"core {i} should be enabled")
+        if enabled < AIC:
+            self.assertEqual(
+                int(fa[enabled, 0]), 0, "core after last enabled must be disabled"
+            )
+        # full batch coverage: last enabled core closes the batch dimension
+        self.assertEqual(
+            int(fa[enabled - 1, 4]), batch, "last enabled core must finish all batches"
+        )
+        # FD is inert (supportFd disabled in the upstream build)
+        self.assertEqual(int((fd[:AIV, 0] == 1).sum()), 0)
+
+    # --- functional / validity --------------------------------------------------
+    def test_decode_mixed(self):
+        B = 8
+        cu = torch.arange(B + 1, dtype=torch.int32)
+        skv = torch.tensor(
+            [128, 256, 512, 1024, 2048, 4096, 8192, 12345], dtype=torch.int32
+        )
+        o = host_call(cu, skv, 1, False)
+        self._assert_contract(o)
+        fa, _ = _fa_fd(o.cpu())
+        # decode: one q-token/req -> one core per active request
+        self.assertEqual(_enabled_fa(fa), B)
+        self._assert_valid_schedule(o, B)
+
+    def test_all_paths_uniform(self):
+        B = 8
+        cu = torch.arange(B + 1, dtype=torch.int32)
+        skv = torch.full((B,), 4096, dtype=torch.int32)
+        for cr, hc, tk in [(1, False, 0), (4, True, 512), (128, True, 0)]:
+            o = host_call(cu, skv, cr, hc, tk)
+            self._assert_contract(o)
+            self._assert_valid_schedule(o, B)
+
+    def test_prefill_uses_multiple_cores(self):
+        T = 32768
+        cu = torch.tensor([0, T], dtype=torch.int32)
+        skv = torch.tensor([T], dtype=torch.int32)
+        o = host_call(cu, skv, 1, False)
+        self._assert_contract(o)
+        fa, _ = _fa_fd(o.cpu())
+        # large M -> work spread over several cube cores
+        self.assertGreater(_enabled_fa(fa), 1)
+        self._assert_valid_schedule(o, 1)
+
+    def test_single_request_long_context(self):
+        cu = torch.tensor([0, 1], dtype=torch.int32)  # decode, B=1
+        skv = torch.tensor([65536], dtype=torch.int32)
+        o = host_call(cu, skv, 1, False)
+        self._assert_contract(o)
+        self._assert_valid_schedule(o, 1)
+
+    def test_determinism(self):
+        cu = torch.arange(9, dtype=torch.int32)
+        skv = torch.full((8,), 4096, dtype=torch.int32)
+        a = host_call(cu, skv, 4, True, 512).cpu()
+        b = host_call(cu, skv, 4, True, 512).cpu()
+        self.assertTrue(torch.equal(a, b))
+
+    def test_invalid_cmp_topk_rejected(self):
+        cu = torch.arange(3, dtype=torch.int32)
+        skv = torch.tensor([100, 100], dtype=torch.int32)
+        # cmp_topk must be 0 / 512 / 1024; 64 is invalid -> the op must raise.
+        with self.assertRaises(Exception):
+            host_call(cu, skv, 4, True, cmp_topk=64)
+
+    def test_invalid_cmp_ratio_rejected(self):
+        cu = torch.arange(3, dtype=torch.int32)
+        skv = torch.tensor([100, 100], dtype=torch.int32)
+        # cmp_ratio must be 4 or 128 when has_cmp_kv; 7 is invalid -> must raise.
+        with self.assertRaises(Exception):
+            host_call(cu, skv, 7, True, cmp_topk=512)
+
+    # --- optional cross-check vs the live AICPU op (decode only) ----------------
+    @unittest.skipUnless(
+        _aicpu_ok(), "live AICPU op (custom_ops + vendor aclnn) not runnable"
+    )
+    def test_byte_identical_decode_vs_aicpu(self):
+        # Decode is M=1 -> version-insensitive, so host matches any deployed AICPU build.
+        B = 8
+        cu = torch.arange(B + 1, dtype=torch.int32)
+        skv = torch.tensor(
+            [128, 256, 512, 1024, 2048, 4096, 8192, 12345], dtype=torch.int32
+        )
+        for cr, hc, tk in [(1, False, 0), (4, True, 512), (128, True, 0)]:
+            h = host_call(cu, skv, cr, hc, tk).cpu()
+            a = aicpu_call(cu, skv, cr, hc, tk).cpu()
+            fa_h, _ = _fa_fd(h)
+            fa_a, _ = _fa_fd(a)
+            for i in range(AIC):
+                if int(fa_h[i, 0]) == 1:  # only enabled cores are read by the consumer
+                    self.assertTrue(
+                        torch.equal(fa_h[i], fa_a[i]),
+                        f"decode core {i} mismatch (cmp_ratio={cr})",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/sgl_kernel_npu/test_sparse_attn_sharedkv_metadata_host.py
+++ b/tests/python/sgl_kernel_npu/test_sparse_attn_sharedkv_metadata_host.py
@@ -23,7 +23,6 @@ HOST = torch.ops.npu.sparse_attn_sharedkv_metadata_host
 _PROPS = torch.npu.get_device_properties(0)
 AIC = int(_PROPS.cube_core_num)
 AIV = int(_PROPS.vector_core_num)
-SOC = str(_PROPS.name)
 
 # Buffer capacity (consumer strides). Runtime aic/aiv only bound enabled-entry counts.
 FA_SLOTS = 36  # AIC_CORE_NUM
@@ -40,17 +39,15 @@ except Exception:  # pragma: no cover - env dependent
 
 
 def _topology():
-    return AIC, AIV, SOC
+    return AIC, AIV  # device-side expectations for assertions only
 
 
 def host_call(cu, skv, cmp_ratio, has_cmp, cmp_topk=0):
+    # aic/aiv/soc are queried inside the op (auto-detected from the device).
     return HOST(
         64,
         1,
         512,
-        AIC,
-        AIV,
-        SOC,
         "TND",
         "PA_ND",
         cu,


### PR DESCRIPTION
## Motivation
Providing our own definitions of the dsv4 spark‑related operators in the sglang kernel repository

## Modifications
1、add definition of sparse_attn_sharedkv_metadata_host

## Accuracy Tests
This operator does not affect accuracy.

## Speed Tests and Profiling
Use the replaced operator after：

```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 160       
Successful requests:                     160       
Benchmark duration (s):                  51.04     
Total input tokens:                      1310720   
Total input text tokens:                 1310720   
Total generated tokens:                  163840    
Total generated tokens (retokenized):    163832    
Request throughput (req/s):              3.13      
Input token throughput (tok/s):          25681.59  
Output token throughput (tok/s):         3210.20   
Peak output token throughput (tok/s):    9005.00   
Peak concurrent requests:                160       
Total token throughput (tok/s):          28891.79  
Concurrency:                             144.42    
Accept length:                           5.41      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   46068.74  
Median E2E Latency (ms):                 45406.44  
P90 E2E Latency (ms):                    48402.04  
P95 E2E Latency (ms):                    48758.49  
P99 E2E Latency (ms):                    49494.62  
---------------Time to First Token----------------
Mean TTFT (ms):                          16861.65  
Median TTFT (ms):                        17061.21  
P90 TTFT (ms):                           27113.55  
P95 TTFT (ms):                           27407.58  
P99 TTFT (ms):                           27411.84  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          28.55     
Median TPOT (ms):                        28.91     
P90 TPOT (ms):                           37.69     
P95 TPOT (ms):                           38.65     
P99 TPOT (ms):                           41.16     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           28.55     
Median ITL (ms):                         17.06     
P90 ITL (ms):                            21.43     
P95 ITL (ms):                            25.83     
P99 ITL (ms):                            398.31    
Max ITL (ms):                            12023.96  
==================================================
```

before:

```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 160       
Successful requests:                     160       
Benchmark duration (s):                  50.85     
Total input tokens:                      1310720   
Total input text tokens:                 1310720   
Total generated tokens:                  163840    
Total generated tokens (retokenized):    163832    
Request throughput (req/s):              3.15      
Input token throughput (tok/s):          25777.97  
Output token throughput (tok/s):         3222.25   
Peak output token throughput (tok/s):    9127.00   
Peak concurrent requests:                160       
Total token throughput (tok/s):          29000.22  
Concurrency:                             144.54    
Accept length:                           5.65      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   45934.77  
Median E2E Latency (ms):                 45278.62  
P90 E2E Latency (ms):                    48245.83  
P95 E2E Latency (ms):                    48588.53  
P99 E2E Latency (ms):                    49312.42  
---------------Time to First Token----------------
Mean TTFT (ms):                          16870.18  
Median TTFT (ms):                        17077.78  
P90 TTFT (ms):                           27131.82  
P95 TTFT (ms):                           27414.92  
P99 TTFT (ms):                           27418.62  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          28.41     
Median TPOT (ms):                        28.76     
P90 TPOT (ms):                           37.59     
P95 TPOT (ms):                           38.53     
P99 TPOT (ms):                           41.01     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           28.41     
Median ITL (ms):                         16.93     
P90 ITL (ms):                            21.24     
P95 ITL (ms):                            25.59     
P99 ITL (ms):                            397.80    
Max ITL (ms):                            12014.81  
==================================================
```

Unit profiling test:
| scenario | AICPU | host | speedup |
| --- | --- | --- | --- |
| prefill 8k | ~358 µs | ~310 µs | ~1.15× |
| prefill 32k | ~889 µs | ~852 µs | ~1.04× |