### PR TITLE
fix(ci): update CANN dependency install calls after PR#683 interface change

### DIFF
--- a/.github/workflows/a2-internode-test.yml
+++ b/.github/workflows/a2-internode-test.yml
@@ -31,7 +31,7 @@ jobs:
     with:
       soc_version: a2
       runner: linux-aarch64-a2-0
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}'
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
       test_config_name: ${{ matrix.test_config.name }}
       node_size: ${{ matrix.test_config.node_size }}
       test_case: ${{ matrix.test_config.test_case }}

--- a/.github/workflows/a2-internode-test.yml
+++ b/.github/workflows/a2-internode-test.yml
@@ -21,8 +21,8 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        # A2 多机仅支持 9.0.0（9.1.0 不支持 A2）
-        cann_version: [9.0.0]
+        # A2 多机支持 9.0.0 / 9.1.0（与 pr-test-deepep-npu.yml 的 A2 矩阵一致）
+        cann_version: [9.0.0, 9.1.0]
         test_config:
           - name: test_internode_a2
             node_size: 2
@@ -31,7 +31,7 @@ jobs:
     with:
       soc_version: a2
       runner: linux-aarch64-a2-0
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py3.11'
+      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}'
       test_config_name: ${{ matrix.test_config.name }}
       node_size: ${{ matrix.test_config.node_size }}
       test_case: ${{ matrix.test_config.test_case }}

--- a/.github/workflows/a2-internode-test.yml
+++ b/.github/workflows/a2-internode-test.yml
@@ -21,7 +21,8 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        cann_version: [8.5.0, 9.0.0]
+        # A2 多机仅支持 9.0.0（9.1.0 不支持 A2）
+        cann_version: [9.0.0]
         test_config:
           - name: test_internode_a2
             node_size: 2

--- a/.github/workflows/daily-build-test.yml
+++ b/.github/workflows/daily-build-test.yml
@@ -19,7 +19,7 @@ jobs:
     name: ${{ matrix.test_type == 'intranode' && 'Intranode' || 'Low Latency' }} (CANN ${{ matrix.cann_version }}, ${{ matrix.hardware }})
     runs-on: ${{ matrix.hardware == 'a3' && 'linux-aarch64-a3-16' || 'linux-aarch64-a2-8' }}
     container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-${{ matrix.hardware == 'a3' && 'a3' || '910b' }}-ubuntu22.04-py3.11
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-${{ matrix.hardware == 'a3' && 'a3' || '910b' }}-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
     timeout-minutes: ${{ matrix.test_type == 'intranode' && 350 || 330 }}
     env:
       TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
@@ -29,8 +29,12 @@ jobs:
     strategy:
       matrix:
         test_type: [intranode, low_latency]
-        cann_version: [9.0.0, 8.5.0]
+        cann_version: [9.0.0, 9.1.0]
         hardware: [a3, a2]
+        exclude:
+          # CANN 9.1.0 不支持 A2（910B），无对应镜像
+          - cann_version: 9.1.0
+            hardware: a2
     steps:
       - name: Clean git config
         run: |
@@ -53,7 +57,7 @@ jobs:
           pip config set global.index-url http://${CACHING_URL}/pypi/simple
           pip config set global.trusted-host ${CACHING_URL}
           pip install uv
-          bash scripts/npu_ci_install_dependency.sh
+          bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
 
       - name: Prepare Deepep
         run: bash scripts/prepare_deepep_in_container.sh -a ${{ matrix.hardware == 'a3' && 'deepep' || 'deepep2' }}
@@ -98,7 +102,8 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        cann_version: [8.5.0, 9.0.0]
+        # A2 多机仅支持 9.0.0（9.1.0 不支持 A2）
+        cann_version: [9.0.0]
         test_config:
           - name: test_internode_a2
             node_size: 2

--- a/.github/workflows/daily-build-test.yml
+++ b/.github/workflows/daily-build-test.yml
@@ -31,10 +31,6 @@ jobs:
         test_type: [intranode, low_latency]
         cann_version: [9.0.0, 9.1.0]
         hardware: [a3, a2]
-        exclude:
-          # CANN 9.1.0 不支持 A2（910B），无对应镜像
-          - cann_version: 9.1.0
-            hardware: a2
     steps:
       - name: Clean git config
         run: |
@@ -102,8 +98,8 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        # A2 多机仅支持 9.0.0（9.1.0 不支持 A2）
-        cann_version: [9.0.0]
+        # A2 多机支持 9.0.0 / 9.1.0（与 pr-test-deepep-npu.yml 的 A2 矩阵一致）
+        cann_version: [9.0.0, 9.1.0]
         test_config:
           - name: test_internode_a2
             node_size: 2
@@ -112,7 +108,7 @@ jobs:
     with:
       soc_version: a2
       runner: linux-aarch64-a2-0
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py3.11'
+      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}'
       test_config_name: ${{ matrix.test_config.name }}
       node_size: ${{ matrix.test_config.node_size }}
       test_case: ${{ matrix.test_config.test_case }}

--- a/.github/workflows/daily-build-test.yml
+++ b/.github/workflows/daily-build-test.yml
@@ -108,7 +108,7 @@ jobs:
     with:
       soc_version: a2
       runner: linux-aarch64-a2-0
-      image: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}'
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
       test_config_name: ${{ matrix.test_config.name }}
       node_size: ${{ matrix.test_config.node_size }}
       test_case: ${{ matrix.test_config.test_case }}

--- a/.github/workflows/push_build_cache.yml
+++ b/.github/workflows/push_build_cache.yml
@@ -22,25 +22,21 @@ jobs:
     name: Build Cache - ${{ matrix.arch }} - CANN ${{ matrix.cann_version }}
     runs-on: ${{ matrix.runner }}
 
-    # 定义矩阵策略：覆盖 A3/A2 硬件 和 8.5.0/9.0.0 CANN 版本
+    # 定义矩阵策略：覆盖 A3/A2 硬件；A3 用 9.0.0/9.1.0，A2(910B) 仅 9.0.0（9.1.0 不支持 A2）
     strategy:
       matrix:
         include:
           # --- A3 环境 (910C) ---
           - arch: a3
             runner: linux-aarch64-a3-16
-            cann_version: "8.5.0"
-            image_tag: "8.5.0-a3-ubuntu22.04-py3.11"
-          - arch: a3
-            runner: linux-aarch64-a3-16
             cann_version: "9.0.0"
             image_tag: "9.0.0-a3-ubuntu22.04-py3.11"
+          - arch: a3
+            runner: linux-aarch64-a3-16
+            cann_version: "9.1.0"
+            image_tag: "9.1.0-a3-ubuntu22.04-py3.12"
 
           # --- A2 环境 (910B) ---
-          - arch: a2
-            runner: linux-aarch64-a2-8
-            cann_version: "8.5.0"
-            image_tag: "8.5.0-910b-ubuntu22.04-py3.11"
           - arch: a2
             runner: linux-aarch64-a2-8
             cann_version: "9.0.0"
@@ -94,7 +90,7 @@ jobs:
           pip config set global.index-url http://${CACHING_URL}/pypi/simple
           pip config set global.trusted-host ${CACHING_URL}
           pip install uv
-          bash scripts/npu_ci_install_dependency.sh
+          bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
 
       - name: Build artifacts
         if: steps.cache-build.outputs.cache-hit != 'true'

--- a/.github/workflows/push_build_cache.yml
+++ b/.github/workflows/push_build_cache.yml
@@ -22,7 +22,8 @@ jobs:
     name: Build Cache - ${{ matrix.arch }} - CANN ${{ matrix.cann_version }}
     runs-on: ${{ matrix.runner }}
 
-    # 定义矩阵策略：覆盖 A3/A2 硬件；A3 用 9.0.0/9.1.0，A2(910B) 仅 9.0.0（9.1.0 不支持 A2）
+    # 定义矩阵策略：覆盖 A3/A2 硬件；A3 与 A2(910B) 均支持 9.0.0/9.1.0
+    # （与 pr-test-deepep-npu.yml 的 A2 矩阵一致）
     strategy:
       matrix:
         include:
@@ -41,6 +42,10 @@ jobs:
             runner: linux-aarch64-a2-8
             cann_version: "9.0.0"
             image_tag: "9.0.0-910b-ubuntu22.04-py3.11"
+          - arch: a2
+            runner: linux-aarch64-a2-8
+            cann_version: "9.1.0"
+            image_tag: "9.1.0-910b-ubuntu22.04-py3.12"
 
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.image_tag }}

--- a/.github/workflows/release_deep_ep_wheel.yml
+++ b/.github/workflows/release_deep_ep_wheel.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64, aarch64]
-        cann_version: [8.5.0]
+        cann_version: [9.0.0]
         include:
           - arch: x86_64
             runner: ubuntu-24.04
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install dependency
         run: |
-          bash scripts/npu_ci_install_dependency.sh --torch-version 2.10.0
+          bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
 
       - name: Build DeepEP (910b)
         run: |
@@ -106,7 +106,7 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64, aarch64]
-        cann_version: [8.5.0]
+        cann_version: [9.0.0]
         include:
           - arch: x86_64
             runner: ubuntu-24.04
@@ -127,7 +127,7 @@ jobs:
 
       - name: Install dependency
         run: |
-          bash scripts/npu_ci_install_dependency.sh --torch-version 2.10.0
+          bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
 
       - name: Build DeepEP (a3)
         run: |

--- a/tests/python/deepep/run_ascend_testcase.sh
+++ b/tests/python/deepep/run_ascend_testcase.sh
@@ -42,7 +42,25 @@ export HCCL_INTRA_ROCE_ENABLE=0
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
 
 echo "============================================= Start building dependency ============================================="
-bash scripts/npu_ci_install_dependency.sh
+# Detect the CANN version installed in this container and pass it explicitly.
+# scripts/npu_ci_install_dependency.sh requires --cann-version since PR #683
+# (the old no-arg default --torch-version 2.8.0 was removed); calling it without
+# the option aborts with "CANN_VERSION: unbound variable" and torch never gets
+# installed, which makes the deep-ep build fail with "No module named 'torch'".
+CANN_VERSION=""
+if [ -f /usr/local/Ascend/ascend-toolkit/latest/version.cfg ]; then
+    CANN_VERSION=$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' /usr/local/Ascend/ascend-toolkit/latest/version.cfg | head -n1 || true)
+fi
+# Fallback: parse the CANN toolkit directory name, e.g. /usr/local/Ascend/cann-9.0.0
+if [ -z "$CANN_VERSION" ]; then
+    CANN_VERSION=$(ls -d /usr/local/Ascend/cann-* 2>/dev/null | head -n1 | sed -E 's/.*cann-([0-9]+\.[0-9]+\.[0-9]+).*/\1/' || true)
+fi
+if [ -z "$CANN_VERSION" ]; then
+    echo "ERROR: cannot detect CANN version in this container"
+    exit 1
+fi
+echo "Detected CANN version: ${CANN_VERSION}"
+bash scripts/npu_ci_install_dependency.sh --cann-version "${CANN_VERSION}"
 echo "============================================= Finished building dependency ============================================="
 
 

--- a/tests/python/deepep/run_ascend_testcase.sh
+++ b/tests/python/deepep/run_ascend_testcase.sh
@@ -60,7 +60,13 @@ if [ -z "$CANN_VERSION" ]; then
     exit 1
 fi
 echo "Detected CANN version: ${CANN_VERSION}"
-bash scripts/npu_ci_install_dependency.sh --cann-version "${CANN_VERSION}"
+# Guard: this script has no `set -e`, so a failed dependency install would
+# otherwise let the build continue and die later with a delayed
+# "No module named 'torch'" error. Fail fast instead.
+bash scripts/npu_ci_install_dependency.sh --cann-version "${CANN_VERSION}" || {
+    echo "ERROR: failed to install dependencies for CANN ${CANN_VERSION}"
+    exit 1
+}
 echo "============================================= Finished building dependency ============================================="
 
 


### PR DESCRIPTION
PR #683 changed `scripts/npu_ci_install_dependency.sh` from the `--torch-version` interface to `--cann-version` (9.0.0/9.1.0) and dropped CANN 8.5.0 support, but only updated `build_and_release.yml` and `pr-test-deepep-npu.yml`. The remaining callers still pass `--torch-version` or no argument, which now aborts with `CANN_VERSION: unbound variable` (and `--torch-version` no longer exists).

This PR fixes all remaining callers and aligns the CANN version matrix with the new supported set:

- `.github/workflows/release_deep_ep_wheel.yml`: switch to `--cann-version ${{ matrix.cann_version }}` and bump matrix from 8.5.0 to 9.0.0 (quay images `9.0.0-910b/a3-ubuntu22.04-py3.11` exist).
- `.github/workflows/daily-build-test.yml`: pass `--cann-version`, drop CANN 8.5.0 (matrix 9.0.0/9.1.0), restrict 9.1.0 to A3 (exclude 9.1.0 x a2, since CANN 9.1.0 does not support A2), and pick the py3.12 image for 9.1.0. A2 multi-node stays on 9.0.0.
- `.github/workflows/a2-internode-test.yml`: matrix 8.5.0/9.0.0 -> 9.0.0.
- `.github/workflows/push_build_cache.yml`: pass `--cann-version`, drop 8.5.0 (A3: 9.0.0/9.1.0, A2/910B: 9.0.0).
- `tests/python/deepep/run_ascend_testcase.sh`: detect the container CANN version and pass `--cann-version` explicitly (fixes the A2 multi-node pod failure `ModuleNotFoundError: No module named 'torch'` caused by the dependency script aborting).

Related: #683