### PR TITLE
ci: treat all-skipped kernel tests as pass in finish gate

### DIFF
--- a/.github/workflows/pr-test-kernels.yml
+++ b/.github/workflows/pr-test-kernels.yml
@@ -552,7 +552,7 @@ jobs:
             fi
           done
           if [ "$any_run" = "false" ]; then
-            echo "All operator test jobs were skipped: no test-group/common paths changed."
-            exit 1
+            echo "All operator test jobs were skipped: no test-group/common paths changed. Nothing to gate, treat as pass."
+            exit 0
           fi
           echo "All kernel operator tests passed"


### PR DESCRIPTION
## Problem
`finish` gate in `pr-test-kernels.yml` exits 1 when ALL test-group jobs are skipped.

This happens when a PR touches files matching the workflow-level path filter (e.g. `csrc/**`) but none of the per-group/common path filters — e.g. #722 changed only `csrc/sparse_attention_score/op_kernel/arch35/*.h`. Result: all 7 test jobs skipped, `finish` fails, PR is blocked by the required check even though no kernel test needed to run.

## Fix
When no test job actually ran (all skipped), `finish` now exits 0 (nothing to gate). Real failures / cancellations still exit 1 and block the PR.

## Verification
- #722 (which hit this): all 7 test jobs `skipped`, `Check changed files` success → previously `finish: failure`; after this fix `finish` would pass.
- A PR that changes a test-group path still runs that group; if it fails, `finish` still fails. Behavior for the "tests actually ran" path is unchanged.
