### PR TITLE
[fix] fused Moe A5: Fix the occasional accuracy issue of the A5 Moe fused operator running continuously

### DIFF
--- a/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/gemm/kernel/dispatch_mx_gmm1_swiglu.h
+++ b/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/gemm/kernel/dispatch_mx_gmm1_swiglu.h
@@ -36,6 +36,9 @@ constexpr int32_t SUB_AIV_NUM = 2;
 constexpr int32_t ODD_EVEN_BASE = 2;
 constexpr int32_t BUFFER_NUM = 2;
 constexpr int32_t GATHER_SECOND_NUM = 2;
+constexpr uint32_t TOKEN_READY_FLAG_INDEX = 0;
+constexpr uint32_t TOKEN_RESERVED_FLAG_INDEX = 1;
+static_assert(TOKEN_RESERVED_FLAG_INDEX == TOKEN_READY_FLAG_INDEX + 1);
 constexpr uint8_t DISPATCH_SEND_PRIVATE_FORMAT_V1 = 1;
 constexpr uint8_t DISPATCH_RECV_PRIVATE_FORMAT_V1 = 1;
 #define OPT_RANK_OFFSET 512
@@ -1019,8 +1022,7 @@ public:
                 AscendC::DataCopy(tmpLocalTensor, tokGlobalInt32, INT32_COUNT_PER_BLOCK);
                 AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(0);
                 AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(0);
-                if (tmpLocalTensor.GetValue(0) == tokenFlag) {
-                    SetValueAndFlush<int32_t>(tokGlobalInt32, 1, 0);
+                if (tmpLocalTensor.GetValue(TOKEN_READY_FLAG_INDEX) == tokenFlag) {
                     break;
                 }
                 SPIN_WAIT_CYCLES();
@@ -1029,6 +1031,7 @@ public:
             AscendC::DataCopy(xTmpTensor_, tokGlobal, MxByte2Count<ElementA>(hCommuSize));
             AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(0);
             AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(0);
+            SetValueAndFlush<int32_t>(tokGlobalInt32, TOKEN_READY_FLAG_INDEX, 0);
             AscendC::DataCopyPad(dynamicScalesOutGMTensor_[currentTokenIdx * x1MxScaleNum], xOutFp32Tensor_,
                                  dataCopyParamsFloat);
             AscendC::DataCopy(expandXOutGlobal, xTmpTensor_, tokenLength);


### PR DESCRIPTION
## Motivation

Fix the occasional accuracy issue of the A5 Moe fused operator running continuously
fixed issue: https://github.com/sgl-project/sgl-kernel-npu/issues/721

## Modifications

csrc\deepep\ops\op_kernel\fused_deep_moe_a5\fused_deep_moe\gemm\kernel\dispatch_mx_gmm1_swiglu.h

## Testing
```bash
Config: num_processes=4, base_num_tokens=32, single_active_rank=None, num_token_jitter=0, num_token_jitter_seed=2026, per_rank_num_tokens=[32, 32, 32, 32], padded_num_tokens=32, real_global_bs=128, small_op_global_bs=128, hidden=7168, moe_intermediate_size=3072, num_experts=32, num_topk=8, quant=fp8_e4m3, kernel_trace_dir=None, num_warmups=3, num_tests=30, small_first_warmup_gmm_burn_in_repeats=100
[rank3]:[W818 15:37:38.054232600 ToKernelNpu.cpp:40] Warning: Device do not support double dtype now, dtype cast replace with float. (function operator())
[rank2]:[W818 15:37:38.055367380 ToKernelNpu.cpp:40] Warning: Device do not support double dtype now, dtype cast replace with float. (function operator())
[rank1]:[W818 15:37:38.063841900 ToKernelNpu.cpp:40] Warning: Device do not support double dtype now, dtype cast replace with float. (function operator())
[rank0]:[W818 15:37:38.067649070 ToKernelNpu.cpp:40] Warning: Device do not support double dtype now, dtype cast replace with float. (function operator())
/usr/local/python3.11.10/lib/python3.11/site-packages/torch/distributed/c10d_logger.py:83: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
  return func(*args, **kwargs)
fused counts (per rank):
| Rank | Local Experts | Fused Counts         | Sum |
|-----:|--------------:|----------------------|----:|
|    0 |             8 | [32, 32, 32, 32, 32, 32, 32, 32] | 256 |
|    1 |             8 | [32, 32, 32, 32, 32, 32, 32, 32] | 256 |
|    2 |             8 | [32, 32, 32, 32, 32, 32, 32, 32] | 256 |
|    3 |             8 | [32, 32, 32, 32, 32, 32, 32, 32] | 256 |
Accuracy check passed. avg_diff=0.000000, max_diff=0.000000, calc_diff=0.000000

Profiled NPU op time:
small-op breakdown (mean over ranks):
| Stage        |    Avg (us) |    Min (us) |    Max (us) |  Share % |
|--------------|-------------:|-------------:|-------------:|---------:|
| dispatch     |        43.35 |        26.01 |       208.30 |    5.74% |
| gmm1         |       272.85 |       238.45 |       412.54 |   36.10% |
| swiglu       |        13.08 |         8.16 |        74.40 |    1.73% |
| requant      |         8.84 |         4.91 |        78.41 |    1.17% |
| gmm2         |       150.84 |       120.66 |       262.07 |   19.96% |
| combine      |       266.76 |        62.15 |      1325.40 |   35.30% |
| total        |       755.72 |       470.46 |      2224.86 |  100.00% |
fused buffer path (mean over ranks):
| Stage        |    Avg (us) |    Min (us) |    Max (us) |  Share % |
|--------------|-------------:|-------------:|-------------:|---------:|
| fused        |       416.15 |       393.96 |       495.53 |  100.00% |
speedup=1.8160x, delta_pct=-44.93%
rank skew summary:
| Rank | Dispatch (us) | GMM1 (us) | SwiGLU (us) | Requant (us) | GMM2 (us) | Combine (us) | Small Total (us) | Fused (us) |
|-----:|--------------:|----------:|------------:|-------------:|----------:|-------------:|-----------------:|-----------:|
|    0 |         36.35 |    380.12 |       27.18 |        19.09 |    243.29 |        41.59 |           747.63 |     412.37 |
|    1 |         46.38 |    236.26 |        8.56 |         5.02 |    118.49 |       343.73 |           758.43 |     417.40 |
|    2 |         45.39 |    238.95 |        8.34 |         6.17 |    123.18 |       336.42 |           758.45 |     417.43 |
|    3 |         45.28 |    236.09 |        8.23 |         5.09 |    118.39 |       345.29 |           758.38 |     417.40 |
| mean |         43.35 |    272.85 |       13.08 |         8.84 |    150.84 |       266.76 |           755.72 |     416.15 |
communication overlap rate: ((755.72 - 416.15) / (43.35 + 266.76)) = 1.0950
```

## Benchmarking and Profiling

NA

## Checklist

- [x] Format your code.
- [ ] Add unit tests.
- [ ] Update documentation.
- [x] Provide accuracy and speed benchmark results.