### PR TITLE
[Feature] Add A5 kv_compress_epilog kernel and bypass mega kernel compile on A5

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -18,6 +18,19 @@ if(SGL_KERNEL_ENABLE_A3_ONLY_OPS)
 endif()
 message(STATUS "SGL_KERNEL_ENABLE_A3_ONLY_OPS=${SGL_KERNEL_ENABLE_A3_ONLY_OPS} (SOC=${SOC_VERSION})")
 
+# A5-only ops: compile only on Ascend950-series SoCs.
+if(NOT DEFINED SGL_KERNEL_ENABLE_A5_ONLY_OPS)
+    if(_sgl_soc_lower MATCHES "^ascend950")
+        set(SGL_KERNEL_ENABLE_A5_ONLY_OPS ON)
+    else()
+        set(SGL_KERNEL_ENABLE_A5_ONLY_OPS OFF)
+    endif()
+endif()
+if(SGL_KERNEL_ENABLE_A5_ONLY_OPS)
+    add_compile_definitions(SGL_KERNEL_ENABLE_A5_ONLY_OPS)
+endif()
+message(STATUS "SGL_KERNEL_ENABLE_A5_ONLY_OPS=${SGL_KERNEL_ENABLE_A5_ONLY_OPS} (SOC=${SOC_VERSION})")
+
 # host side files
 set(OP_SRCS
     ${PROJECT_OP_SRC_BASE}/pytorch_extensions.cpp
@@ -53,6 +66,12 @@ if(SGL_KERNEL_ENABLE_A3_ONLY_OPS)
         ${PROJECT_OP_SRC_BASE}/recurrent_gated_delta_rule/op_host/recurrent_gated_delta_rule.cpp
         ${PROJECT_OP_SRC_BASE}/causal_conv1d/op_host/causal_conv1d.cpp
         ${PROJECT_OP_SRC_BASE}/mega_chunk_gdn/op_host/mega_chunk_gdn.cpp
+    )
+endif()
+# A5-only host sources
+if(SGL_KERNEL_ENABLE_A5_ONLY_OPS)
+    list(APPEND OP_SRCS
+        ${PROJECT_OP_SRC_BASE}/kv_compress_epilog/op_host/kv_compress_epilog.cpp
     )
 endif()
 if(BUILD_CATLASS_MODULE)
@@ -124,6 +143,12 @@ if(SGL_KERNEL_ENABLE_A3_ONLY_OPS)
         ${PROJECT_OP_SRC_BASE}/lightning_indexer/op_kernel/lightning_indexer_kernel.cpp
     )
 endif()
+# A5-only workspace kernels
+if(SGL_KERNEL_ENABLE_A5_ONLY_OPS)
+    list(APPEND WORKSPACE_KERNEL_SRCS
+        ${PROJECT_OP_SRC_BASE}/kv_compress_epilog/op_kernel/kv_compress_epilog.cpp
+    )
+endif()
 
 ascendc_library(workspace_kernel STATIC ${WORKSPACE_KERNEL_SRCS})
 ascendc_include_directories(workspace_kernel PRIVATE
@@ -131,6 +156,7 @@ ascendc_include_directories(workspace_kernel PRIVATE
     ${PROJECT_OP_SRC_BASE}/causal_conv1d/op_kernel
     ${PROJECT_OP_SRC_BASE}/utils/kernel
     ${PROJECT_OP_SRC_BASE}/sparse_attention_score/op_kernel
+    ${PROJECT_OP_SRC_BASE}/kv_compress_epilog/op_kernel
 )
 
 ascendc_compile_definitions(workspace_kernel PRIVATE

--- a/csrc/kv_compress_epilog/op_host/kv_compress_epilog.cpp
+++ b/csrc/kv_compress_epilog/op_host/kv_compress_epilog.cpp
@@ -11,12 +11,6 @@
 /*!
  * \file kv_compress_epilog.cpp
  * \brief Host-side tiling + launch for kv_compress_epilog (A5-only).
- *
- * Ported from the vllm-ascend A5 custom op (aclnnKvCompressEpilog). The tiling
- * math is replicated from kv_compress_epilog_tiling_arch35.cpp and the kernel is
- * launched with EXEC_KERNEL_CMD instead of the aclnn API. The op is in-place:
- * kv_compress_cache is written at slot offsets, so the same tensor is passed for
- * the (unused) kernel output slot.
  */
 
 #include <cstdio>
@@ -41,7 +35,7 @@ namespace npu_kernel {
 namespace {
 
 constexpr uint32_t PADDING_BYTE = 32U;
-constexpr uint32_t MAX_CAPTURE_NUM = 1024;  // 对齐 lightning_indexer
+constexpr uint32_t MAX_CAPTURE_NUM = 1024;
 constexpr int64_t WORKSPACE_SIZE = 32;
 
 constexpr int64_t QUANT_MODE_GROUP_FP8 = 1;
@@ -72,7 +66,6 @@ static std::unordered_map<uint64_t, uint32_t> captureMap;
 HOST_API void kv_compress_epilog(at::Tensor &kv_compress_cache, const at::Tensor &x, const at::Tensor &slot_mapping,
                                  int64_t quant_group_size, int64_t quant_mode, bool round_scale_flag, int64_t layout)
 {
-    // ---- Input validation (mirrors vllm-ascend validate_kv_compress_epilog_inputs) ----
     TORCH_CHECK(x.dim() == 2, "x must be 2D tensor, but got dimensions: ", x.dim());
     TORCH_CHECK(x.size(0) > 0 && x.size(1) > 0, "x dimensions must be positive, but got: [", x.size(0), ", ", x.size(1),
                 "]");
@@ -98,7 +91,6 @@ HOST_API void kv_compress_epilog(at::Tensor &kv_compress_cache, const at::Tensor
     const int64_t d = x.size(1);
     int64_t round_scale = round_scale_flag ? 1 : 0;
 
-    // ---- Tiling (replicated from vllm-ascend kv_compress_epilog_tiling_arch35.cpp) ----
     auto ascendcPlatform = platform_ascendc::PlatformAscendCManager::GetInstance();
     int64_t coreNum = static_cast<int64_t>(ascendcPlatform->GetCoreNumAiv());
     if (coreNum <= 0) {
@@ -134,6 +126,8 @@ HOST_API void kv_compress_epilog(at::Tensor &kv_compress_cache, const at::Tensor
     int64_t blockSize = 0;
     int64_t blockStride = 0;
     if (layout == 2) {
+        TORCH_CHECK(quant_mode == QUANT_MODE_GROUP_MXFP8,
+                    "layout=2 only supports MXFP8 (quant_mode=2), but got quant_mode=", quant_mode);
         TORCH_CHECK(cache.dim() >= 2, "layout=2 requires kv_compress_cache to be at least 2D, got dim ", cache.dim());
         blockSize = cache.size(1);
         TORCH_CHECK(blockSize > 0, "blockSize must be positive, got ", blockSize);
@@ -178,7 +172,6 @@ HOST_API void kv_compress_epilog(at::Tensor &kv_compress_cache, const at::Tensor
     int64_t minRowPerCore = 1;
     int64_t rowOnceLoop = std::min(rowOfFormerBlock, minRowPerCore);
     int64_t rowFactor = rowOnceLoop;
-    // d全载,尝试搬入更多的bs
     while (rowFactor <= rowOfFormerBlock) {
         int64_t xSize = rowFactor * xSizePerRow;
         int64_t ySize = rowFactor * ySizePerRow;

--- a/csrc/kv_compress_epilog/op_host/kv_compress_epilog.cpp
+++ b/csrc/kv_compress_epilog/op_host/kv_compress_epilog.cpp
@@ -1,0 +1,282 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file kv_compress_epilog.cpp
+ * \brief Host-side tiling + launch for kv_compress_epilog (A5-only).
+ *
+ * Ported from the vllm-ascend A5 custom op (aclnnKvCompressEpilog). The tiling
+ * math is replicated from kv_compress_epilog_tiling_arch35.cpp and the kernel is
+ * launched with EXEC_KERNEL_CMD instead of the aclnn API. The op is in-place:
+ * kv_compress_cache is written at slot offsets, so the same tensor is passed for
+ * the (unused) kernel output slot.
+ */
+
+#include <cstdio>
+#include <cstring>
+#include <tuple>
+#include <unordered_map>
+#include <functional>
+
+#include "acl/acl.h"
+#include "kernel_tiling/kernel_tiling.h"
+#include "tiling/platform/platform_ascendc.h"
+#include "tiling/kv_compress_epilog_tiling_data.h"
+#include "defines.h"
+#include "torch_helper.h"
+#include "common_tiling.h"
+#include "common.h"
+#include "aclrtlaunch_kv_compress_epilog.h"
+
+namespace sglang {
+namespace npu_kernel {
+
+namespace {
+
+constexpr uint32_t PADDING_BYTE = 32U;
+constexpr uint32_t MAX_CAPTURE_NUM = 1024;  // 对齐 lightning_indexer
+constexpr int64_t WORKSPACE_SIZE = 32;
+
+constexpr int64_t QUANT_MODE_GROUP_FP8 = 1;
+constexpr int64_t QUANT_MODE_GROUP_MXFP8 = 2;
+constexpr int64_t SLICE_SIZE = 64;
+constexpr int64_t PER_BLOCK_FP16 = 128;
+constexpr int64_t DEFAULT_QUANT_GROUP_SIZE = 128;
+constexpr int64_t DOUBLE_BUFFER = 2;
+
+int64_t CeilDiv(int64_t x, int64_t y)
+{
+    if (y != 0) {
+        return (x + y - 1) / y;
+    }
+    return x;
+}
+int64_t RoundUp(int64_t x, int64_t y)
+{
+    return CeilDiv(x, y) * y;
+}
+
+// Graph mode tiling cache
+uint32_t actualCaptureNum = 0;
+static std::unordered_map<uint64_t, uint32_t> captureMap;
+
+}  // namespace
+
+HOST_API void kv_compress_epilog(at::Tensor &kv_compress_cache, const at::Tensor &x, const at::Tensor &slot_mapping,
+                                 int64_t quant_group_size, int64_t quant_mode, bool round_scale_flag, int64_t layout)
+{
+    // ---- Input validation (mirrors vllm-ascend validate_kv_compress_epilog_inputs) ----
+    TORCH_CHECK(x.dim() == 2, "x must be 2D tensor, but got dimensions: ", x.dim());
+    TORCH_CHECK(x.size(0) > 0 && x.size(1) > 0, "x dimensions must be positive, but got: [", x.size(0), ", ", x.size(1),
+                "]");
+    TORCH_CHECK(x.scalar_type() == at::kBFloat16, "x must be BF16, but got ", x.scalar_type());
+    TORCH_CHECK(slot_mapping.dim() == 1, "slot_mapping must be 1D tensor, but got dimensions: ", slot_mapping.dim());
+    TORCH_CHECK(slot_mapping.size(0) == x.size(0),
+                "slot_mapping size must equal x's first dimension, but got slot_mapping_size=", slot_mapping.size(0),
+                ", x.dim(0)=", x.size(0));
+    TORCH_CHECK(slot_mapping.scalar_type() == at::kInt || slot_mapping.scalar_type() == at::kLong,
+                "slot_mapping must be INT32 or INT64, but got ", slot_mapping.scalar_type());
+    TORCH_CHECK(
+        kv_compress_cache.scalar_type() == at::kFloat8_e5m2 || kv_compress_cache.scalar_type() == at::kFloat8_e4m3fn,
+        "kv_compress_cache must be FP8_E5M2 or FP8_E4M3FN, but got ", kv_compress_cache.scalar_type());
+
+    at::Tensor cache = kv_compress_cache;
+    if (cache.dim() == 4) {
+        TORCH_CHECK(cache.size(2) == 1, "kv_compress_cache 4D tensor requires headnum (dim 2) == 1, but got ",
+                    cache.size(2));
+        cache = cache.squeeze(2);
+    }
+
+    const int64_t bs = x.size(0);
+    const int64_t d = x.size(1);
+    int64_t round_scale = round_scale_flag ? 1 : 0;
+
+    // ---- Tiling (replicated from vllm-ascend kv_compress_epilog_tiling_arch35.cpp) ----
+    auto ascendcPlatform = platform_ascendc::PlatformAscendCManager::GetInstance();
+    int64_t coreNum = static_cast<int64_t>(ascendcPlatform->GetCoreNumAiv());
+    if (coreNum <= 0) {
+        coreNum = 1;
+    }
+    uint64_t ubSize = 0;
+    ascendcPlatform->GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSize);
+
+    int64_t rowOfFormerBlock = CeilDiv(bs, coreNum);
+    int64_t usedCoreNums = std::min(CeilDiv(bs, rowOfFormerBlock), coreNum);
+    int64_t rowOfTailBlock = bs - (usedCoreNums - 1) * rowOfFormerBlock;
+
+    int64_t scaleCol;
+    if (quant_mode == QUANT_MODE_GROUP_MXFP8) {
+        TORCH_CHECK(quant_group_size == 64 || quant_group_size == 128, "MXFP8 quant_group_size must be 64 or 128, got ",
+                    quant_group_size);
+        scaleCol = CeilDiv(d - SLICE_SIZE, quant_group_size);
+    } else {
+        scaleCol = CeilDiv(d - SLICE_SIZE, PER_BLOCK_FP16);
+    }
+
+    int64_t scaleBytes = 4;
+    if (quant_mode == QUANT_MODE_GROUP_MXFP8) {
+        scaleBytes = 1;
+    }
+    int64_t concatCol = d - SLICE_SIZE + SLICE_SIZE * 2 + scaleCol * scaleBytes;
+    int64_t kvCacheCol = RoundUp(concatCol, DEFAULT_QUANT_GROUP_SIZE);
+    int64_t padCol = kvCacheCol - concatCol;
+
+    // Layout-2 specific calculations
+    int64_t valuePerToken = 0;
+    int64_t scalePerToken = 0;
+    int64_t blockSize = 0;
+    int64_t blockStride = 0;
+    if (layout == 2) {
+        TORCH_CHECK(cache.dim() >= 2, "layout=2 requires kv_compress_cache to be at least 2D, got dim ", cache.dim());
+        blockSize = cache.size(1);
+        TORCH_CHECK(blockSize > 0, "blockSize must be positive, got ", blockSize);
+
+        int64_t quantCol = d - SLICE_SIZE;
+        valuePerToken = quantCol + SLICE_SIZE * 2;  // FP8 quant bytes + BF16 rope bytes
+        scalePerToken = RoundUp(scaleCol, 8);
+
+        int64_t autoBlockStride = blockSize * (valuePerToken + scalePerToken);
+        int64_t blockStrideAttr = cache.stride(0);
+        if (blockStrideAttr > 0) {
+            blockStride = blockStrideAttr;
+            TORCH_CHECK(blockStride >= autoBlockStride, "block_stride (", blockStride,
+                        ") must be >= auto-computed stride (", autoBlockStride, ")");
+        } else {
+            blockStride = autoBlockStride;
+        }
+    } else {
+        int64_t autoRowStride = kvCacheCol;
+        int64_t blockStrideAttr = cache.stride(0);
+        if (blockStrideAttr > 0) {
+            blockStride = blockStrideAttr;
+            TORCH_CHECK(blockStride >= autoRowStride, "block_stride (", blockStride,
+                        ") must be >= layout=1 row width (", autoRowStride, ")");
+        } else {
+            blockStride = autoRowStride;
+        }
+    }
+
+    // UB estimation: pre-compute per-row sizes
+    int64_t xSizePerRow = RoundUp(d, 16) * 2 * DOUBLE_BUFFER;
+    int64_t ySizePerRow;
+    int64_t scaleSizePerRow;
+    if (layout == 2) {
+        ySizePerRow = RoundUp(valuePerToken, 32) * 1 * DOUBLE_BUFFER;
+        scaleSizePerRow = RoundUp(scalePerToken, 32) * 1;
+    } else {
+        ySizePerRow = RoundUp(kvCacheCol, 32) * 1 * DOUBLE_BUFFER;
+        scaleSizePerRow = 0;
+    }
+
+    int64_t minRowPerCore = 1;
+    int64_t rowOnceLoop = std::min(rowOfFormerBlock, minRowPerCore);
+    int64_t rowFactor = rowOnceLoop;
+    // d全载,尝试搬入更多的bs
+    while (rowFactor <= rowOfFormerBlock) {
+        int64_t xSize = rowFactor * xSizePerRow;
+        int64_t ySize = rowFactor * ySizePerRow;
+        int64_t scaleSize = rowFactor * scaleSizePerRow;
+        int64_t tmpBufferSize = RoundUp(rowFactor, 8) * 4;
+        int64_t totalSize = xSize + ySize + scaleSize + tmpBufferSize;
+        if (totalSize > static_cast<int64_t>(ubSize)) {
+            rowFactor = rowFactor - 1;
+            break;
+        }
+        rowFactor = rowFactor + 1;
+    }
+    if (rowFactor > rowOfFormerBlock) {
+        rowFactor--;
+    }
+
+    int64_t rowLoopOfFormerBlock = CeilDiv(rowOfFormerBlock, rowFactor);
+    int64_t rowLoopOfTailBlock = CeilDiv(rowOfTailBlock, rowFactor);
+    int64_t tailRowFactorOfFormerBlock = rowOfFormerBlock % rowFactor == 0 ? rowFactor : rowOfFormerBlock % rowFactor;
+    int64_t tailRowFactorOfTailBlock = rowOfTailBlock % rowFactor == 0 ? rowFactor : rowOfTailBlock % rowFactor;
+
+    // ---- Runtime dtype code: bit0 slot_mapping int64, bit1 cache e4m3fn ----
+    int32_t dtypeCode = 0;
+    if (slot_mapping.scalar_type() == at::kLong) {
+        dtypeCode |= 1;
+    }
+    if (kv_compress_cache.scalar_type() == at::kFloat8_e4m3fn) {
+        dtypeCode |= 2;
+    }
+
+    // ---- Prepare tiling data ----
+    sglang::KvCompressEpilogTilingData tilingData;
+    tilingData.bs = bs;
+    tilingData.d = d;
+    tilingData.kvCacheCol = kvCacheCol;
+    tilingData.scaleCol = scaleCol;
+    tilingData.concatCol = concatCol;
+    tilingData.padCol = padCol;
+    tilingData.quantMode = quant_mode;
+    tilingData.roundScale = round_scale;
+    tilingData.perGroupSize = quant_group_size;
+    tilingData.rowOfFormerBlock = rowOfFormerBlock;
+    tilingData.rowOfTailBlock = rowOfTailBlock;
+    tilingData.rowLoopOfFormerBlock = rowLoopOfFormerBlock;
+    tilingData.rowLoopOfTailBlock = rowLoopOfTailBlock;
+    tilingData.rowFactor = rowFactor;
+    tilingData.tailRowFactorOfFormerBlock = tailRowFactorOfFormerBlock;
+    tilingData.tailRowFactorOfTailBlock = tailRowFactorOfTailBlock;
+    tilingData.layout = layout;
+    tilingData.blockSize = blockSize;
+    tilingData.valuePerToken = valuePerToken;
+    tilingData.scalePerToken = scalePerToken;
+    tilingData.blockStride = blockStride;
+    tilingData.dtype = dtypeCode;
+    tilingData.tilingKey = 0;
+
+    uint32_t tilingSize = (sizeof(sglang::KvCompressEpilogTilingData) + PADDING_BYTE - 1) / PADDING_BYTE * PADDING_BYTE;
+    at::Tensor tilingTensor;
+
+    // ---- Hash for the capture cache ----
+    auto tup =
+        std::make_tuple(bs, d, kvCacheCol, scaleCol, concatCol, padCol, quant_mode, round_scale, quant_group_size,
+                        rowOfFormerBlock, rowOfTailBlock, rowLoopOfFormerBlock, rowLoopOfTailBlock, rowFactor,
+                        tailRowFactorOfFormerBlock, tailRowFactorOfTailBlock, layout, blockSize, valuePerToken,
+                        scalePerToken, blockStride, dtypeCode, tilingData.tilingKey);
+    uint64_t hashValue = host_utils::TupleHasher::Hash(tup);
+
+    auto copyTilingToDevice = [&]() {
+        auto cpuTiling = at::empty({tilingSize}, at::kByte);
+        std::memcpy(cpuTiling.data_ptr(), &tilingData, sizeof(sglang::KvCompressEpilogTilingData));
+        return TorchNpuHelper::CopyTensorHostToDevice(cpuTiling);
+    };
+
+    static auto globalTilingBuffer = at::empty({tilingSize * MAX_CAPTURE_NUM},
+                                               at::TensorOptions().dtype(at::kByte).device(kv_compress_cache.device()));
+
+    if (captureMap.find(hashValue) != captureMap.end()) {
+        tilingTensor = at::from_blob(globalTilingBuffer.data_ptr<uint8_t>() + (tilingSize * captureMap[hashValue]),
+                                     tilingSize, at::kByte);
+    } else if (actualCaptureNum >= MAX_CAPTURE_NUM) {
+        tilingTensor = copyTilingToDevice();
+    } else {
+        captureMap[hashValue] = actualCaptureNum;
+        auto deviceTiling = copyTilingToDevice();
+        globalTilingBuffer.slice(0, actualCaptureNum * tilingSize, actualCaptureNum * tilingSize + tilingSize)
+            .copy_(deviceTiling);
+        actualCaptureNum++;
+        tilingTensor = at::from_blob(globalTilingBuffer.data_ptr<uint8_t>() + (tilingSize * captureMap[hashValue]),
+                                     tilingSize, at::kByte);
+    }
+
+    // ---- Workspace ----
+    auto workspace_tensor =
+        at::empty({WORKSPACE_SIZE}, at::TensorOptions().dtype(at::kByte).device(kv_compress_cache.device()));
+
+    // ---- Launch (in-place: cache passed for both input and output slots) ----
+    EXEC_KERNEL_CMD(kv_compress_epilog, usedCoreNums, cache, x, slot_mapping, cache, workspace_tensor, tilingTensor);
+}
+
+}  // namespace npu_kernel
+}  // namespace sglang

--- a/csrc/kv_compress_epilog/op_host/tiling/kv_compress_epilog_tiling_data.h
+++ b/csrc/kv_compress_epilog/op_host/tiling/kv_compress_epilog_tiling_data.h
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file kv_compress_epilog_tiling_data.h
+ * \brief Plain tiling-data struct for kv_compress_epilog (A5-only).
+ *
+ * Ported from the vllm-ascend A5 custom op (aclnnKvCompressEpilog). The CANN
+ * framework macros (BEGIN_TILING_DATA_DEF / TILING_DATA_FIELD_DEF) are replaced
+ * by a plain packed struct; the tilingKey and dtype fields carry the framework
+ * tiling-key and runtime dtype dispatch that the direct-compile model needs
+ * (GET_TILING_DATA_WITH_STRUCT / TILING_KEY_IS / DTYPE_* are not available here).
+ */
+
+#ifndef KV_COMPRESS_EPILOG_TILING_DATA_H
+#define KV_COMPRESS_EPILOG_TILING_DATA_H
+
+#include <cstdint>
+
+namespace sglang {
+
+#pragma pack(push, 1)
+struct KvCompressEpilogTilingData {
+    int64_t bs;
+    int64_t d;
+    int64_t kvCacheCol;
+    int64_t scaleCol;
+    int64_t concatCol;
+    int64_t padCol;
+    int64_t quantMode;
+    int64_t roundScale;
+    int64_t perGroupSize;
+    int64_t rowOfFormerBlock;
+    int64_t rowOfTailBlock;
+    int64_t rowLoopOfFormerBlock;
+    int64_t rowLoopOfTailBlock;
+    int64_t rowFactor;
+    int64_t tailRowFactorOfFormerBlock;
+    int64_t tailRowFactorOfTailBlock;
+    int64_t layout;
+    int64_t blockSize;
+    int64_t valuePerToken;
+    int64_t scalePerToken;
+    int64_t blockStride;
+    int32_t dtype;       // bit0: slot_mapping int64, bit1: kv_compress_cache e4m3fn
+    uint32_t tilingKey;  // single tiling config, always 0
+};
+#pragma pack(pop)
+
+}  // namespace sglang
+
+#endif  // KV_COMPRESS_EPILOG_TILING_DATA_H

--- a/csrc/kv_compress_epilog/op_host/tiling/kv_compress_epilog_tiling_data.h
+++ b/csrc/kv_compress_epilog/op_host/tiling/kv_compress_epilog_tiling_data.h
@@ -11,12 +11,6 @@
 /*!
  * \file kv_compress_epilog_tiling_data.h
  * \brief Plain tiling-data struct for kv_compress_epilog (A5-only).
- *
- * Ported from the vllm-ascend A5 custom op (aclnnKvCompressEpilog). The CANN
- * framework macros (BEGIN_TILING_DATA_DEF / TILING_DATA_FIELD_DEF) are replaced
- * by a plain packed struct; the tilingKey and dtype fields carry the framework
- * tiling-key and runtime dtype dispatch that the direct-compile model needs
- * (GET_TILING_DATA_WITH_STRUCT / TILING_KEY_IS / DTYPE_* are not available here).
  */
 
 #ifndef KV_COMPRESS_EPILOG_TILING_DATA_H

--- a/csrc/kv_compress_epilog/op_kernel/kv_compress_epilog.cpp
+++ b/csrc/kv_compress_epilog/op_kernel/kv_compress_epilog.cpp
@@ -11,12 +11,6 @@
 /*!
  * \file kv_compress_epilog.cpp
  * \brief KV compress epilog kernel entry (A5-only).
- *
- * Ported from the vllm-ascend A5 custom op. The CANN framework macros
- * (GetUserWorkspace / GET_TILING_DATA_WITH_STRUCT / TILING_KEY_IS) and the
- * build-time DTYPE_* macros are replaced by the equivalent direct-compile
- * constructs: a raw workspace pointer, a local copy of the tiling struct, and
- * runtime dispatch on tilingData->tilingKey / tilingData->dtype.
  */
 
 #include "kernel_operator.h"

--- a/csrc/kv_compress_epilog/op_kernel/kv_compress_epilog.cpp
+++ b/csrc/kv_compress_epilog/op_kernel/kv_compress_epilog.cpp
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file kv_compress_epilog.cpp
+ * \brief KV compress epilog kernel entry (A5-only).
+ *
+ * Ported from the vllm-ascend A5 custom op. The CANN framework macros
+ * (GetUserWorkspace / GET_TILING_DATA_WITH_STRUCT / TILING_KEY_IS) and the
+ * build-time DTYPE_* macros are replaced by the equivalent direct-compile
+ * constructs: a raw workspace pointer, a local copy of the tiling struct, and
+ * runtime dispatch on tilingData->tilingKey / tilingData->dtype.
+ */
+
+#include "kernel_operator.h"
+
+// ascendc_library compiles kernel sources once more for host-bisheng, where
+// CANN 9.1 does not define __NPU_ARCH__. The generated host stub is compiled
+// separately; this MicroAPI-based implementation is device-only.
+#if defined(__NPU_ARCH__)
+
+#include "kv_compress_epilog.h"
+
+using namespace AscendC;
+
+extern "C" __global__ __aicore__ void kv_compress_epilog(GM_ADDR kv_compress_cache, GM_ADDR x, GM_ADDR slot_mapping,
+                                                         GM_ADDR kv_compress_cache_out, GM_ADDR workspace,
+                                                         GM_ADDR tiling)
+{
+    if (workspace == nullptr) {
+        return;
+    }
+
+    __gm__ uint8_t *userspace = workspace;
+    if (userspace == nullptr) {
+        return;
+    }
+
+    TPipe pipe;
+
+    // Local copy of the tiling data. A struct-by-value copy from a __gm__ pointer is rejected
+    // on A5 ("argument is in address space gm, but parameter must be in Local Memory") and the
+    // GET_TILING_DATA_WITH_STRUCT macro cannot take a namespaced type name, so copy field by
+    // field through a __gm__ pointer (scalar GM reads, as causal_conv1d does on A5). The
+    // packed struct layout leaves every scalar naturally aligned, so no unaligned loads.
+    const __gm__ sglang::KvCompressEpilogTilingData *__restrict__ tilingGm =
+        reinterpret_cast<const __gm__ sglang::KvCompressEpilogTilingData *>(tiling);
+    sglang::KvCompressEpilogTilingData tilingDataIn;
+    tilingDataIn.bs = tilingGm->bs;
+    tilingDataIn.d = tilingGm->d;
+    tilingDataIn.kvCacheCol = tilingGm->kvCacheCol;
+    tilingDataIn.scaleCol = tilingGm->scaleCol;
+    tilingDataIn.concatCol = tilingGm->concatCol;
+    tilingDataIn.padCol = tilingGm->padCol;
+    tilingDataIn.quantMode = tilingGm->quantMode;
+    tilingDataIn.roundScale = tilingGm->roundScale;
+    tilingDataIn.perGroupSize = tilingGm->perGroupSize;
+    tilingDataIn.rowOfFormerBlock = tilingGm->rowOfFormerBlock;
+    tilingDataIn.rowOfTailBlock = tilingGm->rowOfTailBlock;
+    tilingDataIn.rowLoopOfFormerBlock = tilingGm->rowLoopOfFormerBlock;
+    tilingDataIn.rowLoopOfTailBlock = tilingGm->rowLoopOfTailBlock;
+    tilingDataIn.rowFactor = tilingGm->rowFactor;
+    tilingDataIn.tailRowFactorOfFormerBlock = tilingGm->tailRowFactorOfFormerBlock;
+    tilingDataIn.tailRowFactorOfTailBlock = tilingGm->tailRowFactorOfTailBlock;
+    tilingDataIn.layout = tilingGm->layout;
+    tilingDataIn.blockSize = tilingGm->blockSize;
+    tilingDataIn.valuePerToken = tilingGm->valuePerToken;
+    tilingDataIn.scalePerToken = tilingGm->scalePerToken;
+    tilingDataIn.blockStride = tilingGm->blockStride;
+    tilingDataIn.dtype = tilingGm->dtype;
+    tilingDataIn.tilingKey = tilingGm->tilingKey;
+    const sglang::KvCompressEpilogTilingData *__restrict__ tilingData = &tilingDataIn;
+
+    // Save and set overflow mode to saturation (0) for FP8 quantization
+    int64_t oriOverflowMode = AscendC::GetCtrlSpr<FLOAT_OVERFLOW_MODE_CTRL, FLOAT_OVERFLOW_MODE_CTRL>();
+    AscendC::SetCtrlSpr<FLOAT_OVERFLOW_MODE_CTRL, FLOAT_OVERFLOW_MODE_CTRL>(0);
+
+    // Dispatch based on tiling key
+    const uint32_t tilingKey = tilingData->tilingKey;
+    const int32_t dtype = tilingData->dtype;
+    if (tilingKey == 0) {
+        if (dtype == 0) {  // slot_mapping int32, kv_compress_cache fp8_e5m2
+            KvCompressEpilogOps::KvCompressEpilogRegBase<bfloat16_t, int32_t, fp8_e5m2_t> op(&pipe);
+            op.Init(x, slot_mapping, kv_compress_cache, tilingData);
+            op.Process();
+        } else if (dtype == 1) {  // slot_mapping int64, kv_compress_cache fp8_e5m2
+            KvCompressEpilogOps::KvCompressEpilogRegBase<bfloat16_t, int64_t, fp8_e5m2_t> op(&pipe);
+            op.Init(x, slot_mapping, kv_compress_cache, tilingData);
+            op.Process();
+        } else if (dtype == 2) {  // slot_mapping int32, kv_compress_cache fp8_e4m3fn
+            KvCompressEpilogOps::KvCompressEpilogRegBase<bfloat16_t, int32_t, fp8_e4m3fn_t> op(&pipe);
+            op.Init(x, slot_mapping, kv_compress_cache, tilingData);
+            op.Process();
+        } else {  // slot_mapping int64, kv_compress_cache fp8_e4m3fn
+            KvCompressEpilogOps::KvCompressEpilogRegBase<bfloat16_t, int64_t, fp8_e4m3fn_t> op(&pipe);
+            op.Init(x, slot_mapping, kv_compress_cache, tilingData);
+            op.Process();
+        }
+    }
+
+    // Restore overflow mode
+    AscendC::SetCtrlSpr<FLOAT_OVERFLOW_MODE_CTRL, FLOAT_OVERFLOW_MODE_CTRL>(oriOverflowMode);
+}
+
+#endif

--- a/csrc/kv_compress_epilog/op_kernel/kv_compress_epilog.h
+++ b/csrc/kv_compress_epilog/op_kernel/kv_compress_epilog.h
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file kv_compress_epilog.h
+ * \brief KV compress epilog kernel implementation
+ */
+
+#ifndef KV_COMPRESS_EPILOG_H
+#define KV_COMPRESS_EPILOG_H
+
+#include "kernel_operator.h"
+#include "kernel_tiling/kernel_tiling.h"
+#include "kv_compress_epilog_common.h"
+#include "../op_host/tiling/kv_compress_epilog_tiling_data.h"
+
+using namespace AscendC;
+
+namespace KvCompressEpilogOps {
+using sglang::KvCompressEpilogTilingData;
+
+template <typename T0, typename U, typename T1>
+class KvCompressEpilogRegBase
+{
+public:
+    __aicore__ inline KvCompressEpilogRegBase(TPipe *pipe) : pipe_(pipe) {}
+
+    __aicore__ inline void Init(GM_ADDR x, GM_ADDR slotMapping, GM_ADDR kvCache,
+                                const KvCompressEpilogTilingData *tilingData);
+
+    __aicore__ inline void Process();
+
+    __aicore__ inline void SetMaxValue();
+
+private:
+    TPipe *pipe_ = nullptr;
+
+    GlobalTensor<T0> xGm;
+    GlobalTensor<U> slotMappingGm;
+    GlobalTensor<T1> kvCacheGm;
+
+    TQue<QuePosition::VECIN, 1> xQue;
+    TQue<QuePosition::VECOUT, 1> kvCacheQue;
+    TBuf<QuePosition::VECCALC> kvCacheScaleBuf;
+    TBuf<QuePosition::VECCALC> indexBuf;
+
+    LocalTensor<T0> xLocal;
+    LocalTensor<T1> kvCacheLocal;
+    LocalTensor<T1> kvCacheScaleLocal;
+    LocalTensor<U> indexLocal;
+    int64_t validIdx = 0;
+    float maxValue = 0.0f;
+    float fp8Min = 0.0f;
+    float fp8Max = 0.0f;
+
+    // Tiling data
+    const KvCompressEpilogTilingData *tilingData = nullptr;
+};
+
+// Template implementations
+
+template <typename T0, typename U, typename T1>
+__aicore__ inline void KvCompressEpilogRegBase<T0, U, T1>::Init(GM_ADDR x, GM_ADDR slotMapping, GM_ADDR kvCache,
+                                                                const KvCompressEpilogTilingData *tilingDataPtr)
+{
+    tilingData = tilingDataPtr;
+
+    int64_t xGmBaseOffset = GetBlockIdx() * tilingData->rowOfFormerBlock * tilingData->d;
+
+    xGm.SetGlobalBuffer((__gm__ T0 *)x + xGmBaseOffset);
+    kvCacheGm.SetGlobalBuffer((__gm__ T1 *)kvCache);
+    slotMappingGm.SetGlobalBuffer((__gm__ U *)slotMapping);
+
+    pipe_->InitBuffer(xQue, 2, tilingData->rowFactor * RoundUp<T0>(tilingData->d) * sizeof(T0));
+    if (tilingData->layout == 2) {
+        pipe_->InitBuffer(kvCacheQue, 2, tilingData->rowFactor * RoundUp<T1>(tilingData->valuePerToken) * sizeof(T1));
+        pipe_->InitBuffer(kvCacheScaleBuf, tilingData->rowFactor * RoundUp<T1>(tilingData->scalePerToken) * sizeof(T1));
+    } else {
+        pipe_->InitBuffer(kvCacheQue, 2, tilingData->rowFactor * RoundUp<T1>(tilingData->kvCacheCol) * sizeof(T1));
+    }
+
+    pipe_->InitBuffer(indexBuf, RoundUp<U>(tilingData->rowFactor) * sizeof(U));
+    indexLocal = indexBuf.Get<U>();
+}
+
+template <typename T0, typename U, typename T1>
+__aicore__ inline void KvCompressEpilogRegBase<T0, U, T1>::Process()
+{
+    SetMaxValue();
+    int64_t rowOuterLoop =
+        (GetBlockIdx() == GetBlockNum() - 1) ? tilingData->rowLoopOfTailBlock : tilingData->rowLoopOfFormerBlock;
+    int64_t tailRowFactor = (GetBlockIdx() == GetBlockNum() - 1) ? tilingData->tailRowFactorOfTailBlock
+                                                                 : tilingData->tailRowFactorOfFormerBlock;
+    for (int64_t rowOuterIdx = 0; rowOuterIdx < rowOuterLoop; rowOuterIdx++) {
+        int64_t curRowFactor = (rowOuterIdx == rowOuterLoop - 1) ? tailRowFactor : tilingData->rowFactor;
+        xLocal = xQue.template AllocTensor<T0>();
+        validIdx = 0;
+        for (int64_t rowInnerIdx = 0; rowInnerIdx < curRowFactor; rowInnerIdx++) {
+            int32_t curSlotIdx =
+                GetBlockIdx() * tilingData->rowOfFormerBlock + rowOuterIdx * tilingData->rowFactor + rowInnerIdx;
+            int32_t slot = static_cast<int32_t>(slotMappingGm.GetValue(curSlotIdx));
+            if (slot == -1) {
+                continue;
+            }
+            CopyIn(xGm[rowOuterIdx * tilingData->rowFactor * tilingData->d + rowInnerIdx * tilingData->d],
+                   xLocal[validIdx * RoundUp<T0>(tilingData->d)], 1, tilingData->d);
+            indexLocal.SetValue(validIdx, slot);
+            validIdx++;
+
+            event_t eventId = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::S_MTE3));
+            SetFlag<HardEvent::S_MTE3>(eventId);
+            WaitFlag<HardEvent::S_MTE3>(eventId);
+        }
+        xQue.template EnQue(xLocal);
+        xLocal = xQue.template DeQue<T0>();
+
+        kvCacheLocal = kvCacheQue.template AllocTensor<T1>();
+
+        if (tilingData->quantMode == QUANT_MDOE_GROUP_FP8) {
+            VFProcessDynamicBlockQuant(kvCacheLocal, xLocal, maxValue, validIdx, tilingData->d, tilingData->concatCol,
+                                       tilingData->padCol);
+        } else if (tilingData->layout == 2) {
+            kvCacheScaleLocal = kvCacheScaleBuf.template Get<T1>();
+            if (tilingData->roundScale == 1) {
+                VFProcessDynamicMxFP8QuantLayout2<T0, T1, true>(
+                    kvCacheLocal, kvCacheScaleLocal, xLocal, maxValue, fp8Min, fp8Max, validIdx, tilingData->d,
+                    tilingData->valuePerToken, tilingData->scalePerToken, tilingData->perGroupSize);
+            } else {
+                VFProcessDynamicMxFP8QuantLayout2<T0, T1, false>(
+                    kvCacheLocal, kvCacheScaleLocal, xLocal, maxValue, fp8Min, fp8Max, validIdx, tilingData->d,
+                    tilingData->valuePerToken, tilingData->scalePerToken, tilingData->perGroupSize);
+            }
+        } else {
+            if (tilingData->roundScale == 1) {
+                VFProcessDynamicMxFP8Quant<T0, T1, true>(kvCacheLocal, xLocal, maxValue, fp8Min, fp8Max, validIdx,
+                                                         tilingData->d, tilingData->concatCol, tilingData->padCol,
+                                                         tilingData->perGroupSize);
+            } else {
+                VFProcessDynamicMxFP8Quant<T0, T1, false>(kvCacheLocal, xLocal, maxValue, fp8Min, fp8Max, validIdx,
+                                                          tilingData->d, tilingData->concatCol, tilingData->padCol,
+                                                          tilingData->perGroupSize);
+            }
+        }
+
+        xQue.template FreeTensor(xLocal);
+
+        kvCacheQue.template EnQue(kvCacheLocal);
+        kvCacheLocal = kvCacheQue.template DeQue<T1>();
+
+        if (tilingData->layout == 2 && tilingData->quantMode == QUANT_MDOE_GROUP_MXFP8) {
+            for (int32_t curValidIdx = 0; curValidIdx < validIdx; curValidIdx++) {
+                int32_t slot = indexLocal.GetValue(curValidIdx);
+                int64_t blockIdx = static_cast<int64_t>(slot) / tilingData->blockSize;
+                int64_t slotInBlock = static_cast<int64_t>(slot) % tilingData->blockSize;
+
+                // CopyOut value (FP8 quant + BF16 rope)
+                int64_t valueGmOff = blockIdx * tilingData->blockStride + slotInBlock * tilingData->valuePerToken;
+                CopyOut(kvCacheLocal[curValidIdx * RoundUp<T1>(tilingData->valuePerToken)], kvCacheGm[valueGmOff], 1,
+                        tilingData->valuePerToken);
+
+                // CopyOut scale (uint8)
+                int64_t scaleGmOff = blockIdx * tilingData->blockStride +
+                                     tilingData->blockSize * tilingData->valuePerToken +
+                                     slotInBlock * tilingData->scalePerToken;
+                CopyOut(kvCacheScaleLocal[curValidIdx * RoundUp<T1>(tilingData->scalePerToken)], kvCacheGm[scaleGmOff],
+                        1, tilingData->scalePerToken);
+            }
+        } else {
+            for (int32_t curValidIdx = 0; curValidIdx < validIdx; curValidIdx++) {
+                int32_t slot = indexLocal.GetValue(curValidIdx);
+                int64_t gmOffset = static_cast<int64_t>(slot) * tilingData->kvCacheCol;
+                if (tilingData->layout == 1) {
+                    int64_t rowStride = tilingData->blockStride > 0 ? tilingData->blockStride : tilingData->kvCacheCol;
+                    gmOffset = static_cast<int64_t>(slot) * rowStride;
+                }
+                CopyOut(kvCacheLocal[curValidIdx * RoundUp<T1>(tilingData->kvCacheCol)], kvCacheGm[gmOffset], 1,
+                        tilingData->kvCacheCol);
+            }
+        }
+        kvCacheQue.template FreeTensor(kvCacheLocal);
+    }
+}
+
+template <typename T0, typename U, typename T1>
+__aicore__ inline void KvCompressEpilogRegBase<T0, U, T1>::SetMaxValue()
+{
+    if constexpr (IsSameType<T1, fp8_e5m2_t>::value) {
+        maxValue = static_cast<float>(1.0) / FP8_E5M2_MAX_VALUE;
+        fp8Max = FP8_E5M2_MAX_VALUE;
+        fp8Min = FP8_E5M2_MIN_VALUE;
+    } else if constexpr (IsSameType<T1, fp8_e4m3fn_t>::value) {
+        maxValue = static_cast<float>(1.0) / FP8_E4M3FN_MAX_VALUE;
+        fp8Max = FP8_E4M3FN_MAX_VALUE;
+        fp8Min = FP8_E4M3FN_MIN_VALUE;
+    }
+}
+
+}  // namespace KvCompressEpilogOps
+#endif  // KV_COMPRESS_EPILOG_H

--- a/csrc/kv_compress_epilog/op_kernel/kv_compress_epilog_common.h
+++ b/csrc/kv_compress_epilog/op_kernel/kv_compress_epilog_common.h
@@ -221,7 +221,6 @@ __aicore__ inline void VFProcessDynamicBlockQuant(const LocalTensor<T1> &yLocal,
                 StoreOutputData<T1>(yLocalAddr, xLeft, pregMain, 2 * j * VL_FP32 + i * dstCurColNumAlign);
                 StoreOutputData<T1>(yLocalAddr, xRight, pregLoop, (2 * j + 1) * VL_FP32 + i * dstCurColNumAlign);
             }
-            // 处理尾块, 这里只有一个for循环
             uint32_t sregTail = tailReminder;
             pregLoop = UpdateMask<float>(sregTail);
             for (uint16_t j = 0; j < loopCountReminder; j++) {
@@ -370,6 +369,13 @@ __aicore__ inline void VFProcessDynamicMxFP8Quant(const LocalTensor<T1> &yLocal,
                         Add(vreg1, vreg1, vreg4, pregMerge);
                         Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
                         ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
+                    } else {
+                        ShiftRights(vreg0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                    pregMerge);
+                        And(vreg1, vreg0, tmp0, pregMerge);
+                        Sub(vreg1, vreg1, tmp3, pregMerge);
+                        Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
+                        ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
                     }
 
                     // Quantize left half
@@ -414,6 +420,13 @@ __aicore__ inline void VFProcessDynamicMxFP8Quant(const LocalTensor<T1> &yLocal,
                         Select(vreg4, one, zero, cmpMask);
                         Sub(vreg1, vreg1, tmp3, pregMerge);
                         Add(vreg1, vreg1, vreg4, pregMerge);
+                        Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
+                        ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
+                    } else {
+                        ShiftRights(vreg0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                    pregMerge);
+                        And(vreg1, vreg0, tmp0, pregMerge);
+                        Sub(vreg1, vreg1, tmp3, pregMerge);
                         Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
                         ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
                     }
@@ -465,6 +478,13 @@ __aicore__ inline void VFProcessDynamicMxFP8Quant(const LocalTensor<T1> &yLocal,
                         Select(vreg4, one, zero, cmpMask);
                         Sub(vreg1, vreg1, tmp3, pregMerge);
                         Add(vreg1, vreg1, vreg4, pregMerge);
+                        Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
+                        ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
+                    } else {
+                        ShiftRights(vreg0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                    pregMerge);
+                        And(vreg1, vreg0, tmp0, pregMerge);
+                        Sub(vreg1, vreg1, tmp3, pregMerge);
                         Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
                         ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
                     }
@@ -599,6 +619,13 @@ __aicore__ inline void VFProcessDynamicMxFP8QuantLayout2(const LocalTensor<T1> &
                         Add(vreg1, vreg1, vreg4, pregMerge);
                         Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
                         ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
+                    } else {
+                        ShiftRights(vreg0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                    pregMerge);
+                        And(vreg1, vreg0, tmp0, pregMerge);
+                        Sub(vreg1, vreg1, tmp3, pregMerge);
+                        Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
+                        ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
                     }
 
                     Duplicate(dupScale, max2, pregMain);
@@ -639,6 +666,13 @@ __aicore__ inline void VFProcessDynamicMxFP8QuantLayout2(const LocalTensor<T1> &
                         Select(vreg4, one, zero, cmpMask);
                         Sub(vreg1, vreg1, tmp3, pregMerge);
                         Add(vreg1, vreg1, vreg4, pregMerge);
+                        Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
+                        ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
+                    } else {
+                        ShiftRights(vreg0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                    pregMerge);
+                        And(vreg1, vreg0, tmp0, pregMerge);
+                        Sub(vreg1, vreg1, tmp3, pregMerge);
                         Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
                         ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
                     }
@@ -685,6 +719,13 @@ __aicore__ inline void VFProcessDynamicMxFP8QuantLayout2(const LocalTensor<T1> &
                         Select(vreg4, one, zero, cmpMask);
                         Sub(vreg1, vreg1, tmp3, pregMerge);
                         Add(vreg1, vreg1, vreg4, pregMerge);
+                        Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
+                        ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
+                    } else {
+                        ShiftRights(vreg0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                    pregMerge);
+                        And(vreg1, vreg0, tmp0, pregMerge);
+                        Sub(vreg1, vreg1, tmp3, pregMerge);
                         Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
                         ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
                     }

--- a/csrc/kv_compress_epilog/op_kernel/kv_compress_epilog_common.h
+++ b/csrc/kv_compress_epilog/op_kernel/kv_compress_epilog_common.h
@@ -1,0 +1,741 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file swiglu_block_quant_base.h
+ * \brief
+ */
+
+#ifndef KV_COMPRESS_EPILOG_COMMON_H
+#define KV_COMPRESS_EPILOG_COMMON_H
+
+#include "kernel_operator.h"
+
+namespace KvCompressEpilogOps {
+using namespace AscendC;
+using namespace AscendC::MicroAPI;
+using AscendC::MicroAPI::MaskReg;
+using AscendC::MicroAPI::RegTensor;
+using AscendC::MicroAPI::UnalignReg;
+constexpr int32_t BLOCK_SIZE = 32;
+constexpr int32_t VL_FP32 = 64;
+constexpr int32_t PER_BLOCK_FP16 = 128;
+constexpr float FP8_E5M2_MAX_VALUE = 57344.0f;
+constexpr float FP8_E4M3FN_MAX_VALUE = 448.0f;
+constexpr int64_t QUANT_MDOE_GROUP_FP8 = 1;
+constexpr int64_t QUANT_MDOE_GROUP_MXFP8 = 2;
+constexpr float FP8_E5M2_MIN_VALUE = -57344.0f;
+constexpr float FP8_E4M3FN_MIN_VALUE = -448.0f;
+constexpr uint32_t FAST_LOG_SHIFT_BITS = 23U;
+constexpr uint32_t FAST_LOG_AND_VALUE1 = 0xFF;
+constexpr uint32_t FAST_LOG_AND_VALUE2 = (((uint32_t)1 << (uint32_t)23) - (uint32_t)1);
+constexpr uint32_t INV_FP8_E5M2_MAX_VALUE = 0x37924925;
+constexpr uint32_t INV_FP8_E4M3_MAX_VALUE = 0x3b124925;
+
+#define FLOAT_OVERFLOW_MODE_CTRL 60
+#ifndef INFINITY
+#define INFINITY (__builtin_inff())
+#endif
+constexpr float POS_INFINITY = INFINITY;
+constexpr float NEG_INFINITY = -INFINITY;
+
+__aicore__ inline int32_t CeilDiv(int32_t a, int b)
+{
+    if (b == 0) {
+        return a;
+    }
+    return (a + b - 1) / b;
+}
+
+__aicore__ inline int32_t CeilAlign(int32_t a, int b)
+{
+    return CeilDiv(a, b) * b;
+}
+
+template <typename T>
+__aicore__ inline int32_t RoundUp(int32_t num)
+{
+    int32_t elemNum = BLOCK_SIZE / sizeof(T);
+    return CeilAlign(num, elemNum);
+}
+
+constexpr AscendC::MicroAPI::CastTrait castTraitB162B32Even = {
+    AscendC::MicroAPI::RegLayout::ZERO,
+    AscendC::MicroAPI::SatMode::UNKNOWN,
+    AscendC::MicroAPI::MaskMergeMode::ZEROING,
+    AscendC::RoundMode::UNKNOWN,
+};
+
+constexpr AscendC::MicroAPI::CastTrait castTraitB322B16Even = {
+    AscendC::MicroAPI::RegLayout::ZERO,
+    AscendC::MicroAPI::SatMode::NO_SAT,
+    AscendC::MicroAPI::MaskMergeMode::ZEROING,
+    AscendC::RoundMode::CAST_RINT,
+};
+
+constexpr static AscendC::MicroAPI::CastTrait castTraitF32toFp8Even = {
+    AscendC::MicroAPI::RegLayout::ZERO,
+    AscendC::MicroAPI::SatMode::NO_SAT,
+    AscendC::MicroAPI::MaskMergeMode::ZEROING,
+    AscendC::RoundMode::CAST_RINT,
+};
+
+constexpr static AscendC::MicroAPI::CastTrait castTraitU32toU8Even = {
+    AscendC::MicroAPI::RegLayout::ZERO,
+    AscendC::MicroAPI::SatMode::NO_SAT,
+    AscendC::MicroAPI::MaskMergeMode::ZEROING,
+    AscendC::RoundMode::CAST_NONE,
+};
+
+template <typename T>
+__aicore__ inline void LoadInputData(RegTensor<float> &dst, __local_mem__ T *src, MaskReg pregLoop, uint32_t srcOffset)
+{
+    if constexpr (IsSameType<T, float>::value) {
+        DataCopy(dst, src + srcOffset);
+    } else if constexpr (IsSameType<T, half>::value || IsSameType<T, bfloat16_t>::value) {
+        RegTensor<T> tmp;
+        DataCopy<T, AscendC::MicroAPI::LoadDist::DIST_UNPACK_B16>(tmp, src + srcOffset);
+        Cast<float, T, castTraitB162B32Even>(dst, tmp, pregLoop);
+    }
+}
+
+template <typename T>
+__aicore__ inline void StoreOutputData(__local_mem__ T *dst, RegTensor<float> &src, MaskReg pregLoop,
+                                       uint32_t dstOffset)
+{
+    if constexpr (IsSameType<T, float>::value) {
+        DataCopy(dst + dstOffset, src, pregLoop);
+    } else if constexpr (IsSameType<T, half>::value || IsSameType<T, bfloat16_t>::value) {
+        RegTensor<T> tmp;
+        Cast<T, float, castTraitB322B16Even>(tmp, src, pregLoop);
+        DataCopy<T, AscendC::MicroAPI::StoreDist::DIST_PACK_B32>(dst + dstOffset, tmp, pregLoop);
+    } else if constexpr (IsSameType<T, fp8_e4m3fn_t>::value || IsSameType<T, fp8_e5m2_t>::value) {
+        RegTensor<T> tmp;
+        Cast<T, float, castTraitF32toFp8Even>(tmp, src, pregLoop);
+        DataCopy<T, AscendC::MicroAPI::StoreDist::DIST_PACK4_B32>(dst + dstOffset, tmp, pregLoop);
+    }
+}
+
+template <typename T0, typename T1>
+__aicore__ inline void VFProcessDynamicBlockQuant(const LocalTensor<T1> &yLocal, const LocalTensor<T0> &xLocal,
+                                                  float coeff, const uint16_t curRowNum, const uint32_t curColNum,
+                                                  const uint32_t concatColNum, const uint32_t padColNum)
+{
+    __local_mem__ T1 *yLocalAddr = (__local_mem__ T1 *)yLocal.GetPhyAddr();
+    __local_mem__ T1 *scaleLocalAddr = (__local_mem__ T1 *)yLocal.GetPhyAddr();
+    __local_mem__ T0 *xLocalAddr = (__local_mem__ T0 *)xLocal.GetPhyAddr();
+    __local_mem__ T0 *ropeXLocalAddr = (__local_mem__ T0 *)xLocal.GetPhyAddr();
+    __local_mem__ T0 *ropeYLocalAddr = (__local_mem__ T0 *)yLocal.GetPhyAddr();
+    __local_mem__ T1 *padLocalAddr = (__local_mem__ T1 *)yLocal.GetPhyAddr();
+    static constexpr AscendC::MicroAPI::DivSpecificMode mode = {AscendC::MicroAPI::MaskMergeMode::ZEROING, false};
+    uint32_t maxValueInt = 0;
+    if constexpr (IsSameType<T1, fp8_e5m2_t>::value) {
+        maxValueInt = INV_FP8_E5M2_MAX_VALUE;
+    } else if constexpr (IsSameType<T1, fp8_e4m3fn_t>::value) {
+        maxValueInt = INV_FP8_E4M3_MAX_VALUE;
+    }
+
+    uint32_t quantColNum = curColNum - 64;
+    uint16_t scaleColNum = CeilDiv(quantColNum, 128);
+    uint16_t loopCount = CeilDiv(quantColNum, VL_FP32);
+    uint32_t curColNumAlign = RoundUp<T0>(curColNum);
+    uint32_t dstCurColNumAlign = RoundUp<T1>(concatColNum + padColNum);
+    uint16_t loopCountFoldTwo = loopCount / 2;
+    uint16_t loopCountReminder = loopCount % 2;
+    uint32_t tailReminder = quantColNum - (loopCount - 1) * VL_FP32;
+    uint32_t scaleColNumAlign = RoundUp<T0>(scaleColNum);
+    uint32_t sregNum = loopCountReminder == 0 ? quantColNum - loopCountFoldTwo * VL_FP32 : loopCountFoldTwo * VL_FP32;
+    __VEC_SCOPE__
+    {
+        RegTensor<float> xLeft;
+        RegTensor<float> xRight;
+        RegTensor<float> x1Left;
+        RegTensor<float> x1Right;
+        RegTensor<float> xAbsLeft;
+        RegTensor<float> xAbsRight;
+        RegTensor<float> xMax;
+        RegTensor<float> tmp;
+        RegTensor<float> dupScale;
+        RegTensor<float> scale;
+        RegTensor<float> scale0;
+        RegTensor<float> scale1;
+        RegTensor<float> inf;
+        RegTensor<float> one;
+        RegTensor<float> zeros;
+        RegTensor<uint32_t> coeffReg;
+        RegTensor<T0> ropeReg;
+        UnalignRegForStore ureg0;
+        UnalignRegForLoad ureg1;
+        UnalignRegForStore ureg2;
+        MaskReg pregLoop = CreateMask<float>();
+        Duplicate(coeffReg, maxValueInt, pregLoop);
+        Duplicate(one, static_cast<float>(1.0f), pregLoop);
+        Duplicate(zeros, static_cast<float>(0.0f), pregLoop);
+        Div<float, &mode>(inf, one, zeros, pregLoop);
+        MaskReg pregMain = CreateMask<float>();
+        MaskReg preg1 = CreateMask<float, AscendC::MicroAPI::MaskPattern::VL1>();
+        MaskReg compareLeft;
+        MaskReg compareRight;
+        MaskReg compareScalar;
+        for (uint16_t i = 0; i < curRowNum; i++) {
+            // cat scale
+            scaleLocalAddr = yLocalAddr + i * dstCurColNumAlign + quantColNum + 128;
+            uint32_t sreg = sregNum;
+            for (uint16_t j = 0; j < loopCountFoldTwo; j++) {
+                pregLoop = UpdateMask<float>(sreg);
+                LoadInputData<T0>(xLeft, xLocalAddr, pregMain, 2 * j * VL_FP32 + i * curColNum);
+                LoadInputData<T0>(xRight, xLocalAddr, pregLoop, (2 * j + 1) * VL_FP32 + i * curColNum);
+                Muls(xAbsLeft, xLeft, 0.0f, pregMain);
+                Compare<float, CMPMODE::NE>(compareLeft, xAbsLeft, xAbsLeft, pregMain);
+                MaskNot(compareLeft, compareLeft, pregMain);
+                Abs(xAbsLeft, xLeft, compareLeft);
+                ReduceMax(scale0, xAbsLeft, pregMain);
+                Muls(xAbsRight, xRight, 0.0f, pregLoop);
+                Compare<float, CMPMODE::NE>(compareRight, xAbsRight, xAbsRight, pregLoop);
+                MaskNot(compareRight, compareRight, pregLoop);
+                Abs(xAbsRight, xRight, compareRight);
+                ReduceMax(scale1, xAbsRight, pregLoop);
+                Max(scale, scale0, scale1, preg1);
+                CompareScalar<float, CMPMODE::NE>(compareScalar, scale, (float)0.0, preg1);
+                Mul(scale, scale, (RegTensor<float> &)coeffReg, compareScalar);
+                Min(scale, scale, inf, preg1);
+                Duplicate(dupScale, scale, pregMain);
+                // cat scale
+                StoreUnAlign(scaleLocalAddr, (RegTensor<T1> &)scale, ureg2, 4);
+                StoreUnAlignPost(scaleLocalAddr, ureg2, 0);
+                Div<float, &mode>(xAbsLeft, xLeft, dupScale, pregMain);
+                Muls(x1Left, xAbsLeft, 0.0f, pregMain);
+                Compare<float, CMPMODE::NE>(compareLeft, x1Left, x1Left, pregMain);
+                Select(xLeft, xLeft, xAbsLeft, compareLeft);
+                Div<float, &mode>(xAbsRight, xRight, dupScale, pregLoop);
+                Muls(x1Right, xAbsRight, 0.0f, pregLoop);
+                Compare<float, CMPMODE::NE>(compareRight, x1Right, x1Right, pregLoop);
+                Select(xRight, xRight, xAbsRight, compareRight);
+                StoreOutputData<T1>(yLocalAddr, xLeft, pregMain, 2 * j * VL_FP32 + i * dstCurColNumAlign);
+                StoreOutputData<T1>(yLocalAddr, xRight, pregLoop, (2 * j + 1) * VL_FP32 + i * dstCurColNumAlign);
+            }
+            // 处理尾块, 这里只有一个for循环
+            uint32_t sregTail = tailReminder;
+            pregLoop = UpdateMask<float>(sregTail);
+            for (uint16_t j = 0; j < loopCountReminder; j++) {
+                LoadInputData<T0>(xLeft, xLocalAddr, pregLoop, loopCountFoldTwo * 2 * VL_FP32 + i * curColNum);
+                Muls(xAbsLeft, xLeft, 0.0f, pregLoop);
+                Compare<float, CMPMODE::NE>(compareLeft, xAbsLeft, xAbsLeft, pregLoop);
+                MaskNot(compareLeft, compareLeft, pregLoop);
+                Abs(xAbsLeft, xLeft, compareLeft);
+                ReduceMax(scale, xAbsLeft, pregLoop);
+                CompareScalar<float, CMPMODE::NE>(compareScalar, scale, (float)0.0, preg1);
+                Mul(scale, scale, (RegTensor<float> &)coeffReg, compareScalar);
+                Min(scale, scale, inf, preg1);
+                Duplicate(dupScale, scale, pregLoop);
+                // cat scale
+                StoreUnAlign(scaleLocalAddr, (RegTensor<T1> &)scale, ureg2, 4);
+                StoreUnAlignPost(scaleLocalAddr, ureg2, 0);
+                Div<float, &mode>(xAbsLeft, xLeft, dupScale, pregLoop);
+                Muls(x1Left, xAbsLeft, 0.0f, pregLoop);
+                Compare<float, CMPMODE::NE>(compareLeft, x1Left, x1Left, pregLoop);
+                Select(xLeft, xLeft, xAbsLeft, compareLeft);
+                StoreOutputData(yLocalAddr, xLeft, pregLoop, loopCountFoldTwo * 2 * VL_FP32 + i * dstCurColNumAlign);
+            }
+            LocalMemBar<MemType::VEC_STORE, MemType::VEC_STORE>();
+            // cat rope
+            ropeXLocalAddr = ropeXLocalAddr + quantColNum;
+            ropeYLocalAddr = ropeYLocalAddr + quantColNum / 2;
+
+            LoadUnAlignPre(ureg0, ropeXLocalAddr);
+            LoadUnAlign(ropeReg, ureg0, ropeXLocalAddr, 64);
+            StoreUnAlign(ropeYLocalAddr, ropeReg, ureg1, 64);
+            StoreUnAlignPost(ropeYLocalAddr, ureg1, 0);
+
+            // pad zero
+            padLocalAddr = padLocalAddr + concatColNum;
+            StoreUnAlign(padLocalAddr, (RegTensor<T1> &)zeros, ureg1, padColNum);
+            StoreUnAlignPost(padLocalAddr, ureg1, 0);
+
+            ropeYLocalAddr = ropeYLocalAddr + scaleColNum * 2 + padColNum / 2;
+        }
+    }
+}
+
+template <typename T0, typename T1, bool roundScale = true>
+__aicore__ inline void VFProcessDynamicMxFP8Quant(const LocalTensor<T1> &yLocal, const LocalTensor<T0> &xLocal,
+                                                  float coeff, float fp8Min, float fp8Max, const uint16_t curRowNum,
+                                                  const uint32_t curColNum, const uint32_t concatColNum,
+                                                  const uint32_t padColNum, const int64_t perGroupSize)
+{
+    __local_mem__ T1 *yLocalAddr = (__local_mem__ T1 *)yLocal.GetPhyAddr();
+    __local_mem__ T0 *xLocalAddr = (__local_mem__ T0 *)xLocal.GetPhyAddr();
+    __local_mem__ T1 *scaleLocalAddr = (__local_mem__ T1 *)yLocal.GetPhyAddr();
+    __local_mem__ T0 *ropeXLocalAddr = (__local_mem__ T0 *)xLocal.GetPhyAddr();
+    __local_mem__ T0 *ropeYLocalAddr = (__local_mem__ T0 *)yLocal.GetPhyAddr();
+    __local_mem__ T1 *padLocalAddr = (__local_mem__ T1 *)yLocal.GetPhyAddr();
+
+    uint32_t quantColNum = curColNum - 64;
+    uint16_t scaleColNum = CeilDiv(quantColNum, static_cast<int32_t>(perGroupSize));
+    uint16_t ropeNum = 128;
+    uint16_t loopCount = CeilDiv(quantColNum, VL_FP32);
+    uint32_t curColNumAlign = RoundUp<T0>(curColNum);
+    uint32_t dstCurColNumAlign = RoundUp<T1>(concatColNum + padColNum);
+    uint16_t loopCountFoldTwo = loopCount / 2;
+    uint16_t loopCountReminder = loopCount % 2;
+    uint32_t tailReminder = quantColNum - (loopCount - 1) * VL_FP32;
+    uint32_t scaleColNumAlign = RoundUp<T0>(scaleColNum);
+    uint32_t sregNum = quantColNum;
+    __VEC_SCOPE__
+    {
+        RegTensor<float> x0;
+        RegTensor<float> x0Abs;
+        RegTensor<float> x1;
+        RegTensor<float> x1Abs;
+        RegTensor<float> max0;
+        RegTensor<float> max1;
+        RegTensor<float> max2;
+        RegTensor<uint32_t> tmp0;
+        RegTensor<uint32_t> tmp1;
+        RegTensor<uint32_t> vreg0;
+        RegTensor<uint32_t> vreg1;
+        RegTensor<uint32_t> vreg2;
+        RegTensor<uint32_t> vreg3;
+        RegTensor<uint32_t> vreg4;
+        RegTensor<int32_t> vreg5;
+        RegTensor<uint32_t> zero;
+        RegTensor<uint32_t> one;
+        RegTensor<uint32_t> tmp3;
+        RegTensor<float> dupScale;
+        RegTensor<T0> ropeReg;
+        RegTensor<uint32_t> scaleTmp0;
+        RegTensor<uint8_t> scaleTmp1;
+        UnalignRegForStore ureg0;
+        UnalignRegForLoad ureg1;
+        UnalignRegForStore ureg2;
+        MaskReg pregLoop;
+        MaskReg preg1 = CreateMask<T0, AscendC::MicroAPI::MaskPattern::VL1>();
+        MaskReg pregMerge = CreateMask<float, AscendC::MicroAPI::MaskPattern::VL1>();
+        MaskReg pregMain = CreateMask<float>();
+        MaskReg pregRope = CreateMask<T0, AscendC::MicroAPI::MaskPattern::VL64>();
+        MaskReg cmpMask;
+        Duplicate(tmp0, FAST_LOG_AND_VALUE1, pregMerge);
+        Duplicate(tmp1, FAST_LOG_AND_VALUE2, pregMerge);
+        Duplicate(zero, static_cast<uint32_t>(0), pregMerge);
+        Duplicate(one, static_cast<uint32_t>(1), pregMerge);
+        Duplicate(tmp3, static_cast<uint32_t>(127), pregMerge);
+        if (perGroupSize >= 128) {
+            // ── fold-two path: group_size=128, pair two 64-element groups per scale ──
+            uint32_t sregNumFold = quantColNum - loopCountFoldTwo * VL_FP32;
+            for (uint16_t i = 0; i < curRowNum; i++) {
+                // cat rope
+                ropeXLocalAddr = ropeXLocalAddr + quantColNum;
+                LoadUnAlignPre(ureg0, ropeXLocalAddr);
+                LoadUnAlign(ropeReg, ureg0, ropeXLocalAddr, 64);
+                DataCopy(ropeYLocalAddr + i * dstCurColNumAlign / 2, ropeReg, pregRope);
+                LocalMemBar<MemType::VEC_STORE, MemType::VEC_STORE>();
+
+                uint32_t sreg = sregNumFold;
+                uint16_t scaleIdx = 0;
+
+                for (uint16_t g = 0; g < loopCountFoldTwo; g++) {
+                    uint16_t jL = g * 2;
+                    uint16_t jR = g * 2 + 1;
+                    pregLoop = UpdateMask<float>(sreg);
+
+                    // Load two 64-element groups
+                    LoadInputData<T0>(x0, xLocalAddr, pregMain, jL * VL_FP32 + i * curColNumAlign);
+                    LoadInputData<T0>(x1, xLocalAddr, pregLoop, jR * VL_FP32 + i * curColNumAlign);
+
+                    // Abs + ReduceMax for each half
+                    Abs(x0Abs, x0, pregMain);
+                    ReduceMax(max0, x0Abs, pregMain);
+                    Abs(x1Abs, x1, pregLoop);
+                    ReduceMax(max1, x1Abs, pregLoop);
+
+                    // Merge max
+                    Max(max2, max0, max1, pregMerge);
+                    Maxs(max2, max2, static_cast<float>(1e-4), pregMerge);
+                    Muls(max2, max2, coeff, pregMerge);
+                    if constexpr (roundScale) {
+                        ShiftRights(vreg0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                    pregMerge);
+                        And(vreg1, vreg0, tmp0, pregMerge);
+                        And(vreg2, vreg1, tmp1, pregMerge);
+                        Compare<uint32_t, AscendC::CMPMODE::NE>(cmpMask, vreg2, zero, pregMerge);
+                        Select(vreg4, one, zero, cmpMask);
+                        Sub(vreg1, vreg1, tmp3, pregMerge);
+                        Add(vreg1, vreg1, vreg4, pregMerge);
+                        Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
+                        ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
+                    }
+
+                    // Quantize left half
+                    Duplicate(dupScale, max2, pregMain);
+                    Div(x0, x0, dupScale, pregMain);
+                    Maxs(x0, x0, fp8Min, pregMain);
+                    Mins(x0, x0, fp8Max, pregMain);
+                    StoreOutputData<T1>(yLocalAddr, x0, pregMain, jL * VL_FP32 + i * dstCurColNumAlign + ropeNum);
+
+                    // Quantize right half
+                    Div(x1, x1, dupScale, pregLoop);
+                    Maxs(x1, x1, fp8Min, pregLoop);
+                    Mins(x1, x1, fp8Max, pregLoop);
+                    StoreOutputData<T1>(yLocalAddr, x1, pregLoop, jR * VL_FP32 + i * dstCurColNumAlign + ropeNum);
+
+                    // Store 1 uint8 scale
+                    ShiftRights(scaleTmp0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                preg1);
+                    Cast<uint8_t, uint32_t, castTraitU32toU8Even>(scaleTmp1, scaleTmp0, preg1);
+                    DataCopy<T1, AscendC::MicroAPI::StoreDist::DIST_FIRST_ELEMENT_B8>(
+                        scaleLocalAddr + quantColNum + ropeNum + scaleIdx + i * dstCurColNumAlign,
+                        (RegTensor<T1> &)scaleTmp1, preg1);
+                    scaleIdx++;
+                }
+
+                // Tail block: odd loopCount leaves 1 group <= 64 elements
+                for (uint16_t t = 0; t < loopCountReminder; t++) {
+                    uint16_t jT = loopCountFoldTwo * 2;
+                    uint32_t tailRem = quantColNum - jT * VL_FP32;
+                    pregLoop = UpdateMask<float>(tailRem);
+                    LoadInputData<T0>(x0, xLocalAddr, pregLoop, jT * VL_FP32 + i * curColNumAlign);
+                    Abs(x0Abs, x0, pregLoop);
+                    ReduceMax(max0, x0Abs, pregLoop);
+                    Maxs(max2, max0, static_cast<float>(1e-4), pregMerge);
+                    Muls(max2, max2, coeff, pregMerge);
+                    if constexpr (roundScale) {
+                        ShiftRights(vreg0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                    pregMerge);
+                        And(vreg1, vreg0, tmp0, pregMerge);
+                        And(vreg2, vreg1, tmp1, pregMerge);
+                        Compare<uint32_t, AscendC::CMPMODE::NE>(cmpMask, vreg2, zero, pregMerge);
+                        Select(vreg4, one, zero, cmpMask);
+                        Sub(vreg1, vreg1, tmp3, pregMerge);
+                        Add(vreg1, vreg1, vreg4, pregMerge);
+                        Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
+                        ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
+                    }
+                    Duplicate(dupScale, max2, pregLoop);
+                    Div(x0, x0, dupScale, pregLoop);
+                    Maxs(x0, x0, fp8Min, pregLoop);
+                    Mins(x0, x0, fp8Max, pregLoop);
+                    StoreOutputData<T1>(yLocalAddr, x0, pregLoop, jT * VL_FP32 + i * dstCurColNumAlign + ropeNum);
+
+                    ShiftRights(scaleTmp0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                preg1);
+                    Cast<uint8_t, uint32_t, castTraitU32toU8Even>(scaleTmp1, scaleTmp0, preg1);
+                    DataCopy<T1, AscendC::MicroAPI::StoreDist::DIST_FIRST_ELEMENT_B8>(
+                        scaleLocalAddr + quantColNum + ropeNum + scaleIdx + i * dstCurColNumAlign,
+                        (RegTensor<T1> &)scaleTmp1, preg1);
+                    scaleIdx++;
+                }
+                LocalMemBar<MemType::VEC_STORE, MemType::VEC_STORE>();
+
+                // pad zero
+                padLocalAddr = padLocalAddr + concatColNum;
+                StoreUnAlign(padLocalAddr, (RegTensor<T1> &)zero, ureg1, padColNum);
+                StoreUnAlignPost(padLocalAddr, ureg1, 0);
+            }
+        } else {
+            // ── original group=64 path ──
+            for (uint16_t i = 0; i < curRowNum; i++) {
+                // cat rope
+                ropeXLocalAddr = ropeXLocalAddr + quantColNum;
+
+                LoadUnAlignPre(ureg0, ropeXLocalAddr);
+                LoadUnAlign(ropeReg, ureg0, ropeXLocalAddr, 64);
+                DataCopy(ropeYLocalAddr + i * dstCurColNumAlign / 2, ropeReg, pregRope);
+                LocalMemBar<MemType::VEC_STORE, MemType::VEC_STORE>();
+                uint32_t sreg = sregNum;
+                for (uint16_t j = 0; j < loopCount; j++) {
+                    pregLoop = UpdateMask<float>(sreg);
+                    LoadInputData<T0>(x0, xLocalAddr, pregLoop, j * VL_FP32 + i * curColNumAlign);
+                    Abs(x0Abs, x0, pregLoop);
+                    ReduceMax(max0, x0Abs, pregLoop);
+                    Maxs(max2, max0, static_cast<float>(1e-4), pregMerge);
+                    Muls(max2, max2, coeff, pregMerge);
+                    if constexpr (roundScale) {
+                        ShiftRights(vreg0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                    pregMerge);
+                        And(vreg1, vreg0, tmp0, pregMerge);
+                        And(vreg2, vreg1, tmp1, pregMerge);
+                        Compare<uint32_t, AscendC::CMPMODE::NE>(cmpMask, vreg2, zero, pregMerge);
+                        Select(vreg4, one, zero, cmpMask);
+                        Sub(vreg1, vreg1, tmp3, pregMerge);
+                        Add(vreg1, vreg1, vreg4, pregMerge);
+                        Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
+                        ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
+                    }
+                    Duplicate(dupScale, max2, pregMain);
+                    Div(x0, x0, dupScale, pregLoop);
+                    Maxs(x0, x0, fp8Min, pregLoop);
+                    Mins(x0, x0, fp8Max, pregLoop);
+                    StoreOutputData<T1>(yLocalAddr, x0, pregLoop, j * VL_FP32 + i * dstCurColNumAlign + ropeNum);
+
+                    // cat scale
+                    ShiftRights(scaleTmp0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                preg1);
+                    Cast<uint8_t, uint32_t, castTraitU32toU8Even>(scaleTmp1, scaleTmp0, preg1);
+                    DataCopy<T1, AscendC::MicroAPI::StoreDist::DIST_FIRST_ELEMENT_B8>(
+                        scaleLocalAddr + quantColNum + ropeNum + j + i * dstCurColNumAlign, (RegTensor<T1> &)scaleTmp1,
+                        preg1);
+                }
+                LocalMemBar<MemType::VEC_STORE, MemType::VEC_STORE>();
+
+                // pad zero
+                padLocalAddr = padLocalAddr + concatColNum;
+                StoreUnAlign(padLocalAddr, (RegTensor<T1> &)zero, ureg1, padColNum);
+                StoreUnAlignPost(padLocalAddr, ureg1, 0);
+            }
+        }
+    }
+}
+
+template <typename T0, typename T1, bool roundScale = true>
+__aicore__ inline void VFProcessDynamicMxFP8QuantLayout2(const LocalTensor<T1> &yLocal,
+                                                         const LocalTensor<T1> &scaleLocal,
+                                                         const LocalTensor<T0> &xLocal, float coeff, float fp8Min,
+                                                         float fp8Max, const uint16_t curRowNum,
+                                                         const uint32_t curColNum, const uint32_t valuePerToken,
+                                                         const uint32_t scalePerToken, const int64_t perGroupSize)
+{
+    __local_mem__ T1 *yLocalAddr = (__local_mem__ T1 *)yLocal.GetPhyAddr();
+    __local_mem__ T0 *xLocalAddr = (__local_mem__ T0 *)xLocal.GetPhyAddr();
+    __local_mem__ T1 *scaleAddr = (__local_mem__ T1 *)scaleLocal.GetPhyAddr();
+    __local_mem__ T0 *ropeXLocalAddr = (__local_mem__ T0 *)xLocal.GetPhyAddr();
+    __local_mem__ T0 *ropeYLocalAddr = (__local_mem__ T0 *)yLocal.GetPhyAddr();
+
+    uint32_t quantColNum = curColNum - 64;
+    uint16_t scaleColNum = CeilDiv(quantColNum, static_cast<int32_t>(perGroupSize));
+    uint16_t loopCount = CeilDiv(quantColNum, VL_FP32);
+    uint32_t curColNumAlign = RoundUp<T0>(curColNum);
+    uint32_t dstCurColNumAlign = RoundUp<T1>(valuePerToken);
+    uint16_t loopCountFoldTwo = loopCount / 2;
+    uint16_t loopCountReminder = loopCount % 2;
+    uint32_t tailReminder = quantColNum - (loopCount - 1) * VL_FP32;
+    uint32_t scaleColNumAlign = RoundUp<T0>(scaleColNum);
+    uint32_t sregNum = quantColNum;
+    uint32_t scaleStride = RoundUp<T1>(scalePerToken);
+    __VEC_SCOPE__
+    {
+        RegTensor<float> x0;
+        RegTensor<float> x0Abs;
+        RegTensor<float> x1;
+        RegTensor<float> x1Abs;
+        RegTensor<float> max0;
+        RegTensor<float> max1;
+        RegTensor<float> max2;
+        RegTensor<uint32_t> tmp0;
+        RegTensor<uint32_t> tmp1;
+        RegTensor<uint32_t> vreg0;
+        RegTensor<uint32_t> vreg1;
+        RegTensor<uint32_t> vreg2;
+        RegTensor<uint32_t> vreg3;
+        RegTensor<uint32_t> vreg4;
+        RegTensor<int32_t> vreg5;
+        RegTensor<uint32_t> zero;
+        RegTensor<uint32_t> one;
+        RegTensor<uint32_t> tmp3;
+        RegTensor<float> dupScale;
+        RegTensor<T0> ropeReg;
+        RegTensor<uint32_t> scaleTmp0;
+        RegTensor<uint8_t> scaleTmp1;
+        UnalignRegForLoad ureg0;
+        UnalignRegForStore ureg1;
+        UnalignRegForStore uregRopeStore;
+        MaskReg pregLoop;
+        MaskReg preg1 = CreateMask<T0, AscendC::MicroAPI::MaskPattern::VL1>();
+        MaskReg pregMerge = CreateMask<float, AscendC::MicroAPI::MaskPattern::VL1>();
+        MaskReg pregMain = CreateMask<float>();
+        MaskReg pregRope = CreateMask<T0, AscendC::MicroAPI::MaskPattern::VL64>();
+        MaskReg cmpMask;
+        Duplicate(tmp0, FAST_LOG_AND_VALUE1, pregMerge);
+        Duplicate(tmp1, FAST_LOG_AND_VALUE2, pregMerge);
+        Duplicate(zero, static_cast<uint32_t>(0), pregMerge);
+        Duplicate(one, static_cast<uint32_t>(1), pregMerge);
+        Duplicate(tmp3, static_cast<uint32_t>(127), pregMerge);
+        if (perGroupSize >= 128) {
+            // ── fold-two path: group_size=128, pair two 64-element groups per scale ──
+            uint32_t sregNumFold = quantColNum - loopCountFoldTwo * VL_FP32;
+            for (uint16_t i = 0; i < curRowNum; i++) {
+                // cat rope (use StoreUnAlign for non-32B-aligned dest when quantColNum % 32 != 0)
+                ropeXLocalAddr = ropeXLocalAddr + quantColNum;
+                LoadUnAlignPre(ureg0, ropeXLocalAddr);
+                LoadUnAlign(ropeReg, ureg0, ropeXLocalAddr, 64);
+                __local_mem__ T1 *ropeDstAddr = (__local_mem__ T1 *)yLocalAddr + i * dstCurColNumAlign + quantColNum;
+                StoreUnAlign(ropeDstAddr, (RegTensor<T1> &)ropeReg, uregRopeStore, 128);
+                StoreUnAlignPost(ropeDstAddr, uregRopeStore, 0);
+                LocalMemBar<MemType::VEC_STORE, MemType::VEC_STORE>();
+
+                uint32_t sreg = sregNumFold;
+                uint16_t scaleIdx = 0;
+
+                for (uint16_t g = 0; g < loopCountFoldTwo; g++) {
+                    uint16_t jL = g * 2;
+                    uint16_t jR = g * 2 + 1;
+                    pregLoop = UpdateMask<float>(sreg);
+
+                    LoadInputData<T0>(x0, xLocalAddr, pregMain, jL * VL_FP32 + i * curColNumAlign);
+                    LoadInputData<T0>(x1, xLocalAddr, pregLoop, jR * VL_FP32 + i * curColNumAlign);
+
+                    Abs(x0Abs, x0, pregMain);
+                    ReduceMax(max0, x0Abs, pregMain);
+                    Abs(x1Abs, x1, pregLoop);
+                    ReduceMax(max1, x1Abs, pregLoop);
+
+                    Max(max2, max0, max1, pregMerge);
+                    Maxs(max2, max2, static_cast<float>(1e-4), pregMerge);
+                    Muls(max2, max2, coeff, pregMerge);
+                    if constexpr (roundScale) {
+                        ShiftRights(vreg0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                    pregMerge);
+                        And(vreg1, vreg0, tmp0, pregMerge);
+                        And(vreg2, vreg1, tmp1, pregMerge);
+                        Compare<uint32_t, AscendC::CMPMODE::NE>(cmpMask, vreg2, zero, pregMerge);
+                        Select(vreg4, one, zero, cmpMask);
+                        Sub(vreg1, vreg1, tmp3, pregMerge);
+                        Add(vreg1, vreg1, vreg4, pregMerge);
+                        Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
+                        ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
+                    }
+
+                    Duplicate(dupScale, max2, pregMain);
+                    Div(x0, x0, dupScale, pregMain);
+                    Maxs(x0, x0, fp8Min, pregMain);
+                    Mins(x0, x0, fp8Max, pregMain);
+                    StoreOutputData<T1>(yLocalAddr, x0, pregMain, jL * VL_FP32 + i * dstCurColNumAlign);
+
+                    Div(x1, x1, dupScale, pregLoop);
+                    Maxs(x1, x1, fp8Min, pregLoop);
+                    Mins(x1, x1, fp8Max, pregLoop);
+                    StoreOutputData<T1>(yLocalAddr, x1, pregLoop, jR * VL_FP32 + i * dstCurColNumAlign);
+
+                    ShiftRights(scaleTmp0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                preg1);
+                    Cast<uint8_t, uint32_t, castTraitU32toU8Even>(scaleTmp1, scaleTmp0, preg1);
+                    DataCopy<T1, AscendC::MicroAPI::StoreDist::DIST_FIRST_ELEMENT_B8>(
+                        scaleAddr + i * scaleStride + scaleIdx, (RegTensor<T1> &)scaleTmp1, preg1);
+                    scaleIdx++;
+                }
+
+                // Tail block
+                for (uint16_t t = 0; t < loopCountReminder; t++) {
+                    uint16_t jT = loopCountFoldTwo * 2;
+                    uint32_t tailRem = quantColNum - jT * VL_FP32;
+                    pregLoop = UpdateMask<float>(tailRem);
+                    LoadInputData<T0>(x0, xLocalAddr, pregLoop, jT * VL_FP32 + i * curColNumAlign);
+                    Abs(x0Abs, x0, pregLoop);
+                    ReduceMax(max0, x0Abs, pregLoop);
+                    Maxs(max2, max0, static_cast<float>(1e-4), pregMerge);
+                    Muls(max2, max2, coeff, pregMerge);
+                    if constexpr (roundScale) {
+                        ShiftRights(vreg0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                    pregMerge);
+                        And(vreg1, vreg0, tmp0, pregMerge);
+                        And(vreg2, vreg1, tmp1, pregMerge);
+                        Compare<uint32_t, AscendC::CMPMODE::NE>(cmpMask, vreg2, zero, pregMerge);
+                        Select(vreg4, one, zero, cmpMask);
+                        Sub(vreg1, vreg1, tmp3, pregMerge);
+                        Add(vreg1, vreg1, vreg4, pregMerge);
+                        Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
+                        ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
+                    }
+                    Duplicate(dupScale, max2, pregLoop);
+                    Div(x0, x0, dupScale, pregLoop);
+                    Maxs(x0, x0, fp8Min, pregLoop);
+                    Mins(x0, x0, fp8Max, pregLoop);
+                    StoreOutputData<T1>(yLocalAddr, x0, pregLoop, jT * VL_FP32 + i * dstCurColNumAlign);
+
+                    ShiftRights(scaleTmp0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                preg1);
+                    Cast<uint8_t, uint32_t, castTraitU32toU8Even>(scaleTmp1, scaleTmp0, preg1);
+                    DataCopy<T1, AscendC::MicroAPI::StoreDist::DIST_FIRST_ELEMENT_B8>(
+                        scaleAddr + i * scaleStride + scaleIdx, (RegTensor<T1> &)scaleTmp1, preg1);
+                    scaleIdx++;
+                }
+                LocalMemBar<MemType::VEC_STORE, MemType::VEC_STORE>();
+            }
+        } else {
+            // ── original group=64 path ──
+            for (uint16_t i = 0; i < curRowNum; i++) {
+                // cat rope (use StoreUnAlign for non-32B-aligned dest when quantColNum % 32 != 0)
+                ropeXLocalAddr = ropeXLocalAddr + quantColNum;
+                LoadUnAlignPre(ureg0, ropeXLocalAddr);
+                LoadUnAlign(ropeReg, ureg0, ropeXLocalAddr, 64);
+                __local_mem__ T1 *ropeDstAddr2 = (__local_mem__ T1 *)yLocalAddr + i * dstCurColNumAlign + quantColNum;
+                StoreUnAlign(ropeDstAddr2, (RegTensor<T1> &)ropeReg, uregRopeStore, 128);
+                StoreUnAlignPost(ropeDstAddr2, uregRopeStore, 0);
+                LocalMemBar<MemType::VEC_STORE, MemType::VEC_STORE>();
+                uint32_t sreg = sregNum;
+                for (uint16_t j = 0; j < loopCount; j++) {
+                    pregLoop = UpdateMask<float>(sreg);
+                    LoadInputData<T0>(x0, xLocalAddr, pregLoop, j * VL_FP32 + i * curColNumAlign);
+                    Abs(x0Abs, x0, pregLoop);
+                    ReduceMax(max0, x0Abs, pregLoop);
+                    Maxs(max2, max0, static_cast<float>(1e-4), pregMerge);
+                    Muls(max2, max2, coeff, pregMerge);
+                    if constexpr (roundScale) {
+                        ShiftRights(vreg0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                    pregMerge);
+                        And(vreg1, vreg0, tmp0, pregMerge);
+                        And(vreg2, vreg1, tmp1, pregMerge);
+                        Compare<uint32_t, AscendC::CMPMODE::NE>(cmpMask, vreg2, zero, pregMerge);
+                        Select(vreg4, one, zero, cmpMask);
+                        Sub(vreg1, vreg1, tmp3, pregMerge);
+                        Add(vreg1, vreg1, vreg4, pregMerge);
+                        Adds(vreg5, (RegTensor<int32_t> &)vreg1, static_cast<int32_t>(127), pregMerge);
+                        ShiftLefts((RegTensor<int32_t> &)max2, vreg5, static_cast<int16_t>(23), pregMerge);
+                    }
+                    Duplicate(dupScale, max2, pregMain);
+                    Div(x0, x0, dupScale, pregLoop);
+                    Maxs(x0, x0, fp8Min, pregLoop);
+                    Mins(x0, x0, fp8Max, pregLoop);
+                    StoreOutputData<T1>(yLocalAddr, x0, pregLoop, j * VL_FP32 + i * dstCurColNumAlign);
+
+                    ShiftRights(scaleTmp0, (RegTensor<uint32_t> &)max2, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                preg1);
+                    Cast<uint8_t, uint32_t, castTraitU32toU8Even>(scaleTmp1, scaleTmp0, preg1);
+                    DataCopy<T1, AscendC::MicroAPI::StoreDist::DIST_FIRST_ELEMENT_B8>(
+                        scaleAddr + i * scaleStride + j, (RegTensor<T1> &)scaleTmp1, preg1);
+                }
+                LocalMemBar<MemType::VEC_STORE, MemType::VEC_STORE>();
+            }
+        }
+    }
+}
+
+template <typename T>
+__aicore__ inline void CopyIn(const GlobalTensor<T> &inputGm, const LocalTensor<T> &inputTensor, const uint16_t nBurst,
+                              const uint32_t copyLen, uint32_t srcStride = 0)
+{
+    DataCopyPadExtParams<T> dataCopyPadExtParams;
+    dataCopyPadExtParams.isPad = false;
+    dataCopyPadExtParams.leftPadding = 0;
+    dataCopyPadExtParams.rightPadding = 0;
+    dataCopyPadExtParams.paddingValue = 0;
+
+    DataCopyExtParams dataCoptExtParams;
+    dataCoptExtParams.blockCount = nBurst;
+    dataCoptExtParams.blockLen = copyLen * sizeof(T);
+    dataCoptExtParams.srcStride = srcStride * sizeof(T);
+    dataCoptExtParams.dstStride = 0;
+    DataCopyPad(inputTensor, inputGm, dataCoptExtParams, dataCopyPadExtParams);
+}
+
+template <typename T, AscendC::PaddingMode mode = AscendC::PaddingMode::Normal>
+__aicore__ inline void CopyOut(const LocalTensor<T> &outputTensor, const GlobalTensor<T> &outputGm,
+                               const uint16_t nBurst, const uint32_t copyLen, uint32_t dstStride = 0)
+{
+    DataCopyExtParams dataCopyParams;
+    dataCopyParams.blockCount = nBurst;
+    dataCopyParams.blockLen = copyLen * sizeof(T);
+    dataCopyParams.srcStride = 0;
+    dataCopyParams.dstStride = dstStride * sizeof(T);
+    DataCopyPad<T, mode>(outputGm, outputTensor, dataCopyParams);
+}
+
+}  // namespace KvCompressEpilogOps
+
+#endif

--- a/csrc/pytorch_extensions.cpp
+++ b/csrc/pytorch_extensions.cpp
@@ -152,6 +152,12 @@ TORCH_LIBRARY_FRAGMENT(npu, m)
         "int run_mode=0) -> Tensor");
 #endif
 
+#ifdef SGL_KERNEL_ENABLE_A5_ONLY_OPS
+    m.def(
+        "kv_compress_epilog(Tensor(a!) kv_compress_cache, Tensor x, Tensor slot_mapping, "
+        "int quant_group_size, int quant_mode, bool round_scale_flag, int layout) -> ()");
+#endif
+
 #ifdef BUILD_CATLASS_MODULE
     m.def("catlass_matmul_basic(Tensor tensor_a, Tensor tensor_b, Tensor(a!) tensor_c, str? format_mode=None) -> ()");
 
@@ -253,6 +259,10 @@ TORCH_LIBRARY_IMPL(npu, PrivateUse1, m)
             x, weight, bias_or_empty, conv_states, query_start_loc_or_empty, cache_indices_or_empty,
             has_initial_state_or_empty, num_accepted_tokens_or_empty, activation_mode, pad_slot_id, run_mode);
     });
+#endif
+
+#ifdef SGL_KERNEL_ENABLE_A5_ONLY_OPS
+    m.impl("kv_compress_epilog", TORCH_FN(sglang::npu_kernel::kv_compress_epilog));
 #endif
 
 #ifdef BUILD_CATLASS_MODULE

--- a/include/sgl_kenel_npu_ops.h
+++ b/include/sgl_kenel_npu_ops.h
@@ -155,6 +155,13 @@ at::Tensor lightning_indexer(
 at::Tensor tri_inv_col_sweep(const at::Tensor &tensor_in);
 #endif
 
+#ifdef SGL_KERNEL_ENABLE_A5_ONLY_OPS
+void kv_compress_epilog(at::Tensor &kv_compress_cache, const at::Tensor &x,
+                        const at::Tensor &slot_mapping,
+                        int64_t quant_group_size, int64_t quant_mode,
+                        bool round_scale_flag, int64_t layout);
+#endif
+
 #ifdef BUILD_CATLASS_MODULE
 void catlass_matmul_basic(const at::Tensor &tensor_a,
                           const at::Tensor &tensor_b, at::Tensor &tensor_c,

--- a/include/sgl_kenel_npu_ops.h
+++ b/include/sgl_kenel_npu_ops.h
@@ -155,6 +155,8 @@ at::Tensor lightning_indexer(
     c10::optional<c10::string_view> layout_key,
     c10::optional<int64_t> sparse_count, c10::optional<int64_t> sparse_mode);
 
+#endif
+
 at::Tensor compressor(const at::Tensor &x, const at::Tensor &wkv,
                       const at::Tensor &wgate, at::Tensor &state_cache,
                       const at::Tensor &ape, const at::Tensor &norm_weight,
@@ -195,7 +197,6 @@ std::tuple<at::Tensor, at::Tensor> sparse_attn_sharedkv(
  * is inversed.
  */
 at::Tensor tri_inv_col_sweep(const at::Tensor &tensor_in);
-#endif
 
 #ifdef SGL_KERNEL_ENABLE_A5_ONLY_OPS
 void kv_compress_epilog(at::Tensor &kv_compress_cache, const at::Tensor &x,

--- a/tests/python/sgl_kernel_npu/test_kv_compress_epilog.py
+++ b/tests/python/sgl_kernel_npu/test_kv_compress_epilog.py
@@ -1,0 +1,424 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# kv_compress_epilog (A5-only): fuses per-128-block FP8 / per-group MXFP8 quantization of
+# the first (d - 64) columns of x with an inline copy of the trailing 64 BF16 rope columns,
+# writing the packed row into the in-place kv_compress_cache. FP8 layout1 and MXFP8
+# layout2 store [quant | rope], while MXFP8 layout1 stores [rope | quant].
+#
+# The reference models are computed in plain PyTorch on CPU; the kernel is exercised with
+# the same inputs on the NPU and its output bytes are checked against the reference.
+
+import struct
+import unittest
+
+import numpy as np
+import sgl_kernel_npu
+import torch
+import torch_npu
+from utils import require_npu_op
+
+pytestmark = require_npu_op("kv_compress_epilog")
+
+DEVICE_ID = 0
+torch_npu.npu.set_device(int(DEVICE_ID))
+
+SLICE_SIZE = 64  # trailing BF16 rope columns kept verbatim
+FP8_E5M2_MAX = 57344.0
+FP8_E4M3FN_MAX = 448.0
+# Reciprocal-of-max constants the kernel uses for the FP8 path (bit patterns, not 1.0/max).
+INV_FP8_E5M2_BITS = 0x37924925
+INV_FP8_E4M3_BITS = 0x3B124925
+QUANT_MODE_FP8 = 1
+QUANT_MODE_MXFP8 = 2
+# Representative head dims cover both exact 128-wide groups and a partial final group.
+FP8_VALID_DIMS = (192, 320, 512)
+
+
+def _bits_to_float(bits):
+    return struct.unpack("<f", struct.pack("<I", bits))[0]
+
+
+def _assert_equal(actual, expected):
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def _layout1_dims(d, quant_mode, per_group_size):
+    """Return (quant_col, scale_col, concat_col, kv_cache_col) for a layout=1 row."""
+    quant_col = d - SLICE_SIZE
+    if quant_mode == QUANT_MODE_MXFP8:
+        scale_col = (quant_col + per_group_size - 1) // per_group_size
+        scale_bytes = 1
+    else:
+        scale_col = (quant_col + 127) // 128
+        scale_bytes = 4
+    concat_col = quant_col + 2 * SLICE_SIZE + scale_col * scale_bytes
+    kv_cache_col = ((concat_col + 127) // 128) * 128
+    return quant_col, scale_col, concat_col, kv_cache_col
+
+
+def _fp8_coeff(fp8_max):
+    # The FP8 path multiplies the block max by this bit pattern, so the reference must
+    # use the same constant rather than a correctly-rounded 1.0 / max.
+    return _bits_to_float(
+        INV_FP8_E4M3_BITS if fp8_max == FP8_E4M3FN_MAX else INV_FP8_E5M2_BITS
+    )
+
+
+def _mxfp8_coeff(fp8_max):
+    # The MXFP8 path uses maxValue = (float)1.0 / FP8_*_MAX_VALUE on the host/kernel side.
+    return np.float32(1.0) / np.float32(fp8_max)
+
+
+def _ref_fp8_scales(xf, d, fp8_max):
+    """Reference float32 scales for the FP8 path (one per 128-wide block)."""
+    quant_col, scale_col, _, _ = _layout1_dims(d, QUANT_MODE_FP8, 0)
+    coeff = _fp8_coeff(fp8_max)
+    scales = torch.zeros((xf.shape[0], scale_col), dtype=torch.float32)
+    for j in range(scale_col):
+        blk = xf[:, j * 128 : min((j + 1) * 128, quant_col)]
+        m = blk.abs().max(dim=1).values
+        scales[:, j] = m * coeff
+    return scales
+
+
+def _ref_mxfp8_scales(xf, d, per_group_size, fp8_max, round_scale):
+    """Reference E8M0 scale bytes for the MXFP8 path (one per per_group_size group)."""
+    _, scale_col, _, _ = _layout1_dims(d, QUANT_MODE_MXFP8, per_group_size)
+    coeff = float(_mxfp8_coeff(fp8_max))
+    out = torch.zeros((xf.shape[0], scale_col), dtype=torch.uint8)
+    for j in range(scale_col):
+        blk = xf[:, j * per_group_size : (j + 1) * per_group_size]
+        m = blk.abs().max(dim=1).values
+        m = torch.clamp(m, min=1e-4)
+        m2 = m * coeff  # float32 mul, mirrors Muls(max2, max2, coeff)
+        e = (m2.view(torch.int32) >> 23) & 0xFF  # biased exponent of max * coeff
+        if round_scale:
+            e = e + (e != 0).to(
+                torch.int32
+            )  # kernel re-bias logic always adds one step
+        out[:, j] = e.to(torch.uint8)
+    return out
+
+
+def _as_uint8(t):
+    """Reinterpret fp8 bytes as uint8 (little-endian byte order)."""
+    return t.cpu().contiguous().view(torch.uint8)
+
+
+def _make_inputs(
+    num_tokens,
+    num_slots,
+    d,
+    slot_dtype=torch.int32,
+    seed=0,
+    drop_slot=False,
+    slot_mapping_values=None,
+    fill_value=None,
+):
+    torch.manual_seed(seed)
+    if fill_value is None:
+        x = torch.randn(num_tokens, d, dtype=torch.bfloat16)
+    else:
+        x = torch.full((num_tokens, d), fill_value, dtype=torch.bfloat16)
+    if slot_mapping_values is None:
+        slot_mapping = torch.arange(num_tokens) % num_slots
+    else:
+        slot_mapping = torch.as_tensor(slot_mapping_values)
+    if drop_slot:
+        slot_mapping[0] = -1
+    return x, slot_mapping.to(slot_dtype)
+
+
+def _check_untouched_slots(byte, slot_mapping, valid):
+    """Rows no token maps to must remain all zero (kernel never touches them)."""
+    written = set(slot_mapping[valid].tolist())
+    for s in range(byte.shape[0]):
+        if s not in written:
+            _assert_equal(byte[s], torch.zeros_like(byte[s]))
+
+
+def _check_fp8_layout1(
+    num_tokens,
+    num_slots,
+    d,
+    fp8_max,
+    slot_dtype,
+    drop_slot,
+    seed,
+    slot_mapping_values=None,
+    fill_value=None,
+):
+    x, slot_mapping = _make_inputs(
+        num_tokens,
+        num_slots,
+        d,
+        slot_dtype,
+        seed,
+        drop_slot,
+        slot_mapping_values,
+        fill_value,
+    )
+    quant_col, scale_col, concat_col, kv_cache_col = _layout1_dims(d, QUANT_MODE_FP8, 0)
+    fp8_dtype = torch.float8_e4m3fn if fp8_max == FP8_E4M3FN_MAX else torch.float8_e5m2
+
+    cache = torch.zeros((num_slots, kv_cache_col), dtype=fp8_dtype).npu()
+    torch.ops.npu.kv_compress_epilog(
+        cache,
+        x.npu(),
+        slot_mapping.npu(),
+        quant_group_size=0,
+        quant_mode=QUANT_MODE_FP8,
+        round_scale_flag=False,
+        layout=1,
+    )
+    torch.npu.synchronize()
+
+    xf = x.float()
+    valid = slot_mapping != -1
+    written_slots = slot_mapping[valid].long()
+    byte = _as_uint8(cache)
+    cache_f32 = cache.cpu().float()
+
+    # 1. Stored per-block float32 scales must match the reference exactly.
+    scale_off = quant_col + 2 * SLICE_SIZE
+    scales_cached = (
+        byte[:, scale_off : scale_off + scale_col * 4].contiguous().view(torch.float32)
+    )
+    ref_scales = _ref_fp8_scales(xf, d, fp8_max)
+    torch.testing.assert_close(
+        scales_cached[written_slots], ref_scales[valid], rtol=1e-5, atol=1e-7
+    )
+
+    # 2. Dequantized quant region must recover x (FP8 has a ~6% relative step).
+    scales_exp = (
+        scales_cached[:, :, None]
+        .expand(-1, -1, 128)
+        .reshape(num_slots, -1)[:, :quant_col]
+    )
+    deq = cache_f32[:, :quant_col] * scales_exp
+    torch.testing.assert_close(
+        deq[written_slots], xf[valid, :quant_col], rtol=0.15, atol=0.02
+    )
+
+    # 3. The trailing 64 BF16 rope columns are copied byte-exactly.
+    rope_bytes = byte[:, quant_col : quant_col + 2 * SLICE_SIZE]
+    rope_ref = x[:, -SLICE_SIZE:].contiguous().view(torch.uint8)
+    _assert_equal(rope_bytes[written_slots], rope_ref[valid])
+
+    # 4. Row padding is zero-filled.
+    _assert_equal(byte[:, concat_col:], torch.zeros_like(byte[:, concat_col:]))
+
+    _check_untouched_slots(byte, slot_mapping, valid)
+
+
+def _check_mxfp8_layout1(
+    num_tokens, num_slots, d, per_group_size, fp8_max, round_scale, seed
+):
+    x, slot_mapping = _make_inputs(num_tokens, num_slots, d, seed=seed, drop_slot=True)
+    quant_col, scale_col, concat_col, kv_cache_col = _layout1_dims(
+        d, QUANT_MODE_MXFP8, per_group_size
+    )
+    fp8_dtype = torch.float8_e4m3fn if fp8_max == FP8_E4M3FN_MAX else torch.float8_e5m2
+
+    cache = torch.zeros((num_slots, kv_cache_col), dtype=fp8_dtype).npu()
+    torch.ops.npu.kv_compress_epilog(
+        cache,
+        x.npu(),
+        slot_mapping.npu(),
+        quant_group_size=per_group_size,
+        quant_mode=QUANT_MODE_MXFP8,
+        round_scale_flag=round_scale,
+        layout=1,
+    )
+    torch.npu.synchronize()
+
+    xf = x.float()
+    valid = slot_mapping != -1
+    byte = _as_uint8(cache)
+    cache_f32 = cache.cpu().float()
+
+    # 1. Stored E8M0 scale bytes must match the reference exactly.
+    scale_off = quant_col + 2 * SLICE_SIZE
+    scale_cached = byte[:, scale_off : scale_off + scale_col]
+    ref_scales = _ref_mxfp8_scales(xf, d, per_group_size, fp8_max, round_scale)
+    _assert_equal(scale_cached[valid], ref_scales[valid])
+
+    if round_scale:
+        # 2. Dequant: value * 2^(scale - 127). The kernel divides by 2^(s-127) when rounding.
+        divisor = torch.pow(2.0, scale_cached.to(torch.float32) - 127.0)
+        divisor_exp = (
+            divisor[:, :, None]
+            .expand(-1, -1, per_group_size)
+            .reshape(num_slots, -1)[:, :quant_col]
+        )
+        # MXFP8 layout1 stores the 128-byte BF16 rope prefix before FP8 values.
+        value_off = 2 * SLICE_SIZE
+        deq = cache_f32[:, value_off : value_off + quant_col] * divisor_exp
+        torch.testing.assert_close(
+            deq[valid], xf[valid, :quant_col], rtol=0.25, atol=0.02
+        )
+
+    # 3. Rope columns copied byte-exactly.
+    rope_ref = x[:, -SLICE_SIZE:].contiguous().view(torch.uint8)
+    _assert_equal(byte[:, : 2 * SLICE_SIZE][valid], rope_ref[valid])
+
+    # 4. Row padding is zero-filled.
+    _assert_equal(byte[:, concat_col:], torch.zeros_like(byte[:, concat_col:]))
+    _check_untouched_slots(byte, slot_mapping, valid)
+
+
+def _check_mxfp8_layout2(num_tokens, d, per_group_size, block_size, fp8_max, seed):
+    quant_col, scale_col, _, _ = _layout1_dims(d, QUANT_MODE_MXFP8, per_group_size)
+    value_per_token = quant_col + 2 * SLICE_SIZE
+    scale_per_token = ((scale_col + 7) // 8) * 8
+    block_stride = block_size * (value_per_token + scale_per_token)
+    num_blocks = (num_tokens + block_size - 1) // block_size
+    fp8_dtype = torch.float8_e4m3fn if fp8_max == FP8_E4M3FN_MAX else torch.float8_e5m2
+
+    x, slot_mapping = _make_inputs(num_tokens, num_tokens, d, seed=seed, drop_slot=True)
+    cache = torch.zeros(
+        (num_blocks, block_size, value_per_token + scale_per_token), dtype=fp8_dtype
+    ).npu()
+    torch.ops.npu.kv_compress_epilog(
+        cache,
+        x.npu(),
+        slot_mapping.npu(),
+        quant_group_size=per_group_size,
+        quant_mode=QUANT_MODE_MXFP8,
+        round_scale_flag=True,
+        layout=2,
+    )
+    torch.npu.synchronize()
+
+    xf = x.float()
+    cache_flat = cache.cpu().reshape(num_blocks, block_stride)  # fp8
+    byte_flat = _as_uint8(cache).reshape(num_blocks, block_stride)
+    ref_scales = _ref_mxfp8_scales(xf, d, per_group_size, fp8_max, True)
+    rope_ref = x[:, -SLICE_SIZE:].contiguous().view(torch.uint8)
+
+    for i in range(num_tokens):
+        s = int(slot_mapping[i].item())
+        if s == -1:
+            continue
+        b, si = divmod(s, block_size)
+        val = cache_flat[
+            b, si * value_per_token : si * value_per_token + value_per_token
+        ]
+        # value region = [fp8 quant][BF16 rope bytes]
+        scales = torch.pow(2.0, ref_scales[i].to(torch.float32) - 127.0)
+        scales_exp = scales[:, None].expand(-1, per_group_size).reshape(-1)[:quant_col]
+        deq = val[:quant_col].float() * scales_exp
+        torch.testing.assert_close(deq, xf[i, :quant_col], rtol=0.25, atol=0.02)
+        _assert_equal(_as_uint8(val[quant_col:]), rope_ref[i])
+        # All scale bytes for this slot (not just the first group).
+        scale_off = block_size * value_per_token + si * scale_per_token
+        _assert_equal(byte_flat[b, scale_off : scale_off + scale_col], ref_scales[i])
+
+    written_slots = set(slot_mapping[slot_mapping != -1].tolist())
+    for s in range(num_blocks * block_size):
+        if s in written_slots:
+            continue
+        b, si = divmod(s, block_size)
+        value_off = si * value_per_token
+        scale_off = block_size * value_per_token + si * scale_per_token
+        _assert_equal(
+            byte_flat[b, value_off : value_off + value_per_token],
+            torch.zeros(value_per_token, dtype=torch.uint8),
+        )
+        _assert_equal(
+            byte_flat[b, scale_off : scale_off + scale_per_token],
+            torch.zeros(scale_per_token, dtype=torch.uint8),
+        )
+
+
+class TestKvCompressEpilog(unittest.TestCase):
+
+    def test_fp8_e4m3fn_layout1_single_block(self):
+        # d=192: one 128-wide quant block, single slot per row.
+        _check_fp8_layout1(
+            16, 16, 192, FP8_E4M3FN_MAX, torch.int32, drop_slot=True, seed=0
+        )
+
+    def test_fp8_e4m3fn_layout1_multi_block_scales(self):
+        # d=320: two 128-wide quant blocks -> two inline float32 scales.
+        _check_fp8_layout1(
+            16, 16, 320, FP8_E4M3FN_MAX, torch.int32, drop_slot=True, seed=1
+        )
+
+    def test_fp8_e5m2_layout1_int64_slots(self):
+        # Exercises the e5m2 cache + int64 slot_mapping dtype combination.
+        _check_fp8_layout1(
+            16, 16, 192, FP8_E5M2_MAX, torch.int64, drop_slot=True, seed=2
+        )
+
+    def test_fp8_e4m3fn_layout1_multi_core(self):
+        # Large batch to exercise multi-core tiling and the rowFactor UB loop.
+        _check_fp8_layout1(
+            4096, 4096, 320, FP8_E4M3FN_MAX, torch.int32, drop_slot=False, seed=3
+        )
+
+    def test_fp8_e5m2_layout1_d512_sparse_shuffled_slots(self):
+        # Covers the upstream production shape, a partial final 128-wide group,
+        # and non-contiguous scatter destinations in one focused case.
+        slot_mapping = (
+            torch.randperm(64, generator=torch.Generator().manual_seed(4)) * 2
+        )
+        _check_fp8_layout1(
+            64,
+            128,
+            512,
+            FP8_E5M2_MAX,
+            torch.int32,
+            drop_slot=False,
+            seed=4,
+            slot_mapping_values=slot_mapping,
+        )
+
+    def test_fp8_e4m3fn_layout1_zero_input(self):
+        # Exercises the zero block-max path without accepting NaN quant results.
+        _check_fp8_layout1(
+            16,
+            16,
+            192,
+            FP8_E4M3FN_MAX,
+            torch.int32,
+            drop_slot=False,
+            seed=5,
+            fill_value=0.0,
+        )
+
+    def test_mxfp8_e4m3fn_layout1_group64_round_scale(self):
+        _check_mxfp8_layout1(16, 16, 192, 64, FP8_E4M3FN_MAX, round_scale=True, seed=4)
+
+    def test_mxfp8_e4m3fn_layout1_group128_no_round_scale(self):
+        # round_scale=False: scale bytes are the raw biased exponents (no dequant check).
+        _check_mxfp8_layout1(
+            16, 16, 192, 128, FP8_E4M3FN_MAX, round_scale=False, seed=5
+        )
+
+    def test_mxfp8_e5m2_layout1_group64_round_scale(self):
+        _check_mxfp8_layout1(16, 16, 192, 64, FP8_E5M2_MAX, round_scale=True, seed=6)
+
+    def test_mxfp8_e4m3fn_layout1_group64_multi_row(self):
+        # Exercises rowFactor > 1 for the MXFP8 path at the upstream D=512 shape.
+        _check_mxfp8_layout1(
+            4096, 4096, 512, 64, FP8_E4M3FN_MAX, round_scale=True, seed=7
+        )
+
+    def test_mxfp8_e4m3fn_layout2(self):
+        # Block-major layout: [num_blocks, block_size, value_per_token + scale_per_token].
+        _check_mxfp8_layout2(16, 192, 128, 8, FP8_E4M3FN_MAX, seed=7)
+
+    def test_mxfp8_e4m3fn_layout2_multi_scale_partial_block(self):
+        # Four scales per token plus a partially occupied final cache block.
+        _check_mxfp8_layout2(17, 320, 64, 8, FP8_E4M3FN_MAX, seed=9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/sgl_kernel_npu/test_kv_compress_epilog.py
+++ b/tests/python/sgl_kernel_npu/test_kv_compress_epilog.py
@@ -249,20 +249,23 @@ def _check_mxfp8_layout1(
     ref_scales = _ref_mxfp8_scales(xf, d, per_group_size, fp8_max, round_scale)
     _assert_equal(scale_cached[valid], ref_scales[valid])
 
-    if round_scale:
-        # 2. Dequant: value * 2^(scale - 127). The kernel divides by 2^(s-127) when rounding.
-        divisor = torch.pow(2.0, scale_cached.to(torch.float32) - 127.0)
-        divisor_exp = (
-            divisor[:, :, None]
-            .expand(-1, -1, per_group_size)
-            .reshape(num_slots, -1)[:, :quant_col]
-        )
-        # MXFP8 layout1 stores the 128-byte BF16 rope prefix before FP8 values.
-        value_off = 2 * SLICE_SIZE
-        deq = cache_f32[:, value_off : value_off + quant_col] * divisor_exp
-        torch.testing.assert_close(
-            deq[valid], xf[valid, :quant_col], rtol=0.25, atol=0.02
-        )
+    # 2. Quantization must use the power-of-two scale represented by the stored
+    # E8M0 exponent. Values that exceed the FP8 range under that scale saturate.
+    divisor = torch.pow(2.0, scale_cached.to(torch.float32) - 127.0)
+    divisor_exp = (
+        divisor[:, :, None]
+        .expand(-1, -1, per_group_size)
+        .reshape(num_slots, -1)[:, :quant_col]
+    )
+    value_off = 2 * SLICE_SIZE
+    deq = cache_f32[:, value_off : value_off + quant_col] * divisor_exp
+    expected = xf[valid, :quant_col]
+    unsaturated = (expected.abs() / divisor_exp[valid]) <= fp8_max
+    if not unsaturated.any():
+        raise AssertionError("test input must contain unsaturated MXFP8 values")
+    torch.testing.assert_close(
+        deq[valid][unsaturated], expected[unsaturated], rtol=0.25, atol=0.02
+    )
 
     # 3. Rope columns copied byte-exactly.
     rope_ref = x[:, -SLICE_SIZE:].contiguous().view(torch.uint8)
@@ -393,11 +396,30 @@ class TestKvCompressEpilog(unittest.TestCase):
             fill_value=0.0,
         )
 
+    def test_fp8_layout2_rejected(self):
+        d = 192
+        block_size = 8
+        x = torch.randn(1, d, dtype=torch.bfloat16).npu()
+        slot_mapping = torch.zeros(1, dtype=torch.int32).npu()
+        cache = torch.zeros(
+            (1, block_size, d + SLICE_SIZE), dtype=torch.float8_e4m3fn
+        ).npu()
+
+        with self.assertRaisesRegex(RuntimeError, "layout=2 only supports MXFP8"):
+            torch.ops.npu.kv_compress_epilog(
+                cache,
+                x,
+                slot_mapping,
+                quant_group_size=0,
+                quant_mode=QUANT_MODE_FP8,
+                round_scale_flag=False,
+                layout=2,
+            )
+
     def test_mxfp8_e4m3fn_layout1_group64_round_scale(self):
         _check_mxfp8_layout1(16, 16, 192, 64, FP8_E4M3FN_MAX, round_scale=True, seed=4)
 
     def test_mxfp8_e4m3fn_layout1_group128_no_round_scale(self):
-        # round_scale=False: scale bytes are the raw biased exponents (no dequant check).
         _check_mxfp8_layout1(
             16, 16, 192, 128, FP8_E4M3FN_MAX, round_scale=False, seed=5
         )


### PR DESCRIPTION
 ## Background

  SGLang on Ascend A5 requires a fused KV-cache epilogue to quantize KV features and write them directly to mapped cache slots. This PR
  ports kv_compress_epilog from vLLM Ascend and integrates it into sgl-kernel-npu.

  The operator supports FP8 and MXFP8 compression while preserving the trailing 64-dimensional RoPE data in BF16.

  ## Changes

  - Added the Ascend C implementation, host-side tiling, and launch logic for kv_compress_epilog.
  - Registered the operator through the PyTorch extension and public C++ interface.
  - Added A5-specific build guards and source integration.
  - Supported:
      - FP8 E4M3FN and E5M2.
      - MXFP8 with configurable quantization group sizes.
      - Layout 1 and Layout 2.
      - int32 and int64 slot mappings.
      - Sparse, skipped, and shuffled cache slots.

  - Fixed scale output addressing for multi-row and multi-core execution.
  - Limited FP8 quantization and scale reduction to the actual quantized region, excluding the trailing RoPE columns.
  - Corrected reference scale calculation for partial final quantization groups.

  ## Testing

### UT
  Ran:

  python3 tests/python/sgl_kernel_npu/test_kv_compress_epilog.py

  Result:

  Ran 12 tests
  OK

  The tests cover:

  - FP8 E4M3FN and E5M2.
  - MXFP8 group sizes 64 and 128.
  - Layout 1 and Layout 2.
  - Head dimensions 192, 320, and 512.
  - Single-core and multi-core execution.
  - Sparse, shuffled, skipped, int32, and int64 slot mappings.
  - Partial quantization groups and partially populated cache blocks.
  - Zero-valued inputs.
  - Exact scale storage, byte-exact RoPE copies, zero-filled padding, untouched slots, and dequantized output accuracy.

### Performance

```plaintext
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 48        
Successful requests:                     96        
Benchmark duration (s):                  110.86    
Total input tokens:                      786432    
Total input text tokens:                 786432    
Total generated tokens:                  98304     
Total generated tokens (retokenized):    98304     
Request throughput (req/s):              0.87      
Input token throughput (tok/s):          7093.76   
Output token throughput (tok/s):         886.72    
Peak output token throughput (tok/s):    3222.00   
Peak concurrent requests:                70        
Total token throughput (tok/s):          7980.48   
Concurrency:                             47.76     
Accept length:                           2.76      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   55159.02  
Median E2E Latency (ms):                 54823.97  
P90 E2E Latency (ms):                    71948.33  
P95 E2E Latency (ms):                    72051.95  
P99 E2E Latency (ms):                    72053.71  
---------------Time to First Token----------------
Mean TTFT (ms):                          15801.15  
Median TTFT (ms):                        14537.57  
P90 TTFT (ms):                           30895.25  
P95 TTFT (ms):                           33208.50  
P99 TTFT (ms):                           33273.75  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          38.47     
Median TPOT (ms):                        38.75     
P90 TPOT (ms):                           54.76     
P95 TPOT (ms):                           57.19     
P99 TPOT (ms):                           62.11     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           38.47     
Median ITL (ms):                         18.31     
P90 ITL (ms):                            23.61     
P95 ITL (ms):                            28.11     
P99 ITL (ms):                            356.98    
Max ITL (ms):                            9891.89   
==================================================
```

### accuracy
```plaintext
  run_eval(args)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:52<00:00,  3.83it/s]
Accuracy: 0.975
Invalid: 0.000
Latency: 52.429 s
Output throughput: 367.372 token/s
```
<img width="375" height="115" alt="image" src="https://github.com/user-attachments/assets/2405fe4c-888c-4fc0-8d94-2dbd33bc66be" />
