### PR TITLE
fix sparse_attention_score a5 compile probelms

### DIFF
--- a/csrc/sparse_attention_score/op_kernel/arch35/sparse_attention_score_kernel_arch35_full_quant.h
+++ b/csrc/sparse_attention_score/op_kernel/arch35/sparse_attention_score_kernel_arch35_full_quant.h
@@ -51,8 +51,8 @@ public:
 
     __aicore__ inline void operator()(SasaFullQuantKernelParamsArch35 const &params)
     {
-        __gm__ SparseAttentionScoreTilingData *sasaTilingData =
-            reinterpret_cast<__gm__ SparseAttentionScoreTilingData *>(params.tiling);
+        __gm__ SparseAttn::SparseAttentionScoreTilingData *sasaTilingData =
+            reinterpret_cast<__gm__ SparseAttn::SparseAttentionScoreTilingData *>(params.tiling);
         FetchBaseShapeInfo(sasaTilingData);
         CalcOnChipBufTileInfo(sasaTilingData);
 
@@ -320,7 +320,7 @@ public:
     }
 
 private:
-    __aicore__ inline void FetchBaseShapeInfo(__gm__ SparseAttentionScoreTilingData *tilingData)
+    __aicore__ inline void FetchBaseShapeInfo(__gm__ SparseAttn::SparseAttentionScoreTilingData *tilingData)
     {
         batch_ = tilingData->batch;
         qHeads_ = tilingData->numHeads;
@@ -336,7 +336,7 @@ private:
         actSeqAval_ = true;
     }
 
-    __aicore__ inline void CalcOnChipBufTileInfo(__gm__ SparseAttentionScoreTilingData *tilingData)
+    __aicore__ inline void CalcOnChipBufTileInfo(__gm__ SparseAttn::SparseAttentionScoreTilingData *tilingData)
     {
         // Fixed tile sizes matching blockSize; L1 tile M = L0 tile M size for BlockMmad.
         mm1L1TileM_ = 128;


### PR DESCRIPTION
## Motivation
The sparse_attention_score operator fails to compile in the A5 scenario because the corresponding namespace is not specified.

## Modification
using SparseAttn::SparseAttentionScoreTilingData instread of SparseAttentionScoreTilingData in csrc/sparse_attention_score/op_kernel/arch35/sparse_attention_score_kernel_arch35_full_quant.h

## Result
kernel compiling on A5 SUCCEED!
Due to network limitations, I am unable to upload the success screenshot. This time, I have only uploaded the compilation success log：
```
running install_scripts
creating build/bdist.linux-x86_64/wheel/sgl_kernel_npu-2026.6.1.dist-info/WHEEL
...
removing build/bdist.linux-x86_64/wheel
renamed 'dist/sgl_kernel_npu-2026.6.1-cp311-cp311-linux_x86_64.whl' -> '/home/w00889861/sgl-kernel-npu/output/sgl_kernel_npu-2026.6.1-cp311-cp311-linux_x86_64.whl'
```
