### PR TITLE
fix(kernels): sparse_attention_score tiling data missing namespace

### DIFF
--- a/csrc/sparse_attention_score/op_kernel/arch35/sparse_attention_score_kernel_arch35_full_quant.h
+++ b/csrc/sparse_attention_score/op_kernel/arch35/sparse_attention_score_kernel_arch35_full_quant.h
@@ -51,8 +51,8 @@ public:
 
     __aicore__ inline void operator()(SasaFullQuantKernelParamsArch35 const &params)
     {
-        __gm__ SparseAttentionScoreTilingData *sasaTilingData =
-            reinterpret_cast<__gm__ SparseAttentionScoreTilingData *>(params.tiling);
+        __gm__ SparseAttn::SparseAttentionScoreTilingData *sasaTilingData =
+            reinterpret_cast<__gm__ SparseAttn::SparseAttentionScoreTilingData *>(params.tiling);
         FetchBaseShapeInfo(sasaTilingData);
         CalcOnChipBufTileInfo(sasaTilingData);
 
@@ -320,7 +320,7 @@ public:
     }
 
 private:
-    __aicore__ inline void FetchBaseShapeInfo(__gm__ SparseAttentionScoreTilingData *tilingData)
+    __aicore__ inline void FetchBaseShapeInfo(__gm__ SparseAttn::SparseAttentionScoreTilingData *tilingData)
     {
         batch_ = tilingData->batch;
         qHeads_ = tilingData->numHeads;
@@ -336,7 +336,7 @@ private:
         actSeqAval_ = true;
     }
 
-    __aicore__ inline void CalcOnChipBufTileInfo(__gm__ SparseAttentionScoreTilingData *tilingData)
+    __aicore__ inline void CalcOnChipBufTileInfo(__gm__ SparseAttn::SparseAttentionScoreTilingData *tilingData)
     {
         // Fixed tile sizes matching blockSize; L1 tile M = L0 tile M size for BlockMmad.
         mm1L1TileM_ = 128;


### PR DESCRIPTION
Fixes ` bash build.sh -a kernels Ascend950pr_9599` on 2492024f30e14415a4399960e230fc8b34d1e622

### Log

```
bash build.sh -a kernels Ascend950pr_9599
Build target: kernels
CMake SOC_VERSION: Ascend950pr_9599
Warning: Cannot find ASCConfig.cmake under /home/zouzias/Ascend/cann-9.1.0
ASCEND_HOME_PATH: /home/zouzias/Ascend/cann-9.1.0
ASCEND_TOOLKIT_HOME: /home/zouzias/Ascend/cann-9.1.0
ASCEND_INCLUDE_DIR: /home/zouzias/Ascend/cann-9.1.0/x86_64-linux/include
Output directory: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/output
CANN path: /home/zouzias/Ascend/cann-9.1.0
-- The CXX compiler identification is GNU 11.4.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- build type set to RELEASE
-- set GIT_LAST_COMMIT to  as compile definition
-- run python script successfully, output string is [/home/zouzias/github-repos/zouzias/sgl-kernel-npu/venv/lib/python3.10/site-packages/torch /home/zouzias/github-repos/zouzias/sgl-kernel-npu/venv/lib/python3.10/site-packages/torch_npu /home/zouzias/github-repos/zouzias/sgl-kernel-npu/venv/lib/python3.10/site-packages/pybind11 True]
-- SOC_VERSION=Ascend950pr_9599
-- TORCH_DIR=/home/zouzias/github-repos/zouzias/sgl-kernel-npu/venv/lib/python3.10/site-packages/torch
-- TORCH_NPU_DIR=/home/zouzias/github-repos/zouzias/sgl-kernel-npu/venv/lib/python3.10/site-packages/torch_npu
-- PYBIND11_DIR=/home/zouzias/github-repos/zouzias/sgl-kernel-npu/venv/lib/python3.10/site-packages/pybind11
-- _GLIBCXX_USE_CXX11_ABI=1
-- ASCEND_CANN_PACKAGE_PATH = /home/zouzias/Ascend/cann-9.1.0
-- ASCEND_HOME_PATH = /home/zouzias/Ascend/cann-9.1.0
-- Found ccache: /usr/bin/ccache
-- SGL_KERNEL_ENABLE_A3_ONLY_OPS=OFF (SOC=Ascend950pr_9599)
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    DEEPEP_IS_A5_BUILD


-- Build files have been written to: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build
[  1%] Creating directories for 'no_workspace_kernel_precompile'
[  2%] Creating directories for 'workspace_kernel_precompile'
[  2%] No download step for 'workspace_kernel_precompile'
[  3%] No download step for 'no_workspace_kernel_precompile'
[  4%] No update step for 'workspace_kernel_precompile'
[  5%] No update step for 'no_workspace_kernel_precompile'
[  6%] No patch step for 'workspace_kernel_precompile'
[  7%] No patch step for 'no_workspace_kernel_precompile'
[  8%] Performing configure step for 'workspace_kernel_precompile'
[  9%] Performing configure step for 'no_workspace_kernel_precompile'
-- The C compiler identification is GNU 11.4.0
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    DYNAMIC_MODE
    INCLUDE_DIR


-- Build files have been written to: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_precompile-prefix/src/no_workspace_kernel_precompile-build
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    DYNAMIC_MODE
    INCLUDE_DIR


[ 10%] Performing build step for 'no_workspace_kernel_precompile'
-- Build files have been written to: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/workspace_kernel_precompile-prefix/src/workspace_kernel_precompile-build
[ 11%] Performing build step for 'workspace_kernel_precompile'
[ 20%] Building CXX object CMakeFiles/precompile_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/cache_location_assign/op_kernel/cache_loc_assign_kernel.cpp.o
[ 20%] Building CXX object CMakeFiles/precompile_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/assign_cache_op/op_kernel/assign_cache_op.cpp.o
[ 30%] Building CXX object CMakeFiles/precompile_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/helloworld/op_kernel/kernel_helloworld.cpp.o
[ 40%] Building CXX object CMakeFiles/precompile_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_expand_kernel.cpp.o
[ 50%] Building CXX object CMakeFiles/precompile_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_shrink_kernel.cpp.o
[ 60%] Building CXX object CMakeFiles/precompile_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_expand_kernel.cpp.o
[ 70%] Building CXX object CMakeFiles/precompile_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_shrink_kernel.cpp.o
[ 80%] Building CXX object CMakeFiles/precompile_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp.o
[ 90%] Building CXX object CMakeFiles/precompile_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_shrink_kernel.cpp.o
[100%] Building CXX object CMakeFiles/precompile_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/apply_token_bitmask/op_kernel/apply_token_bitmask.cpp.o
[ 14%] Building CXX object CMakeFiles/precompile_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/alloc_extend/op_kernel/alloc_extend_kernel.cpp.o
[ 28%] Building CXX object CMakeFiles/precompile_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/build_tree/op_kernel/build_tree_kernel.cpp.o
[ 42%] Building CXX object CMakeFiles/precompile_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/causal_conv1d_update/op_kernel/causal_conv1d_update.cpp.o
[ 57%] Building CXX object CMakeFiles/precompile_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmc_expand_kernel.cpp.o
[ 71%] Building CXX object CMakeFiles/precompile_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/causal_conv1d/op_kernel/causal_conv1d.cpp.o
[ 85%] Building CXX object CMakeFiles/precompile_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmc_shrink_kernel.cpp.o
[100%] Building CXX object CMakeFiles/precompile_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score.cpp.o
[100%] Built target precompile_obj
[100%] Built target precompile_obj
[100%] Built target check_src_template
[ 12%] No install step for 'no_workspace_kernel_precompile'
[ 13%] Completed 'no_workspace_kernel_precompile'
[ 13%] Built target no_workspace_kernel_precompile
[ 14%] Creating directories for 'no_workspace_kernel_preprocess'
[ 15%] No download step for 'no_workspace_kernel_preprocess'
[ 16%] No update step for 'no_workspace_kernel_preprocess'
[ 17%] No patch step for 'no_workspace_kernel_preprocess'
[100%] Built target check_src_template
[ 18%] No install step for 'workspace_kernel_precompile'
[ 19%] Performing configure step for 'no_workspace_kernel_preprocess'
[ 20%] Completed 'workspace_kernel_precompile'
-- The C compiler identification is GNU 11.4.0
[ 20%] Built target workspace_kernel_precompile
[ 21%] Creating directories for 'workspace_kernel_preprocess'
-- The CXX compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
[ 22%] No download step for 'workspace_kernel_preprocess'
-- Detecting C compiler ABI info - done
[ 23%] No update step for 'workspace_kernel_preprocess'
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
[ 25%] No patch step for 'workspace_kernel_preprocess'
[ 26%] Performing configure step for 'workspace_kernel_preprocess'
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- The C compiler identification is GNU 11.4.0
-- Configuring done
-- Generating done
-- Build files have been written to: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build
[ 27%] Performing build step for 'no_workspace_kernel_preprocess'
-- The CXX compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
[  3%] Building CXX object CMakeFiles/preprocess_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/helloworld/op_kernel/kernel_helloworld.cpp.o
[  6%] Building CXX object CMakeFiles/preprocess_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/assign_cache_op/op_kernel/assign_cache_op.cpp.o
[ 10%] Building CXX object CMakeFiles/preprocess_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_shrink_kernel.cpp.o
[ 13%] Building CXX object CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/cache_location_assign/op_kernel/cache_loc_assign_kernel.cpp.o
[ 16%] Building CXX object CMakeFiles/preprocess_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_expand_kernel.cpp.o
[ 23%] Building CXX object CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/assign_cache_op/op_kernel/assign_cache_op.cpp.o
[ 26%] Building CXX object CMakeFiles/preprocess_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_shrink_kernel.cpp.o
[ 26%] Building CXX object CMakeFiles/preprocess_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/cache_location_assign/op_kernel/cache_loc_assign_kernel.cpp.o
[ 30%] Building CXX object CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_expand_kernel.cpp.o
[ 33%] Building CXX object CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/helloworld/op_kernel/kernel_helloworld.cpp.o
[ 36%] Building CXX object CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/cache_location_assign/op_kernel/cache_loc_assign_kernel.cpp.o
[ 40%] Building CXX object CMakeFiles/preprocess_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_expand_kernel.cpp.o
[ 43%] Building CXX object CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/assign_cache_op/op_kernel/assign_cache_op.cpp.o
[ 46%] Building CXX object CMakeFiles/preprocess_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp.o
[ 50%] Building CXX object CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/helloworld/op_kernel/kernel_helloworld.cpp.o
[ 53%] Building CXX object CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_shrink_kernel.cpp.o
-- Detecting C compiler ABI info - done
[ 56%] Building CXX object CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_expand_kernel.cpp.o
[ 60%] Building CXX object CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_shrink_kernel.cpp.o
[ 63%] Building CXX object CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp.o
[ 66%] Building CXX object CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_expand_kernel.cpp.o
[ 70%] Building CXX object CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_shrink_kernel.cpp.o
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
[ 73%] Building CXX object CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/apply_token_bitmask/op_kernel/apply_token_bitmask.cpp.o
-- Detecting CXX compiler ABI info
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_shrink_kernel.cpp:161:9: warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension [-Wc++20-extensions]
        ReduceSum<float>(wTmpTensor, wTmpTensor, wTmpTensor, numElements);
        ^
1 warning generated.
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_shrink_kernel.cpp:165:9: warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension [-Wc++20-extensions]
        ReduceSum<float>(wTmpTensor, wTmpTensor, wTmpTensor, numElements);
        ^
1 warning generated.
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_shrink_kernel.cpp:174:9: warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension [-Wc++20-extensions]
        ReduceSum<float>(wTmpTensor, wTmpTensor, wTmpTensor, numElements);
        ^
1 warning generated.
[ 76%] Building CXX object CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_shrink_kernel.cpp.o
[ 80%] Building CXX object CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_expand_kernel.cpp.o
[ 86%] Building CXX object CMakeFiles/preprocess_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_shrink_kernel.cpp.o
[ 86%] Building CXX object CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_shrink_kernel.cpp.o
[ 90%] Building CXX object CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp.o
[ 93%] Building CXX object CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_shrink_kernel.cpp.o
[ 93%] Built target aic_obj
[ 96%] Building CXX object CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/apply_token_bitmask/op_kernel/apply_token_bitmask.cpp.o
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_shrink_kernel.cpp:161:9: warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension [-Wc++20-extensions]
        ReduceSum<float>(wTmpTensor, wTmpTensor, wTmpTensor, numElements);
        ^
1 warning generated.
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_shrink_kernel.cpp:174:9: warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension [-Wc++20-extensions]
        ReduceSum<float>(wTmpTensor, wTmpTensor, wTmpTensor, numElements);
        ^
1 warning generated.
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_shrink_kernel.cpp:165:9: warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension [-Wc++20-extensions]
        ReduceSum<float>(wTmpTensor, wTmpTensor, wTmpTensor, numElements);
        ^
1 warning generated.
[100%] Building CXX object CMakeFiles/preprocess_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/apply_token_bitmask/op_kernel/apply_token_bitmask.cpp.o
/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/helloworld/op_kernel/kernel_helloworld.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/helloworld/op_kernel/kernel_helloworld.cpp.o[100%] Built target aiv_obj
-- Detecting CXX compiler ABI info - done
/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/cache_location_assign/op_kernel/cache_loc_assign_kernel.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/cache_location_assign/op_kernel/cache_loc_assign_kernel.cpp.o/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/assign_cache_op/op_kernel/assign_cache_op.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/assign_cache_op/op_kernel/assign_cache_op.cpp.o/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/helloworld/op_kernel/kernel_helloworld.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/helloworld/op_kernel/kernel_helloworld.cpp.o-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_expand_kernel.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_expand_kernel.cpp.o/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/cache_location_assign/op_kernel/cache_loc_assign_kernel.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/cache_location_assign/op_kernel/cache_loc_assign_kernel.cpp.o/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_shrink_kernel.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_shrink_kernel.cpp.o/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/assign_cache_op/op_kernel/assign_cache_op.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/assign_cache_op/op_kernel/assign_cache_op.cpp.o-- Generating done
/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_expand_kernel.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_expand_kernel.cpp.o-- Build files have been written to: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/workspace_kernel_preprocess-prefix/src/workspace_kernel_preprocess-build
/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_shrink_kernel.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_shrink_kernel.cpp.o/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_expand_kernel.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_expand_kernel.cpp.o/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp.o/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_shrink_kernel.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_shrink_kernel.cpp.o[ 28%] Performing build step for 'workspace_kernel_preprocess'
/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_expand_kernel.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_expand_kernel.cpp.o/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_shrink_kernel.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_shrink_kernel.cpp.o/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_shrink_kernel.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_shrink_kernel.cpp.o/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/apply_token_bitmask/op_kernel/apply_token_bitmask.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/apply_token_bitmask/op_kernel/apply_token_bitmask.cpp.o/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp.o/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_shrink_kernel.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_shrink_kernel.cpp.o[100%] Built target merge_aic_obj_text
[  4%] Building CXX object CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/alloc_extend/op_kernel/alloc_extend_kernel.cpp.o
[ 14%] Building CXX object CMakeFiles/preprocess_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/causal_conv1d_update/op_kernel/causal_conv1d_update.cpp.o
[ 14%] Building CXX object CMakeFiles/preprocess_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/build_tree/op_kernel/build_tree_kernel.cpp.o
[ 19%] Building CXX object CMakeFiles/preprocess_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/alloc_extend/op_kernel/alloc_extend_kernel.cpp.o
[ 23%] Building CXX object CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/causal_conv1d_update/op_kernel/causal_conv1d_update.cpp.o
[ 28%] Building CXX object CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/build_tree/op_kernel/build_tree_kernel.cpp.o
[ 33%] Building CXX object CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/causal_conv1d/op_kernel/causal_conv1d.cpp.o
[ 38%] Building CXX object CMakeFiles/preprocess_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/causal_conv1d/op_kernel/causal_conv1d.cpp.o
/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld -m aicorelinux -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/apply_token_bitmask/op_kernel/apply_token_bitmask.cpp.o -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_preprocess-prefix/src/no_workspace_kernel_preprocess-build/CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/apply_token_bitmask/op_kernel/apply_token_bitmask.cpp.o[ 42%] Building CXX object CMakeFiles/preprocess_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmc_shrink_kernel.cpp.o
[ 47%] Building CXX object CMakeFiles/preprocess_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmc_expand_kernel.cpp.o
[ 52%] Building CXX object CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/alloc_extend/op_kernel/alloc_extend_kernel.cpp.o
[ 57%] Building CXX object CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/build_tree/op_kernel/build_tree_kernel.cpp.o
[ 61%] Building CXX object CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmc_expand_kernel.cpp.o
[100%] Built target merge_aiv_obj_text
[ 66%] Building CXX object CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmc_shrink_kernel.cpp.o
[ 71%] Building CXX object CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score.cpp.o
[ 76%] Building CXX object CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/causal_conv1d_update/op_kernel/causal_conv1d_update.cpp.o
[ 80%] Building CXX object CMakeFiles/preprocess_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score.cpp.o
[ 85%] Building CXX object CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/causal_conv1d/op_kernel/causal_conv1d.cpp.o
[ 90%] Building CXX object CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmc_shrink_kernel.cpp.o
[ 95%] Building CXX object CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmc_expand_kernel.cpp.o
[100%] Building CXX object CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score.cpp.o
[100%] Built target preprocess_obj
[100%] Built target preprocess_obj
[WARNING]: Multiple kernel functions are detected. It is recommended to define only one kernel function per file.
[WARNING]: Multiple kernel functions are detected. It is recommended to define only one kernel function per file.
[WARNING]: Multiple kernel functions are detected. It is recommended to define only one kernel function per file.
[WARNING]: Multiple kernel functions are detected. It is recommended to define only one kernel function per file.
[WARNING]: Multiple kernel functions are detected. It is recommended to define only one kernel function per file.
[WARNING]: Multiple kernel functions are detected. It is recommended to define only one kernel function per file.
[WARNING]: Multiple kernel functions are detected. It is recommended to define only one kernel function per file.
[100%] Built target _host_cpp
[ 29%] No install step for 'no_workspace_kernel_preprocess'
[ 29%] Completed 'no_workspace_kernel_preprocess'
[ 29%] Built target no_workspace_kernel_preprocess
[ 30%] Creating directories for 'no_workspace_kernel_host'
[ 31%] Creating directories for 'no_workspace_kernel_aic_device'
[ 32%] Creating directories for 'no_workspace_kernel_aiv_device'
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score.cpp:14:
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score_kernel_interface.cpp:21:
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/arch35/sparse_attention_score_kernel_arch35_full_quant.h:323:54: error: unknown type name 'SparseAttentionScoreTilingData'; did you mean 'SparseAttn::SparseAttentionScoreTilingData'?
    __aicore__ inline void FetchBaseShapeInfo(__gm__ SparseAttentionScoreTilingData *tilingData)
                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                     SparseAttn::SparseAttentionScoreTilingData
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/arch35/../kernel_common.hpp:18:8: note: 'SparseAttn::SparseAttentionScoreTilingData' declared here
struct SparseAttentionScoreTilingData {
       ^
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score.cpp:14:
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score_kernel_interface.cpp:21:
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/arch35/sparse_attention_score_kernel_arch35_full_quant.h:339:57: error: unknown type name 'SparseAttentionScoreTilingData'; did you mean 'SparseAttn::SparseAttentionScoreTilingData'?
    __aicore__ inline void CalcOnChipBufTileInfo(__gm__ SparseAttentionScoreTilingData *tilingData)
                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                        SparseAttn::SparseAttentionScoreTilingData
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/arch35/../kernel_common.hpp:18:8: note: 'SparseAttn::SparseAttentionScoreTilingData' declared here
struct SparseAttentionScoreTilingData {
       ^
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score.cpp:14:
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score_kernel_interface.cpp:21:
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/arch35/sparse_attention_score_kernel_arch35_full_quant.h:54:16: error: unknown type name 'SparseAttentionScoreTilingData'; did you mean 'SparseAttn::SparseAttentionScoreTilingData'?
        __gm__ SparseAttentionScoreTilingData *sasaTilingData =
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
               SparseAttn::SparseAttentionScoreTilingData
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/arch35/../kernel_common.hpp:18:8: note: 'SparseAttn::SparseAttentionScoreTilingData' declared here
struct SparseAttentionScoreTilingData {
       ^
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score.cpp:14:
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score_kernel_interface.cpp:21:
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/arch35/sparse_attention_score_kernel_arch35_full_quant.h:55:37: error: unknown type name 'SparseAttentionScoreTilingData'; did you mean 'SparseAttn::SparseAttentionScoreTilingData'?
            reinterpret_cast<__gm__ SparseAttentionScoreTilingData *>(params.tiling);
                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                    SparseAttn::SparseAttentionScoreTilingData
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/arch35/../kernel_common.hpp:18:8: note: 'SparseAttn::SparseAttentionScoreTilingData' declared here
struct SparseAttentionScoreTilingData {
       ^
4 errors generated.
gmake[5]: *** [CMakeFiles/aiv_obj.dir/build.make:160: CMakeFiles/aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score.cpp.o] Error 1
gmake[4]: *** [CMakeFiles/Makefile2:119: CMakeFiles/aiv_obj.dir/all] Error 2
gmake[4]: *** Waiting for unfinished jobs....
[ 33%] No download step for 'no_workspace_kernel_aic_device'
[ 34%] No download step for 'no_workspace_kernel_host'
[ 34%] No download step for 'no_workspace_kernel_aiv_device'
[ 35%] No update step for 'no_workspace_kernel_aic_device'
[ 35%] No update step for 'no_workspace_kernel_host'
[ 36%] No update step for 'no_workspace_kernel_aiv_device'
[ 37%] No patch step for 'no_workspace_kernel_aic_device'
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score.cpp:14:
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score_kernel_interface.cpp:21:
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/arch35/sparse_attention_score_kernel_arch35_full_quant.h:323:54: error: unknown type name 'SparseAttentionScoreTilingData'; did you mean 'SparseAttn::SparseAttentionScoreTilingData'?
    __aicore__ inline void FetchBaseShapeInfo(__gm__ SparseAttentionScoreTilingData *tilingData)
                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                     SparseAttn::SparseAttentionScoreTilingData
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/arch35/../kernel_common.hpp:18:8: note: 'SparseAttn::SparseAttentionScoreTilingData' declared here
struct SparseAttentionScoreTilingData {
       ^
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score.cpp:14:
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score_kernel_interface.cpp:21:
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/arch35/sparse_attention_score_kernel_arch35_full_quant.h:339:57: error: unknown type name 'SparseAttentionScoreTilingData'; did you mean 'SparseAttn::SparseAttentionScoreTilingData'?
    __aicore__ inline void CalcOnChipBufTileInfo(__gm__ SparseAttentionScoreTilingData *tilingData)
                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                        SparseAttn::SparseAttentionScoreTilingData
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/arch35/../kernel_common.hpp:18:8: note: 'SparseAttn::SparseAttentionScoreTilingData' declared here
struct SparseAttentionScoreTilingData {
       ^
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score.cpp:14:
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score_kernel_interface.cpp:21:
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/arch35/sparse_attention_score_kernel_arch35_full_quant.h:54:16: error: unknown type name 'SparseAttentionScoreTilingData'; did you mean 'SparseAttn::SparseAttentionScoreTilingData'?
        __gm__ SparseAttentionScoreTilingData *sasaTilingData =
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
               SparseAttn::SparseAttentionScoreTilingData
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/arch35/../kernel_common.hpp:18:8: note: 'SparseAttn::SparseAttentionScoreTilingData' declared here
struct SparseAttentionScoreTilingData {
       ^
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score.cpp:14:
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score_kernel_interface.cpp:21:
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/arch35/sparse_attention_score_kernel_arch35_full_quant.h:55:37: error: unknown type name 'SparseAttentionScoreTilingData'; did you mean 'SparseAttn::SparseAttentionScoreTilingData'?
            reinterpret_cast<__gm__ SparseAttentionScoreTilingData *>(params.tiling);
                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                    SparseAttn::SparseAttentionScoreTilingData
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/arch35/../kernel_common.hpp:18:8: note: 'SparseAttn::SparseAttentionScoreTilingData' declared here
struct SparseAttentionScoreTilingData {
       ^
4 errors generated.
[ 38%] No patch step for 'no_workspace_kernel_host'
gmake[5]: *** [CMakeFiles/aic_obj.dir/build.make:160: CMakeFiles/aic_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/sparse_attention_score/op_kernel/sparse_attention_score.cpp.o] Error 1
gmake[4]: *** [CMakeFiles/Makefile2:171: CMakeFiles/aic_obj.dir/all] Error 2
gmake[3]: *** [Makefile:91: all] Error 2
gmake[2]: *** [csrc/CMakeFiles/workspace_kernel_preprocess.dir/build.make:89: csrc/workspace_kernel_preprocess-prefix/src/workspace_kernel_preprocess-stamp/workspace_kernel_preprocess-build] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:421: csrc/CMakeFiles/workspace_kernel_preprocess.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
[ 39%] No patch step for 'no_workspace_kernel_aiv_device'
[ 40%] Performing configure step for 'no_workspace_kernel_aic_device'
[ 41%] Performing configure step for 'no_workspace_kernel_host'
[ 42%] Performing configure step for 'no_workspace_kernel_aiv_device'
-- The C compiler identification is GNU 11.4.0
-- The C compiler identification is GNU 11.4.0
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting C compiler ABI info - done
-- Detecting C compiler ABI info - done
-- Detecting CXX compiler ABI info
-- Check for working C compiler: /usr/bin/cc - skipped
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_MODE


-- Build files have been written to: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_aic_device-prefix/src/no_workspace_kernel_aic_device-build
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Configuring done
[ 43%] Performing build step for 'no_workspace_kernel_aic_device'
-- Generating done
-- Build files have been written to: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_aiv_device-prefix/src/no_workspace_kernel_aiv_device-build
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    ASCEND_PYTHON_EXECUTABLE


-- Build files have been written to: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_host-prefix/src/no_workspace_kernel_host-build
[ 44%] Performing build step for 'no_workspace_kernel_aiv_device'
[ 45%] Performing build step for 'no_workspace_kernel_host'
[ 46%] No install step for 'no_workspace_kernel_aic_device'
[ 47%] Completed 'no_workspace_kernel_aic_device'
[ 20%] Building CXX object CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_cache_loc_assign_kernel.cpp.o
[ 20%] Building CXX object CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_kernel_helloworld.cpp.o
[ 30%] Building CXX object CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_assign_cache_op.cpp.o
[ 40%] Building CXX object CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_sgmv_expand_kernel.cpp.o
[ 50%] Building CXX object CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_sgemmv_expand_kernel.cpp.o
[ 60%] Building CXX object CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_sgemmv_shrink_kernel.cpp.o
[ 70%] Building CXX object CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_sgmv_shrink_kernel.cpp.o
[ 80%] Building CXX object CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_bgmv_shrink_kernel.cpp.o
[ 90%] Building CXX object CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_apply_token_bitmask.cpp.o
[ 10%] Building CXX object CMakeFiles/host_bisheng_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/helloworld/op_kernel/kernel_helloworld.cpp.o
[100%] Building CXX object CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_bgmv_expand_kernel.cpp.o
[ 20%] Building CXX object CMakeFiles/host_bisheng_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/assign_cache_op/op_kernel/assign_cache_op.cpp.o
[ 30%] Building CXX object CMakeFiles/host_bisheng_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/cache_location_assign/op_kernel/cache_loc_assign_kernel.cpp.o
[ 40%] Building CXX object CMakeFiles/host_bisheng_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_shrink_kernel.cpp.o
[ 50%] Building CXX object CMakeFiles/host_bisheng_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_expand_kernel.cpp.o
[ 60%] Building CXX object CMakeFiles/host_bisheng_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_expand_kernel.cpp.o
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_sgemmv_shrink_kernel.cpp:8:
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_shrink_kernel.cpp:174:9: warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension [-Wc++20-extensions]
        ReduceSum<float>(wTmpTensor, wTmpTensor, wTmpTensor, numElements);
        ^
1 warning generated.
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_sgmv_shrink_kernel.cpp:8:
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_shrink_kernel.cpp:165:9: warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension [-Wc++20-extensions]
        ReduceSum<float>(wTmpTensor, wTmpTensor, wTmpTensor, numElements);
        ^
1 warning generated.
In file included from /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_bgmv_shrink_kernel.cpp:8:
/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_shrink_kernel.cpp:161:9: warning: use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension [-Wc++20-extensions]
        ReduceSum<float>(wTmpTensor, wTmpTensor, wTmpTensor, numElements);
        ^
1 warning generated.
[ 70%] Building CXX object CMakeFiles/host_bisheng_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp.o
[ 80%] Building CXX object CMakeFiles/host_bisheng_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_shrink_kernel.cpp.o
[ 90%] Building CXX object CMakeFiles/host_bisheng_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_shrink_kernel.cpp.o
[100%] Building CXX object CMakeFiles/host_bisheng_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/apply_token_bitmask/op_kernel/apply_token_bitmask.cpp.o
[ 47%] Built target no_workspace_kernel_aic_device
[100%] Built target device_aiv_obj
[100%] Built target host_bisheng_obj
/home/zouzias/Ascend/cann-9.1.0/x86_64-linux/ccec_compiler/bin/ld.lld  -m aicorelinux -r  -Ttext=0 /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_aiv_device-prefix/src/no_workspace_kernel_aiv_device-build/CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_kernel_helloworld.cpp.o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_aiv_device-prefix/src/no_workspace_kernel_aiv_device-build/CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_cache_loc_assign_kernel.cpp.o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_aiv_device-prefix/src/no_workspace_kernel_aiv_device-build/CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_assign_cache_op.cpp.o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_aiv_device-prefix/src/no_workspace_kernel_aiv_device-build/CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_bgmv_expand_kernel.cpp.o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_aiv_device-prefix/src/no_workspace_kernel_aiv_device-build/CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_bgmv_shrink_kernel.cpp.o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_aiv_device-prefix/src/no_workspace_kernel_aiv_device-build/CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_sgmv_expand_kernel.cpp.o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_aiv_device-prefix/src/no_workspace_kernel_aiv_device-build/CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_sgmv_shrink_kernel.cpp.o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_aiv_device-prefix/src/no_workspace_kernel_aiv_device-build/CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_sgemmv_expand_kernel.cpp.o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_aiv_device-prefix/src/no_workspace_kernel_aiv_device-build/CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_sgemmv_shrink_kernel.cpp.o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_aiv_device-prefix/src/no_workspace_kernel_aiv_device-build/CMakeFiles/device_aiv_obj.dir/home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/auto_gen/no_workspace_kernel/auto_gen_apply_token_bitmask.cpp.o -static -o /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_aiv_device_dir/device_aiv.o
[ 48%] Performing install step for 'no_workspace_kernel_host'
[100%] Built target merge_aiv_device_obj
[ 50%] No install step for 'no_workspace_kernel_aiv_device'
[ 51%] Completed 'no_workspace_kernel_aiv_device'
Consolidate compiler generated dependencies of target host_bisheng_obj
[100%] Built target host_bisheng_obj
Install the project...
[ 51%] Built target no_workspace_kernel_aiv_device
-- Install configuration: "RELEASE"
-- Installing: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_host_dir/./objects-RELEASE/host_bisheng_obj/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/helloworld/op_kernel/kernel_helloworld.cpp.o
-- Installing: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_host_dir/./objects-RELEASE/host_bisheng_obj/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/cache_location_assign/op_kernel/cache_loc_assign_kernel.cpp.o
-- Installing: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_host_dir/./objects-RELEASE/host_bisheng_obj/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/assign_cache_op/op_kernel/assign_cache_op.cpp.o
-- Installing: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_host_dir/./objects-RELEASE/host_bisheng_obj/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_expand_kernel.cpp.o
-- Installing: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_host_dir/./objects-RELEASE/host_bisheng_obj/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/bgmv_shrink_kernel.cpp.o
-- Installing: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_host_dir/./objects-RELEASE/host_bisheng_obj/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_expand_kernel.cpp.o
-- Installing: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_host_dir/./objects-RELEASE/host_bisheng_obj/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgmv_shrink_kernel.cpp.o
-- Installing: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_host_dir/./objects-RELEASE/host_bisheng_obj/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp.o
-- Installing: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_host_dir/./objects-RELEASE/host_bisheng_obj/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/lora/op_kernel/sgemmv_shrink_kernel.cpp.o
-- Installing: /home/zouzias/github-repos/zouzias/sgl-kernel-npu/build/csrc/no_workspace_kernel_host_dir/./objects-RELEASE/host_bisheng_obj/home/zouzias/github-repos/zouzias/sgl-kernel-npu/csrc/apply_token_bitmask/op_kernel/apply_token_bitmask.cpp.o
[ 52%] Completed 'no_workspace_kernel_host'
[ 52%] Built target no_workspace_kernel_host
gmake: *** [Makefile:136: all] Error 2

```