### PR TITLE
fix(wy_fast): Correct equal-length path indexing in recompute_w_u_fwd…

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/wy_fast.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/wy_fast.py
@@ -40,9 +40,8 @@ def recompute_w_u_fwd_kernel_npu_kernel(
     IS_VARLEN: tl.constexpr,
 ):
     T_max = T
-    i_t_o, _ = tl.program_id(0), tl.program_id(1)
-    for i_bh in range(H):
-        i_b, i_h = i_bh // H, i_bh % H
+    i_t_o = tl.program_id(0)
+    for i_h in range(H):
         if IS_VARLEN:
             i_n, i_t = tl.load(chunk_indices + i_t_o * 2).to(tl.int32), tl.load(
                 chunk_indices + i_t_o * 2 + 1
@@ -51,8 +50,12 @@ def recompute_w_u_fwd_kernel_npu_kernel(
                 cu_seqlens + i_n + 1
             ).to(tl.int32)
             T = eos - bos
+            bos_bh = bos
         else:
+            i_b = tl.program_id(1)
             bos, eos = i_b * T, i_b * T + T
+            i_t = i_t_o
+            bos_bh = i_b * H * T_max
 
         offs_t = tl.arange(0, BT)
         global_offs_t = i_t * BT + offs_t
@@ -64,10 +67,10 @@ def recompute_w_u_fwd_kernel_npu_kernel(
         mask_A = mask_t[:, None]
         b_A = tl.load(ptr_A, mask=mask_A, other=0.0).to(tl.float32)
 
-        ptr_g = g + bos + i_h * T_max + global_offs_t
+        ptr_g = g + bos_bh + i_h * T_max + global_offs_t
         b_g = tl.exp(tl.load(ptr_g, mask=mask_t, other=0.0)).to(tl.float32)
 
-        ptr_beta = beta + bos + i_h * T_max + global_offs_t
+        ptr_beta = beta + bos_bh + i_h * T_max + global_offs_t
         b_beta = tl.load(ptr_beta, mask=mask_t, other=0.0).to(tl.float32)
 
         for i_v in range(tl.cdiv(V, BV)):

--- a/tests/python/sgl_kernel_npu/test_wy_fast.py
+++ b/tests/python/sgl_kernel_npu/test_wy_fast.py
@@ -1,0 +1,75 @@
+import pytest
+import torch
+from sgl_kernel_npu.fla.wy_fast import recompute_w_u_fwd_npu
+
+device = "npu"
+
+
+@torch.inference_mode()
+def test_recompute_w_u_fwd_equal_length():
+    # Equal-length (cu_seqlens=None) regression test.
+    # Covers: i_t initialization in the else branch, batch index from
+    # tl.program_id(1), and the [B, H, T] pointer base for the transposed
+    # beta / g_cumsum tensors. Distinct per-batch values make any batch
+    # index error visible in the outputs.
+    # See https://github.com/vllm-project/vllm-ascend/pull/14333
+    batch_size, seq_len, key_heads, value_heads = 2, 96, 2, 4
+    key_dim = value_dim = chunk_size = 64
+
+    k = torch.randn(
+        batch_size,
+        seq_len,
+        key_heads,
+        key_dim,
+        dtype=torch.float32,
+        device=device,
+    )
+    v = torch.randn(
+        batch_size,
+        seq_len,
+        value_heads,
+        value_dim,
+        dtype=torch.float32,
+        device=device,
+    )
+    batch_values = torch.arange(
+        1, batch_size + 1, dtype=torch.float32, device=device
+    ).view(batch_size, 1, 1)
+    beta = batch_values.expand(batch_size, seq_len, value_heads).contiguous()
+    g_cumsum = batch_values.log().expand_as(beta).contiguous()
+
+    # Identity rows: token t activates column t % chunk_size, so the
+    # kernel reduces to w = k * beta * exp(g), u = v * beta.
+    A = torch.zeros(
+        batch_size,
+        seq_len,
+        value_heads,
+        chunk_size,
+        dtype=torch.float32,
+        device=device,
+    )
+    token_indices = torch.arange(seq_len, device=device)
+    A[:, token_indices, :, token_indices % chunk_size] = 1
+
+    w, u = recompute_w_u_fwd_npu(
+        k,
+        v,
+        beta,
+        g_cumsum,
+        A,
+        cu_seqlens=None,
+    )
+
+    expected_w = (
+        k.repeat_interleave(value_heads // key_heads, dim=2)
+        * beta.unsqueeze(-1)
+        * g_cumsum.exp().unsqueeze(-1)
+    )
+    expected_u = v * beta.unsqueeze(-1)
+
+    torch.testing.assert_close(w, expected_w)
+    torch.testing.assert_close(u, expected_u)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fix three related indexing bugs in the equal-length (`cu_seqlens=None`) path of `recompute_w_u_fwd_kernel_npu_kernel` in `wy_fast.py`.

Fixes #690
Fixes #709

## Problem

The equal-length branch had three bugs that were introduced during NPU adaptation:

1. **`i_t` uninitialized (NameError)**: The variable `i_t` was only assigned in the `IS_VARLEN` branch, causing Triton compilation to fail with `NameError: i_t is not defined` when `cu_seqlens=None`.

2. **`i_b` always zero (silent corruption)**: The batch index was computed as `i_bh // H` inside a loop `for i_bh in range(H)`, which always evaluates to 0. This caused all batches to write to batch 0's memory location.

3. **Incorrect pointer offset for transposed tensors (silent corruption)**: `beta` and `g_cumsum` are transposed to `[B, H, T]` layout before kernel launch, but the pointer calculation used `bos` (which assumes `[B, T, H]` layout) without the `H` dimension multiplier.

## Fix

- Changed the loop from `for i_bh in range(H)` with `i_b, i_h = i_bh // H, i_bh % H` to `for i_h in range(H)`
- In the `else` (equal-length) branch:
  - Compute `i_b` from `tl.program_id(1)` (grid dim 1)
  - Add `i_t = i_t_o` to initialize chunk index
  - Introduce `bos_bh = i_b * H * T_max` for correct transposed tensor pointer calculation
- Use `bos_bh` instead of `bos` for `g` and `beta` pointer calculation

**Key point**: varlen path has zero behavior change—the original code only used `i_b` in the `else` branch, and `bos_bh = bos` is equivalent to the original expression in varlen (B=1 packed). Serving path is unaffected.

## Changes

- `python/sgl_kernel_npu/sgl_kernel_npu/fla/wy_fast.py`: Fixed equal-length path indexing
- `tests/python/sgl_kernel_npu/test_wy_fast.py`: Added regression test with B=2 to catch all three bugs

## Testing

Tested on Ascend 910C with CANN 9.0.0:

```bash
pytest tests/python/sgl_kernel_npu/test_wy_fast.py -v
```

```
===================================== test session starts =====================================
platform linux -- Python 3.11.15, pytest-8.3.2, pluggy-1.6.0
collected 1 item

test_wy_fast.py::test_recompute_w_u_fwd_equal_length PASSED                              [100%]

====================================== 1 passed in 19.69s =======================================
```

## Related

- vllm-ascend PR (same fix): https://github.com/vllm-project/vllm-ascend/pull/14333
- vllm-ascend Issue: https://github.com/vllm-project/vllm-ascend/issues/14154
- sglang upstream (`python/sglang/kernels/ops/attention/fla/wy_fast.py`) uses grid `(NT, B*H)` and does not have this bug; the bug was introduced during the NPU adaptation that changed the grid to `(NT, B)` with an in-kernel head loop