### PR TITLE
[feat] add quant_mode mx_fp4_e2m1 in alltoall mode

### DIFF
--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -475,10 +475,13 @@ jobs:
         env:
           DEEP_MOE_MODE: alltoall
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type int8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --use-fp8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --use-mxfp4
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type int8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type bf16
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type bf16
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type mx_fp4_e2m1
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type mx_fp8_e4m3
 
   test-build-deepep-a2:
     needs: get-changed-files
@@ -872,6 +875,8 @@ jobs:
         timeout-minutes: 10
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --num-processes 4
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --num-processes 4 --use-mxfp4
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --num-processes 4 --use-mxfp8
 
       - name: Run alltoall low-latency
         timeout-minutes: 10

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -476,12 +476,9 @@ jobs:
           DEEP_MOE_MODE: alltoall
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --use-fp8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --use-mxfp4
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type int8
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type bf16
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type mx_fp4_e2m1
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type mx_fp8_e4m3
 
   test-build-deepep-a2:
     needs: get-changed-files

--- a/python/deep_ep/README.md
+++ b/python/deep_ep/README.md
@@ -411,7 +411,7 @@ DeepEP-Ascend 采用**策略式架构**，通信实现被抽象为可互换的�
 | `DEEP_USE_MODE=alltoall` | `AlltoAllNormalCommStrategy`（torch.distributed alltoallv） | `AllToAllLowLatencyCommStrategy`（torch.distributed alltoall） |
 | `DEEP_USE_MODE=ops` | `DefaultNormalCommStrategy`（deep_ep_cpp 自定义算子） | `OpsLowLatencyCommStrategy`（torch_npu 算子） |
 
-> **注意**：无效配置（如 `DEEP_USE_MODE=error`）会抛出 `ValueError`。
+> **注意**：无效配置（如 `DEEP_USE_MODE=error`）会抛出 `ValueError`, A5 + cann9.0.0场景下不支持low-latency模式选择alltoall策略。
 
 ### API 总览
 

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -373,6 +373,9 @@ class Buffer:
 
         # Resolve quant_mode from bool flags + device architecture
         quant_mode = _resolve_quant_mode(use_fp8, use_mxfp4, use_mxfp8)
+        if quant_mode is None:
+            is_quant_env = os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT", "0")
+            quant_mode = "int8" if is_quant_env == "1" else "bf16"
 
         # Delegate to normal strategy
         return self.normal_strategy.dispatch(
@@ -682,15 +685,7 @@ class Buffer:
             event: the event after executing the kernel (valid only if `async_finish` is set).
             hook: the receiving hook function (valid only if `return_recv_hook` is set).
         """
-        quant_mode = None
-        if self.low_latency_strategy.get_name() == "default":
-            resolved_use_mxfp8 = use_mxfp8 or (use_fp8 and use_ue8m0)
-            resolved_use_fp8 = use_fp8 and not use_ue8m0
-            quant_mode = _resolve_quant_mode(
-                use_fp8=resolved_use_fp8,
-                use_mxfp4=use_mxfp4,
-                use_mxfp8=resolved_use_mxfp8,
-            )
+        quant_mode = _resolve_quant_mode(use_fp8, use_mxfp4, use_mxfp8)
 
         return self.low_latency_strategy.low_latency_dispatch(
             x=x,

--- a/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
@@ -495,6 +495,29 @@ class AllToAllLowLatencyCommStrategy(LowLatencyEPCommStrategy):
         device = x.device
         hidden = x.size(1)
         aligned_num_tokens = num_max_dispatch_tokens_per_rank
+        VALID_QUANT_MODES = {
+            "bf16",
+            "int8",
+            "mx_fp8_e5m2",
+            "mx_fp8_e4m3",
+            "mx_fp4_e2m1",
+        }
+        if quant_mode is None:
+            quant_mode = self.get_quant_mode_from_bool(use_fp8, use_ue8m0, use_mxfp4)
+        if quant_mode not in VALID_QUANT_MODES:
+            raise NotImplementedError(
+                f"quant_mode '{quant_mode}' is not supported by the alltoall strategy. "
+                f"Only 'bf16', 'int8', 'mx_fp4_e2m1', 'mx_fp8_e5m2', 'mx_fp8_e4m3' are supported."
+            )
+        hidden_shape = x.shape
+
+        quant_mode_type = {
+            "bf16": torch.bfloat16,
+            "int8": torch.int8,
+            "mx_fp8_e5m2": torch.float8_e5m2,
+            "mx_fp8_e4m3": torch.float8_e4m3fn,
+            "mx_fp4_e2m1": torch_npu.float4_e2m1fn_x2,
+        }[quant_mode]
         num_tokens = x.size(0)
         padding_size = aligned_num_tokens - num_tokens
         x_padding = torch.zeros(
@@ -548,7 +571,21 @@ class AllToAllLowLatencyCommStrategy(LowLatencyEPCommStrategy):
         recv_x = recv_all.reshape(
             num_local_experts * group_size * expert_capacity, hidden
         )
-        recv_x_out = (torch_npu.npu_dynamic_quant(recv_x)) if use_fp8 else recv_x
+        recv_x_out = recv_x
+        if quant_mode != "bf16":
+            recv_x_scale = (
+                torch_npu.npu_dynamic_quant(recv_x)
+                if quant_mode == "int8"
+                else torch_npu.npu_dynamic_mx_quant(recv_x, dst_type=quant_mode_type)
+            )
+            recv_x_out = (
+                recv_x_scale[0].view(
+                    torch.float4_e2m1fn_x2
+                    if quant_mode_type == torch_npu.float4_e2m1fn_x2
+                    else quant_mode_type
+                ),
+                recv_x_scale[1],
+            )
 
         packed_recv_count = torch.full(
             (num_local_experts,),
@@ -574,6 +611,21 @@ class AllToAllLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             EventOverlap(),
             lambda: None,
         )
+
+    def get_quant_mode_from_bool(
+        self,
+        use_fp8=False,
+        use_ue8m0=False,
+        use_mxfp4=False,
+    ):
+        quant_mode = "bf16"
+        if use_fp8:
+            quant_mode = "int8"
+            if use_ue8m0:
+                quant_mode = "mx_fp8_e4m3"
+            elif use_mxfp4:
+                quant_mode = "mx_fp4_e2m1"
+        return quant_mode
 
     def low_latency_combine(
         self,

--- a/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/low_latency_strategy.py
@@ -503,7 +503,7 @@ class AllToAllLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             "mx_fp4_e2m1",
         }
         if quant_mode is None:
-            quant_mode = self.get_quant_mode_from_bool(use_fp8, use_ue8m0, use_mxfp4)
+            quant_mode = "bf16"
         if quant_mode not in VALID_QUANT_MODES:
             raise NotImplementedError(
                 f"quant_mode '{quant_mode}' is not supported by the alltoall strategy. "
@@ -611,21 +611,6 @@ class AllToAllLowLatencyCommStrategy(LowLatencyEPCommStrategy):
             EventOverlap(),
             lambda: None,
         )
-
-    def get_quant_mode_from_bool(
-        self,
-        use_fp8=False,
-        use_ue8m0=False,
-        use_mxfp4=False,
-    ):
-        quant_mode = "bf16"
-        if use_fp8:
-            quant_mode = "int8"
-            if use_ue8m0:
-                quant_mode = "mx_fp8_e4m3"
-            elif use_mxfp4:
-                quant_mode = "mx_fp4_e2m1"
-        return quant_mode
 
     def low_latency_combine(
         self,

--- a/python/deep_ep/deep_ep/strategies/normal_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/normal_strategy.py
@@ -593,9 +593,6 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
         num_experts = layout["num_experts"]
         topk_idx_int = topk_idx.to(torch.int32)
 
-        if quant_mode is None:
-            is_quant_env = os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT", "0")
-            quant_mode = "int8" if is_quant_env == "1" else "bf16"
         if quant_mode not in self._SUPPORTED_QUANT_MODES:
             raise NotImplementedError(
                 f"quant_mode '{quant_mode}' is not supported by the alltoall strategy. "

--- a/python/deep_ep/deep_ep/strategies/normal_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/normal_strategy.py
@@ -3,6 +3,7 @@ Normal mode EP communication strategies.
 All normal mode strategy implementations are in this file.
 """
 
+import os
 from typing import Callable, List, Optional, Tuple, Union
 
 import torch
@@ -447,7 +448,7 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
     Internode and intranode use the same implementation.
     """
 
-    _SUPPORTED_QUANT_MODES = frozenset({"bf16", "int8"})
+    _SUPPORTED_QUANT_MODES = frozenset({"bf16", "int8", "mx_fp8_e4m3", "mx_fp4_e2m1"})
 
     def __init__(self, runtime, group: dist.ProcessGroup):
         super().__init__(group)
@@ -593,16 +594,27 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
         topk_idx_int = topk_idx.to(torch.int32)
 
         if quant_mode is None:
-            quant_mode = "bf16"
+            is_quant_env = os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT", "0")
+            quant_mode = "int8" if is_quant_env == "1" else "bf16"
         if quant_mode not in self._SUPPORTED_QUANT_MODES:
             raise NotImplementedError(
                 f"quant_mode '{quant_mode}' is not supported by the alltoall strategy. "
-                f"Only 'bf16' and 'int8' are supported; use the default strategy for "
-                f"FP8/FP4 modes."
+                f"Only 'bf16' , 'mx_fp8_e4m3', 'mx_fp4_e2m1' and 'int8' are supported."
             )
         hidden_shape = x.shape
 
-        use_quant = 1 if quant_mode == "int8" else -1
+        use_quant = {
+            "bf16": -1,
+            "int8": 1,
+            "mx_fp8_e4m3": 3,
+            "mx_fp4_e2m1": 9,
+        }[quant_mode]
+        quant_mode_type = {
+            "bf16": torch.bfloat16,
+            "int8": torch.int8,
+            "mx_fp8_e4m3": torch.float8_e4m3fn,
+            "mx_fp4_e2m1": torch.float4_e2m1fn_x2,
+        }[quant_mode]
 
         (permutated_tokens, reversed_local_mapping, _, dynamic_scale) = (
             torch_npu.npu_moe_init_routing_v2(
@@ -616,10 +628,19 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
                 active_expert_range=[0, num_experts],
             )
         )
-
-        if use_quant == 1:
+        if use_quant != -1:
+            # During quantization performed by moe_init_routing_v2, the quantization parameters of the float8_e8m0fnu
+            # type are returned in mxfp8 mode, which does not match the input parameters supported by the alltoall
+            # communication operator used here. Therefore, hu needs to be forcibly converted to uint8.
             _, dynamic_scale_after_all2all, scale_handle = self._async_all_to_all(
-                dynamic_scale, output_splits, input_splits, self.group
+                (
+                    dynamic_scale.view(torch.uint8)
+                    if use_quant != "int8"
+                    else dynamic_scale
+                ),
+                output_splits,
+                input_splits,
+                self.group,
             )
             scale_handle.wait()
             dynamic_scale.untyped_storage().resize_(0)
@@ -637,13 +658,32 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
             global_tokens_indices = global_tokens_indices.reshape(
                 global_tokens_indices.size(0), 1
             )
-            if use_quant == 1:
-                dynamic_scale_after_all2all = dynamic_scale_after_all2all.reshape(
-                    dynamic_scale_after_all2all.size(0), 1
+            if use_quant != -1:
+                dynamic_scale_after_all2all = (
+                    dynamic_scale_after_all2all.reshape(
+                        dynamic_scale_after_all2all.size(0), -1, 2
+                    )
+                    if quant_mode != "int8"
+                    else dynamic_scale_after_all2all
                 )
-                (dynamic_scale_after_routing, reversed_global_mapping, _, _) = (
+                (
+                    dispatch_out,
+                    reversed_global_mapping,
+                    _,
+                    dynamic_scale_after_routing,
+                ) = torch_npu.npu_moe_init_routing_v2(
+                    global_input_tokens,
+                    global_tokens_indices,
+                    scale=dynamic_scale_after_all2all,
+                    expert_num=num_local_experts,
+                    expert_tokens_num_flag=True,
+                    active_expert_range=[0, num_local_experts],
+                    x_dtype=quant_mode_type,
+                )
+            else:
+                (dispatch_out, reversed_global_mapping, _, _) = (
                     torch_npu.npu_moe_init_routing_v2(
-                        dynamic_scale_after_all2all,
+                        global_input_tokens,
                         global_tokens_indices,
                         quant_mode=-1,
                         expert_num=num_local_experts,
@@ -653,23 +693,11 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
                         active_expert_range=[0, num_local_experts],
                     )
                 )
-                dynamic_scale_after_routing = dynamic_scale_after_routing.reshape(
-                    dynamic_scale_after_routing.size(0)
-                )
-            (dispatch_out, reversed_global_mapping, _, _) = (
-                torch_npu.npu_moe_init_routing_v2(
-                    global_input_tokens,
-                    global_tokens_indices,
-                    quant_mode=-1,
-                    expert_num=num_local_experts,
-                    expert_tokens_num_type=1,
-                    expert_tokens_num_flag=True,
-                    row_idx_type=0,
-                    active_expert_range=[0, num_local_experts],
-                )
-            )
         else:
             dispatch_out = global_input_tokens
+            dynamic_scale_after_routing = (
+                dynamic_scale_after_all2all if use_quant != -1 else None
+            )
             reversed_global_mapping = None
 
         num_recv_tokens_per_expert_list = (
@@ -687,8 +715,8 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
             "num_local_experts": num_local_experts,
         }
         recv_x = (
-            (dispatch_out, dynamic_scale_after_routing)
-            if use_quant == 1
+            (dispatch_out.view(quant_mode_type), dynamic_scale_after_routing)
+            if use_quant != -1
             else dispatch_out
         )
 

--- a/python/deep_ep/deep_ep/strategies/normal_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/normal_strategy.py
@@ -635,7 +635,7 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
             _, dynamic_scale_after_all2all, scale_handle = self._async_all_to_all(
                 (
                     dynamic_scale.view(torch.uint8)
-                    if use_quant != "int8"
+                    if quant_mode != "int8"
                     else dynamic_scale
                 ),
                 output_splits,

--- a/python/deep_ep/deep_ep/utils.py
+++ b/python/deep_ep/deep_ep/utils.py
@@ -52,8 +52,7 @@ def _resolve_quant_mode(
 
     Priority:
     1. ``use_mxfp4`` / ``use_mxfp8`` / ``use_fp8`` bool flags (table lookup).
-    2. ``DEEP_NORMAL_MODE_USE_INT8_QUANT=1`` env var (deprecated fallback).
-    3. ``None`` (BF16, no quantization).
+    2. ``None`` (BF16, no quantization).
     """
     if sum([use_fp8, use_mxfp8, use_mxfp4]) > 1:
         raise ValueError("at most one of use_mxfp8, use_mxfp4, use_fp8 can be True")
@@ -77,10 +76,6 @@ def _resolve_quant_mode(
             f"{param_type} is not supported on device version {version_code} "
             f"({DEVICE_VERSION_TABLE.get(version_code, 'unknown')})."
         )
-
-    # Deprecated env-var fallback for backward compatibility
-    if os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT") == "1":
-        return "int8"
 
     return None
 

--- a/python/deep_ep/doc/NORMAL_API.md
+++ b/python/deep_ep/doc/NORMAL_API.md
@@ -128,7 +128,7 @@ The quantization mode for `dispatch` is resolved in `Buffer._resolve_normal_quan
 > **Per-path differences:**
 > - **intranode** (default strategy): full priority order above. FP8/FP4 modes supported on A5.
 > - **internode** (default strategy): only `"bf16"` and `"int8"` are supported. Other quant_mode values raise `NotImplementedError`.
-> - **alltoall** strategy (`DEEP_USE_MODE=alltoall`): only `"bf16"` and `"int8"` are supported. FP8/FP4 modes require the default strategy.
+> - **alltoall** strategy (`DEEP_USE_MODE=alltoall`): only `"mx_fp4_e2m1"` `"bf16"` and `"mx_fp8_e4m3"` are supported.
 >
 > **Platform support:** INT8 is supported on **all** platforms (A2/A3/A5). FP8/FP4 modes (`pertoken_fp8_e4m3`, `mx_fp8_e4m3`, `mx_fp4_e2m1`) are **A5-only**.
 >
@@ -318,7 +318,7 @@ dispatch(
 > **各路径差异：**
 > - **intranode**（default 策略）：完整优先级顺序。FP8/FP4 模式仅 A5 支持。
 > - **internode**（default 策略）：仅支持 `"bf16"` 和 `"int8"`。其他 quant_mode 值抛 `NotImplementedError`。
-> - **alltoall** 策略（`DEEP_USE_MODE=alltoall`）：仅支持 `"bf16"` 和 `"int8"`。FP8/FP4 模式需使用 default 策略。
+> - **alltoall** 策略（`DEEP_USE_MODE=alltoall`）：仅支持 `"mx_fp4_e2m1"` `"bf16"` 和 `"mx_fp8_e4m3"`。
 >
 > **平台支持：** INT8 **全平台**（A2/A3/A5）支持。FP8/FP4 模式（`pertoken_fp8_e4m3`、`mx_fp8_e4m3`、`mx_fp4_e2m1`）**仅 A5**。
 >

--- a/tests/python/deepep/test_ll_alltoall.py
+++ b/tests/python/deepep/test_ll_alltoall.py
@@ -163,9 +163,9 @@ def test(
         max_diff = torch.max(torch.abs(combined_x - golden) / golden_nozero).item()
         avg_diff = torch.mean(torch.abs(combined_x - golden) / golden_nozero).item()
         print(
-            f"rank {rank} PASSED [{quant_mode=}] avg_diff={avg_diff:.5f}, max_diff={max_diff:.5f}, cosine_diff={diff:.5f}"
+            f"rank {rank} PASSED [{quant_type=}] avg_diff={avg_diff:.5f}, max_diff={max_diff:.5f}, cosine_diff={diff:.5f}"
         )
-        diff_threshold = get_diff_threshold(quant_mode)
+        diff_threshold = get_diff_threshold(quant_type)
 
         assert diff < diff_threshold, f"Error: {diff=}"
         hash_value ^= hash_tensor(combined_x)
@@ -187,7 +187,7 @@ def test(
             topk_weights=topk_weights,
         )
         simulated_gemm_x_local = (
-            per_token_cast_back(*recv_x) if not quant_mode == "bf16" else recv_x
+            per_token_cast_back(*recv_x) if not quant_type == "bf16" else recv_x
         )
         combined_x, event, hook = buffer.low_latency_combine(
             simulated_gemm_x_local,
@@ -271,7 +271,7 @@ def test(
     # tuning combine
     recv_x, _, handle, _, _ = buffer.low_latency_dispatch(**dispatch_args)
     simulated_gemm_x_local = (
-        per_token_cast_back(*recv_x) if not quant_mode == "bf16" else recv_x
+        per_token_cast_back(*recv_x) if not quant_type == "bf16" else recv_x
     )
     combine_args = {
         "x": simulated_gemm_x_local,

--- a/tests/python/deepep/test_ll_alltoall.py
+++ b/tests/python/deepep/test_ll_alltoall.py
@@ -187,9 +187,8 @@ def test(
             return_recv_hook=return_recv_hook,
             topk_weights=topk_weights,
         )
-        simulated_gemm_x_local = per_token_cast_back(*recv_x)
         combined_x, event, hook = buffer.low_latency_combine(
-            simulated_gemm_x_local,
+            recv_x,
             topk_idx,
             topk_weights,
             handle,
@@ -270,9 +269,8 @@ def test(
 
     # tuning combine
     recv_x, _, handle, _, _ = buffer.low_latency_dispatch(**dispatch_args)
-    simulated_gemm_x_local = per_token_cast_back(*recv_x)
     combine_args = {
-        "x": simulated_gemm_x_local,
+        "x": recv_x,
         "topk_idx": topk_idx,
         "topk_weights": topk_weights,
         "handle": handle,

--- a/tests/python/deepep/test_ll_alltoall.py
+++ b/tests/python/deepep/test_ll_alltoall.py
@@ -39,7 +39,7 @@ def test(
     group: dist.ProcessGroup,
     buffer: Buffer,
     seed: int = 0,
-    quant_type: str = "no",
+    quant_type: str = "bf16",
     local_rank: int = 0,
 ):
     torch.manual_seed(seed + rank)
@@ -109,70 +109,68 @@ def test(
                 else packed_recv_x
             )
 
-            padding_size = aligned_num_tokens - num_tokens
-            if padding_size > 0:
-                padding_tensor = torch.full(
-                    (padding_size, num_topk),
-                    fill_value=-1,
-                    dtype=topk_idx.dtype,
-                    device="npu",
-                )
-                topk_idx_padded = torch.cat([topk_idx, padding_tensor], dim=0)
-            else:
-                topk_idx_padded = topk_idx
-
-            all_topk_idx = torch.empty(
-                (num_ranks, aligned_num_tokens, num_topk),
+        padding_size = aligned_num_tokens - num_tokens
+        if padding_size > 0:
+            padding_tensor = torch.full(
+                (padding_size, num_topk),
+                fill_value=-1,
                 dtype=topk_idx.dtype,
                 device="npu",
             )
-            dist.all_gather_into_tensor(all_topk_idx, topk_idx_padded, group=group)
+            topk_idx_padded = torch.cat([topk_idx, padding_tensor], dim=0)
+        else:
+            topk_idx_padded = topk_idx
 
-        # Check combine correctness
-        src_info = handle[0]
-        layout_range = handle[1]
-        num_max_dispatch_tokens_per_rank = handle[2]
-        hidden = handle[3]
-        packed_recv_count = handle[5]
-        expand_scales = handle[6]
-
-        out = torch.empty(
-            (aligned_num_tokens, hidden), dtype=torch.bfloat16, device="npu"
+        all_topk_idx = torch.empty(
+            (num_ranks, aligned_num_tokens, num_topk),
+            dtype=topk_idx.dtype,
+            device="npu",
         )
-        combined_x, event, hook = buffer.low_latency_combine(
-            simulated_gemm_x,
-            topk_idx,
-            topk_weights,
-            handle,
-            async_finish=not return_recv_hook,
-            zero_copy=False,
-            return_recv_hook=return_recv_hook,
-            out=out,
-        )
+        dist.all_gather_into_tensor(all_topk_idx, topk_idx_padded, group=group)
 
-        if do_check:
-            ref_x = x_pure_rand if current_x is x_pure_rand else x
-            diff = calc_diff(
-                ref_x
-                * topk_weights.masked_fill(topk_idx == -1, 0).sum(dim=1).view(-1, 1),
-                combined_x,
-            )
-            assert torch.isnan(combined_x).sum().item() == 0
-            golden = ref_x * topk_weights.masked_fill(topk_idx == -1, 0).sum(
-                dim=1
-            ).view(-1, 1)
-            eps = 1e-8
-            golden_nozero = torch.where(golden == 0, eps, golden)
-            max_diff = torch.max(torch.abs(combined_x - golden) / golden_nozero).item()
-            avg_diff = torch.mean(torch.abs(combined_x - golden) / golden_nozero).item()
-            print(
-                f"rank {rank} PASSED [{quant_type=}] avg_diff={avg_diff:.5f}, max_diff={max_diff:.5f}, cosine_diff={diff:.5f}"
-            )
-            diff_threshold = get_diff_threshold(quant_type)
-            assert diff < diff_threshold, f"Error: {diff=}, {diff_threshold=}"
-            hash_value ^= hash_tensor(combined_x)
-            if local_rank == 0:
-                print(" passed", flush=True)
+    # Check combine correctness
+    src_info = handle[0]
+    layout_range = handle[1]
+    num_max_dispatch_tokens_per_rank = handle[2]
+    hidden = handle[3]
+    packed_recv_count = handle[5]
+    expand_scales = handle[6]
+
+    out = torch.empty((aligned_num_tokens, hidden), dtype=torch.bfloat16, device="npu")
+    combined_x, event, hook = buffer.low_latency_combine(
+        simulated_gemm_x,
+        topk_idx,
+        topk_weights,
+        handle,
+        async_finish=not return_recv_hook,
+        zero_copy=False,
+        return_recv_hook=return_recv_hook,
+        out=out,
+    )
+
+    if do_check:
+        ref_x = x_pure_rand if current_x is x_pure_rand else x
+        diff = calc_diff(
+            ref_x * topk_weights.masked_fill(topk_idx == -1, 0).sum(dim=1).view(-1, 1),
+            combined_x,
+        )
+        assert torch.isnan(combined_x).sum().item() == 0
+        golden = ref_x * topk_weights.masked_fill(topk_idx == -1, 0).sum(dim=1).view(
+            -1, 1
+        )
+        eps = 1e-8
+        golden_nozero = torch.where(golden == 0, eps, golden)
+        max_diff = torch.max(torch.abs(combined_x - golden) / golden_nozero).item()
+        avg_diff = torch.mean(torch.abs(combined_x - golden) / golden_nozero).item()
+        print(
+            f"rank {rank} PASSED [{quant_mode=}] avg_diff={avg_diff:.5f}, max_diff={max_diff:.5f}, cosine_diff={diff:.5f}"
+        )
+        diff_threshold = get_diff_threshold(quant_mode)
+
+        assert diff < diff_threshold, f"Error: {diff=}"
+        hash_value ^= hash_tensor(combined_x)
+        if local_rank == 0:
+            print(" passed", flush=True)
     if local_rank == 0:
         print("", flush=True)
 
@@ -184,15 +182,12 @@ def test(
             aligned_num_tokens,
             num_experts,
             cumulative_local_expert_recv_stats=cumulative_local_expert_recv_stats,
-            use_fp8=dispatch_use_fp8,
-            use_ue8m0=dispatch_use_ue8m0,
-            use_mxfp4=dispatch_use_mxfp4,
             async_finish=False,
             return_recv_hook=return_recv_hook,
             topk_weights=topk_weights,
         )
         simulated_gemm_x_local = (
-            per_token_cast_back(*recv_x) if dispatch_use_fp8 else recv_x
+            per_token_cast_back(*recv_x) if not quant_mode == "bf16" else recv_x
         )
         combined_x, event, hook = buffer.low_latency_combine(
             simulated_gemm_x_local,
@@ -207,12 +202,36 @@ def test(
     def calculate_dispatch_bytes(num_tokens, hidden, quant_type):
         BLOCK_SIZE = 32
         num_values = num_tokens * hidden
-        if quant_type == "int8":
-            data_bytes = num_values * 1
-            scale_bytes = num_tokens * 4
-            return data_bytes + scale_bytes
+        if quant_type == "bf16":
+            # BF16: each value occupies 2 bytes
+            recv_bytes = num_values * 2
+        elif quant_type == "int8":
+            # INT8 per-token quantization:
+            # - Data: num_values * 1 byte
+            # - Scale: num_tokens * 2 bytes (BF16 scale)
+            data_bytes = num_values
+            scale_bytes = num_tokens * 2
+            recv_bytes = data_bytes + scale_bytes
+        elif quant_type in ("mx_fp8_e4m3", "mx_fp8_e5m2"):
+            # MX-FP8:
+            # - Data: each FP8 value occupies 1 byte
+            # - Scale: one MX scale per BLOCK_SIZE values
+            #          E8M0 scale occupies 1 byte
+            data_bytes = num_values
+            num_blocks = (num_values + BLOCK_SIZE - 1) // BLOCK_SIZE
+            scale_bytes = num_blocks
+            recv_bytes = data_bytes + scale_bytes
+        elif quant_type == "mx_fp4_e2m1":
+            # MX-FP4:
+            # - Data: two FP4 values packed into 1 byte
+            # - Scale: one E8M0 scale per BLOCK_SIZE values
+            data_bytes = (num_values + 1) // 2
+            num_blocks = (num_values + BLOCK_SIZE - 1) // BLOCK_SIZE
+            scale_bytes = num_blocks
+            recv_bytes = data_bytes + scale_bytes
         else:
-            return num_values * 2
+            raise ValueError(f"Unsupported quant_type: {quant_type}")
+        return recv_bytes
 
     num_bf16_bytes = hidden * 2
     num_dispatch_comm_bytes, num_combine_comm_bytes = 0, 0
@@ -237,12 +256,8 @@ def test(
         "num_max_dispatch_tokens_per_rank": aligned_num_tokens,
         "num_experts": num_experts,
         "cumulative_local_expert_recv_stats": cumulative_local_expert_recv_stats,
-        "use_fp8": dispatch_use_fp8,
-        "use_ue8m0": dispatch_use_ue8m0,
-        "use_mxfp4": dispatch_use_mxfp4,
         "topk_weights": topk_weights,
     }
-    # dispatch_t = bench(lambda: buffer.low_latency_dispatch(**dispatch_args))[0]
     dispatch_alltoall_t = bench_kineto(
         lambda: buffer.low_latency_dispatch(**dispatch_args),
         kernel_names=("MoeInitRoutingV3", "hcom_alltoallv_"),
@@ -256,7 +271,7 @@ def test(
     # tuning combine
     recv_x, _, handle, _, _ = buffer.low_latency_dispatch(**dispatch_args)
     simulated_gemm_x_local = (
-        per_token_cast_back(*recv_x) if dispatch_use_fp8 else recv_x
+        per_token_cast_back(*recv_x) if not quant_mode == "bf16" else recv_x
     )
     combine_args = {
         "x": simulated_gemm_x_local,
@@ -391,8 +406,8 @@ if __name__ == "__main__":
         dest="quant_type",
         type=str,
         default="bf16",
-        choices=["bf16", "int8"],
-        help="Quantization type for dispatch: bf16, int8 (per-token)",
+        choices=["bf16", "int8", "mx_fp4_e2m1", "mx_fp8_e4m3", "mx_fp8_e5m2"],
+        help="Quantization type for dispatch: bf16, int8 (per-token), mx_fp4_e2m1, mx_fp8_e4m3, mx_fp8_e5m2",
     )
     args = parser.parse_args()
 

--- a/tests/python/deepep/test_ll_alltoall.py
+++ b/tests/python/deepep/test_ll_alltoall.py
@@ -186,9 +186,7 @@ def test(
             return_recv_hook=return_recv_hook,
             topk_weights=topk_weights,
         )
-        simulated_gemm_x_local = (
-            per_token_cast_back(*recv_x) if not quant_type == "bf16" else recv_x
-        )
+        simulated_gemm_x_local = per_token_cast_back(*recv_x)
         combined_x, event, hook = buffer.low_latency_combine(
             simulated_gemm_x_local,
             topk_idx,
@@ -270,9 +268,7 @@ def test(
 
     # tuning combine
     recv_x, _, handle, _, _ = buffer.low_latency_dispatch(**dispatch_args)
-    simulated_gemm_x_local = (
-        per_token_cast_back(*recv_x) if not quant_type == "bf16" else recv_x
-    )
+    simulated_gemm_x_local = per_token_cast_back(*recv_x)
     combine_args = {
         "x": simulated_gemm_x_local,
         "topk_idx": topk_idx,

--- a/tests/python/deepep/test_ll_alltoall.py
+++ b/tests/python/deepep/test_ll_alltoall.py
@@ -181,6 +181,7 @@ def test(
             topk_idx,
             aligned_num_tokens,
             num_experts,
+            use_fp8=False,
             cumulative_local_expert_recv_stats=cumulative_local_expert_recv_stats,
             async_finish=False,
             return_recv_hook=return_recv_hook,
@@ -253,6 +254,7 @@ def test(
         "topk_idx": topk_idx,
         "num_max_dispatch_tokens_per_rank": aligned_num_tokens,
         "num_experts": num_experts,
+        "use_fp8": False,
         "cumulative_local_expert_recv_stats": cumulative_local_expert_recv_stats,
         "topk_weights": topk_weights,
     }

--- a/tests/python/deepep/test_normal_alltoall.py
+++ b/tests/python/deepep/test_normal_alltoall.py
@@ -39,7 +39,6 @@ def test_main(
     base_num_tokens, hidden = args.num_tokens, args.hidden
     num_topk, num_experts = args.num_topk, args.num_experts
     enable_dynamic_tokens = args.enable_dynamic_tokens
-    quant_type = args.quant_type  # bf16, int8
 
     num_servers = num_ranks // num_local_ranks
     expert_token_nums_type = int(os.getenv("MOE_EXPERT_TOKEN_NUMS_TYPE", 1))
@@ -185,14 +184,23 @@ def test_main(
     )
 
     # Test dispatch
-    dispatch_quant_mode = quant_type
+    if args.use_mxfp4:
+        dispatch_quant_mode = "mx_fp4_e2m1"
+    elif args.use_mxfp8:
+        dispatch_quant_mode = "mx_fp8_e4m3"
+    elif args.use_fp8:
+        dispatch_quant_mode = "int8"
+    else:
+        dispatch_quant_mode = "bf16"
+    quant_dispatch_kwargs = {
+        "use_mxfp4": args.use_mxfp4,
+        "use_mxfp8": args.use_mxfp8,
+        "use_fp8": args.use_fp8,
+    }
     for current_x in filter(lambda elem: elem is not None, (x_pure_rand, x)):
-        iter_quant = dispatch_quant_mode if current_x is x_pure_rand else "bf16"
-        if iter_quant is None:
-            iter_quant = "bf16"
         if local_rank == 0:
             print(
-                f"[testing] Running with {iter_quant.upper()}, with top-k {num_topk} ...",
+                f"[testing] Running with {dispatch_quant_mode.upper()}, with top-k {num_topk} ...",
                 flush=True,
             )
         dispatch_args = {
@@ -205,7 +213,7 @@ def test_main(
             "topk_weights": (
                 topk_weights_pure_rand if current_x is x_pure_rand else topk_weights
             ),
-            "use_fp8": (quant_type != "bf16") if current_x is x_pure_rand else False,
+            **quant_dispatch_kwargs,
         }
 
         (
@@ -271,8 +279,10 @@ def test_main(
 
         avg_diff = torch.mean(torch.abs(check_x - golden) / golden_nozero).item()
         print(f"{rank=}, {avg_diff=:.5f}, {max_diff=:.5f}, cosine_diff={diff:.5f}")
-        diff_threshold = get_diff_threshold(iter_quant)
-        assert diff < diff_threshold, f"Error: {diff=}, {diff_threshold=}"
+        diff_threshold = get_diff_threshold(dispatch_quant_mode)
+        assert (
+            diff < diff_threshold
+        ), f"Assertion diff failed on {rank=}, Error: {diff=}, {diff_threshold=}"
 
         # For later tuning
         dispatch_bf16_recv_bytes = recv_x.numel() * 2
@@ -284,10 +294,37 @@ def test_main(
         print("", flush=True)
 
     # Tune dispatch performance
+    def calculate_recv_bytes(dispatch_bf16_recv_bytes, dispatch_quant_mode):
+        hidden_dim = hidden
+        bs = dispatch_bf16_recv_bytes / 2 / hidden_dim
+        num_values = bs * hidden_dim
+        scale_bytes = 0
+        if dispatch_quant_mode == "bf16":
+            # No quantization, use original BF16 communication
+            data_bytes = dispatch_bf16_recv_bytes
+        elif dispatch_quant_mode.startswith("int8"):
+            # INT8 per-token quantization:
+            # - Data: num_values * 1 byte (INT8)
+            # - Scale: x tokens * 2 bytes each (BF16)
+            data_bytes = num_values * 1
+            scale_bytes = bs * 2
+        elif dispatch_quant_mode.startswith("mx_fp4"):
+            data_bytes = num_values // 2
+            scale_bytes = num_values // 32
+        elif dispatch_quant_mode.startswith("mx_fp8"):
+            data_bytes = num_values
+            scale_bytes = num_values // 32
+        else:
+            raise ValueError(f"Unsupported quant_type: {dispatch_quant_mode}")
+        recv_bytes = data_bytes + scale_bytes
+        return recv_bytes
+
     config = deep_ep.Config(24, 8, buffer_size)
 
-    # BF16 dispatch tuning
-    tune_args_bf16 = {
+    quant_recv_bytes = calculate_recv_bytes(
+        dispatch_bf16_recv_bytes, dispatch_quant_mode
+    )
+    tune_args_quant = {
         "x": x,
         "config": config,
         "num_tokens_per_rank": ref_num_tokens_per_rank,
@@ -295,43 +332,15 @@ def test_main(
         "num_tokens_per_expert": ref_num_tokens_per_expert,
         "topk_idx": topk_idx,
         "topk_weights": topk_weights,
+        **quant_dispatch_kwargs,
     }
-    t = bench(lambda: buffer.dispatch(**tune_args_bf16))[0]
+    t = bench(lambda: buffer.dispatch(**tune_args_quant))[0]
     if local_rank == 0:
         print(
-            f"[tuning] Dispatch (BF16, raw_bytes={dispatch_bf16_recv_bytes/1e9:.3f}GB) "
-            f"raw_bw={dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s, equiv_bw={dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
+            f"[tuning] Dispatch ({dispatch_quant_mode}, raw_bytes={quant_recv_bytes/1e9:.3f}GB) "
+            f"raw_bw={quant_recv_bytes / 1e9 / t:.2f} GB/s, equiv_bw={dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
             flush=True,
         )
-
-    # Quantized dispatch tuning (int8)
-    if dispatch_quant_mode not in ("bf16", None):
-        num_recv_tokens = dispatch_bf16_recv_bytes // (hidden * 2)
-        if dispatch_quant_mode == "int8":
-            quant_data_bytes = num_recv_tokens * hidden
-            quant_scale_bytes = num_recv_tokens * 4
-        else:
-            raise ValueError(
-                f"Unsupported quant_mode for bandwidth calculation: {dispatch_quant_mode}"
-            )
-        quant_recv_bytes = quant_data_bytes + quant_scale_bytes
-        tune_args_quant = {
-            "x": x,
-            "config": config,
-            "num_tokens_per_rank": ref_num_tokens_per_rank,
-            "is_token_in_rank": ref_is_token_in_rank,
-            "num_tokens_per_expert": ref_num_tokens_per_expert,
-            "topk_idx": topk_idx,
-            "topk_weights": topk_weights,
-            "use_fp8": (quant_type != "bf16"),
-        }
-        t = bench(lambda: buffer.dispatch(**tune_args_quant))[0]
-        if local_rank == 0:
-            print(
-                f"[tuning] Dispatch ({dispatch_quant_mode}, raw_bytes={quant_recv_bytes/1e9:.3f}GB) "
-                f"raw_bw={quant_recv_bytes / 1e9 / t:.2f} GB/s, equiv_bw={dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
-                flush=True,
-            )
 
     dispatch_args = {
         "x": x,
@@ -341,7 +350,7 @@ def test_main(
         "config": config,
         "topk_idx": topk_idx,
         "topk_weights": topk_weights,
-        "use_fp8": (quant_type != "bf16"),
+        **quant_dispatch_kwargs,
     }
     recv_x, _, _, _, handle, _ = buffer.dispatch(**dispatch_args)
     recv_x = per_token_cast_back(*recv_x) if isinstance(recv_x, tuple) else recv_x
@@ -420,11 +429,28 @@ if __name__ == "__main__":
         help="Whether to enable dynamic tokens for testing",
     )
     parser.add_argument(
-        "--quant-type",
-        dest="quant_type",
-        type=str,
-        default="bf16",
-        help="quant type: bf16, int8",
+        "--use-mxfp8",
+        dest="use_mxfp8",
+        action="store_true",
+        help="Use use_mxfp8=True bool flag for normal dispatch. "
+        "A5 -> mx_fp8_e4m3, A2/A3 -> not supported. "
+        "Mutually exclusive with --quant-type.",
+    )
+    parser.add_argument(
+        "--use-mxfp4",
+        dest="use_mxfp4",
+        action="store_true",
+        help="Use use_mxfp4=True bool flag for normal dispatch. "
+        "A5 -> mx_fp4_e2m1, A2/A3 -> not supported. "
+        "Mutually exclusive with --quant-type.",
+    )
+    parser.add_argument(
+        "--use-fp8",
+        dest="use_fp8",
+        action="store_true",
+        help="Use use_fp8=True bool flag for normal dispatch. Architecture-aware: "
+        "A5 -> not supported, A2/A3 -> int8 (with warning). "
+        "Mutually exclusive with --quant-type.",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Motivation
Quantization mode be added to the AlltoAll mode to be aligned with the A5 mode. fix #691 
Modifications
normal_strategy.py:Added Quantitative Type.
test_normal_alltoall.py:Provide quantitative parameters
Testing
python test_normal_alltoall.py --num-processes 2 
python test_normal_alltoall.py --num-processes 2 --use-fp8
python test_normal_alltoall.py --num-processes 2 --use-mxfp4
python test_ll_alltoall.py --num-processes 2 --quant-type bf16
python test_ll_alltoall.py --num-processes 2 --quant-type int8
python test_ll_alltoall.py --num-processes 2 --quant-type mx_fp8_e5m2
python test_ll_alltoall.py --num-processes 2 --quant-type mx_fp8_e4m3
python test_ll_alltoall.py --num-processes 2 --quant-type mx_fp4_e2m1

Benchmarking and Profiling

before：
【normal-bf16】
[testing] Running with BF16, with top-k 8 ...
rank=1, avg_diff=0.00000, max_diff=0.00000, cosine_diff=0.00000
rank=0, avg_diff=0.00000, max_diff=0.00392, cosine_diff=0.00000
[test] passed, dispatch_bf16_recv_bytes=469762048
rank=1, avg_diff=0.00000, max_diff=0.00559, cosine_diff=0.00000
[tuning] Dispatch (quant_type='bf16') 53.86 GB/s (HCCS), avg_t: 8721.78 us
[tuning] Combine 68.22 GB/s (HCCS), avg_t: 6885.71 us

【normal-int8】
[testing] Running with BF16, with top-k 8 ...
rank=0, avg_diff=0.00002, max_diff=1.00701, cosine_diff=0.00004
[test] passed, dispatch_bf16_recv_bytes=469762048
rank=1, avg_diff=0.00001, max_diff=1.00759, cosine_diff=0.00004
[tuning] Dispatch (quant_type='int8') 44.22 GB/s (HCCS), avg_t: 5312.96 us
[tuning] Combine 69.42 GB/s (HCCS), avg_t: 6767.04 us

【lowlatency-bf16】
[testing] Running with quant_type='bf16', data=rand ...
rank 0 PASSED [quant_type='bf16'] avg_diff=0.00000, max_diff=0.00389, cosine_diff=0.00000
rank 1 PASSED [quant_type='bf16'] avg_diff=0.00000, max_diff=0.00389, cosine_diff=0.00000
 passed
[test] finish.
[test] finish.
[rank 0] Dispatch bandwidth: 0.09 GB/s, avg_t=11058.02 us | Combine bandwidth: 0.10 GB/s, avg_t=10454.10 us
[rank 1] Dispatch bandwidth: 0.09 GB/s, avg_t=11058.98 us | Combine bandwidth: 0.10 GB/s, avg_t=10453.95 us
Average Dispatch bandwidth: 0.09 GB/s, avg_t=11058.50 us 
Average Combine bandwidth: 0.10 GB/s, avg_t=10454.03 us

【lowlatency-int8】
[testing] Running with quant_type='int8', data=rand ...
rank 0 PASSED [quant_type='int8'] avg_diff=-0.00014, max_diff=1.00619, cosine_diff=0.00004
rank 1 PASSED [quant_type='int8'] avg_diff=0.00010, max_diff=1.00554, cosine_diff=0.00004
 passed
[test] finish.
[test] finish.
[rank 0] Dispatch bandwidth: 0.05 GB/s, avg_t=11035.74 us | Combine bandwidth: 0.10 GB/s, avg_t=10448.94 us
[rank 1] Dispatch bandwidth: 0.05 GB/s, avg_t=11039.25 us | Combine bandwidth: 0.10 GB/s, avg_t=10448.50 us
Average Dispatch bandwidth: 0.05 GB/s, avg_t=11037.50 us 
Average Combine bandwidth: 0.10 GB/s, avg_t=10448.72 us

after：
【normal-bf16】
[testing] Running with BF16, with top-k 8 ...
rank=0, avg_diff=-0.00000, max_diff=0.00389, cosine_diff=0.00000
[test] passed, dispatch_bf16_recv_bytes=469762048
[testing] Running with BF16, with top-k 8 ...
rank=1, avg_diff=-0.00000, max_diff=0.00407, cosine_diff=0.00000
rank=0, avg_diff=0.00000, max_diff=0.00000, cosine_diff=0.00000
[test] passed, dispatch_bf16_recv_bytes=469762048

rank=1, avg_diff=0.00000, max_diff=0.00000, cosine_diff=0.00000
[tuning] Dispatch (bf16, raw_bytes=0.470GB) raw_bw=64.35 GB/s, equiv_bw=64.35 GB/s (HCCS), avg_t: 7300.36 us
[tuning] Combine 72.81 GB/s (HCCS), avg_t: 6451.53 us

【normal-fp8】
[testing] Running with MX_FP8_E4M3, with top-k 8 ...
rank=0, avg_diff=0.00000, max_diff=1.00000, cosine_diff=0.00038
[test] passed, dispatch_bf16_recv_bytes=469762048
[testing] Running with MX_FP8_E4M3, with top-k 8 ...
rank=1, avg_diff=-0.00001, max_diff=1.00000, cosine_diff=0.00038
rank=1, avg_diff=0.00000, max_diff=0.00000, cosine_diff=0.00000
rank=0, avg_diff=0.00000, max_diff=0.00000, cosine_diff=0.00000
[test] passed, dispatch_bf16_recv_bytes=469762048

[tuning] Dispatch (mx_fp8_e4m3, raw_bytes=0.235GB) raw_bw=44.73 GB/s, equiv_bw=89.43 GB/s (HCCS), avg_t: 5252.62 us
[tuning] Combine 70.43 GB/s (HCCS), avg_t: 6670.02 us


【normal-fp4】
[testing] Running with MX_FP4_E2M1, with top-k 8 ...
rank=1, avg_diff=-0.00006, max_diff=1.98814, cosine_diff=0.00700
rank=0, avg_diff=-0.00002, max_diff=1.98797, cosine_diff=0.00701
[test] passed, dispatch_bf16_recv_bytes=469762048
[testing] Running with MX_FP4_E2M1, with top-k 8 ...
rank=1, avg_diff=0.00000, max_diff=0.00000, cosine_diff=0.00000
rank=0, avg_diff=0.00000, max_diff=0.00000, cosine_diff=0.00000
[test] passed, dispatch_bf16_recv_bytes=469762048

[tuning] Dispatch (mx_fp4_e2m1, raw_bytes=0.125GB) raw_bw=35.86 GB/s, equiv_bw=135.00 GB/s (HCCS), avg_t: 3479.70 us
[tuning] Combine 70.31 GB/s (HCCS), avg_t: 6681.09 us


【lowlatency-bf16】
[testing] Running with quant_type='bf16', data=rand ...
[rank0]:[W831 17:33:27.462082210 ToKernelNpu.cpp:40] Warning: Device do not support double dtype now, dtype cast replace with float. (function operator())
rank 0 PASSED [quant_mode='bf16'] avg_diff=0.00000, max_diff=0.00389, cosine_diff=0.00000
rank 1 PASSED [quant_mode='bf16'] avg_diff=0.00000, max_diff=0.00389, cosine_diff=0.00000
 passed
[test] finish.
[test] finish.
[rank 0] Dispatch raw_bw=0.09 GB/s, equiv_bw=0.09 GB/s, avg_t=11059.70 us | Combine raw_bw=0.10 GB/s, equiv_bw=0.10 GB/s, avg_t=10454.52 us
[rank 1] Dispatch raw_bw=0.09 GB/s, equiv_bw=0.09 GB/s, avg_t=11068.01 us | Combine raw_bw=0.10 GB/s, equiv_bw=0.10 GB/s, avg_t=10455.04 us
Average Dispatch bandwidth: 0.09 GB/s, avg_t=11063.86 us 
Average Combine bandwidth: 0.10 GB/s, avg_t=10454.78 us

【lowlatency-int8】
[testing] Running with quant_type='int8', data=rand ...
rank 0 PASSED [quant_mode='int8'] avg_diff=-0.00014, max_diff=1.00619, cosine_diff=0.00004
rank 1 PASSED [quant_mode='int8'] avg_diff=0.00010, max_diff=1.00554, cosine_diff=0.00004
 passed
[test] finish.
[test] finish.
[rank 1] Dispatch raw_bw=0.05 GB/s, equiv_bw=0.09 GB/s, avg_t=11043.20 us | Combine raw_bw=0.10 GB/s, equiv_bw=0.10 GB/s, avg_t=10449.18 us
[rank 0] Dispatch raw_bw=0.05 GB/s, equiv_bw=0.10 GB/s, avg_t=11036.65 us | Combine raw_bw=0.10 GB/s, equiv_bw=0.10 GB/s, avg_t=10449.14 us
Average Dispatch bandwidth: 0.05 GB/s, avg_t=11039.93 us 
Average Combine bandwidth: 0.10 GB/s, avg_t=10449.16 us

【lowlatency-mx_fp8_e4m3】
[testing] Running with quant_type='mx_fp8_e4m3', data=rand ...
rank 0 PASSED [quant_mode='mx_fp8_e4m3'] avg_diff=-0.00002, max_diff=1.00000, cosine_diff=0.00042
rank 1 PASSED [quant_mode='mx_fp8_e4m3'] avg_diff=0.00000, max_diff=1.00000, cosine_diff=0.00042
 passed
[test] finish.
[test] finish.
[rank 0] Dispatch raw_bw=0.05 GB/s, equiv_bw=0.09 GB/s, avg_t=11038.53 us | Combine raw_bw=0.10 GB/s, equiv_bw=0.10 GB/s, avg_t=10448.49 us
[rank 1] Dispatch raw_bw=0.05 GB/s, equiv_bw=0.09 GB/s, avg_t=11049.95 us | Combine raw_bw=0.10 GB/s, equiv_bw=0.10 GB/s, avg_t=10447.61 us
Average Dispatch bandwidth: 0.05 GB/s, avg_t=11044.24 us 
Average Combine bandwidth: 0.10 GB/s, avg_t=10448.05 us

【lowlatency-mx_fp8_e5m2】
[testing] Running with quant_type='mx_fp8_e5m2', data=rand ...
rank 1 PASSED [quant_mode='mx_fp8_e5m2'] avg_diff=0.00003, max_diff=0.12464, cosine_diff=0.00143
rank 0 PASSED [quant_mode='mx_fp8_e5m2'] avg_diff=0.00001, max_diff=0.12486, cosine_diff=0.00143
 passed
[test] finish.
[test] finish.
[rank 1] Dispatch raw_bw=0.05 GB/s, equiv_bw=0.09 GB/s, avg_t=11054.82 us | Combine raw_bw=0.10 GB/s, equiv_bw=0.10 GB/s, avg_t=10458.10 us
[rank 0] Dispatch raw_bw=0.05 GB/s, equiv_bw=0.09 GB/s, avg_t=11039.64 us | Combine raw_bw=0.10 GB/s, equiv_bw=0.10 GB/s, avg_t=10449.48 us
Average Dispatch bandwidth: 0.05 GB/s, avg_t=11047.23 us 
Average Combine bandwidth: 0.10 GB/s, avg_t=10453.79 us

【lowlatency-mx_fp4_e2m1】
[testing] Running with quant_type='mx_fp4_e2m1', data=rand ...
rank 0 PASSED [quant_mode='mx_fp4_e2m1'] avg_diff=-0.00027, max_diff=1.98737, cosine_diff=0.00773
rank 1 PASSED [quant_mode='mx_fp4_e2m1'] avg_diff=-0.00024, max_diff=1.98707, cosine_diff=0.00772
 passed
[test] finish.
[test] finish.
[rank 1] Dispatch raw_bw=0.03 GB/s, equiv_bw=0.09 GB/s, avg_t=11061.22 us | Combine raw_bw=0.10 GB/s, equiv_bw=0.10 GB/s, avg_t=10454.26 us
[rank 0] Dispatch raw_bw=0.03 GB/s, equiv_bw=0.09 GB/s, avg_t=11047.46 us | Combine raw_bw=0.10 GB/s, equiv_bw=0.10 GB/s, avg_t=10449.40 us
Average Dispatch bandwidth: 0.03 GB/s, avg_t=11054.34 us 
Average Combine bandwidth: 0.10 GB/s, avg_t=10451.83 us

Checklist
 Format your code.
 Add unit tests.
 Update documentation.
 Provide accuracy and speed benchmark results.