### PR TITLE
[DeepEP] [fix] Security and bug fixes for deepep kernels

### DIFF
--- a/csrc/deepep/config.cpp
+++ b/csrc/deepep/config.cpp
@@ -16,6 +16,9 @@ int get_value_from_env(const std::string &name, int defaultValue)
         if (errno == ERANGE || *end != '\0' || !std::isdigit(*rank_str)) {
             return retValue;
         }
+        if (val < std::numeric_limits<int>::min() || val > std::numeric_limits<int>::max()) {
+            return retValue;
+        }
         retValue = static_cast<int>(val);
         return retValue;
     } else {

--- a/csrc/deepep/config.hpp
+++ b/csrc/deepep/config.hpp
@@ -3,6 +3,7 @@
 #include <pybind11/pytypes.h>
 #include <cstdlib>
 #include <cctype>
+#include <limits>
 #include <string>
 
 namespace deep_ep {

--- a/csrc/deepep/deep_ep.cpp
+++ b/csrc/deepep/deep_ep.cpp
@@ -844,6 +844,7 @@ Buffer::low_latency_dispatch(const at::Tensor &x, const at::Tensor &topk_idx,
 
     auto num_tokens = static_cast<int>(x.size(0)), hidden = static_cast<int>(x.size(1));
     auto num_scales = hidden / 128, num_topk = static_cast<int>(topk_idx.size(1));
+    EP_HOST_ASSERT(num_ranks > shared_expert_rank_num);
     int32_t num_local_experts = num_experts / (num_ranks - shared_expert_rank_num);
     int64_t global_bs = num_max_dispatch_tokens_per_rank * num_ranks;
     auto num_max_tokens = 0;

--- a/csrc/deepep/ops/op_host/cam_moe_dispatch_normal_tiling.cc
+++ b/csrc/deepep/ops/op_host/cam_moe_dispatch_normal_tiling.cc
@@ -468,7 +468,8 @@ static ge::graphStatus CheckAttrs(gert::TilingContext *context, const char *node
     auto perRoundTokensPtr = attrs->GetAttrPointer<int64_t>(ATTR_PER_ROUND_TOKENS_INDEX);
     auto realMaxBsPtr = attrs->GetAttrPointer<int64_t>(ATTR_REAL_MAX_BS_INDEX);
     OP_TILING_CHECK(roundPtr == nullptr, OP_LOGE(nodeName, "roundPtr is null."), return ge::GRAPH_FAILED);
-    OP_TILING_CHECK(perRoundTokensPtr == nullptr, OP_LOGE(nodeName, "perRoundTokensPtr is null."), return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(perRoundTokensPtr == nullptr, OP_LOGE(nodeName, "perRoundTokensPtr is null."),
+                    return ge::GRAPH_FAILED);
     OP_TILING_CHECK(realMaxBsPtr == nullptr, OP_LOGE(nodeName, "realMaxBsPtr is null."), return ge::GRAPH_FAILED);
     tilingData.camMoeDispatchNormalInfo.round = static_cast<uint32_t>(*roundPtr);
     tilingData.camMoeDispatchNormalInfo.perRoundTokens = static_cast<uint32_t>(*perRoundTokensPtr);

--- a/csrc/deepep/ops/op_host/cam_moe_dispatch_normal_tiling.cc
+++ b/csrc/deepep/ops/op_host/cam_moe_dispatch_normal_tiling.cc
@@ -467,6 +467,9 @@ static ge::graphStatus CheckAttrs(gert::TilingContext *context, const char *node
     auto roundPtr = attrs->GetAttrPointer<int64_t>(ATTR_ROUND_INDEX);
     auto perRoundTokensPtr = attrs->GetAttrPointer<int64_t>(ATTR_PER_ROUND_TOKENS_INDEX);
     auto realMaxBsPtr = attrs->GetAttrPointer<int64_t>(ATTR_REAL_MAX_BS_INDEX);
+    OP_TILING_CHECK(roundPtr == nullptr, OP_LOGE(nodeName, "roundPtr is null."), return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(perRoundTokensPtr == nullptr, OP_LOGE(nodeName, "perRoundTokensPtr is null."), return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(realMaxBsPtr == nullptr, OP_LOGE(nodeName, "realMaxBsPtr is null."), return ge::GRAPH_FAILED);
     tilingData.camMoeDispatchNormalInfo.round = static_cast<uint32_t>(*roundPtr);
     tilingData.camMoeDispatchNormalInfo.perRoundTokens = static_cast<uint32_t>(*perRoundTokensPtr);
     tilingData.camMoeDispatchNormalInfo.realMaxBs = static_cast<uint32_t>(*realMaxBsPtr);

--- a/csrc/deepep/ops/op_host/dispatch_ffn_combine_tiling.cpp
+++ b/csrc/deepep/ops/op_host/dispatch_ffn_combine_tiling.cpp
@@ -44,9 +44,10 @@ static uint64_t GetMaxWindowSize()
 {
     uint16_t defaultWindowSize = 200;
     const char *hcclBuffSize = getenv("DEEPEP_HCCL_BUFFSIZE") == nullptr ? "HCCL_BUFFSIZE" : "DEEPEP_HCCL_BUFFSIZE";
-    if (getenv(hcclBuffSize) != nullptr) {
+    const char *envValue = getenv(hcclBuffSize);
+    if (envValue != nullptr) {
         try {
-            std::string envStr(getenv(hcclBuffSize));
+            std::string envStr(envValue);
             unsigned long val = std::stoul(envStr);
             if (val <= std::numeric_limits<uint16_t>::max()) {
                 defaultWindowSize = static_cast<uint16_t>(val);
@@ -85,8 +86,12 @@ static ge::graphStatus DispatchFFNCombineCheckAttrAndSetTiling(gert::TilingConte
 
     OP_TILING_CHECK(is_trans_b == nullptr, OP_LOGE(K_INNER_DEBUG, "is_trans_b is invalid."), return GRAPH_FAILED);
     OP_TILING_CHECK(weight_nz == nullptr, OP_LOGE(K_INNER_DEBUG, "weight_nz is invalid."), return GRAPH_FAILED);
+    OP_TILING_CHECK(maxOutputSizePtr == nullptr, OP_LOGE(K_INNER_DEBUG, "maxOutputSizePtr is invalid."),
+                    return GRAPH_FAILED);
 
     info.maxOutputSize = *maxOutputSizePtr;
+    OP_TILING_CHECK(info.maxOutputSize <= 0, OP_LOGE(K_INNER_DEBUG, "maxOutputSize must be > 0."),
+                    return GRAPH_FAILED);
     info.isTransposeB = *is_trans_b;
     info.isWeightNz = *weight_nz;
 
@@ -113,10 +118,13 @@ static ge::graphStatus DispatchFFNCombineCheckShapeAndSetTiling(gert::TilingCont
 
     const gert::StorageShape *aStorageShape = context->GetInputShape(X_INDEX);
     auto expertIdxTensor = context->GetInputShape(EXPERTID_INDEX);
+    OP_TILING_CHECK(aStorageShape == nullptr, OP_LOGE(nodeName, "aStorageShape is nullptr."), return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(expertIdxTensor == nullptr, OP_LOGE(nodeName, "expertIdxTensor is nullptr."), return ge::GRAPH_FAILED);
     uint32_t M = aStorageShape->GetStorageShape().GetDim(0);
     uint32_t K = aStorageShape->GetStorageShape().GetDim(1);
 
     auto wTensor = context->GetInputShape(WEIGHT_INDEX);
+    OP_TILING_CHECK(wTensor == nullptr, OP_LOGE(nodeName, "wTensor is nullptr."), return ge::GRAPH_FAILED);
     uint32_t expertPerRank = wTensor->GetStorageShape().GetDim(0);
     uint32_t N = wTensor->GetStorageShape().GetDim(2);
 
@@ -268,12 +276,16 @@ static ge::graphStatus DispatchFFNCombineTilingFuncImpl(gert::TilingContext *con
     uint32_t n2 = info.K;
     uint32_t k2 = info.N / 2;
 
-    uint64_t cocWorkspace = (info.M + 256 - 1) / 256 * 256 * info.topK * sizeof(int32_t) +
-                            info.worldSize * info.worldSize * info.expertPerRank * sizeof(int32_t) * 3 +
-                            info.maxOutputSize * sizeof(float) * 2 + info.maxOutputSize * info.N * sizeof(int16_t) +
-                            info.maxOutputSize * n2 * sizeof(int16_t) + info.maxOutputSize * info.K * sizeof(int8_t) +
-                            info.maxOutputSize * k2 * sizeof(int8_t) + info.worldSize * sizeof(int32_t) * 16 +
-                            (info.expertPerRank + info.worldSize) * sizeof(int32_t) * 16;
+    uint64_t cocWorkspace =
+        static_cast<uint64_t>((info.M + 256 - 1) / 256) * 256 * info.topK * sizeof(int32_t) +
+        static_cast<uint64_t>(info.worldSize) * info.worldSize * info.expertPerRank * sizeof(int32_t) * 3 +
+        static_cast<uint64_t>(info.maxOutputSize) * sizeof(float) * 2 +
+        static_cast<uint64_t>(info.maxOutputSize) * info.N * sizeof(int16_t) +
+        static_cast<uint64_t>(info.maxOutputSize) * n2 * sizeof(int16_t) +
+        static_cast<uint64_t>(info.maxOutputSize) * info.K * sizeof(int8_t) +
+        static_cast<uint64_t>(info.maxOutputSize) * k2 * sizeof(int8_t) +
+        static_cast<uint64_t>(info.worldSize) * sizeof(int32_t) * 16 +
+        (static_cast<uint64_t>(info.expertPerRank) + info.worldSize) * sizeof(int32_t) * 16;
 
     workSpaces[0] = SYSTEM_NEED_WORKSPACE + std::max(cocWorkspace, initRoutingWorkspace);
 

--- a/csrc/deepep/ops/op_host/dispatch_ffn_combine_tiling.cpp
+++ b/csrc/deepep/ops/op_host/dispatch_ffn_combine_tiling.cpp
@@ -90,8 +90,7 @@ static ge::graphStatus DispatchFFNCombineCheckAttrAndSetTiling(gert::TilingConte
                     return GRAPH_FAILED);
 
     info.maxOutputSize = *maxOutputSizePtr;
-    OP_TILING_CHECK(info.maxOutputSize <= 0, OP_LOGE(K_INNER_DEBUG, "maxOutputSize must be > 0."),
-                    return GRAPH_FAILED);
+    OP_TILING_CHECK(info.maxOutputSize <= 0, OP_LOGE(K_INNER_DEBUG, "maxOutputSize must be > 0."), return GRAPH_FAILED);
     info.isTransposeB = *is_trans_b;
     info.isWeightNz = *weight_nz;
 
@@ -119,7 +118,8 @@ static ge::graphStatus DispatchFFNCombineCheckShapeAndSetTiling(gert::TilingCont
     const gert::StorageShape *aStorageShape = context->GetInputShape(X_INDEX);
     auto expertIdxTensor = context->GetInputShape(EXPERTID_INDEX);
     OP_TILING_CHECK(aStorageShape == nullptr, OP_LOGE(nodeName, "aStorageShape is nullptr."), return ge::GRAPH_FAILED);
-    OP_TILING_CHECK(expertIdxTensor == nullptr, OP_LOGE(nodeName, "expertIdxTensor is nullptr."), return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(expertIdxTensor == nullptr, OP_LOGE(nodeName, "expertIdxTensor is nullptr."),
+                    return ge::GRAPH_FAILED);
     uint32_t M = aStorageShape->GetStorageShape().GetDim(0);
     uint32_t K = aStorageShape->GetStorageShape().GetDim(1);
 

--- a/csrc/deepep/ops/op_host/dispatch_ffn_combine_tiling.cpp
+++ b/csrc/deepep/ops/op_host/dispatch_ffn_combine_tiling.cpp
@@ -129,6 +129,9 @@ static ge::graphStatus DispatchFFNCombineCheckShapeAndSetTiling(gert::TilingCont
     info.expertPerRank = expertPerRank;
     info.topK = topK;
     info.listLen = listLen;
+    OP_TILING_CHECK(info.M == 0, OP_LOGE(nodeName, "M must not be 0."), return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(info.K == 0, OP_LOGE(nodeName, "K must not be 0."), return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(info.topK == 0, OP_LOGE(nodeName, "topK must not be 0."), return ge::GRAPH_FAILED);
     OP_LOGD(K_INNER_DEBUG, "M=%d ", info.M);
     OP_LOGD(K_INNER_DEBUG, "K=%d ", info.K);
     OP_LOGD(K_INNER_DEBUG, "N=%d ", info.N);

--- a/csrc/deepep/ops/op_host/dispatch_layout_tiling.cc
+++ b/csrc/deepep/ops/op_host/dispatch_layout_tiling.cc
@@ -126,12 +126,24 @@ static ge::graphStatus GetAttrAndSetTilingData(gert::TilingContext *context, con
             return ge::GRAPH_FAILED);
     }
 
+    OP_TILING_CHECK((*numTokensPtr < 0) || (*numTokensPtr > static_cast<int64_t>(UINT32_MAX)),
+                    OP_LOGE(nodeName, "numTokens is invalid, must be in [0, %ld], but got numTokens=%ld.",
+                            static_cast<int64_t>(UINT32_MAX), *numTokensPtr),
+                    return ge::GRAPH_FAILED);
     tilingData.dispatchLayoutInfo.numTokens = static_cast<uint32_t>(*numTokensPtr);
     tilingData.dispatchLayoutInfo.numRanks = static_cast<uint32_t>(*numRanksPtr);
     tilingData.dispatchLayoutInfo.numExperts = static_cast<uint32_t>(*numExpertsPtr);
     tilingData.dispatchLayoutInfo.numTopk = static_cast<uint32_t>(*numTopkPtr);
     tilingData.dispatchLayoutInfo.localRankSize = static_cast<uint32_t>(*localRankSizePtr);
+    OP_TILING_CHECK((*perRoundTokensPtr < 0) || (*perRoundTokensPtr > static_cast<int64_t>(UINT32_MAX)),
+                    OP_LOGE(nodeName, "perRoundTokens is invalid, must be in [0, %ld], but got perRoundTokens=%ld.",
+                            static_cast<int64_t>(UINT32_MAX), *perRoundTokensPtr),
+                    return ge::GRAPH_FAILED);
     tilingData.dispatchLayoutInfo.perRoundTokens = static_cast<uint32_t>(*perRoundTokensPtr);
+    OP_TILING_CHECK((*rankIdPtr < 0) || (*rankIdPtr > static_cast<int64_t>(UINT32_MAX)),
+                    OP_LOGE(nodeName, "rankId is invalid, must be in [0, %ld], but got rankId=%ld.",
+                            static_cast<int64_t>(UINT32_MAX), *rankIdPtr),
+                    return ge::GRAPH_FAILED);
     tilingData.dispatchLayoutInfo.rankId = static_cast<uint32_t>(*rankIdPtr);
 
     return ge::GRAPH_SUCCESS;

--- a/csrc/deepep/ops/op_host/fused_deep_moe_infer.cpp
+++ b/csrc/deepep/ops/op_host/fused_deep_moe_infer.cpp
@@ -70,6 +70,11 @@ static ge::graphStatus InferShape(gert::InferShapeContext *context)
     uint32_t epRankId = static_cast<uint32_t>(*epRankIdPtr);
     uint32_t sharedExpertRankNum = static_cast<uint32_t>(*sharedExpertRankNumPtr);
 
+    OPS_ERR_IF(epRankSize <= sharedExpertRankNum,
+               OPS_LOG_E(nodeName, "epRankSize (%u) must be > sharedExpertRankNum (%u) to avoid division by zero.",
+                         epRankSize, sharedExpertRankNum),
+               return ge::GRAPH_FAILED);
+
     recvCountOutShape->SetDimNum(1);
     bool isShareExpert = (epRankId < sharedExpertRankNum);
     if (isShareExpert) {

--- a/csrc/deepep/ops/op_host/fused_deep_moe_tiling.cpp
+++ b/csrc/deepep/ops/op_host/fused_deep_moe_tiling.cpp
@@ -221,9 +221,10 @@ static ge::graphStatus GetAttrAndSetTilingData(gert::TilingContext *context, con
     uint32_t moeExpertNum = static_cast<uint32_t>(*moeExpertNumPtr);
     uint32_t sharedExpertNum = static_cast<uint32_t>(*sharedExpertNumPtr);
     uint32_t sharedExpertRankNum = static_cast<uint32_t>(*sharedExpertRankNumPtr);
-    OPS_ERR_IF(epRankSize <= sharedExpertRankNum,
-               OPS_LOG_E(nodeName, "epRankSize (%u) must be > sharedExpertRankNum (%u).", epRankSize, sharedExpertRankNum),
-               return ge::GRAPH_FAILED);
+    OPS_ERR_IF(
+        epRankSize <= sharedExpertRankNum,
+        OPS_LOG_E(nodeName, "epRankSize (%u) must be > sharedExpertRankNum (%u).", epRankSize, sharedExpertRankNum),
+        return ge::GRAPH_FAILED);
     uint32_t moeExpertNumPerRank = moeExpertNum / (epRankSize - sharedExpertRankNum);
 
 #ifdef ENABLE_TILING_CHECK

--- a/csrc/deepep/ops/op_host/fused_deep_moe_tiling.cpp
+++ b/csrc/deepep/ops/op_host/fused_deep_moe_tiling.cpp
@@ -32,11 +32,12 @@ public:
     {
         uint16_t defaultWindowSize = 200;
         const char *hcclBuffSize = getenv("DEEPEP_HCCL_BUFFSIZE") == nullptr ? "HCCL_BUFFSIZE" : "DEEPEP_HCCL_BUFFSIZE";
-        if (getenv(hcclBuffSize) == nullptr) {
+        const char *envValue = getenv(hcclBuffSize);
+        if (envValue == nullptr) {
             OPS_LOG_D(nodeName, "Env HCCL_BUFFSIZE don't set");
         } else {
             try {
-                std::string envStr(getenv(hcclBuffSize));
+                std::string envStr(envValue);
                 defaultWindowSize = std::stoi(envStr);
             } catch (...) {
                 OPS_LOG_E(nodeName, "Unknown Exception encountered when parser env HCCL_BUFFERSIZE");
@@ -220,6 +221,9 @@ static ge::graphStatus GetAttrAndSetTilingData(gert::TilingContext *context, con
     uint32_t moeExpertNum = static_cast<uint32_t>(*moeExpertNumPtr);
     uint32_t sharedExpertNum = static_cast<uint32_t>(*sharedExpertNumPtr);
     uint32_t sharedExpertRankNum = static_cast<uint32_t>(*sharedExpertRankNumPtr);
+    OPS_ERR_IF(epRankSize <= sharedExpertRankNum,
+               OPS_LOG_E(nodeName, "epRankSize (%u) must be > sharedExpertRankNum (%u).", epRankSize, sharedExpertRankNum),
+               return ge::GRAPH_FAILED);
     uint32_t moeExpertNumPerRank = moeExpertNum / (epRankSize - sharedExpertRankNum);
 
 #ifdef ENABLE_TILING_CHECK

--- a/csrc/deepep/ops/op_host/mc2_tiling_utils.h
+++ b/csrc/deepep/ops/op_host/mc2_tiling_utils.h
@@ -23,11 +23,12 @@ public:
     {
         uint16_t defaultWindowSize = 200;
         const char *hcclBuffSize = getenv("DEEPEP_HCCL_BUFFSIZE") == nullptr ? "HCCL_BUFFSIZE" : "DEEPEP_HCCL_BUFFSIZE";
-        if (getenv(hcclBuffSize) == nullptr) {
+        const char *envValue = getenv(hcclBuffSize);
+        if (envValue == nullptr) {
             OP_LOGD("", "Env HCCL_BUFFSIZE don't set");
         } else {
             try {
-                std::string envStr(getenv(hcclBuffSize));
+                std::string envStr(envValue);
                 defaultWindowSize = std::stoi(envStr);
             } catch (const std::invalid_argument &ia) {
                 OP_LOGE("", "Invalid argument when parsing HCCL_BUFFSIZE: %s", ia.what());

--- a/csrc/deepep/ops/op_host/moe_distribute_combine_v2_ccu_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_combine_v2_ccu_tiling.cpp
@@ -242,7 +242,7 @@ static ge::graphStatus GetAttrAndSetTilingData(const gert::TilingContext *contex
                     OP_LOGE(nodeName, "CheckEpAndTpWorldSize failed."), return ge::GRAPH_FAILED);
     OP_TILING_CHECK(CheckEpRankId(context) != ge::GRAPH_SUCCESS, OP_LOGE(nodeName, "CheckEpRankId failed."),
                     return ge::GRAPH_FAILED);
-    OP_TILING_CHECK(CheckTpRankId(context) != ge::GRAPH_SUCCESS, OP_LOGE(nodeName, "CheckEpRankId failed."),
+    OP_TILING_CHECK(CheckTpRankId(context) != ge::GRAPH_SUCCESS, OP_LOGE(nodeName, "CheckTpRankId failed."),
                     return ge::GRAPH_FAILED);
     OP_TILING_CHECK(*expertShardTypePtr != 0,
                     OP_LOGE(nodeName, "The expected value of expertShardType is 0, but the actual value is %ld.",

--- a/csrc/deepep/ops/op_host/moe_distribute_combine_v2_ccu_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_combine_v2_ccu_tiling.cpp
@@ -673,7 +673,7 @@ ge::graphStatus MoeDistributeCombineTilingImpl(gert::TilingContext *context)
     // Tiling implementation
     OP_TILING_CHECK(context == nullptr, OP_LOGE(OP_NAME, "Fail to get tiling context."), return ge::GRAPH_FAILED);
     const char *nodeName = context->GetNodeName();
-    OP_TILING_CHECK(nodeName == nullptr, OP_LOGE(nodeName, "Fail to get nodeName."), return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(nodeName == nullptr, OP_LOGE("unKnownNodeName", "Fail to get nodeName."), return ge::GRAPH_FAILED);
     OP_LOGD(nodeName, "Start MoeDistributeCombineA5 tiling.");
     MoeDistributeCombineV2TilingData *tilingData = context->GetTilingData<MoeDistributeCombineV2TilingData>();
     OP_TILING_CHECK(tilingData == nullptr, OP_LOGE(nodeName, "tilingData is nullptr."), return ge::GRAPH_FAILED);

--- a/csrc/deepep/ops/op_host/moe_distribute_combine_v2_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_combine_v2_tiling.cpp
@@ -1120,7 +1120,9 @@ static ge::graphStatus MoeDistributeCombineA3TilingFuncImpl(gert::TilingContext 
     MoeDistributeCombineV2TilingData *tilingData = context->GetTilingData<MoeDistributeCombineV2TilingData>();
     OP_TILING_CHECK(tilingData == nullptr, OP_LOGE(nodeName, "tilingData is nullptr."), return ge::GRAPH_FAILED);
     auto attrs = context->GetAttrs();
+    OP_TILING_CHECK(attrs == nullptr, OP_LOGE(nodeName, "attrs is nullptr."), return ge::GRAPH_FAILED);
     auto commAlgPtr = attrs->GetAttrPointer<char>(static_cast<int>(ATTR_COMM_ALG_INDEX));
+    OP_TILING_CHECK(commAlgPtr == nullptr, OP_LOGE(nodeName, "commAlgPtr is nullptr."), return ge::GRAPH_FAILED);
     bool ccuFlag = strcmp(commAlgPtr, "ccu") == 0;
     OP_LOGD(nodeName, "commAlgPtr %s", commAlgPtr);
     std::string groupEp = "";

--- a/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_ccu_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_ccu_tiling.cpp
@@ -945,7 +945,7 @@ ge::graphStatus MoeDistributeDispatchTilingImpl(gert::TilingContext *context)
     // Tiling implementation
     OP_TILING_CHECK(context == nullptr, OP_LOGE(OP_NAME, "Fail to get tiling context."), return ge::GRAPH_FAILED);
     const char *nodeName = context->GetNodeName();
-    OP_TILING_CHECK(nodeName == nullptr, OP_LOGE(nodeName, "Fail to get nodeName."), return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(nodeName == nullptr, OP_LOGE("unKnownNodeName", "Fail to get nodeName."), return ge::GRAPH_FAILED);
     OP_LOGD(nodeName, "Start MoeDistributeDispatch tiling.");
     MoeDistributeDispatchV2TilingData *tilingData = context->GetTilingData<MoeDistributeDispatchV2TilingData>();
     OP_TILING_CHECK(tilingData == nullptr, OP_LOGE(nodeName, "tilingData is nullptr."), return ge::GRAPH_FAILED);

--- a/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
@@ -1186,7 +1186,7 @@ static void SetHcommCfg(const gert::TilingContext *context, MoeDistributeDispatc
     auto groupEpPtr = attrs->GetAttrPointer<char>(static_cast<int>(ATTR_GROUP_EP_INDEX));
     auto groupTpPtr = attrs->GetAttrPointer<char>(static_cast<int>(ATTR_GROUP_TP_INDEX));
     std::string groupTp = (groupTpPtr != nullptr) ? std::string(groupTpPtr) : std::string();
-    std::string groupEp = std::string(groupEpPtr);
+    std::string groupEp = (groupEpPtr != nullptr) ? std::string(groupEpPtr) : std::string();
     const char *nodeName = context->GetNodeName();
     OP_LOGD(nodeName, "MoeDistributeDispatchV2 groupEp = %s, groupTp = %s", groupEp.c_str(), groupTp.c_str());
     uint32_t opType1 = OP_TYPE_ALL_TO_ALL;

--- a/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_combine_v2.cpp
+++ b/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_combine_v2.cpp
@@ -19,6 +19,10 @@ enum NnopbaseHcclServerType {
 #define ACLNN_SUCCESS 0
 #endif
 
+#ifndef ACLNN_ERR_INNER_NULLPTR
+#define ACLNN_ERR_INNER_NULLPTR (-1)
+#endif
+
 extern aclnnStatus aclnnInnerMoeLowLatencyCombineV2GetWorkspaceSize(
     const aclTensor *expandX, const aclTensor *expertIds, const aclTensor *assistInfoForCombine,
     const aclTensor *epSendCounts, const aclTensor *expertScales, const aclTensor *tpSendCounts,
@@ -55,8 +59,11 @@ aclnnStatus aclnnMoeLowLatencyCombineV2GetWorkspaceSize(
         tpRankId, expertShardType, sharedExpertNum, sharedExpertRankNum, globalBs, outDtype, commQuantMode,
         groupListType, commAlg, 0, 0, 0, xOut, sendCostStats, workspaceSize, executor);
 
-    if (getWorkspaceSizesRes != ACLNN_SUCCESS || executor == nullptr || *executor == nullptr) {
+    if (getWorkspaceSizesRes != ACLNN_SUCCESS) {
         return getWorkspaceSizesRes;
+    }
+    if (executor == nullptr || *executor == nullptr) {
+        return ACLNN_ERR_INNER_NULLPTR;
     }
 
     if (NnopbaseSetHcclServerType) {

--- a/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_combine_v2.cpp
+++ b/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_combine_v2.cpp
@@ -15,6 +15,10 @@ enum NnopbaseHcclServerType {
     NNOPBASE_HCCL_SERVER_TYPE_END
 };
 
+#ifndef ACLNN_SUCCESS
+#define ACLNN_SUCCESS 0
+#endif
+
 extern aclnnStatus aclnnInnerMoeLowLatencyCombineV2GetWorkspaceSize(
     const aclTensor *expandX, const aclTensor *expertIds, const aclTensor *assistInfoForCombine,
     const aclTensor *epSendCounts, const aclTensor *expertScales, const aclTensor *tpSendCounts,
@@ -51,7 +55,7 @@ aclnnStatus aclnnMoeLowLatencyCombineV2GetWorkspaceSize(
         tpRankId, expertShardType, sharedExpertNum, sharedExpertRankNum, globalBs, outDtype, commQuantMode,
         groupListType, commAlg, 0, 0, 0, xOut, sendCostStats, workspaceSize, executor);
 
-    if (executor == nullptr) {
+    if (getWorkspaceSizesRes != ACLNN_SUCCESS || executor == nullptr || *executor == nullptr) {
         return getWorkspaceSizesRes;
     }
 

--- a/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_dispatch_v2.cpp
+++ b/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_dispatch_v2.cpp
@@ -4,6 +4,10 @@
 #include "graph/types.h"
 #include <cstring>
 
+#ifndef ACLNN_ERR_INNER_NULLPTR
+#define ACLNN_ERR_INNER_NULLPTR (-1)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -43,6 +47,9 @@ aclnnStatus aclnnMoeLowLatencyDispatchV2GetWorkspaceSize(
         groupTp, tpWorldSize, tpRankId, expertShardType, sharedExpertNum, sharedExpertRankNum, quantMode, globalBs,
         expertTokenNumsType, commAlg, 0, 0, 0, expandXOut, dynamicScalesOut, assistInfoForCombineOut,
         expertTokenNumsOut, epRecvCountsOut, tpRecvCountsOut, workspaceSize, executor);
+    if (commAlg == nullptr) {
+        return ACLNN_ERR_INNER_NULLPTR;
+    }
     if (NnopbaseSetHcclServerType) {
         if (std::strcmp(commAlg, "ccu") == 0) {
             NnopbaseSetHcclServerType(*executor, NNOPBASE_HCCL_SERVER_TYPE_CCU);

--- a/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_dispatch_v2.cpp
+++ b/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_dispatch_v2.cpp
@@ -54,8 +54,11 @@ aclnnStatus aclnnMoeLowLatencyDispatchV2GetWorkspaceSize(
         groupTp, tpWorldSize, tpRankId, expertShardType, sharedExpertNum, sharedExpertRankNum, quantMode, globalBs,
         expertTokenNumsType, commAlg, 0, 0, 0, expandXOut, dynamicScalesOut, assistInfoForCombineOut,
         expertTokenNumsOut, epRecvCountsOut, tpRecvCountsOut, workspaceSize, executor);
-    if (getWorkspaceSizesRes != ACLNN_SUCCESS || executor == nullptr || *executor == nullptr) {
+    if (getWorkspaceSizesRes != ACLNN_SUCCESS) {
         return getWorkspaceSizesRes;
+    }
+    if (executor == nullptr || *executor == nullptr) {
+        return ACLNN_ERR_INNER_NULLPTR;
     }
     if (NnopbaseSetHcclServerType) {
         if (std::strcmp(commAlg, "ccu") == 0) {

--- a/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_dispatch_v2.cpp
+++ b/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_dispatch_v2.cpp
@@ -42,14 +42,14 @@ aclnnStatus aclnnMoeLowLatencyDispatchV2GetWorkspaceSize(
     const aclTensor *expertTokenNumsOut, const aclTensor *epRecvCountsOut, const aclTensor *tpRecvCountsOut,
     uint64_t *workspaceSize, aclOpExecutor **executor)
 {
+    if (commAlg == nullptr) {
+        return ACLNN_ERR_INNER_NULLPTR;
+    }
     aclnnStatus getWorkspaceSizesRes = aclnnInnerMoeLowLatencyDispatchV2GetWorkspaceSize(
         x, expertIds, scalesOptional, xActiveMaskOptional, nullptr, groupEp, epWorldSize, epRankId, moeExpertNum,
         groupTp, tpWorldSize, tpRankId, expertShardType, sharedExpertNum, sharedExpertRankNum, quantMode, globalBs,
         expertTokenNumsType, commAlg, 0, 0, 0, expandXOut, dynamicScalesOut, assistInfoForCombineOut,
         expertTokenNumsOut, epRecvCountsOut, tpRecvCountsOut, workspaceSize, executor);
-    if (commAlg == nullptr) {
-        return ACLNN_ERR_INNER_NULLPTR;
-    }
     if (NnopbaseSetHcclServerType) {
         if (std::strcmp(commAlg, "ccu") == 0) {
             NnopbaseSetHcclServerType(*executor, NNOPBASE_HCCL_SERVER_TYPE_CCU);

--- a/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_dispatch_v2.cpp
+++ b/csrc/deepep/ops/op_host/op_api/aclnn_moe_distribute_dispatch_v2.cpp
@@ -8,6 +8,10 @@
 #define ACLNN_ERR_INNER_NULLPTR (-1)
 #endif
 
+#ifndef ACLNN_SUCCESS
+#define ACLNN_SUCCESS 0
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -50,6 +54,9 @@ aclnnStatus aclnnMoeLowLatencyDispatchV2GetWorkspaceSize(
         groupTp, tpWorldSize, tpRankId, expertShardType, sharedExpertNum, sharedExpertRankNum, quantMode, globalBs,
         expertTokenNumsType, commAlg, 0, 0, 0, expandXOut, dynamicScalesOut, assistInfoForCombineOut,
         expertTokenNumsOut, epRecvCountsOut, tpRecvCountsOut, workspaceSize, executor);
+    if (getWorkspaceSizesRes != ACLNN_SUCCESS || executor == nullptr || *executor == nullptr) {
+        return getWorkspaceSizesRes;
+    }
     if (NnopbaseSetHcclServerType) {
         if (std::strcmp(commAlg, "ccu") == 0) {
             NnopbaseSetHcclServerType(*executor, NNOPBASE_HCCL_SERVER_TYPE_CCU);

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine.h
@@ -168,7 +168,7 @@ __aicore__ inline void DispatchFFNCombine<TemplateMMA2ACFunc>::Process()
 
     int64_t activeNum = 0;
     int64_t expertCapacity = 0;
-    int64_t expertNum = expertPerRank * EP;
+    int64_t expertNum = static_cast<int64_t>(expertPerRank) * static_cast<int64_t>(EP);
     int64_t dropPadMode = 0;
     int64_t expertTokensCountOrCumsumFlag = 2;
     bool expertTokensBeforeCapacityFlag = false;
@@ -239,7 +239,7 @@ __aicore__ inline void DispatchFFNCombine<TemplateMMA2ACFunc>::Process()
     GemmCoord problemShape{static_cast<uint32_t>(m), static_cast<uint32_t>(n), static_cast<uint32_t>(k)};
 
     uint32_t epilogueCoreNum = aivNum / 2;
-    uint32_t epilogueGranularity = expertPerRank - 1;
+    uint32_t epilogueGranularity = (expertPerRank > 0) ? (expertPerRank - 1) : 0;
 
     typename MatmulKernel::Params params{problemShape,
                                          static_cast<uint32_t>(EP),

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel.hpp
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel.hpp
@@ -684,7 +684,7 @@ private:
         __gm__ float *flagPtr = workspaceInfo.ptrSoftFlagBase;
         AscendC::GlobalTensor<float> flagGM;
         flagGM.SetGlobalBuffer(flagPtr);
-        int32_t flagBufferSize = max(4, params.EP) * FLAGSTRIDE;
+        int64_t flagBufferSize = static_cast<int64_t>(max(4, params.EP)) * static_cast<int64_t>(FLAGSTRIDE);
         AscendC::LocalTensor<float> dstValueBuffer = resource.ubBuf.template GetBufferByByte<float>(flagBufferSize);
         AscendC::LocalTensor<float> sharedTmpBuffer =
             resource.ubBuf.template GetBufferByByte<float>((flagBufferSize + 64));

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_fullload_dynamic_quant.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_fullload_dynamic_quant.h
@@ -303,6 +303,9 @@ __aicore__ inline void MoeV2FullLoadDynamicQuant<T>::CopyOutXQuant1H()
             if (outIndex == -1 || (this->dropPadMode == DROPLESS_MODE && outIndex >= this->activateRows_)) {
                 continue;
             }
+            if (!(0 <= outIndex && outIndex < this->activateRows_)) {
+                continue;
+            }
             DataCopyPad(expandedXGm_[outIndex * this->cols_scale_], outLocal, intriParams);
         }
 

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_fullload_dynamic_quant.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_fullload_dynamic_quant.h
@@ -182,7 +182,9 @@ __aicore__ inline void MoeV2FullLoadDynamicQuant<T>::ComputeExpertTokenCountOrCu
         int32_t curExpertId = expandedExpertIdxLocal.GetValue(i);
         tokenCount++;
         while (lastExpertId < curExpertId) {
-            expertTokensCount.SetValue(lastExpertId, tokenCount - 1);
+            if (lastExpertId >= 0 && lastExpertId < this->expertNum) {
+                expertTokensCount.SetValue(lastExpertId, tokenCount - 1);
+            }
             if (this->expertTokensCountOrCumsumFlag == EXERPT_TOKENS_COUNT) {
                 tokenCount = 1;
             }
@@ -190,11 +192,15 @@ __aicore__ inline void MoeV2FullLoadDynamicQuant<T>::ComputeExpertTokenCountOrCu
         }
     }
 #ifndef __CCE_KT_TEST__
-    expertTokensCount.SetValue(lastExpertId, tokenCount);
+    if (lastExpertId >= 0 && lastExpertId < this->expertNum) {
+        expertTokensCount.SetValue(lastExpertId, tokenCount);
+    }
     if (this->expertTokensCountOrCumsumFlag == EXERPT_TOKENS_CUMSUM) {
         lastExpertId++;
         while (lastExpertId < this->expertNum) {
-            expertTokensCount.SetValue(lastExpertId, tokenCount);
+            if (lastExpertId >= 0) {
+                expertTokensCount.SetValue(lastExpertId, tokenCount);
+            }
             lastExpertId++;
         }
     }
@@ -304,6 +310,9 @@ __aicore__ inline void MoeV2FullLoadDynamicQuant<T>::CopyOutXQuant1H()
         inputXOutQueue.FreeTensor(outLocal);
     }
     expandedRowIdxCopyOutQueue_.FreeTensor(expandedRowIdx);
+    if (smoothType == 1) {
+        smoothInQueue.FreeTensor(smoothLocal);
+    }
 }
 
 template <typename T>

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_fullload_dynamic_quant.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_fullload_dynamic_quant.h
@@ -300,9 +300,6 @@ __aicore__ inline void MoeV2FullLoadDynamicQuant<T>::CopyOutXQuant1H()
         while (curRowsStart <= curRowsEnd && curRowsStart / this->k_ == row) {
             int32_t outIndex = expandedRowIdx.GetValue(curRowsStart);
             curRowsStart++;
-            if (outIndex == -1 || (this->dropPadMode == DROPLESS_MODE && outIndex >= this->activateRows_)) {
-                continue;
-            }
             if (!(0 <= outIndex && outIndex < this->activateRows_)) {
                 continue;
             }

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_fullload_quant.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_fullload_quant.h
@@ -107,9 +107,10 @@ __aicore__ inline void MoeV2FullLoadQuant<T>::CopyOutX()
     for (int64_t i = startXRow; i <= endXRow; i++) {
         for (; k < this->perCoreRows && curRowsStart / this->k == i; curRowsStart++, k++) {
             int32_t outIndex = expandedRowIdx.GetValue(curRowsStart);
-            if (outIndex < this->activateRows) {
-                DataCopyPad(expandedXGm[outIndex * this->cols], outLocal[(i - startXRow) * inFactor], intriParams);
+            if (!(0 <= outIndex && outIndex < this->activateRows)) {
+                continue;
             }
+            DataCopyPad(expandedXGm[outIndex * this->cols], outLocal[(i - startXRow) * inFactor], intriParams);
         }
     }
     expandedRowIdxCopyOutQueue.FreeTensor(expandedRowIdx);

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_fullload_quant_base.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_fullload_quant_base.h
@@ -177,18 +177,24 @@ __aicore__ inline void MoeV2FullLoadQuantBase::ComputeExpertTokenCountOrCumsum()
         int32_t curExpertId = expandedExpertIdx.GetValue(i);
         tokenCount++;
         while (lastExpertId < curExpertId) {
-            expertTokensCount.SetValue(lastExpertId, tokenCount - 1);
+            if (lastExpertId >= 0 && lastExpertId < this->expertNum) {
+                expertTokensCount.SetValue(lastExpertId, tokenCount - 1);
+            }
             if (this->expertTokensCountOrCumsumFlag == EXERPT_TOKENS_COUNT) {
                 tokenCount = 1;
             }
             lastExpertId++;
         }
     }
-    expertTokensCount.SetValue(lastExpertId, tokenCount);
+    if (lastExpertId >= 0 && lastExpertId < this->expertNum) {
+        expertTokensCount.SetValue(lastExpertId, tokenCount);
+    }
     if (this->expertTokensCountOrCumsumFlag == EXERPT_TOKENS_CUMSUM) {
         lastExpertId++;
         while (lastExpertId < this->expertNum) {
-            expertTokensCount.SetValue(lastExpertId, tokenCount);
+            if (lastExpertId >= 0) {
+                expertTokensCount.SetValue(lastExpertId, tokenCount);
+            }
             lastExpertId++;
         }
     }

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_gather_dynamic_quant.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_gather_dynamic_quant.h
@@ -352,6 +352,9 @@ __aicore__ inline void MoeV2GatherDynamicQuant<T>::CopyOutPartialXQuantEH(int64_
         }
         int32_t srcIdx = indicesLocal.GetValue(i);
         int32_t expertIdx = indicesLocal.GetValue(currentLoopRowsAlign + i);
+        if (srcIdx < 0 || srcIdx >= this->totalLength) {
+            continue;
+        }
 
         LocalTensor<float> inLocal = inputXInQueue.AllocTensor<float>();
         LocalTensor<float> tempLocal = calcQueue.AllocTensor<float>();

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_gather_dynamic_quant.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_gather_dynamic_quant.h
@@ -201,6 +201,9 @@ __aicore__ inline void MoeV2GatherDynamicQuant<T>::CopyOutXQuant1H(int64_t progr
         inputXOutQueue.FreeTensor(outLocal);
     }
     expandRowIdxInQueue.FreeTensor(indicesLocal);
+    if (smoothType == 1) {
+        smoothInQueue.FreeTensor(smoothLocal);
+    }
 }
 
 template <typename T>

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_gather_dynamic_quant.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_gather_dynamic_quant.h
@@ -188,9 +188,6 @@ __aicore__ inline void MoeV2GatherDynamicQuant<T>::CopyOutXQuant1H(int64_t progr
             int32_t outIndex = indicesLocal.GetValue(curLoopRow);
             curLoopRow++;
             initialRow++;
-            if (outIndex == -1 || (this->dropPadMode == DROPLESS_MODE && outIndex >= this->activateRows)) {
-                continue;
-            }
             if (!(0 <= outIndex && outIndex < activateRows)) {
                 continue;
             }
@@ -435,9 +432,6 @@ __aicore__ inline void MoeV2GatherDynamicQuant<T>::CopyOutPartialXQuant1H(int64_
             int32_t outIndex = indicesLocal.GetValue(curLoopRow);
             curLoopRow++;
             initialRow++;
-            if (outIndex == -1 || (this->dropPadMode == DROPLESS_MODE && outIndex >= this->activateRows)) {
-                continue;
-            }
             if (!(0 <= outIndex && outIndex < activateRows)) {
                 continue;
             }

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_gather_out.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_gather_out.h
@@ -102,6 +102,9 @@ __aicore__ inline void MoeV2GatherOut<T>::CopyOut(int64_t progress)
                 if (outIndex == -1 || (this->dropPadMode == DROPLESS_MODE && outIndex >= this->activateRows)) {
                     continue;
                 }
+                if (!(0 <= outIndex && outIndex < this->activateRows)) {
+                    continue;
+                }
                 outOffset = outIndex * cols + colsLoop * this->perLoopCols;
 #ifdef __CCE_KT_TEST__
                 // CPU twin debugging cannot use multi-core sync, so index may contain uninitialized dirty data; handle

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_gather_out.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_gather_out.h
@@ -99,9 +99,6 @@ __aicore__ inline void MoeV2GatherOut<T>::CopyOut(int64_t progress)
                 int32_t outIndex = indicesLocal.GetValue(curLoopRow);
                 curLoopRow++;
                 initialRow++;
-                if (outIndex == -1 || (this->dropPadMode == DROPLESS_MODE && outIndex >= this->activateRows)) {
-                    continue;
-                }
                 if (!(0 <= outIndex && outIndex < this->activateRows)) {
                     continue;
                 }

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_gather_quant.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_gather_quant.h
@@ -156,6 +156,9 @@ __aicore__ inline void MoeV2GatherQuant<T>::CopyOut(int64_t progress)
                 if (outIndex < 0 || (this->dropPadMode == DROPLESS_MODE && outIndex >= this->activateRows)) {
                     continue;
                 }
+                if (!(0 <= outIndex && outIndex < this->activateRows)) {
+                    continue;
+                }
                 outOffset = outIndex * cols + colsLoop * this->perLoopCols;
                 DataCopyPad(expandedXGm[outOffset], outLocal, intriParams);
             }

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_gather_quant.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_gather_quant.h
@@ -153,7 +153,7 @@ __aicore__ inline void MoeV2GatherQuant<T>::CopyOut(int64_t progress)
                 int32_t outIndex = indicesLocal.GetValue(curLoopRow);
                 curLoopRow++;
                 initialRow++;
-                if (outIndex == -1 || (this->dropPadMode == DROPLESS_MODE && outIndex >= this->activateRows)) {
+                if (outIndex < 0 || (this->dropPadMode == DROPLESS_MODE && outIndex >= this->activateRows)) {
                     continue;
                 }
                 outOffset = outIndex * cols + colsLoop * this->perLoopCols;

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_gather_quant.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_gather_quant.h
@@ -153,9 +153,6 @@ __aicore__ inline void MoeV2GatherQuant<T>::CopyOut(int64_t progress)
                 int32_t outIndex = indicesLocal.GetValue(curLoopRow);
                 curLoopRow++;
                 initialRow++;
-                if (outIndex < 0 || (this->dropPadMode == DROPLESS_MODE && outIndex >= this->activateRows)) {
-                    continue;
-                }
                 if (!(0 <= outIndex && outIndex < this->activateRows)) {
                     continue;
                 }

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_init_routing_fullload.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_init_routing_fullload.h
@@ -173,18 +173,24 @@ __aicore__ inline void MoeV2FullLoad<T>::ComputeExpertTokenCountOrCumsum()
         int32_t curExpertId = expandedExpertIdx.GetValue(i);
         tokenCount++;
         while (lastExpertId < curExpertId) {
-            expertTokensCount.SetValue(lastExpertId, tokenCount - 1);
+            if (lastExpertId >= 0 && lastExpertId < this->expertNum) {
+                expertTokensCount.SetValue(lastExpertId, tokenCount - 1);
+            }
             if (this->expertTokensCountOrCumsumFlag == EXERPT_TOKENS_COUNT) {
                 tokenCount = 1;
             }
             lastExpertId++;
         }
     }
-    expertTokensCount.SetValue(lastExpertId, tokenCount);
+    if (lastExpertId >= 0 && lastExpertId < this->expertNum) {
+        expertTokensCount.SetValue(lastExpertId, tokenCount);
+    }
     if (this->expertTokensCountOrCumsumFlag == EXERPT_TOKENS_CUMSUM) {
         lastExpertId++;
         while (lastExpertId < this->expertNum) {
-            expertTokensCount.SetValue(lastExpertId, tokenCount);
+            if (lastExpertId >= 0) {
+                expertTokensCount.SetValue(lastExpertId, tokenCount);
+            }
             lastExpertId++;
         }
     }
@@ -220,7 +226,7 @@ __aicore__ inline void MoeV2FullLoad<T>::CopyOutX()
     for (int64_t i = startXRow; i <= endXRow; i++) {
         for (; k < this->perCoreRows_ && curRowsStart / this->k_ == i; curRowsStart++, k++) {
             int32_t outIndex = expandedRowIdx.GetValue(curRowsStart);
-            if (outIndex < this->activateRows_) {
+            if (0 <= outIndex && outIndex < this->activateRows_) {
                 DataCopyPad(expandedXGm_[outIndex * this->cols_], xLocal[(i - startXRow) * inFactor], intriParams);
             }
         }

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_src_to_dst_and_gather.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_src_to_dst_and_gather.h
@@ -219,6 +219,9 @@ __aicore__ inline void MoeV2SrcToDstAndGather<T, TilingData>::CopyOut(int64_t pr
     }
     for (int64_t idx = 0; idx < currentLoopRows; idx++) {
         int32_t expertIdx = inLocal[length].GetValue(idx);
+        if (!(0 <= expertIdx && expertIdx < this->expertNum)) {
+            continue;
+        }
         SetWaitFlag<HardEvent::S_MTE3>(HardEvent::S_MTE3);
         int32_t index = 0;
         while (this->lastExpertId < expertIdx) {
@@ -234,6 +237,10 @@ __aicore__ inline void MoeV2SrcToDstAndGather<T, TilingData>::CopyOut(int64_t pr
 
         if (this->tokenCount < this->expertCapacity) {
             int32_t outOffset = inLocal.GetValue(idx);
+            if (!(0 <= outOffset && outOffset < this->totalLength)) {
+                this->tokenCount++;
+                continue;
+            }
             index = expertIdx * this->expertCapacity + this->tokenCount;
             outLocal.SetValue(0, index);
             SetWaitFlag<HardEvent::S_MTE3>(HardEvent::S_MTE3);
@@ -382,6 +389,9 @@ __aicore__ inline void MoeV2SrcToDstAndGather<T, TilingData>::CopyOutLoops(int64
     }
     for (int64_t idx = 0; idx < currentLoopRows; idx++) {
         int32_t expertIdx = inLocal[length].GetValue(idx);
+        if (!(0 <= expertIdx && expertIdx < this->expertNum)) {
+            continue;
+        }
         SetWaitFlag<HardEvent::S_MTE3>(HardEvent::S_MTE3);
         int32_t index = 0;
         while (this->lastExpertId < expertIdx) {
@@ -407,6 +417,10 @@ __aicore__ inline void MoeV2SrcToDstAndGather<T, TilingData>::CopyOutLoops(int64
 
         if (this->tokenCount < this->expertCapacity) {
             int32_t outOffset = inLocal.GetValue(idx);
+            if (!(0 <= outOffset && outOffset < this->totalLength)) {
+                this->tokenCount++;
+                continue;
+            }
             index = expertIdx * this->expertCapacity + this->tokenCount;
             outLocal.SetValue(0, index);
             SetWaitFlag<HardEvent::S_MTE3>(HardEvent::S_MTE3);

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_src_to_dst_and_gather.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_src_to_dst_and_gather.h
@@ -238,7 +238,6 @@ __aicore__ inline void MoeV2SrcToDstAndGather<T, TilingData>::CopyOut(int64_t pr
         if (this->tokenCount < this->expertCapacity) {
             int32_t outOffset = inLocal.GetValue(idx);
             if (!(0 <= outOffset && outOffset < this->totalLength)) {
-                this->tokenCount++;
                 continue;
             }
             index = expertIdx * this->expertCapacity + this->tokenCount;
@@ -418,7 +417,6 @@ __aicore__ inline void MoeV2SrcToDstAndGather<T, TilingData>::CopyOutLoops(int64
         if (this->tokenCount < this->expertCapacity) {
             int32_t outOffset = inLocal.GetValue(idx);
             if (!(0 <= outOffset && outOffset < this->totalLength)) {
-                this->tokenCount++;
                 continue;
             }
             index = expertIdx * this->expertCapacity + this->tokenCount;

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_src_to_dst_op.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_src_to_dst_op.h
@@ -88,9 +88,11 @@ __aicore__ inline void MoeV2SrcToDstOp::CopyOut()
     DataCopyParams intriParams;
     intriParams.blockCount = 1;
     intriParams.blockLen = sizeof(int32_t);
-    uint32_t outOffset;
     for (int64_t idx = 0; idx < currentLoopRows; idx++) {
-        outOffset = inLocal.GetValue(idx);
+        int32_t outOffset = inLocal.GetValue(idx);
+        if (!(0 <= outOffset && outOffset < this->totalLength)) {
+            continue;
+        }
         DataCopyPad(expandSrcToDstRowGm[outOffset], outLocal[idx * INT32_ONE_BLOCK_NUM], intriParams);
     }
 

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_src_to_dst_with_capacity.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_src_to_dst_with_capacity.h
@@ -115,6 +115,9 @@ __aicore__ inline void MoeV2SrcToDstWithCapacity<T, TilingData>::CopyOut(int64_t
     }
     for (int64_t idx = 0; idx < currentLoopRows; idx++) {
         int32_t expertIdx = inLocal[length].GetValue(idx);
+        if (!(0 <= expertIdx && expertIdx < this->expertNum)) {
+            continue;
+        }
         SetWaitFlag<HardEvent::S_MTE3>(HardEvent::S_MTE3);
         int32_t index = 0;
         while (this->lastExpertId < expertIdx) {
@@ -146,6 +149,10 @@ __aicore__ inline void MoeV2SrcToDstWithCapacity<T, TilingData>::CopyOut(int64_t
 
         if (this->tokenCount < this->expertCapacity) {
             int32_t outOffset = inLocal.GetValue(idx);
+            if (!(0 <= outOffset && outOffset < this->totalLength)) {
+                this->tokenCount++;
+                continue;
+            }
             index = expertIdx * this->expertCapacity + this->tokenCount;
             outLocal.SetValue(0, index);
             SetWaitFlag<HardEvent::S_MTE3>(HardEvent::S_MTE3);

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_src_to_dst_with_capacity.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/moe_init_routing_quant_v2/moe_v2_src_to_dst_with_capacity.h
@@ -150,7 +150,6 @@ __aicore__ inline void MoeV2SrcToDstWithCapacity<T, TilingData>::CopyOut(int64_t
         if (this->tokenCount < this->expertCapacity) {
             int32_t outOffset = inLocal.GetValue(idx);
             if (!(0 <= outOffset && outOffset < this->totalLength)) {
-                this->tokenCount++;
                 continue;
             }
             index = expertIdx * this->expertCapacity + this->tokenCount;

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/utils/block_epilogue_pertoken_swiglu.hpp
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/utils/block_epilogue_pertoken_swiglu.hpp
@@ -219,6 +219,9 @@ public:
 
             // TODO: compare the efficiency of the two calculation methods
             ElementPerTokenScale GMubDequantScale = ubReduceMax.GetValue(0);
+            if (GMubDequantScale == 0.f) {
+                GMubDequantScale = 1.f;
+            }
             AscendC::SetFlag<AscendC::HardEvent::S_V>(0);
 
             auto ubPerTokenScaleOutputOffset = loopIdx - loopStartIdx;

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/utils/moe_distribute_base.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/utils/moe_distribute_base.h
@@ -377,7 +377,7 @@ __aicore__ inline void cacheWriteThrough(__gm__ uint8_t *sourceAddr, uint64_t le
         (__gm__ uint8_t *)(((uint64_t)sourceAddr + length) / AscendC::CACHE_LINE_SIZE * AscendC::CACHE_LINE_SIZE);
     AscendC::GlobalTensor<uint8_t> global;
     global.SetGlobalBuffer(start);
-    for (uint32_t i = 0; i <= end - start; i += AscendC::CACHE_LINE_SIZE) {
+    for (uint32_t i = 0; i < end - start; i += AscendC::CACHE_LINE_SIZE) {
         AscendC::DataCacheCleanAndInvalid<uint8_t, AscendC::CacheLine::SINGLE_CACHE_LINE,
                                           AscendC::DcciDst::CACHELINE_OUT>(global[i]);
     }

--- a/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/utils/moe_distribute_base.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_ffn_combine_kernel/utils/moe_distribute_base.h
@@ -373,11 +373,14 @@ __aicore__ inline void cacheWriteThrough(__gm__ uint8_t *sourceAddr, uint64_t le
 {
     __gm__ uint8_t *start =
         (__gm__ uint8_t *)((uint64_t)sourceAddr / AscendC::CACHE_LINE_SIZE * AscendC::CACHE_LINE_SIZE);
+    if (length == 0) {
+        return;
+    }
     __gm__ uint8_t *end =
-        (__gm__ uint8_t *)(((uint64_t)sourceAddr + length) / AscendC::CACHE_LINE_SIZE * AscendC::CACHE_LINE_SIZE);
+        (__gm__ uint8_t *)(((uint64_t)sourceAddr + length - 1) / AscendC::CACHE_LINE_SIZE * AscendC::CACHE_LINE_SIZE);
     AscendC::GlobalTensor<uint8_t> global;
     global.SetGlobalBuffer(start);
-    for (uint32_t i = 0; i < end - start; i += AscendC::CACHE_LINE_SIZE) {
+    for (uint32_t i = 0; i <= end - start; i += AscendC::CACHE_LINE_SIZE) {
         AscendC::DataCacheCleanAndInvalid<uint8_t, AscendC::CacheLine::SINGLE_CACHE_LINE,
                                           AscendC::DcciDst::CACHELINE_OUT>(global[i]);
     }

--- a/csrc/deepep/ops/op_kernel/dispatch_layout.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_layout.h
@@ -57,21 +57,21 @@ public:
         if (coreIdx_ < restNum) {
             ++tempTokens_;
         }
-        topkIdx32AlignIntLen_ = Ceil(tempTokens_ * numTopk_ * sizeof(int64_t), UB_32_ALIGN) * UB_32_ALIGN;
+        topkIdx32AlignIntLen_ = Ceil(static_cast<uint64_t>(tempTokens_) * numTopk_ * sizeof(int64_t), UB_32_ALIGN) * UB_32_ALIGN;
         numTokensPerRank32AlignIntLen_ = Ceil(numRanks_ * sizeof(T), UB_32_ALIGN) * UB_32_ALIGN;
         numTokensPerExpert32AlignIntLen_ = Ceil(numExperts_ * sizeof(T), UB_32_ALIGN) * UB_32_ALIGN;
-        isTokenInRank32AlignIntLen_ = Ceil(tempTokens_ * numRanks_ * sizeof(T), UB_32_ALIGN) * UB_32_ALIGN;
+        isTokenInRank32AlignIntLen_ = Ceil(static_cast<uint64_t>(tempTokens_) * numRanks_ * sizeof(T), UB_32_ALIGN) * UB_32_ALIGN;
 
         if (coreIdx_ < restNum) {
-            topkIdxOffset_ = coreIdx_ * tempTokens_ * numTopk_ * sizeof(int64_t);
-            sendIdxOffset_ = coreIdx_ * tempTokens_ * numTopk_ * sizeof(T);
-            isTokenOffset_ = coreIdx_ * tempTokens_ * numRanks_ * sizeof(T);
-            tokenIdxOffset_ = coreIdx_ * tempTokens_ * sizeof(T);
+            topkIdxOffset_ = static_cast<int64_t>(coreIdx_) * tempTokens_ * numTopk_ * sizeof(int64_t);
+            sendIdxOffset_ = static_cast<int64_t>(coreIdx_) * tempTokens_ * numTopk_ * sizeof(T);
+            isTokenOffset_ = static_cast<int64_t>(coreIdx_) * tempTokens_ * numRanks_ * sizeof(T);
+            tokenIdxOffset_ = static_cast<int64_t>(coreIdx_) * tempTokens_ * sizeof(T);
         } else {
-            topkIdxOffset_ = (restNum + coreIdx_ * tempTokens_) * numTopk_ * sizeof(int64_t);
-            sendIdxOffset_ = (restNum + coreIdx_ * tempTokens_) * numTopk_ * sizeof(T);
-            isTokenOffset_ = (restNum + coreIdx_ * tempTokens_) * numRanks_ * sizeof(T);
-            tokenIdxOffset_ = (restNum + coreIdx_ * tempTokens_) * sizeof(T);
+            topkIdxOffset_ = (restNum + static_cast<int64_t>(coreIdx_) * tempTokens_) * numTopk_ * sizeof(int64_t);
+            sendIdxOffset_ = (restNum + static_cast<int64_t>(coreIdx_) * tempTokens_) * numTopk_ * sizeof(T);
+            isTokenOffset_ = (restNum + static_cast<int64_t>(coreIdx_) * tempTokens_) * numRanks_ * sizeof(T);
+            tokenIdxOffset_ = (restNum + static_cast<int64_t>(coreIdx_) * tempTokens_) * sizeof(T);
         }
 
         tempExpertGM_.SetGlobalBuffer((__gm__ T *)notifySendData);
@@ -105,19 +105,19 @@ public:
                 if (coreIdx_ < restNum) {
                     tempTokens_++;
                 }
-                topkIdx32AlignIntLen_ = Ceil(tempTokens_ * numTopk_ * sizeof(int64_t), UB_32_ALIGN) * UB_32_ALIGN;
-                isTokenInRank32AlignIntLen_ = Ceil(tempTokens_ * numRanks_ * sizeof(T), UB_32_ALIGN) * UB_32_ALIGN;
+                topkIdx32AlignIntLen_ = Ceil(static_cast<uint64_t>(tempTokens_) * numTopk_ * sizeof(int64_t), UB_32_ALIGN) * UB_32_ALIGN;
+                isTokenInRank32AlignIntLen_ = Ceil(static_cast<uint64_t>(tempTokens_) * numRanks_ * sizeof(T), UB_32_ALIGN) * UB_32_ALIGN;
 
                 if (coreIdx_ < restNum) {
-                    topkIdxOffset_ = coreIdx_ * tempTokens_ * numTopk_ * sizeof(int64_t);
-                    sendIdxOffset_ = coreIdx_ * tempTokens_ * numTopk_ * sizeof(T);
-                    isTokenOffset_ = coreIdx_ * tempTokens_ * numRanks_ * sizeof(T);
-                    tokenIdxOffset_ = coreIdx_ * tempTokens_ * sizeof(T);
+                    topkIdxOffset_ = static_cast<int64_t>(coreIdx_) * tempTokens_ * numTopk_ * sizeof(int64_t);
+                    sendIdxOffset_ = static_cast<int64_t>(coreIdx_) * tempTokens_ * numTopk_ * sizeof(T);
+                    isTokenOffset_ = static_cast<int64_t>(coreIdx_) * tempTokens_ * numRanks_ * sizeof(T);
+                    tokenIdxOffset_ = static_cast<int64_t>(coreIdx_) * tempTokens_ * sizeof(T);
                 } else {
-                    topkIdxOffset_ = (restNum + coreIdx_ * tempTokens_) * numTopk_ * sizeof(int64_t);
-                    sendIdxOffset_ = (restNum + coreIdx_ * tempTokens_) * numTopk_ * sizeof(T);
-                    isTokenOffset_ = (restNum + coreIdx_ * tempTokens_) * numRanks_ * sizeof(T);
-                    tokenIdxOffset_ = (restNum + coreIdx_ * tempTokens_) * sizeof(T);
+                    topkIdxOffset_ = (restNum + static_cast<int64_t>(coreIdx_) * tempTokens_) * numTopk_ * sizeof(int64_t);
+                    sendIdxOffset_ = (restNum + static_cast<int64_t>(coreIdx_) * tempTokens_) * numTopk_ * sizeof(T);
+                    isTokenOffset_ = (restNum + static_cast<int64_t>(coreIdx_) * tempTokens_) * numRanks_ * sizeof(T);
+                    tokenIdxOffset_ = (restNum + static_cast<int64_t>(coreIdx_) * tempTokens_) * sizeof(T);
                 }
             }
 
@@ -129,8 +129,8 @@ public:
                 continue;
             }
 
-            int64_t round_topkIdx_offset = r * perRoundTokens_ * numTopk_ * sizeof(int64_t);
-            int64_t round_sendIdx_offset = r * perRoundTokens_ * numTopk_ * sizeof(T);
+            int64_t round_topkIdx_offset = static_cast<int64_t>(r) * perRoundTokens_ * numTopk_ * sizeof(int64_t);
+            int64_t round_sendIdx_offset = static_cast<int64_t>(r) * perRoundTokens_ * numTopk_ * sizeof(T);
 
             sendTokenIdxSmallGM_.SetGlobalBuffer(
                 (__gm__ T *)(sendTokenIdxSmall_ + round_sendIdx_offset + sendIdxOffset_));
@@ -138,7 +138,7 @@ public:
             numTokensPerExpertGM_.SetGlobalBuffer((__gm__ T *)(numTokensPerExpert_ + numExperts_ * r * sizeof(T)));
             // tokens * rank;
             isTokenInRankGM_.SetGlobalBuffer(
-                (__gm__ T *)(isTokenInRank_ + r * perRoundTokens_ * numRanks_ * sizeof(T) + isTokenOffset_));
+                (__gm__ T *)(isTokenInRank_ + static_cast<int64_t>(r) * perRoundTokens_ * numRanks_ * sizeof(T) + isTokenOffset_));
 
             const DataCopyExtParams dataCopyParams{1U, topkIdx32AlignIntLen_, 0U, 0U, 0U};
             const DataCopyPadExtParams<int64_t> padParams{false, 0U, 0U, 0U};
@@ -152,7 +152,7 @@ public:
             SyncFunc<AscendC::HardEvent::V_S>();
             SyncFunc<AscendC::HardEvent::V_MTE3>();
             const DataCopyExtParams clearGmParams{1U, numTokensPerExpert32AlignIntLen_, 0U, 0U, 0U};
-            DataCopyPad(tempExpertGM_[coreIdx_ * numExperts_], numTokensPerExpertTensor, clearGmParams);
+            DataCopyPad(tempExpertGM_[static_cast<int64_t>(coreIdx_) * numExperts_], numTokensPerExpertTensor, clearGmParams);
             PipeBarrier<PIPE_MTE3>();
             SyncAll<true>();
 
@@ -184,7 +184,7 @@ public:
             AscendC::SetAtomicAdd<T>();
             const DataCopyExtParams tempExpertDataCopyParams{1U, numTokensPerExpert32AlignIntLen_, 0U, 0U, 0U};
             for (int i = coreIdx_ + 1; i < aivNum_; ++i) {
-                DataCopyPad(tempExpertGM_[i * numExperts_], numTokensPerExpertTensor, tempExpertDataCopyParams);
+                DataCopyPad(tempExpertGM_[static_cast<int64_t>(i) * numExperts_], numTokensPerExpertTensor, tempExpertDataCopyParams);
             }
             sendSize = numRanks_ * sizeof(T);
             const DataCopyExtParams numTokensPerRankDataCopyParams{1U, sendSize, 0U, 0U, 0U};
@@ -197,7 +197,7 @@ public:
             SyncAll<true>();
             SyncFunc<AscendC::HardEvent::MTE3_MTE2>();
             const DataCopyPadExtParams<T> tempPadParams{false, 0U, 0U, 0U};
-            DataCopyPad(numTokensPerExpertTensor, tempExpertGM_[coreIdx_ * numExperts_], tempExpertDataCopyParams,
+            DataCopyPad(numTokensPerExpertTensor, tempExpertGM_[static_cast<int64_t>(coreIdx_) * numExperts_], tempExpertDataCopyParams,
                         tempPadParams);
             SyncFunc<AscendC::HardEvent::MTE2_S>();
             for (int i = 0; i < tempTokens_; ++i) {

--- a/csrc/deepep/ops/op_kernel/dispatch_layout.h
+++ b/csrc/deepep/ops/op_kernel/dispatch_layout.h
@@ -57,10 +57,12 @@ public:
         if (coreIdx_ < restNum) {
             ++tempTokens_;
         }
-        topkIdx32AlignIntLen_ = Ceil(static_cast<uint64_t>(tempTokens_) * numTopk_ * sizeof(int64_t), UB_32_ALIGN) * UB_32_ALIGN;
+        topkIdx32AlignIntLen_ =
+            Ceil(static_cast<uint64_t>(tempTokens_) * numTopk_ * sizeof(int64_t), UB_32_ALIGN) * UB_32_ALIGN;
         numTokensPerRank32AlignIntLen_ = Ceil(numRanks_ * sizeof(T), UB_32_ALIGN) * UB_32_ALIGN;
         numTokensPerExpert32AlignIntLen_ = Ceil(numExperts_ * sizeof(T), UB_32_ALIGN) * UB_32_ALIGN;
-        isTokenInRank32AlignIntLen_ = Ceil(static_cast<uint64_t>(tempTokens_) * numRanks_ * sizeof(T), UB_32_ALIGN) * UB_32_ALIGN;
+        isTokenInRank32AlignIntLen_ =
+            Ceil(static_cast<uint64_t>(tempTokens_) * numRanks_ * sizeof(T), UB_32_ALIGN) * UB_32_ALIGN;
 
         if (coreIdx_ < restNum) {
             topkIdxOffset_ = static_cast<int64_t>(coreIdx_) * tempTokens_ * numTopk_ * sizeof(int64_t);
@@ -105,8 +107,10 @@ public:
                 if (coreIdx_ < restNum) {
                     tempTokens_++;
                 }
-                topkIdx32AlignIntLen_ = Ceil(static_cast<uint64_t>(tempTokens_) * numTopk_ * sizeof(int64_t), UB_32_ALIGN) * UB_32_ALIGN;
-                isTokenInRank32AlignIntLen_ = Ceil(static_cast<uint64_t>(tempTokens_) * numRanks_ * sizeof(T), UB_32_ALIGN) * UB_32_ALIGN;
+                topkIdx32AlignIntLen_ =
+                    Ceil(static_cast<uint64_t>(tempTokens_) * numTopk_ * sizeof(int64_t), UB_32_ALIGN) * UB_32_ALIGN;
+                isTokenInRank32AlignIntLen_ =
+                    Ceil(static_cast<uint64_t>(tempTokens_) * numRanks_ * sizeof(T), UB_32_ALIGN) * UB_32_ALIGN;
 
                 if (coreIdx_ < restNum) {
                     topkIdxOffset_ = static_cast<int64_t>(coreIdx_) * tempTokens_ * numTopk_ * sizeof(int64_t);
@@ -114,7 +118,8 @@ public:
                     isTokenOffset_ = static_cast<int64_t>(coreIdx_) * tempTokens_ * numRanks_ * sizeof(T);
                     tokenIdxOffset_ = static_cast<int64_t>(coreIdx_) * tempTokens_ * sizeof(T);
                 } else {
-                    topkIdxOffset_ = (restNum + static_cast<int64_t>(coreIdx_) * tempTokens_) * numTopk_ * sizeof(int64_t);
+                    topkIdxOffset_ =
+                        (restNum + static_cast<int64_t>(coreIdx_) * tempTokens_) * numTopk_ * sizeof(int64_t);
                     sendIdxOffset_ = (restNum + static_cast<int64_t>(coreIdx_) * tempTokens_) * numTopk_ * sizeof(T);
                     isTokenOffset_ = (restNum + static_cast<int64_t>(coreIdx_) * tempTokens_) * numRanks_ * sizeof(T);
                     tokenIdxOffset_ = (restNum + static_cast<int64_t>(coreIdx_) * tempTokens_) * sizeof(T);
@@ -138,7 +143,8 @@ public:
             numTokensPerExpertGM_.SetGlobalBuffer((__gm__ T *)(numTokensPerExpert_ + numExperts_ * r * sizeof(T)));
             // tokens * rank;
             isTokenInRankGM_.SetGlobalBuffer(
-                (__gm__ T *)(isTokenInRank_ + static_cast<int64_t>(r) * perRoundTokens_ * numRanks_ * sizeof(T) + isTokenOffset_));
+                (__gm__ T *)(isTokenInRank_ + static_cast<int64_t>(r) * perRoundTokens_ * numRanks_ * sizeof(T) +
+                             isTokenOffset_));
 
             const DataCopyExtParams dataCopyParams{1U, topkIdx32AlignIntLen_, 0U, 0U, 0U};
             const DataCopyPadExtParams<int64_t> padParams{false, 0U, 0U, 0U};
@@ -152,7 +158,8 @@ public:
             SyncFunc<AscendC::HardEvent::V_S>();
             SyncFunc<AscendC::HardEvent::V_MTE3>();
             const DataCopyExtParams clearGmParams{1U, numTokensPerExpert32AlignIntLen_, 0U, 0U, 0U};
-            DataCopyPad(tempExpertGM_[static_cast<int64_t>(coreIdx_) * numExperts_], numTokensPerExpertTensor, clearGmParams);
+            DataCopyPad(tempExpertGM_[static_cast<int64_t>(coreIdx_) * numExperts_], numTokensPerExpertTensor,
+                        clearGmParams);
             PipeBarrier<PIPE_MTE3>();
             SyncAll<true>();
 
@@ -184,7 +191,8 @@ public:
             AscendC::SetAtomicAdd<T>();
             const DataCopyExtParams tempExpertDataCopyParams{1U, numTokensPerExpert32AlignIntLen_, 0U, 0U, 0U};
             for (int i = coreIdx_ + 1; i < aivNum_; ++i) {
-                DataCopyPad(tempExpertGM_[static_cast<int64_t>(i) * numExperts_], numTokensPerExpertTensor, tempExpertDataCopyParams);
+                DataCopyPad(tempExpertGM_[static_cast<int64_t>(i) * numExperts_], numTokensPerExpertTensor,
+                            tempExpertDataCopyParams);
             }
             sendSize = numRanks_ * sizeof(T);
             const DataCopyExtParams numTokensPerRankDataCopyParams{1U, sendSize, 0U, 0U, 0U};
@@ -197,8 +205,8 @@ public:
             SyncAll<true>();
             SyncFunc<AscendC::HardEvent::MTE3_MTE2>();
             const DataCopyPadExtParams<T> tempPadParams{false, 0U, 0U, 0U};
-            DataCopyPad(numTokensPerExpertTensor, tempExpertGM_[static_cast<int64_t>(coreIdx_) * numExperts_], tempExpertDataCopyParams,
-                        tempPadParams);
+            DataCopyPad(numTokensPerExpertTensor, tempExpertGM_[static_cast<int64_t>(coreIdx_) * numExperts_],
+                        tempExpertDataCopyParams, tempPadParams);
             SyncFunc<AscendC::HardEvent::MTE2_S>();
             for (int i = 0; i < tempTokens_; ++i) {
                 for (int j = 0; j < numTopk_; ++j) {

--- a/csrc/deepep/ops/op_kernel/moe_distribute_base.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_base.h
@@ -392,11 +392,14 @@ __aicore__ inline void cacheWriteThrough(__gm__ uint8_t *sourceAddr, uint64_t le
 {
     __gm__ uint8_t *start =
         (__gm__ uint8_t *)((uint64_t)sourceAddr / AscendC::CACHE_LINE_SIZE * AscendC::CACHE_LINE_SIZE);
+    if (length == 0) {
+        return;
+    }
     __gm__ uint8_t *end =
-        (__gm__ uint8_t *)(((uint64_t)sourceAddr + length) / AscendC::CACHE_LINE_SIZE * AscendC::CACHE_LINE_SIZE);
+        (__gm__ uint8_t *)(((uint64_t)sourceAddr + length - 1) / AscendC::CACHE_LINE_SIZE * AscendC::CACHE_LINE_SIZE);
     AscendC::GlobalTensor<uint8_t> global;
     global.SetGlobalBuffer(start);
-    for (uint32_t i = 0; i < end - start; i += AscendC::CACHE_LINE_SIZE) {
+    for (uint32_t i = 0; i <= end - start; i += AscendC::CACHE_LINE_SIZE) {
         AscendC::DataCacheCleanAndInvalid<uint8_t, AscendC::CacheLine::SINGLE_CACHE_LINE,
                                           AscendC::DcciDst::CACHELINE_OUT>(global[i]);
     }

--- a/csrc/deepep/ops/op_kernel/moe_distribute_base.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_base.h
@@ -396,7 +396,7 @@ __aicore__ inline void cacheWriteThrough(__gm__ uint8_t *sourceAddr, uint64_t le
         (__gm__ uint8_t *)(((uint64_t)sourceAddr + length) / AscendC::CACHE_LINE_SIZE * AscendC::CACHE_LINE_SIZE);
     AscendC::GlobalTensor<uint8_t> global;
     global.SetGlobalBuffer(start);
-    for (uint32_t i = 0; i <= end - start; i += AscendC::CACHE_LINE_SIZE) {
+    for (uint32_t i = 0; i < end - start; i += AscendC::CACHE_LINE_SIZE) {
         AscendC::DataCacheCleanAndInvalid<uint8_t, AscendC::CacheLine::SINGLE_CACHE_LINE,
                                           AscendC::DcciDst::CACHELINE_OUT>(global[i]);
     }

--- a/csrc/deepep/ops/op_kernel/moe_distribute_combine_v2_ccu.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_combine_v2_ccu.h
@@ -431,12 +431,12 @@ __aicore__ inline void MoeDistributeCombineA5<TemplateMoeDistributeCombineA5Type
             for (int i = 0; i < localExpertNum_; ++i) {
                 idx = i * epWorldSize_ + epRankId_;
                 count = idx > 0 ? (inputCountLT_(idx) - inputCountLT_(idx - 1)) : inputCountLT_(idx);
-                localDataSize += count * perTokenSize_;
+                localDataSize += static_cast<uint64_t>(count) * perTokenSize_;
             }
         } else {
             idx = epRankId_;
             count = idx > 0 ? (inputCountLT_(idx) - inputCountLT_(idx - 1)) : inputCountLT_(idx);
-            localDataSize += count * perTokenSize_;
+            localDataSize += static_cast<uint64_t>(count) * perTokenSize_;
         }
 
         hcclHandleId_ = hccl_.AlltoAllvWrite<true>(sendBufGM_, sendOffsetGM_, sendSizeGM_, recvOffset_, localDataSize);

--- a/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2_a5.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2_a5.h
@@ -470,7 +470,7 @@ __aicore__ inline void MoeDistributeDispatchV2A5<TemplateMC2TypeFunc>::Init(
     }
     totalExpertNum_ = sharedExpertRankNum_ + moeExpertNum_;
     uint32_t statusBufCntAlign = Ceil(Ceil(totalExpertNum_, aivNum_), 8) * 8;  // 8 = UB_ALIGN / sizeof(int32_t)
-    uint32_t statusBufSize = statusBufCntAlign * UB_ALIGN;
+    uint32_t statusBufSize = recvWinBlockNum_ * UB_ALIGN;
     tpipe_->InitBuffer(statusBuf_, statusBufSize);
     totalUsedUB_ += statusBufSize;
     statusTensor_ = statusBuf_.Get<int32_t>();  // 保存发送数据量及flag，同时用于计算windows中的偏移

--- a/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2_ccu.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2_ccu.h
@@ -591,7 +591,8 @@ __aicore__ inline void MoeDistributeDispatchA5<TemplateMoeDistributeDispatchA5Ty
     GlobalTensor<uint32_t> sendCntGT;
     sendCntGT.SetGlobalBuffer((__gm__ uint32_t *)(sendBufGM_ + startRank * perRankDataSize_));
     uint32_t cntSize = sizeof(uint32_t);
-    DataCopyExtParams cntParams = {static_cast<uint16_t>(rankPerAiv), cntSize, 0, perRankDataSize_ - cntSize, 0};
+    DataCopyExtParams cntParams = {static_cast<uint16_t>(rankPerAiv), cntSize, 0,
+                                   static_cast<int64_t>(perRankDataSize_ - cntSize), 0};
     DataCopyPad(sendCntGT, cntLT, cntParams);
 }
 
@@ -734,7 +735,7 @@ __aicore__ inline void MoeDistributeDispatchA5<TemplateMoeDistributeDispatchA5Ty
     sendCntGT.SetGlobalBuffer((__gm__ uint32_t *)(sendBufGM_ + (startRank + sharedExpertRankNum_) * perRankDataSize_));
     uint32_t cpSize2 = sizeof(uint32_t) * localExpertNum_;
     DataCopyExtParams cntParams = {static_cast<uint16_t>(rankPerAiv), cpSize2, rankCntSize - cpSize2,
-                                   perRankDataSize_ - cpSize2, 0};
+                                   static_cast<int64_t>(perRankDataSize_ - cpSize2), 0};
     DataCopyPad(sendCntGT, cntLT, cntParams);
 }
 

--- a/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2_ccu.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2_ccu.h
@@ -117,7 +117,7 @@ private:
     uint32_t perTokenOutSize_;
     uint32_t perTokenMergeSize_;
     uint32_t perTokenCommSize_;
-    uint32_t perRankDataSize_;
+    uint64_t perRankDataSize_;
     uint32_t expertTokenNumsType_;
     uint32_t scaleOutBytes_;
     uint32_t shareRankRcvTokenCnt_;
@@ -254,7 +254,9 @@ __aicore__ inline void MoeDistributeDispatchA5<TemplateMoeDistributeDispatchA5Ty
     pipe_->InitBuffer(workspaceBuf, histoSize);
     expertCumSumLT_ = workspaceBuf.Get<uint16_t>();
 
-    pipe_->InitBuffer(workspaceBuf, sortNum_ * sizeof(int32_t));
+    uint32_t rankPerAivNum = Ceil<uint32_t, uint32_t>(epWorldSize_, aivNum_);
+    uint32_t indexLtElem = (sortNum_ > rankPerAivNum) ? sortNum_ : rankPerAivNum;
+    pipe_->InitBuffer(workspaceBuf, indexLtElem * sizeof(int32_t));
     indexLT_ = workspaceBuf.Get<int32_t>();
 
     pipe_->InitBuffer(tempBuf_, sortNum_ * sizeof(int32_t) * DUAL_DATA);
@@ -317,7 +319,7 @@ __aicore__ inline void MoeDistributeDispatchA5<TemplateMoeDistributeDispatchA5Ty
     }
 
     perTokenCommSize_ = Align512<uint32_t>(perTokenMergeSize_);
-    perRankDataSize_ = COUNT_OFFSET + perTokenCommSize_ * axisMaxBs_ * localExpertNum_;
+    perRankDataSize_ = COUNT_OFFSET + static_cast<uint64_t>(perTokenCommSize_) * axisMaxBs_ * localExpertNum_;
 
     if constexpr (QuantMode > UNQUANT) {
         pipe_->InitBuffer(tokenInQue_, BUFFER_NUM, perTokenInSize_);

--- a/csrc/deepep/ops/op_kernel/notify_dispatch.h
+++ b/csrc/deepep/ops/op_kernel/notify_dispatch.h
@@ -689,7 +689,7 @@ private:
 
         pipe.InitBuffer(tmpBuf_, Ceil(numRanks * numLocalExperts * sizeof(int32_t), UB_ALIGN_SIZE) * UB_ALIGN_SIZE);
         LocalTensor<int32_t> expSrcTotalTensor = tmpBuf_.Get<int32_t>();
-        Duplicate<int32_t>(expSrcTotalTensor, 0, numExperts);
+        Duplicate<int32_t>(expSrcTotalTensor, 0, numRanks * numLocalExperts);
         SyncFunc<AscendC::HardEvent::V_S>();
 
         for (uint32_t rStart = 0; rStart < round; rStart += batchRounds) {

--- a/csrc/deepep/ops/utils/op_kernel/operator/cam_moe_distribute_combine/op_kernel/a3/cam_moe_distribute_combine.h
+++ b/csrc/deepep/ops/utils/op_kernel/operator/cam_moe_distribute_combine/op_kernel/a3/cam_moe_distribute_combine.h
@@ -87,12 +87,14 @@ private:
     __aicore__ GM_ADDR GetWinAddrByRankId(const int32_t rankId, const uint8_t domain, const uint8_t expertLocalId = 0U)
     {
         if (domain == EP_DOMAIN) {
+            assert(epWinContext_ != nullptr);
             return (GM_ADDR)((epRankId_ == rankId)
                                  ? epWinContext_->localWindowsIn
                                  : ((HcclRankRelationResV2 *)(epWinContext_->remoteRes[rankId].nextDevicePtr))
                                        ->windowsIn) +
                    winDataSizeOffset_ + expertLocalId * expertPerSizeOnWin_ + rankId * OPT_RANK_OFFSET;
         } else {
+            assert(tpWinContext_ != nullptr);
             return (GM_ADDR)((tpRankId_ == rankId)
                                  ? tpWinContext_->localWindowsIn
                                  : ((HcclRankRelationResV2 *)(tpWinContext_->remoteRes[rankId].nextDevicePtr))
@@ -107,6 +109,7 @@ private:
             assert(tpWinContext_ != nullptr);
         }
         if (domain == EP_DOMAIN) {
+            assert(epWinContext_ != nullptr);
             return (GM_ADDR)((epRankId_ == rankId)
                                  ? epWinContext_->localWindowsExp
                                  : ((HcclRankRelationResV2 *)(epWinContext_->remoteRes[rankId].nextDevicePtr))

--- a/csrc/deepep/ops/utils/op_kernel/operator/cam_moe_distribute_combine/op_kernel/a3/cam_moe_distribute_combine.h
+++ b/csrc/deepep/ops/utils/op_kernel/operator/cam_moe_distribute_combine/op_kernel/a3/cam_moe_distribute_combine.h
@@ -295,6 +295,8 @@ __aicore__ inline void CamMoeDistributeCombine<TemplateMC2TypeFunc>::Init(
     bsKNum_ = axisBS_ * axisK_;
 
     if constexpr (IsNeedReduceScatter) {
+        auto contextGM1 = AscendC::GetHcclContext<1>();
+        tpWinContext_ = (__gm__ HcclOpResParam *)contextGM1;
         tpSendCountGM_.SetGlobalBuffer((__gm__ int32_t *)tpSendCount);
         tpWindowGM_ = GetWinAddrByRankId(tpRankId_, TP_DOMAIN);
         tpStatusSpaceGm_ = GetWinStateAddrByRankId(tpRankId_, TP_DOMAIN);

--- a/csrc/deepep/ops/utils/op_kernel/operator/catlass/act/gemm/kernel/grouped_matmul_slice_m_per_token_dequant_multistage_workspace.hpp
+++ b/csrc/deepep/ops/utils/op_kernel/operator/catlass/act/gemm/kernel/grouped_matmul_slice_m_per_token_dequant_multistage_workspace.hpp
@@ -179,8 +179,8 @@ public:
                 stageId = (stageId + 1 < WORKSPACE_STAGES) ? (stageId + 1) : 0;
             }
 
-            gmGroupOffsetA += inGroupProblemShape.m() * inGroupProblemShape.k();
-            gmGroupOffsetB += inGroupProblemShape.k() * inGroupProblemShape.n();
+            gmGroupOffsetA += static_cast<int64_t>(inGroupProblemShape.m()) * inGroupProblemShape.k();
+            gmGroupOffsetB += static_cast<int64_t>(inGroupProblemShape.k()) * inGroupProblemShape.n();
             startCoreIdx = (startCoreIdx + coreLoops) % coreNum;
         }
 
@@ -263,7 +263,7 @@ public:
 
                 gmGroupOffsetScale += inGroupProblemShape.n();
                 gmGroupOffsetPerTokenScale += inGroupProblemShape.m();
-                gmGroupOffsetD += inGroupProblemShape.m() * inGroupProblemShape.n();
+                gmGroupOffsetD += static_cast<int64_t>(inGroupProblemShape.m()) * inGroupProblemShape.n();
 
                 startCoreIdx = (startCoreIdx + coreLoops) % coreNum;
             }

--- a/csrc/deepep/ops/utils/op_kernel/operator/gemm/kernel/grouped_matmul_slice_m_per_token_dequant_swiglu_quant_multistage_workspace.h
+++ b/csrc/deepep/ops/utils/op_kernel/operator/gemm/kernel/grouped_matmul_slice_m_per_token_dequant_swiglu_quant_multistage_workspace.h
@@ -621,8 +621,8 @@ public:
                 stageId = (stageId + 1 < WORKSPACE_STAGES) ? (stageId + 1) : 0;
             }
 
-            gmGroupOffsetA += inGroupProblemShape.m() * inGroupProblemShape.k();
-            gmGroupOffsetB += inGroupProblemShape.k() * inGroupProblemShape.n();
+            gmGroupOffsetA += static_cast<int64_t>(inGroupProblemShape.m()) * inGroupProblemShape.k();
+            gmGroupOffsetB += static_cast<int64_t>(inGroupProblemShape.k()) * inGroupProblemShape.n();
 
             startCoreIdx = (startCoreIdx + coreLoops) % aicNum;
         }
@@ -1175,7 +1175,7 @@ void RecvToken(GM_ADDR gmX1, GM_ADDR gmX1Scale, GM_ADDR gmEpSendCount, uint32_t 
         for (uint32_t j = 0; j < count; j++) {
             tokGlobal.SetGlobalBuffer((__gm__ int8_t *)(wAddr + j * hCommuSize));
             tokGlobalInt32.SetGlobalBuffer((__gm__ int32_t *)(wAddr + j * hCommuSize + hOutSize));
-            expandXOutGlobal.SetGlobalBuffer((__gm__ int8_t *)(gmX1) + (beginIdx + j) * tokenLength, tokenLength);
+            expandXOutGlobal.SetGlobalBuffer((__gm__ int8_t *)(gmX1) + static_cast<uint64_t>(beginIdx + j) * tokenLength, tokenLength);
 
             while (true) {
                 AscendC::DataCopy(tmpLocalTensor, tokGlobalInt32, INT32_COUNT_PER_BLOCK);
@@ -1339,7 +1339,7 @@ void CompCoreFunc(GM_ADDR gmCVSwapBuff, __gm__ ElementScale *gmScale, __gm__ Ele
 
             gmGroupOffsetScale += inGroupProblemShape.n();
             gmGroupOffsetPerTokenScale += inGroupProblemShape.m();
-            gmGroupOffsetD += currentM * nOut;
+            gmGroupOffsetD += static_cast<uint64_t>(currentM) * nOut;
 
             startCoreIdx = (startCoreIdx + coreLoops) % aiCoreGroupNum;
         }
@@ -1853,8 +1853,8 @@ public:
                 stageId = (stageId + 1 < WORKSPACE_STAGES) ? (stageId + 1) : 0;
             }
 
-            gmGroupOffsetA += inGroupProblemShape.m() * inGroupProblemShape.k();
-            gmGroupOffsetB += inGroupProblemShape.k() * inGroupProblemShape.n();
+            gmGroupOffsetA += static_cast<int64_t>(inGroupProblemShape.m()) * inGroupProblemShape.k();
+            gmGroupOffsetB += static_cast<int64_t>(inGroupProblemShape.k()) * inGroupProblemShape.n();
 
             startCoreIdx = (startCoreIdx + coreLoops) % coreNum;
         }
@@ -1940,7 +1940,7 @@ public:
 
                 gmGroupOffsetScale += inGroupProblemShape.n();
                 gmGroupOffsetPerTokenScale += inGroupProblemShape.m();
-                gmGroupOffsetD += currentM * nOut;
+                gmGroupOffsetD += static_cast<uint64_t>(currentM) * nOut;
 
                 startCoreIdx = (startCoreIdx + coreLoops) % coreNum;
             }

--- a/csrc/deepep/ops/utils/op_kernel/operator/gemm/kernel/grouped_matmul_slice_m_per_token_dequant_swiglu_quant_multistage_workspace.h
+++ b/csrc/deepep/ops/utils/op_kernel/operator/gemm/kernel/grouped_matmul_slice_m_per_token_dequant_swiglu_quant_multistage_workspace.h
@@ -1175,7 +1175,8 @@ void RecvToken(GM_ADDR gmX1, GM_ADDR gmX1Scale, GM_ADDR gmEpSendCount, uint32_t 
         for (uint32_t j = 0; j < count; j++) {
             tokGlobal.SetGlobalBuffer((__gm__ int8_t *)(wAddr + j * hCommuSize));
             tokGlobalInt32.SetGlobalBuffer((__gm__ int32_t *)(wAddr + j * hCommuSize + hOutSize));
-            expandXOutGlobal.SetGlobalBuffer((__gm__ int8_t *)(gmX1) + static_cast<uint64_t>(beginIdx + j) * tokenLength, tokenLength);
+            expandXOutGlobal.SetGlobalBuffer(
+                (__gm__ int8_t *)(gmX1) + static_cast<uint64_t>(beginIdx + j) * tokenLength, tokenLength);
 
             while (true) {
                 AscendC::DataCopy(tmpLocalTensor, tokGlobalInt32, INT32_COUNT_PER_BLOCK);

--- a/csrc/deepep/ops2/op_host/dispatch_normal_a2_tiling.cpp
+++ b/csrc/deepep/ops2/op_host/dispatch_normal_a2_tiling.cpp
@@ -37,11 +37,12 @@ public:
     {
         uint16_t defaultWindowSize = 200;
         const char *hcclBuffSize = getenv("DEEPEP_HCCL_BUFFSIZE") == nullptr ? "HCCL_BUFFSIZE" : "DEEPEP_HCCL_BUFFSIZE";
-        if (getenv(hcclBuffSize) == nullptr) {
+        const char *envValue = getenv(hcclBuffSize);
+        if (envValue == nullptr) {
             OP_LOGD("", "Env HCCL_BUFFSIZE don't set");
         } else {
             try {
-                std::string envStr(getenv(hcclBuffSize));
+                std::string envStr(envValue);
                 defaultWindowSize = std::stoi(envStr);
             } catch (const std::invalid_argument &ia) {
                 OP_LOGE("", "Invalid argument when parsing HCCL_BUFFSIZE: %s", ia.what());

--- a/csrc/deepep/ops2/op_host/mc2_tiling_utils.h
+++ b/csrc/deepep/ops2/op_host/mc2_tiling_utils.h
@@ -17,11 +17,12 @@ public:
     {
         uint16_t defaultWindowSize = 200;
         const char *hcclBuffSize = getenv("DEEPEP_HCCL_BUFFSIZE") == nullptr ? "HCCL_BUFFSIZE" : "DEEPEP_HCCL_BUFFSIZE";
-        if (getenv(hcclBuffSize) == nullptr) {
+        const char *envValue = getenv(hcclBuffSize);
+        if (envValue == nullptr) {
             OP_LOGD("", "Env HCCL_BUFFSIZE don't set");
         } else {
             try {
-                std::string envStr(getenv(hcclBuffSize));
+                std::string envStr(envValue);
                 defaultWindowSize = std::stoi(envStr);
             } catch (const std::invalid_argument &ia) {
                 OP_LOGE("", "Invalid argument when parsing HCCL_BUFFSIZE: %s", ia.what());

--- a/csrc/deepep/ops2/op_kernel/moe_distribute_dispatch_v2_single.h
+++ b/csrc/deepep/ops2/op_kernel/moe_distribute_dispatch_v2_single.h
@@ -376,7 +376,9 @@ __aicore__ inline void MoeDistributeDispatchV2Single<TemplateMC2TypeA2SingleFunc
     }
     totalExpertNum_ = sharedExpertRankNum_ + moeExpertNum_;
     uint32_t statusBufCntAlign = Ceil(Ceil(totalExpertNum_, aivNum_), 8) * 8;  // 8 = UB_ALIGN / sizeof(int32_t)
-    tpipe_->InitBuffer(statusBuf_, statusBufCntAlign * UB_ALIGN);
+    uint32_t statusBufCnt =
+        (recvWinBlockNum_ > statusBufCntAlign) ? recvWinBlockNum_ : statusBufCntAlign;  // guard Duplicate overflow
+    tpipe_->InitBuffer(statusBuf_, statusBufCnt * UB_ALIGN);
     statusTensor_ = statusBuf_.Get<int32_t>();  // 保存发送数据量及flag，同时用于计算windows中的偏移
     Duplicate<int32_t>(statusTensor_, 0, recvWinBlockNum_ * 8);  // 8 = UB_ALIGN / sizeof(int32_t)
 

--- a/csrc/deepep/profiling/core/profile_session.cpp
+++ b/csrc/deepep/profiling/core/profile_session.cpp
@@ -2,6 +2,7 @@
 
 #include <cstring>
 #include <filesystem>
+#include <mutex>
 
 #include "exception.hpp"
 #include "profiling/core/profile_exporter.hpp"
@@ -11,6 +12,12 @@ namespace deep_ep::profiling::session {
 namespace {
 
 constexpr uint64_t kMaxBytesPerRank = 128ULL * 1024ULL * 1024ULL;
+
+std::mutex &SessionMutex()
+{
+    static std::mutex mutex;
+    return mutex;
+}
 
 ManagerSessionState &GetManagerSession()
 {
@@ -76,6 +83,8 @@ OpProfileSession &GetExistingOpSession(const char *opKey)
 
 }  // namespace
 
+#define DEEPEP_SESSION_LOCK() const std::lock_guard<std::mutex> sessionLock(SessionMutex())
+
 void ProfileTimeCalibration::Reset()
 {
     valid = false;
@@ -117,31 +126,37 @@ void ManagerSessionState::Reset()
 
 bool IsActive()
 {
+    const std::lock_guard<std::mutex> lock(SessionMutex());
     return GetManagerSession().active;
 }
 
 int64_t GetExpectedLaunches()
 {
+    const std::lock_guard<std::mutex> lock(SessionMutex());
     return GetManagerSession().expectedLaunches;
 }
 
 std::string GetProfileTraceDir()
 {
+    const std::lock_guard<std::mutex> lock(SessionMutex());
     return GetManagerSession().profileTraceDir;
 }
 
 int64_t GetNumProfileSkipLaunches()
 {
+    const std::lock_guard<std::mutex> lock(SessionMutex());
     return GetManagerSession().numProfileSkipLaunches;
 }
 
 int64_t GetNumProfileActiveLaunches()
 {
+    const std::lock_guard<std::mutex> lock(SessionMutex());
     return GetManagerSession().numProfileActiveLaunches;
 }
 
 const ProfileTimeCalibration *GetTimeCalibration(int64_t rank)
 {
+    const std::lock_guard<std::mutex> lock(SessionMutex());
     auto &manager = GetManagerSession();
     auto it = manager.rankCalibrations.find(rank);
     if (it == manager.rankCalibrations.end()) {
@@ -183,11 +198,12 @@ void Begin(int64_t numProfileSkipLaunches, int64_t numProfileActiveLaunches, con
     TORCH_CHECK(numProfileSkipLaunches >= 0, "num_profile_skip_launches must be non-negative");
     TORCH_CHECK(numProfileActiveLaunches >= 0, "num_profile_active_launches must be non-negative");
     TORCH_CHECK(numRanks > 0, "num_ranks must be positive for profile session.");
-    TORCH_CHECK(!GetManagerSession().active, "profile session is already active.");
     int64_t expectedLaunches = numProfileSkipLaunches + numProfileActiveLaunches;
     TORCH_CHECK(expectedLaunches > 0, "profile session needs at least one launch.");
     TORCH_CHECK(static_cast<uint64_t>(expectedLaunches) <= UINT32_MAX,
                 "profile session launch count exceeds uint32 capacity.");
+    const std::lock_guard<std::mutex> lock(SessionMutex());
+    TORCH_CHECK(!GetManagerSession().active, "profile session is already active.");
     auto &manager = GetManagerSession();
     manager.Reset();
     manager.active = true;
@@ -212,6 +228,7 @@ OpProfileSession &EnsureOpSession(const ProfileOpRegistration &registration, con
     TORCH_CHECK(registration.opKey != nullptr && registration.opKey[0] != '\0',
                 "profile registration opKey must be non-empty.");
     TORCH_CHECK(registration.schemaProvider != nullptr, "profile registration schemaProvider is required.");
+    const std::lock_guard<std::mutex> lock(SessionMutex());
     auto &manager = GetManagerSession();
     TORCH_CHECK(manager.active, "profile session is not active.");
     TORCH_CHECK(manager.expectedLaunches > 0, "profile session launch capacity is not set.");
@@ -253,41 +270,49 @@ OpProfileSession &EnsureOpSession(const ProfileOpRegistration &registration, con
 
 void IncrementCapturedLaunches(const char *opKey)
 {
+    DEEPEP_SESSION_LOCK();
     ++GetExistingOpSession(opKey).capturedLaunches;
 }
 
 void IncrementDroppedLaunches(const char *opKey)
 {
+    DEEPEP_SESSION_LOCK();
     ++GetExistingOpSession(opKey).droppedLaunches;
 }
 
 int64_t GetCapturedLaunches(const char *opKey)
 {
+    DEEPEP_SESSION_LOCK();
     return GetExistingOpSession(opKey).capturedLaunches;
 }
 
 int64_t GetDroppedLaunches(const char *opKey)
 {
+    DEEPEP_SESSION_LOCK();
     return GetExistingOpSession(opKey).droppedLaunches;
 }
 
 uint32_t GetLaunchCountCapacity(const char *opKey)
 {
+    DEEPEP_SESSION_LOCK();
     return GetExistingOpSession(opKey).launchCountCapacity;
 }
 
 uint64_t GetProfileBufferBytes(const char *opKey)
 {
+    DEEPEP_SESSION_LOCK();
     return GetExistingOpSession(opKey).profileBufferBytes;
 }
 
 const at::Tensor &GetProfileBuffer(const char *opKey)
 {
+    DEEPEP_SESSION_LOCK();
     return GetExistingOpSession(opKey).profileBuffer;
 }
 
 void UpdateBeginCalibration(int64_t rank, double deviceUs, double hostUs)
 {
+    DEEPEP_SESSION_LOCK();
     auto &calibration = GetManagerSession().rankCalibrations[rank];
     calibration.beginDeviceUs = deviceUs;
     calibration.beginHostUs = hostUs;
@@ -299,6 +324,7 @@ void UpdateBeginCalibration(int64_t rank, double deviceUs, double hostUs)
 
 void UpdateEndCalibration(int64_t rank, double deviceUs, double hostUs)
 {
+    DEEPEP_SESSION_LOCK();
     auto &calibration = GetManagerSession().rankCalibrations[rank];
     calibration.endDeviceUs = deviceUs;
     calibration.endHostUs = hostUs;
@@ -309,6 +335,7 @@ void UpdateEndCalibration(int64_t rank, double deviceUs, double hostUs)
 
 void ExportAndReset(int64_t rank)
 {
+    DEEPEP_SESSION_LOCK();
     auto &manager = GetManagerSession();
     if (!manager.active) {
         return;
@@ -338,7 +365,12 @@ void ExportAndReset(int64_t rank)
         manager.Reset();
         return;
     }
-    const auto *calibration = GetTimeCalibration(rank);
+    // Inline calibration lookup to avoid recursive lock (GetTimeCalibration also locks).
+    const ProfileTimeCalibration *calibration = nullptr;
+    auto calIt = manager.rankCalibrations.find(rank);
+    if (calIt != manager.rankCalibrations.end()) {
+        calibration = &calIt->second;
+    }
     exporter::ExportAggregatedTrace(sources, rank, manager.profileTraceDir, calibration, manager.numRanks);
     manager.Reset();
 }


### PR DESCRIPTION
## Motivation

Security and bug fixes for deepep kernels

## Modifications

- Fix log message mismatch: CheckEpRankId -> CheckTpRankId in moe_distribute_combine_v2_ccu_tiling
- Add NULL check for commAlg before strcmp in aclnn_moe_distribute_dispatch_v2 API
- Fix TOCTOU: store getenv() result and reuse in mc2_tiling_utils GetMaxWindowSize
- Fix off-by-one OOB in cacheWriteThrough: change <= to < in both moe_distribute_base.h files
- Add null check for groupEpPtr in SetHcommCfg (match groupTpPtr pattern)
- Add FreeTensor for smoothLocal to fix memory leak in CopyOutXQuant1H
- Add zero check for GMubDequantScale to prevent divide-by-zero in block_epilogue_pertoken_swiglu
- Add bounds validation for M/K/topK in DispatchFFNCombineCheckShapeAndSetTiling
- Fix Duplicate param: numExperts -> numRanks * numLocalExperts in notify_dispatch BuildsrcRankInExpOffset
- Fix statusBuf allocation: use recvWinBlockNum_ instead of statusBufCntAlign in moe_distribute_dispatch_v2_a5
- Fix indexLT_ allocation: use max(sortNum_, rankPerAiv) in moe_distribute_dispatch_v2_ccu
- Fix uint32_t overflow: cast to uint64_t before multiplication in perRankDataSize_ calculation
- Add null pointer asserts for epWinContext_/tpWinContext_ in cam_moe_distribute_combine
- Add bounds check for expandedExpertIdx in ComputeExpertTokenCountOrCumsum
- Fix negative value check: == -1 -> < 0 in moe_v2_gather_quant CopyOut
- Add srcIdx validation in moe_v2_gather_dynamic_quant CopyOutPartialXQuantEH

## Testing

<img width="663" height="54" alt="image" src="https://github.com/user-attachments/assets/99e93be1-b046-496b-ad74-be3600ba996e" />



## Checklist

- [x] Format your code.
- [x] Add unit tests.
- [x] Update documentation.
- [x] Provide accuracy and speed benchmark results.
