### PR TITLE
[DeepEP] [test] Unify alltoall test scripts with intranode

### DIFF
--- a/tests/python/deepep/test_intranode.py
+++ b/tests/python/deepep/test_intranode.py
@@ -469,14 +469,15 @@ def test_main(
     t = bench(lambda: buffer.dispatch(**tune_args_bf16))[0]
     if local_rank == 0:
         print(
-            f"[tuning] Dispatch (BF16) {dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
+            f"[tuning] Dispatch (BF16, raw_bytes={dispatch_bf16_recv_bytes/1e9:.3f}GB) "
+            f"raw_bw={dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s, equiv_bw={dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
             flush=True,
         )
 
-    # FP8 dispatch tuning (if quantized)
-    if dispatch_quant_mode not in ("bf16", "int8", None):
+    # Quantized dispatch tuning (int8/fp8/fp4)
+    if dispatch_quant_mode not in ("bf16", None):
         num_recv_tokens = dispatch_bf16_recv_bytes // (hidden * 2)
-        if dispatch_quant_mode.startswith("pertoken_fp8"):
+        if dispatch_quant_mode == "int8" or dispatch_quant_mode.startswith("pertoken_fp8"):
             quant_data_bytes = num_recv_tokens * hidden
             quant_scale_bytes = num_recv_tokens * 4
         elif dispatch_quant_mode.startswith("mx_fp8"):
@@ -488,8 +489,8 @@ def test_main(
         else:
             quant_data_bytes = num_recv_tokens * hidden
             quant_scale_bytes = 0
-        fp8_recv_bytes = quant_data_bytes + quant_scale_bytes
-        tune_args_fp8 = {
+        quant_recv_bytes = quant_data_bytes + quant_scale_bytes
+        tune_args_quant = {
             "x": x,
             "config": config,
             "num_tokens_per_rank": ref_num_tokens_per_rank,
@@ -499,11 +500,11 @@ def test_main(
             "topk_weights": topk_weights,
             "quant_mode": dispatch_quant_mode,
         }
-        t = bench(lambda: buffer.dispatch(**tune_args_fp8))[0]
+        t = bench(lambda: buffer.dispatch(**tune_args_quant))[0]
         if local_rank == 0:
             print(
-                f"[tuning] Dispatch ({dispatch_quant_mode}, raw_bytes={fp8_recv_bytes/1e9:.3f}GB) "
-                f"{dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
+                f"[tuning] Dispatch ({dispatch_quant_mode}, raw_bytes={quant_recv_bytes/1e9:.3f}GB) "
+                f"raw_bw={quant_recv_bytes / 1e9 / t:.2f} GB/s, equiv_bw={dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
                 flush=True,
             )
 

--- a/tests/python/deepep/test_intranode.py
+++ b/tests/python/deepep/test_intranode.py
@@ -489,8 +489,9 @@ def test_main(
             quant_data_bytes = num_recv_tokens * hidden // 2
             quant_scale_bytes = num_recv_tokens * hidden // 32
         else:
-            quant_data_bytes = num_recv_tokens * hidden
-            quant_scale_bytes = 0
+            raise ValueError(
+                f"Unsupported quant_mode for bandwidth calculation: {dispatch_quant_mode}"
+            )
         quant_recv_bytes = quant_data_bytes + quant_scale_bytes
         tune_args_quant = {
             "x": x,

--- a/tests/python/deepep/test_intranode.py
+++ b/tests/python/deepep/test_intranode.py
@@ -477,7 +477,9 @@ def test_main(
     # Quantized dispatch tuning (int8/fp8/fp4)
     if dispatch_quant_mode not in ("bf16", None):
         num_recv_tokens = dispatch_bf16_recv_bytes // (hidden * 2)
-        if dispatch_quant_mode == "int8" or dispatch_quant_mode.startswith("pertoken_fp8"):
+        if dispatch_quant_mode == "int8" or dispatch_quant_mode.startswith(
+            "pertoken_fp8"
+        ):
             quant_data_bytes = num_recv_tokens * hidden
             quant_scale_bytes = num_recv_tokens * 4
         elif dispatch_quant_mode.startswith("mx_fp8"):

--- a/tests/python/deepep/test_ll_alltoall.py
+++ b/tests/python/deepep/test_ll_alltoall.py
@@ -13,6 +13,7 @@ from utils import (
     bench_kineto,
     calc_diff,
     calculate_avg_stats,
+    get_diff_threshold,
     hash_tensor,
     init_dist,
     per_token_cast_back,
@@ -95,6 +96,7 @@ def test(
                     async_finish=not return_recv_hook,
                     return_recv_hook=return_recv_hook,
                     topk_weights=topk_weights,
+                    quant_mode="int8" if quant_type == "int8" else None,
                 )
             )
             simulated_gemm_x = (
@@ -162,14 +164,8 @@ def test(
             print(
                 f"rank {rank} PASSED [{quant_type=}] avg_diff={avg_diff:.5f}, max_diff={max_diff:.5f}, cosine_diff={diff:.5f}"
             )
-            if dispatch_use_mxfp4:
-                assert diff < 1e-2, f"Error: {diff=}"
-            elif dispatch_use_ue8m0:
-                assert diff < 1e-3, f"Error: {diff=}"
-            elif dispatch_use_fp8:
-                assert diff < 1e-4, f"Error: {diff=}"
-            else:
-                assert diff < 1e-5, f"Error: {diff=}"
+            diff_threshold = get_diff_threshold(quant_type)
+            assert diff < diff_threshold, f"Error: {diff=}, {diff_threshold=}"
             hash_value ^= hash_tensor(combined_x)
             if local_rank == 0:
                 print(" passed", flush=True)
@@ -190,6 +186,7 @@ def test(
             async_finish=False,
             return_recv_hook=return_recv_hook,
             topk_weights=topk_weights,
+            quant_mode="int8" if quant_type == "int8" else None,
         )
         simulated_gemm_x_local = (
             per_token_cast_back(*recv_x) if dispatch_use_fp8 else recv_x
@@ -241,6 +238,7 @@ def test(
         "use_ue8m0": dispatch_use_ue8m0,
         "use_mxfp4": dispatch_use_mxfp4,
         "topk_weights": topk_weights,
+        "quant_mode": "int8" if quant_type == "int8" else None,
     }
     # dispatch_t = bench(lambda: buffer.low_latency_dispatch(**dispatch_args))[0]
     dispatch_alltoall_t = bench_kineto(

--- a/tests/python/deepep/test_ll_alltoall.py
+++ b/tests/python/deepep/test_ll_alltoall.py
@@ -209,7 +209,7 @@ def test(
         num_values = num_tokens * hidden
         if quant_type == "int8":
             data_bytes = num_values * 1
-            scale_bytes = num_tokens * 2
+            scale_bytes = num_tokens * 4
             return data_bytes + scale_bytes
         else:
             return num_values * 2
@@ -276,8 +276,10 @@ def test(
     combine_t = sum(combine_alltoall_t)
 
     print(
-        f"[rank {rank}] Dispatch bandwidth: {num_dispatch_comm_bytes / 1e9 / dispatch_t:.2f} GB/s, avg_t={dispatch_t * 1e6:.2f} us | "
-        f"Combine bandwidth: {num_combine_comm_bytes / 1e9 / combine_t:.2f} GB/s, avg_t={combine_t * 1e6:.2f} us",
+        f"[rank {rank}] Dispatch raw_bw={num_dispatch_comm_bytes / 1e9 / dispatch_t:.2f} GB/s, "
+        f"equiv_bw={num_combine_comm_bytes / 1e9 / dispatch_t:.2f} GB/s, avg_t={dispatch_t * 1e6:.2f} us | "
+        f"Combine raw_bw={num_combine_comm_bytes / 1e9 / combine_t:.2f} GB/s, "
+        f"equiv_bw={num_combine_comm_bytes / 1e9 / combine_t:.2f} GB/s, avg_t={combine_t * 1e6:.2f} us",
         flush=True,
     )
     calculate_avg_stats(

--- a/tests/python/deepep/test_low_latency.py
+++ b/tests/python/deepep/test_low_latency.py
@@ -356,8 +356,10 @@ def test(
         )
         if not return_recv_hook:
             print(
-                f"[rank {rank}] Dispatch bandwidth: {num_dispatch_comm_bytes / 1e9 / dispatch_t:.2f} GB/s, avg_t={dispatch_t * 1e6:.2f} us | "
-                f"Combine bandwidth: {num_combine_comm_bytes / 1e9 / combine_t:.2f} GB/s, avg_t={combine_t * 1e6:.2f} us",
+                f"[rank {rank}] Dispatch raw_bw={num_dispatch_comm_bytes / 1e9 / dispatch_t:.2f} GB/s, "
+                f"equiv_bw={num_combine_comm_bytes / 1e9 / dispatch_t:.2f} GB/s, avg_t={dispatch_t * 1e6:.2f} us | "
+                f"Combine raw_bw={num_combine_comm_bytes / 1e9 / combine_t:.2f} GB/s, "
+                f"equiv_bw={num_combine_comm_bytes / 1e9 / combine_t:.2f} GB/s, avg_t={combine_t * 1e6:.2f} us",
                 flush=True,
             )
             calculate_avg_stats(

--- a/tests/python/deepep/test_normal_alltoall.py
+++ b/tests/python/deepep/test_normal_alltoall.py
@@ -192,7 +192,7 @@ def test_main(
             iter_quant = "bf16"
         if local_rank == 0:
             print(
-                f'[testing] Running with {iter_quant.upper()}, with top-k {num_topk} ...',
+                f"[testing] Running with {iter_quant.upper()}, with top-k {num_topk} ...",
                 flush=True,
             )
         dispatch_args = {

--- a/tests/python/deepep/test_normal_alltoall.py
+++ b/tests/python/deepep/test_normal_alltoall.py
@@ -14,6 +14,7 @@ from utils import (
     bench,
     calc_diff,
     diagnose_matrix,
+    get_diff_threshold,
     init_dist,
     inplace_unique,
     per_token_cast_back,
@@ -184,10 +185,14 @@ def test_main(
     )
 
     # Test dispatch
-    for current_x in filter(lambda elem: elem is not None, (x, x_pure_rand)):
+    dispatch_quant_mode = quant_type
+    for current_x in filter(lambda elem: elem is not None, (x_pure_rand, x)):
+        iter_quant = dispatch_quant_mode if current_x is x_pure_rand else "bf16"
+        if iter_quant is None:
+            iter_quant = "bf16"
         if local_rank == 0:
             print(
-                f'[testing] Running with {"INT8" if isinstance(current_x, tuple) else "BF16"}, with top-k {num_topk} ...',
+                f'[testing] Running with {iter_quant.upper()}, with top-k {num_topk} ...',
                 flush=True,
             )
         dispatch_args = {
@@ -200,7 +205,7 @@ def test_main(
             "topk_weights": (
                 topk_weights_pure_rand if current_x is x_pure_rand else topk_weights
             ),
-            "quant_mode": quant_type,
+            "quant_mode": dispatch_quant_mode if current_x is x_pure_rand else "bf16",
         }
 
         (
@@ -266,7 +271,8 @@ def test_main(
 
         avg_diff = torch.mean(torch.abs(check_x - golden) / golden_nozero).item()
         print(f"{rank=}, {avg_diff=:.5f}, {max_diff=:.5f}, cosine_diff={diff:.5f}")
-        assert diff < 5e-5, f"Assertion diff failed on {rank=}"
+        diff_threshold = get_diff_threshold(iter_quant)
+        assert diff < diff_threshold, f"Error: {diff=}, {diff_threshold=}"
 
         # For later tuning
         dispatch_bf16_recv_bytes = recv_x.numel() * 2
@@ -278,48 +284,54 @@ def test_main(
         print("", flush=True)
 
     # Tune dispatch performance
-    def calculate_recv_bytes(dispatch_bf16_recv_bytes, quant_type):
-        hidden_dim = hidden
-        bs = dispatch_bf16_recv_bytes / 2 / hidden_dim
-        num_values = bs * hidden_dim
-
-        if quant_type == "bf16":
-            # No quantization, use original BF16 communication
-            recv_bytes = dispatch_bf16_recv_bytes
-        elif quant_type == "int8":
-            # INT8 per-token quantization:
-            # - Data: num_values * 1 byte (INT8)
-            # - Scale: x tokens * 2 bytes each (BF16)
-            data_bytes = num_values * 1
-            scale_bytes = bs * 2
-            recv_bytes = data_bytes + scale_bytes
-        else:
-            raise ValueError(f"Unsupported quant_type: {quant_type}")
-        return recv_bytes
-
     config = deep_ep.Config(24, 8, buffer_size)
-    for current_x in filter(lambda elem: elem is not None, (x,)):
-        # Replace the original recv_bytes calculation with:
-        recv_bytes = calculate_recv_bytes(dispatch_bf16_recv_bytes, quant_type)
 
-        tune_args = {
-            "x": current_x,
+    # BF16 dispatch tuning
+    tune_args_bf16 = {
+        "x": x,
+        "config": config,
+        "num_tokens_per_rank": ref_num_tokens_per_rank,
+        "is_token_in_rank": ref_is_token_in_rank,
+        "num_tokens_per_expert": ref_num_tokens_per_expert,
+        "topk_idx": topk_idx,
+        "topk_weights": topk_weights,
+        "quant_mode": "bf16",
+    }
+    t = bench(lambda: buffer.dispatch(**tune_args_bf16))[0]
+    if local_rank == 0:
+        print(
+            f"[tuning] Dispatch (BF16, raw_bytes={dispatch_bf16_recv_bytes/1e9:.3f}GB) "
+            f"raw_bw={dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s, equiv_bw={dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
+            flush=True,
+        )
+
+    # Quantized dispatch tuning (int8)
+    if dispatch_quant_mode not in ("bf16", None):
+        num_recv_tokens = dispatch_bf16_recv_bytes // (hidden * 2)
+        if dispatch_quant_mode == "int8":
+            quant_data_bytes = num_recv_tokens * hidden
+            quant_scale_bytes = num_recv_tokens * 4
+        else:
+            quant_data_bytes = num_recv_tokens * hidden
+            quant_scale_bytes = 0
+        quant_recv_bytes = quant_data_bytes + quant_scale_bytes
+        tune_args_quant = {
+            "x": x,
             "config": config,
             "num_tokens_per_rank": ref_num_tokens_per_rank,
             "is_token_in_rank": ref_is_token_in_rank,
             "num_tokens_per_expert": ref_num_tokens_per_expert,
             "topk_idx": topk_idx,
             "topk_weights": topk_weights,
-            "quant_mode": quant_type,
+            "quant_mode": dispatch_quant_mode,
         }
-
-        t = bench(lambda: buffer.dispatch(**tune_args))[0]
+        t = bench(lambda: buffer.dispatch(**tune_args_quant))[0]
         if local_rank == 0:
             print(
-                f"[tuning] Dispatch ({quant_type=}) {recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
+                f"[tuning] Dispatch ({dispatch_quant_mode}, raw_bytes={quant_recv_bytes/1e9:.3f}GB) "
+                f"raw_bw={quant_recv_bytes / 1e9 / t:.2f} GB/s, equiv_bw={dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
                 flush=True,
             )
-            print("", flush=True)
 
     dispatch_args = {
         "x": x,
@@ -329,7 +341,7 @@ def test_main(
         "config": config,
         "topk_idx": topk_idx,
         "topk_weights": topk_weights,
-        "quant_mode": quant_type,
+        "quant_mode": dispatch_quant_mode,
     }
     recv_x, _, _, _, handle, _ = buffer.dispatch(**dispatch_args)
     recv_x = per_token_cast_back(*recv_x) if isinstance(recv_x, tuple) else recv_x

--- a/tests/python/deepep/test_normal_alltoall.py
+++ b/tests/python/deepep/test_normal_alltoall.py
@@ -312,8 +312,9 @@ def test_main(
             quant_data_bytes = num_recv_tokens * hidden
             quant_scale_bytes = num_recv_tokens * 4
         else:
-            quant_data_bytes = num_recv_tokens * hidden
-            quant_scale_bytes = 0
+            raise ValueError(
+                f"Unsupported quant_mode for bandwidth calculation: {dispatch_quant_mode}"
+            )
         quant_recv_bytes = quant_data_bytes + quant_scale_bytes
         tune_args_quant = {
             "x": x,


### PR DESCRIPTION
## Motivation

Unify alltoall test scripts with intranode

## Modifications

- test_intranode: include int8 in quantized dispatch tuning, output raw_bw + equiv_bw
- test_normal_alltoall: unify main loop (reverse order, force bf16 on 2nd iter), replace hardcoded 5e-5 with get_diff_threshold, add BF16 dispatch tuning baseline, fix int8 scale bytes (2->4), dual bandwidth output
- test_ll_alltoall: fix int8 scale bytes (2->4), add raw_bw + equiv_bw output

## Testing

<img width="863" height="52" alt="image" src="https://github.com/user-attachments/assets/7b82bfa0-f990-4a70-af73-6ff08a88d347" />


## Checklist

- [x] Format your code.
- [x] Add unit tests.
- [x] Update documentation.
- [x] Provide accuracy and speed benchmark results.
