### PR TITLE
test: cover partial rope and align swiglu quant reference

### DIFF
--- a/tests/python/sgl_kernel_npu/test_split_qkv_rmsnorm_rope.py
+++ b/tests/python/sgl_kernel_npu/test_split_qkv_rmsnorm_rope.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import torch
 import torch_npu
 from sgl_kernel_npu.norm.split_qkv_rmsnorm_rope import (
@@ -40,7 +41,10 @@ def rms_norm(
     return out
 
 
-def test_split_qkv_rmsnorm_rope():
+@pytest.mark.parametrize(
+    "rope_dim", [128, 64], ids=["full_rope_dim", "half_rope_dim"]
+)
+def test_split_qkv_rmsnorm_rope(rope_dim):
     q_hidden_size = 6144
     kv_hidden_size = 1024
     head_dim = 128
@@ -75,8 +79,8 @@ def test_split_qkv_rmsnorm_rope():
         .to(torch.bfloat16)
         .npu()
     )
-    sin = np.random.uniform(0, 1, [bsz, 1, 1, head_dim])
-    cos = np.random.uniform(0, 1, [bsz, 1, 1, head_dim])
+    sin = np.random.uniform(0, 1, [bsz, 1, 1, rope_dim])
+    cos = np.random.uniform(0, 1, [bsz, 1, 1, rope_dim])
     sin = torch.from_numpy(sin).to(torch.bfloat16).npu()
     cos = torch.from_numpy(cos).to(torch.bfloat16).npu()
     # fused kernel
@@ -103,7 +107,15 @@ def test_split_qkv_rmsnorm_rope():
     _k = _k.reshape(bsz, 1, -1, head_dim)
 
     # rope
-    cus_q, cus_k = custom_rope(_q, _k, sin, cos, half_rope_dim=64)
+    rot_q, rot_k = custom_rope(
+        _q[..., :rope_dim],
+        _k[..., :rope_dim],
+        sin,
+        cos,
+        half_rope_dim=rope_dim // 2,
+    )
+    cus_q = np.concatenate((rot_q, _q[..., rope_dim:]), axis=-1)
+    cus_k = np.concatenate((rot_k, _k[..., rope_dim:]), axis=-1)
     cus_q = cus_q.reshape(bsz, -1)
     cus_k = cus_k.reshape(bsz, -1)
 
@@ -162,7 +174,7 @@ def test_split_qkv_rope():
     # rope
     _q = _q.reshape(bsz, 1, -1, head_dim).to(torch.float32).cpu().numpy()
     _k = _k.reshape(bsz, 1, -1, head_dim).to(torch.float32).cpu().numpy()
-    cus_q, cus_k = custom_rope(_q, _k, sin, cos)
+    cus_q, cus_k = custom_rope(_q, _k, sin, cos, half_rope_dim=head_dim // 2)
     cus_q = cus_q.reshape(bsz, -1)
     cus_k = cus_k.reshape(bsz, -1)
 

--- a/tests/python/sgl_kernel_npu/test_split_qkv_rmsnorm_rope.py
+++ b/tests/python/sgl_kernel_npu/test_split_qkv_rmsnorm_rope.py
@@ -8,7 +8,9 @@ from sgl_kernel_npu.norm.split_qkv_rmsnorm_rope import (
 )
 
 
-def custom_rope(q, k, sin, cos, half_rope_dim):
+def custom_rope(q, k, sin, cos, half_rope_dim=None):
+    if half_rope_dim is None:
+        half_rope_dim = q.shape[-1] // 2
     sin = sin.to(torch.float32).cpu().numpy()
     cos = cos.to(torch.float32).cpu().numpy()
     x1 = q[..., :half_rope_dim]
@@ -174,7 +176,7 @@ def test_split_qkv_rope():
     # rope
     _q = _q.reshape(bsz, 1, -1, head_dim).to(torch.float32).cpu().numpy()
     _k = _k.reshape(bsz, 1, -1, head_dim).to(torch.float32).cpu().numpy()
-    cus_q, cus_k = custom_rope(_q, _k, sin, cos, half_rope_dim=head_dim // 2)
+    cus_q, cus_k = custom_rope(_q, _k, sin, cos)
     cus_q = cus_q.reshape(bsz, -1)
     cus_k = cus_k.reshape(bsz, -1)
 

--- a/tests/python/sgl_kernel_npu/test_swiglu_quant.py
+++ b/tests/python/sgl_kernel_npu/test_swiglu_quant.py
@@ -30,9 +30,12 @@ def test_swiglu_quant():
         .npu()
         .to(torch.int64)
     )
-    # torch native
-    swglu_out = torch_npu.npu_swiglu(x)
-    ans1, ans2 = torch_npu.npu_dynamic_quant(swglu_out)
+    # torch native: match the fused kernel's fp32 SwiGLU and quantization path
+    gate, up = x.to(torch.float32).chunk(2, dim=-1)
+    swglu_out = gate * torch.sigmoid(gate) * up
+    ans2 = torch.amax(torch.abs(swglu_out), dim=-1) / 127
+    ans1 = torch.floor(swglu_out / ans2.unsqueeze(-1) + 0.5)
+    ans1 = torch.clamp(ans1, -128, 127).to(torch.int8)
     # fused_triton_kernel
     res1, res2 = swiglu_quant(x, group_list, group_list_type=1)
 


### PR DESCRIPTION
revise tests
cover partial rope path for split_qkv_rmsnorm_rope ops
and align swiglu quant reference so that acc aligned with swiglu_quant ops