### PR TITLE
[DeepEP] Normal dispatch&combine performance optimization

### DIFF
--- a/csrc/deepep/deep_ep.cpp
+++ b/csrc/deepep/deep_ep.cpp
@@ -289,12 +289,16 @@ Buffer::intranode_dispatch(const at::Tensor &x, const std::optional<at::Tensor> 
     } else {
         HCCL_CHECK(HcclGetCommName(ep_comm, hcom_ep_name));
     }
-    at::Tensor total_recv_token = torch::empty({1}, at::dtype(at::kInt).device(x.device()));
+    // 将 max_bs / total_recv_token / recv_tokens_per_expert 合并进同一块连续 buffer，
+    // 布局 [max_bs, total_recv_token, recv_tokens_per_expert(round*num_local_experts)]，
+    // 以便 notify_dispatch 之后仅需一次 D2H 即可读回全部值，消除多次 host 同步停顿。
+    const int64_t nel = static_cast<int64_t>(num_local_experts);
+    at::Tensor recv_header = torch::empty({2 + static_cast<int64_t>(round) * nel}, at::dtype(at::kInt).device(x.device()));
+    at::Tensor max_bs = recv_header.narrow(0, 0, 1);
+    at::Tensor total_recv_token = recv_header.narrow(0, 1, 1);
+    at::Tensor recv_tokens_per_expert = recv_header.narrow(0, 2, static_cast<int64_t>(round) * nel);
     at::Tensor recv_offset = at::empty({round, num_experts}, at::dtype(at::kInt).device(x.device()));
     at::Tensor recv_count = at::empty({round, num_experts}, at::dtype(at::kInt).device(x.device()));
-    at::Tensor max_bs = torch::empty({1}, at::dtype(at::kInt).device(x.device()));
-    at::Tensor recv_tokens_per_expert =
-        torch::empty({round * num_local_experts}, at::dtype(at::kInt).device(x.device()));
     at::Tensor expert_global_offset = at::empty({num_local_experts}, at::dtype(at::kInt).device(x.device()));
     at::Tensor srcrank_in_expert_offset =
         at::empty({num_local_experts * num_ranks}, at::dtype(at::kInt).device(x.device()));
@@ -319,12 +323,16 @@ Buffer::intranode_dispatch(const at::Tensor &x, const std::optional<at::Tensor> 
                  recv_offset, expert_global_offset, srcrank_in_expert_offset, r_in_srcrank_offset, total_recv_token,
                  max_bs, recv_tokens_per_expert);
     auto send_token_idx_small = this->send_token_idx_small;
-    real_max_bs = static_cast<int64_t>(std::max(max_bs.item<int>(), static_cast<int>(num_worst_tokens)));
+    // 仅一次 D2H 读回整个 recv_header，max_bs / total_recv_token / recv_tokens_per_expert 均从 host 缓存取值，
+    // 避免 dispatch 前后多次独立读取造成的 host 同步停顿。
+    auto recv_header_cpu = recv_header.to(at::kCPU);
+    const int32_t *header_ptr = recv_header_cpu.data_ptr<int32_t>();
+    real_max_bs = static_cast<int64_t>(std::max(static_cast<int>(header_ptr[0]), static_cast<int>(num_worst_tokens)));
 
     // dispatch算子内部按照 min(per_round_tokens, real_max_bs)来预留显存
     int64_t global_bs = static_cast<int64_t>(std::min(static_cast<int64_t>(per_round_tokens), real_max_bs) * num_ranks);
 
-    int64_t trt = total_recv_token.item<int>();
+    int64_t trt = static_cast<int64_t>(header_ptr[1]);
     int num_recv_tokens = (trt == 0) ? 1 : trt;
     is_mxfp8_quant = use_quant && (quant_type == "mx_fp8_e4m3" || quant_type == "mx_fp8_e5m2");
     bool is_mxfp4_quant = use_quant && (quant_type == "mx_fp4_e2m1");
@@ -378,8 +386,9 @@ Buffer::intranode_dispatch(const at::Tensor &x, const std::optional<at::Tensor> 
                  rank,       // rankId
                  hcom_ep_name, tp_size, tp_rank, num_experts, quant_mode, real_max_bs, global_bs, round,
                  per_round_tokens, expandx_out, dynamic_scales_out, expand_idx_out, dispatch_wait_recv_cost_stats_out);
-    auto recv_token_per_exp_cpu = recv_tokens_per_expert.to(at::kCPU);
-    auto recv_token_per_exp_ptr = recv_token_per_exp_cpu.data_ptr<int32_t>();
+    // recv_tokens_per_expert 已随 recv_header 在 dispatch 前一次性读回 host（header_ptr + 2），
+    // 此处直接复用缓存，不再发起第二次 D2H 读取。
+    const int32_t *recv_token_per_exp_ptr = header_ptr + 2;
 
     int token_cnt = 0;
     // 多轮处理为一维

--- a/csrc/deepep/deep_ep.cpp
+++ b/csrc/deepep/deep_ep.cpp
@@ -293,7 +293,8 @@ Buffer::intranode_dispatch(const at::Tensor &x, const std::optional<at::Tensor> 
     // 布局 [max_bs, total_recv_token, recv_tokens_per_expert(round*num_local_experts)]，
     // 以便 notify_dispatch 之后仅需一次 D2H 即可读回全部值，消除多次 host 同步停顿。
     const int64_t nel = static_cast<int64_t>(num_local_experts);
-    at::Tensor recv_header = torch::empty({2 + static_cast<int64_t>(round) * nel}, at::dtype(at::kInt).device(x.device()));
+    at::Tensor recv_header =
+        torch::empty({2 + static_cast<int64_t>(round) * nel}, at::dtype(at::kInt).device(x.device()));
     at::Tensor max_bs = recv_header.narrow(0, 0, 1);
     at::Tensor total_recv_token = recv_header.narrow(0, 1, 1);
     at::Tensor recv_tokens_per_expert = recv_header.narrow(0, 2, static_cast<int64_t>(round) * nel);

--- a/csrc/deepep/deep_ep.cpp
+++ b/csrc/deepep/deep_ep.cpp
@@ -289,9 +289,9 @@ Buffer::intranode_dispatch(const at::Tensor &x, const std::optional<at::Tensor> 
     } else {
         HCCL_CHECK(HcclGetCommName(ep_comm, hcom_ep_name));
     }
-    // 将 max_bs / total_recv_token / recv_tokens_per_expert 合并进同一块连续 buffer，
-    // 布局 [max_bs, total_recv_token, recv_tokens_per_expert(round*num_local_experts)]，
-    // 以便 notify_dispatch 之后仅需一次 D2H 即可读回全部值，消除多次 host 同步停顿。
+    // Merge max_bs / total_recv_token / recv_tokens_per_expert into one contiguous buffer,
+    // layout [max_bs, total_recv_token, recv_tokens_per_expert(round*num_local_experts)],
+    // so a single D2H read after notify_dispatch fetches all values back, eliminating multiple host sync stalls.
     const int64_t nel = static_cast<int64_t>(num_local_experts);
     at::Tensor recv_header =
         torch::empty({2 + static_cast<int64_t>(round) * nel}, at::dtype(at::kInt).device(x.device()));
@@ -324,8 +324,8 @@ Buffer::intranode_dispatch(const at::Tensor &x, const std::optional<at::Tensor> 
                  recv_offset, expert_global_offset, srcrank_in_expert_offset, r_in_srcrank_offset, total_recv_token,
                  max_bs, recv_tokens_per_expert);
     auto send_token_idx_small = this->send_token_idx_small;
-    // 仅一次 D2H 读回整个 recv_header，max_bs / total_recv_token / recv_tokens_per_expert 均从 host 缓存取值，
-    // 避免 dispatch 前后多次独立读取造成的 host 同步停顿。
+    // Read back the whole recv_header with a single D2H; max_bs / total_recv_token / recv_tokens_per_expert
+    // are all taken from the host cache, avoiding host sync stalls from multiple independent reads around dispatch.
     auto recv_header_cpu = recv_header.to(at::kCPU);
     const int32_t *header_ptr = recv_header_cpu.data_ptr<int32_t>();
     real_max_bs = static_cast<int64_t>(std::max(static_cast<int>(header_ptr[0]), static_cast<int>(num_worst_tokens)));
@@ -387,8 +387,6 @@ Buffer::intranode_dispatch(const at::Tensor &x, const std::optional<at::Tensor> 
                  rank,       // rankId
                  hcom_ep_name, tp_size, tp_rank, num_experts, quant_mode, real_max_bs, global_bs, round,
                  per_round_tokens, expandx_out, dynamic_scales_out, expand_idx_out, dispatch_wait_recv_cost_stats_out);
-    // recv_tokens_per_expert 已随 recv_header 在 dispatch 前一次性读回 host（header_ptr + 2），
-    // 此处直接复用缓存，不再发起第二次 D2H 读取。
     const int32_t *recv_token_per_exp_ptr = header_ptr + 2;
 
     int token_cnt = 0;

--- a/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_a5.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_a5.h
@@ -20,7 +20,9 @@ constexpr uint32_t MUL_256_ALIGN = 256U;
 constexpr uint64_t WIN_512_ALIGN = 512UL;
 constexpr uint32_t FLOAT_NUM_PER_ALIGN = 8U;
 constexpr uint8_t DOUBLE_BUFFER = 2;
+constexpr uint32_t BATCH_SRC_INFO_CNT = 128U;  // srcInfo 批处理
 constexpr int64_t CYCLE_TO_TIME = 1000;  // cycle num is converted into a fixed base unit of time, set at 1000
+constexpr int64_t WAIT_TIMEOUT_US = 10 * 1000 * 1000;
 
 template <AscendC::HardEvent event>
 __aicore__ inline void SyncFunc()
@@ -56,6 +58,7 @@ private:
     __aicore__ inline void CopyBufferToShareAndSetStatus();
     __aicore__ inline void CopyBufferToShare(uint32_t srcRankId, uint32_t srcTokenId, uint32_t srcTopkId,
                                              uint32_t tkIndex);
+    __aicore__ inline void ProcessSendRange(uint32_t lo, uint32_t cnt, LocalTensor<int32_t> sendCostStatsTensor);
     __aicore__ inline void ReadBufferFromRemote();
     __aicore__ inline void WaitBuffCopy(uint32_t tokenIndex, uint32_t startTokenIndex);
     __aicore__ inline void SetStatusBySrcInfo(uint32_t srcRankId, uint32_t srcTokenId, uint32_t srcTopkId);
@@ -125,6 +128,9 @@ private:
     TBuf<> srcInfoBuf_;
     TBuf<> xOutBuf_;
     TBuf<> tempStateBuf_;
+    TBuf<> recvCountBuf_;        // epRecvCount（E*W 前缀和）拷贝到 UB
+    TBuf<> sendRangeOffsetBuf_;  // 本核子区间列表：起始 token 偏移
+    TBuf<> sendRangeCntBuf_;     // 本核子区间列表：token 数
 
     GlobalTensor<RecvXType> recvXGM_;
     GlobalTensor<SrcInfoType> tokenSrcInfoGM_;
@@ -229,25 +235,28 @@ template <TemplateMC2TypeClass>
 __aicore__ inline void CamMoeCombineNormalA5<TemplateMC2TypeFunc>::CopyBufferToShareAndSetStatus()
 {
     PipeBarrier<PIPE_ALL>();
-    uint32_t perBlockSendNum = 0, startTokenId = 0, endTokenId = 0;
-    SplitCoreCal(selfSendCnt_, perBlockSendNum, startTokenId, endTokenId);
-    if (perBlockSendNum == 0U) {
-        return;
-    }
+    // ---------- 分核：rank-major 两级切分（第一级按 rank，第二级组内按 token 数均衡）----------
+    uint32_t subRangeNum = 0U;    // 本核负责的子区间个数
+    uint32_t totalTokenCnt = 0U;  // 本核负责的 token 总数（打点用）
+    uint32_t myRank = 0U;  // 本核写入的目标 rank（rank-major 分支有效；A<W 降级路径打点用哨兵）
 
-    uint32_t blockLen = static_cast<uint32_t>(perBlockSendNum * TOKEN_SRC_INFO_LEN * sizeof(uint32_t));
     tpipe_->Reset();
+    uint32_t recvCountAlignLen = Ceil(moeExpertNum_ * sizeof(int32_t), UB_32_ALIGN) * UB_32_ALIGN;
+    uint32_t rangeCntAlignLen = Ceil(moeExpertPerRankNum_ * sizeof(int32_t), UB_32_ALIGN) * UB_32_ALIGN;
+    uint32_t srcInfoAlignLen =
+        Ceil(BATCH_SRC_INFO_CNT * TOKEN_SRC_INFO_LEN * sizeof(SrcInfoType), UB_32_ALIGN) * UB_32_ALIGN;
+    tpipe_->InitBuffer(recvCountBuf_, recvCountAlignLen);
+    tpipe_->InitBuffer(sendRangeOffsetBuf_, rangeCntAlignLen);
+    tpipe_->InitBuffer(sendRangeCntBuf_, rangeCntAlignLen);
     tpipe_->InitBuffer(stateBuf_, UB_32_ALIGN);
     tpipe_->InitBuffer(localCopyQueue_, DOUBLE_BUFFER, h32AlignRecvXLen_);
-    tpipe_->InitBuffer(srcInfoBuf_, blockLen);
+    tpipe_->InitBuffer(srcInfoBuf_, srcInfoAlignLen);
+
+    LocalTensor<SrcInfoType> recvCountLocal = recvCountBuf_.Get<SrcInfoType>();
+    LocalTensor<uint32_t> sendRangeOffsetLT = sendRangeOffsetBuf_.Get<uint32_t>();
+    LocalTensor<uint32_t> sendRangeCntLT = sendRangeCntBuf_.Get<uint32_t>();
     LocalTensor<uint32_t> statusTensor = stateBuf_.Get<uint32_t>();
     Duplicate<uint32_t>(statusTensor, 0x3F800000, FLOAT_NUM_PER_ALIGN);
-
-    LocalTensor<SrcInfoType> srcInfoLocal = srcInfoBuf_.Get<SrcInfoType>();
-    const DataCopyExtParams dataCopyParams{1U, blockLen, 0U, 0U, 0U};
-    const DataCopyPadExtParams<SrcInfoType> padParams{false, 0U, 0U, 0U};
-    DataCopyPad(srcInfoLocal, tokenSrcInfoGM_[startTokenId * TOKEN_SRC_INFO_LEN], dataCopyParams, padParams);
-    SyncFunc<AscendC::HardEvent::MTE2_S>();
 
     LocalTensor<int32_t> sendCostStatsTensor;
     if (isEnableDiagnose_) {
@@ -256,23 +265,89 @@ __aicore__ inline void CamMoeCombineNormalA5<TemplateMC2TypeFunc>::CopyBufferToS
         Duplicate<int32_t>(sendCostStatsTensor, 0, sendCostStatsBufSize_ / sizeof(int32_t));
     }
 
-    for (uint32_t tokenIndex = startTokenId; tokenIndex < endTokenId; tokenIndex++) {
-        uint32_t index = (tokenIndex - startTokenId) * TOKEN_SRC_INFO_LEN;
-        uint32_t srcRankId = static_cast<uint32_t>(srcInfoLocal(index + RANK_ID_OFFSET_IN_SRC_INFO));
-        uint32_t srcTokenId = static_cast<uint32_t>(srcInfoLocal(index + TOKEN_IDX_OFFSET_IN_SRC_INFO));
-        uint32_t srcTopkId = static_cast<uint32_t>(srcInfoLocal(index + TOPK_IDX_OFFSET_IN_SRC_INFO));
-        int64_t sendStartCycle = GetSystemCycle();
+    // 读 epRecvCount（E*W 个 int32，expert-major / rank-minor 全前缀和）到 UB
+    const DataCopyExtParams countDp{1U, static_cast<uint32_t>(moeExpertNum_ * sizeof(int32_t)), 0U, 0U, 0U};
+    const DataCopyPadExtParams<SrcInfoType> countPad{false, 0U, 0U, 0U};
+    DataCopyPad(recvCountLocal, epRecvCountGM_[0], countDp, countPad);
+    SyncFunc<AscendC::HardEvent::MTE2_S>();
 
-        CopyBufferToShare(srcRankId, srcTokenId, srcTopkId, tokenIndex);
-        PipeBarrier<PIPE_ALL>();
-        SetStatusBySrcInfo(srcRankId, srcTokenId, srcTopkId);
-
-        if (isEnableDiagnose_) {
-            SyncFunc<AscendC::HardEvent::MTE3_S>();
-            int32_t durationTime = static_cast<int32_t>((GetSystemCycle() - sendStartCycle) / CYCLE_TO_TIME);  // us
-            int32_t preTime = sendCostStatsTensor.GetValue(srcRankId);
-            sendCostStatsTensor.SetValue(srcRankId, preTime + durationTime);
+    uint32_t perRankCore = aivNum_ / epWorldSize_;
+    if (perRankCore == 0U) {
+        // A < W（核数少于 rank 数）：降级为按总 token 数切连续段（与现状一致）
+        uint32_t perBlockSendNum = 0U, startTokenId = 0U, endTokenId = 0U;
+        SplitCoreCal(selfSendCnt_, perBlockSendNum, startTokenId, endTokenId);
+        if (perBlockSendNum == 0U) {
+            return;
         }
+        sendRangeOffsetLT(0U) = startTokenId;
+        sendRangeCntLT(0U) = perBlockSendNum;
+        subRangeNum = 1U;
+        totalTokenCnt = perBlockSendNum;
+    } else {
+        // 第一级：按 rank 分核。rank r 的核组 = [r*perRankCore+min(r,remRankCore),
+        //                                     +perRankCore+(r<remRankCore?1:0))
+        uint32_t remRankCore = aivNum_ % epWorldSize_;
+        uint32_t groupStart = 0U, groupSize = 0U;
+        for (uint32_t r = 0U; r < epWorldSize_; ++r) {
+            uint32_t gStart = r * perRankCore + (r < remRankCore ? r : remRankCore);
+            uint32_t gEnd = gStart + perRankCore + (r < remRankCore ? 1U : 0U);
+            if (coreIdx_ >= gStart && coreIdx_ < gEnd) {
+                myRank = r;
+                groupStart = gStart;
+                groupSize = gEnd - gStart;
+                break;
+            }
+        }
+        uint32_t k = coreIdx_ - groupStart;
+
+        // rank myRank 的 token 总数 T_r = Σ blockCount(e,myRank)
+        // （与下方子区间映射用同一套块计数，保证 [tStart,tEnd) 落在 [0,T_r) 内）
+        uint32_t rankTotal = 0U;
+        for (uint32_t e = 0U; e < moeExpertPerRankNum_; ++e) {
+            uint32_t blockIdx = e * epWorldSize_ + myRank;
+            uint32_t hi = static_cast<uint32_t>(recvCountLocal(blockIdx));
+            uint32_t lo = (blockIdx == 0U) ? 0U : static_cast<uint32_t>(recvCountLocal(blockIdx - 1));
+            rankTotal += hi - lo;
+        }
+
+        // 第二级：组内按 token 数均分，得到本核 token 区间 [tStart, tEnd)
+        uint32_t perCoreToken = rankTotal / groupSize;
+        uint32_t remToken = rankTotal % groupSize;
+        uint32_t tStart = perCoreToken * k + (k < remToken ? k : remToken);
+        uint32_t tEnd = tStart + perCoreToken + (k < remToken ? 1U : 0U);
+        if (tStart == tEnd) {
+            return;
+        }
+
+        // 把 [tStart, tEnd) 映射回各专家块的子区间（按 e 递增累计 blockCount(e,myRank)）
+        uint32_t consumed = 0U;
+        for (uint32_t e = 0U; e < moeExpertPerRankNum_; ++e) {
+            if (consumed >= tEnd) {
+                break;
+            }
+            uint32_t blockIdx = e * epWorldSize_ + myRank;
+            uint32_t hi = static_cast<uint32_t>(recvCountLocal(blockIdx));
+            uint32_t lo = (blockIdx == 0U) ? 0U : static_cast<uint32_t>(recvCountLocal(blockIdx - 1));
+            uint32_t cnt = hi - lo;
+            if (consumed + cnt <= tStart) {
+                consumed += cnt;
+                continue;
+            }
+            uint32_t subLo = lo + ((consumed < tStart) ? (tStart - consumed) : 0U);
+            uint32_t subHi = lo + ((consumed + cnt > tEnd) ? (tEnd - consumed) : cnt);
+            if (subHi > subLo) {
+                sendRangeOffsetLT(subRangeNum) = subLo;
+                sendRangeCntLT(subRangeNum) = subHi - subLo;
+                ++subRangeNum;
+            }
+            consumed += cnt;
+        }
+        totalTokenCnt = tEnd - tStart;
+    }
+
+    // ---------- 发送：遍历本核子区间，保持原有每 token 交错结构（copy + PipeBarrier + status）----------
+    for (uint32_t si = 0U; si < subRangeNum; ++si) {
+        ProcessSendRange(sendRangeOffsetLT(si), sendRangeCntLT(si), sendCostStatsTensor);
     }
 
     if (isEnableDiagnose_) {
@@ -285,6 +360,41 @@ __aicore__ inline void CamMoeCombineNormalA5<TemplateMC2TypeFunc>::CopyBufferToS
     }
 
     SyncFunc<AscendC::HardEvent::MTE3_S>();
+}
+
+template <TemplateMC2TypeClass>
+__aicore__ inline void CamMoeCombineNormalA5<TemplateMC2TypeFunc>::ProcessSendRange(uint32_t lo, uint32_t cnt,
+                                                                                     LocalTensor<int32_t> sendCostStatsTensor)
+{
+    LocalTensor<SrcInfoType> srcInfoLocal = srcInfoBuf_.Get<SrcInfoType>();
+    const DataCopyPadExtParams<SrcInfoType> padParams{false, 0U, 0U, 0U};
+    for (uint32_t batchStart = 0U; batchStart < cnt; batchStart += BATCH_SRC_INFO_CNT) {
+        uint32_t batchCnt = (cnt - batchStart) < BATCH_SRC_INFO_CNT ? (cnt - batchStart) : BATCH_SRC_INFO_CNT;
+        uint32_t batchBytes = batchCnt * TOKEN_SRC_INFO_LEN * sizeof(SrcInfoType);
+        const DataCopyExtParams dataCopyParams{1U, batchBytes, 0U, 0U, 0U};
+        DataCopyPad(srcInfoLocal, tokenSrcInfoGM_[(lo + batchStart) * TOKEN_SRC_INFO_LEN], dataCopyParams, padParams);
+        SyncFunc<AscendC::HardEvent::MTE2_S>();
+
+        for (uint32_t j = 0U; j < batchCnt; ++j) {
+            uint32_t index = j * TOKEN_SRC_INFO_LEN;
+            uint32_t srcRankId = static_cast<uint32_t>(srcInfoLocal(index + RANK_ID_OFFSET_IN_SRC_INFO));
+            uint32_t srcTokenId = static_cast<uint32_t>(srcInfoLocal(index + TOKEN_IDX_OFFSET_IN_SRC_INFO));
+            uint32_t srcTopkId = static_cast<uint32_t>(srcInfoLocal(index + TOPK_IDX_OFFSET_IN_SRC_INFO));
+            uint32_t tkIndex = lo + batchStart + j;
+            int64_t sendStartCycle = GetSystemCycle();
+
+            CopyBufferToShare(srcRankId, srcTokenId, srcTopkId, tkIndex);
+            PipeBarrier<PIPE_ALL>();
+            SetStatusBySrcInfo(srcRankId, srcTokenId, srcTopkId);
+
+            if (isEnableDiagnose_) {
+                SyncFunc<AscendC::HardEvent::MTE3_S>();
+                int32_t durationTime = static_cast<int32_t>((GetSystemCycle() - sendStartCycle) / CYCLE_TO_TIME);  // us
+                int32_t preTime = sendCostStatsTensor.GetValue(srcRankId);
+                sendCostStatsTensor.SetValue(srcRankId, preTime + durationTime);
+            }
+        }
+    }
 }
 
 template <TemplateMC2TypeClass>

--- a/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_a5.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_a5.h
@@ -21,7 +21,7 @@ constexpr uint64_t WIN_512_ALIGN = 512UL;
 constexpr uint32_t FLOAT_NUM_PER_ALIGN = 8U;
 constexpr uint8_t DOUBLE_BUFFER = 2;
 constexpr uint32_t BATCH_SRC_INFO_CNT = 128U;  // srcInfo 批处理
-constexpr int64_t CYCLE_TO_TIME = 1000;  // cycle num is converted into a fixed base unit of time, set at 1000
+constexpr int64_t CYCLE_TO_TIME = 1000;        // cycle num is converted into a fixed base unit of time, set at 1000
 constexpr int64_t WAIT_TIMEOUT_US = 10 * 1000 * 1000;
 
 template <AscendC::HardEvent event>
@@ -363,8 +363,8 @@ __aicore__ inline void CamMoeCombineNormalA5<TemplateMC2TypeFunc>::CopyBufferToS
 }
 
 template <TemplateMC2TypeClass>
-__aicore__ inline void CamMoeCombineNormalA5<TemplateMC2TypeFunc>::ProcessSendRange(uint32_t lo, uint32_t cnt,
-                                                                                     LocalTensor<int32_t> sendCostStatsTensor)
+__aicore__ inline void CamMoeCombineNormalA5<TemplateMC2TypeFunc>::ProcessSendRange(
+    uint32_t lo, uint32_t cnt, LocalTensor<int32_t> sendCostStatsTensor)
 {
     LocalTensor<SrcInfoType> srcInfoLocal = srcInfoBuf_.Get<SrcInfoType>();
     const DataCopyPadExtParams<SrcInfoType> padParams{false, 0U, 0U, 0U};

--- a/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_a5.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_a5.h
@@ -20,7 +20,7 @@ constexpr uint32_t MUL_256_ALIGN = 256U;
 constexpr uint64_t WIN_512_ALIGN = 512UL;
 constexpr uint32_t FLOAT_NUM_PER_ALIGN = 8U;
 constexpr uint8_t DOUBLE_BUFFER = 2;
-constexpr uint32_t BATCH_SRC_INFO_CNT = 128U;  // srcInfo 批处理
+constexpr uint32_t BATCH_SRC_INFO_CNT = 128U;  // srcInfo batching
 constexpr int64_t CYCLE_TO_TIME = 1000;        // cycle num is converted into a fixed base unit of time, set at 1000
 
 template <AscendC::HardEvent event>
@@ -127,9 +127,9 @@ private:
     TBuf<> srcInfoBuf_;
     TBuf<> xOutBuf_;
     TBuf<> tempStateBuf_;
-    TBuf<> recvCountBuf_;        // epRecvCount（E*W 前缀和）拷贝到 UB
-    TBuf<> sendRangeOffsetBuf_;  // 本核子区间列表：起始 token 偏移
-    TBuf<> sendRangeCntBuf_;     // 本核子区间列表：token 数
+    TBuf<> recvCountBuf_;        // epRecvCount (E*W prefix sum) copied to UB
+    TBuf<> sendRangeOffsetBuf_;  // sub-range list of this core: start token offset
+    TBuf<> sendRangeCntBuf_;     // sub-range list of this core: token count
 
     GlobalTensor<RecvXType> recvXGM_;
     GlobalTensor<SrcInfoType> tokenSrcInfoGM_;
@@ -234,10 +234,11 @@ template <TemplateMC2TypeClass>
 __aicore__ inline void CamMoeCombineNormalA5<TemplateMC2TypeFunc>::CopyBufferToShareAndSetStatus()
 {
     PipeBarrier<PIPE_ALL>();
-    // ---------- 分核：rank-major 两级切分（第一级按 rank，第二级组内按 token 数均衡）----------
-    uint32_t subRangeNum = 0U;    // 本核负责的子区间个数
-    uint32_t totalTokenCnt = 0U;  // 本核负责的 token 总数（打点用）
-    uint32_t myRank = 0U;  // 本核写入的目标 rank（rank-major 分支有效；A<W 降级路径打点用哨兵）
+    // Core split: rank-major two-level partition (level 1 by rank, level 2 balances token count within group)
+    uint32_t subRangeNum = 0U;    // number of sub-ranges handled by this core
+    uint32_t totalTokenCnt = 0U;  // total token count handled by this core (for profiling)
+    uint32_t myRank = 0U;  // target rank this core writes to (valid in rank-major branch; sentinel for profiling in the
+                           // A<W fallback path)
 
     tpipe_->Reset();
     uint32_t recvCountAlignLen = Ceil(moeExpertNum_ * sizeof(int32_t), UB_32_ALIGN) * UB_32_ALIGN;
@@ -264,7 +265,7 @@ __aicore__ inline void CamMoeCombineNormalA5<TemplateMC2TypeFunc>::CopyBufferToS
         Duplicate<int32_t>(sendCostStatsTensor, 0, sendCostStatsBufSize_ / sizeof(int32_t));
     }
 
-    // 读 epRecvCount（E*W 个 int32，expert-major / rank-minor 全前缀和）到 UB
+    // Read epRecvCount (E*W int32, expert-major / rank-minor full prefix sum) into UB
     const DataCopyExtParams countDp{1U, static_cast<uint32_t>(moeExpertNum_ * sizeof(int32_t)), 0U, 0U, 0U};
     const DataCopyPadExtParams<SrcInfoType> countPad{false, 0U, 0U, 0U};
     DataCopyPad(recvCountLocal, epRecvCountGM_[0], countDp, countPad);
@@ -272,7 +273,8 @@ __aicore__ inline void CamMoeCombineNormalA5<TemplateMC2TypeFunc>::CopyBufferToS
 
     uint32_t perRankCore = aivNum_ / epWorldSize_;
     if (perRankCore == 0U) {
-        // A < W（核数少于 rank 数）：降级为按总 token 数切连续段（与现状一致）
+        // A < W (fewer cores than ranks): fall back to splitting into contiguous segments by total token count (same as
+        // before)
         uint32_t perBlockSendNum = 0U, startTokenId = 0U, endTokenId = 0U;
         SplitCoreCal(selfSendCnt_, perBlockSendNum, startTokenId, endTokenId);
         if (perBlockSendNum == 0U) {
@@ -283,8 +285,8 @@ __aicore__ inline void CamMoeCombineNormalA5<TemplateMC2TypeFunc>::CopyBufferToS
         subRangeNum = 1U;
         totalTokenCnt = perBlockSendNum;
     } else {
-        // 第一级：按 rank 分核。rank r 的核组 = [r*perRankCore+min(r,remRankCore),
-        //                                     +perRankCore+(r<remRankCore?1:0))
+        // Level 1: split cores by rank. Core group of rank r = [r*perRankCore+min(r,remRankCore),
+        //                                                        +perRankCore+(r<remRankCore?1:0))
         uint32_t remRankCore = aivNum_ % epWorldSize_;
         uint32_t groupStart = 0U, groupSize = 0U;
         for (uint32_t r = 0U; r < epWorldSize_; ++r) {
@@ -299,8 +301,8 @@ __aicore__ inline void CamMoeCombineNormalA5<TemplateMC2TypeFunc>::CopyBufferToS
         }
         uint32_t k = coreIdx_ - groupStart;
 
-        // rank myRank 的 token 总数 T_r = Σ blockCount(e,myRank)
-        // （与下方子区间映射用同一套块计数，保证 [tStart,tEnd) 落在 [0,T_r) 内）
+        // Total token count T_r of rank myRank = Σ blockCount(e,myRank)
+        // (same block counting as the sub-range mapping below, guaranteeing [tStart,tEnd) lies within [0,T_r))
         uint32_t rankTotal = 0U;
         for (uint32_t e = 0U; e < moeExpertPerRankNum_; ++e) {
             uint32_t blockIdx = e * epWorldSize_ + myRank;
@@ -309,7 +311,7 @@ __aicore__ inline void CamMoeCombineNormalA5<TemplateMC2TypeFunc>::CopyBufferToS
             rankTotal += hi - lo;
         }
 
-        // 第二级：组内按 token 数均分，得到本核 token 区间 [tStart, tEnd)
+        // Level 2: split evenly by token count within the group to get this core's token range [tStart, tEnd)
         uint32_t perCoreToken = rankTotal / groupSize;
         uint32_t remToken = rankTotal % groupSize;
         uint32_t tStart = perCoreToken * k + (k < remToken ? k : remToken);
@@ -318,7 +320,7 @@ __aicore__ inline void CamMoeCombineNormalA5<TemplateMC2TypeFunc>::CopyBufferToS
             return;
         }
 
-        // 把 [tStart, tEnd) 映射回各专家块的子区间（按 e 递增累计 blockCount(e,myRank)）
+        // Map [tStart, tEnd) back to sub-ranges of each expert block (accumulate blockCount(e,myRank) in increasing e)
         uint32_t consumed = 0U;
         for (uint32_t e = 0U; e < moeExpertPerRankNum_; ++e) {
             if (consumed >= tEnd) {
@@ -344,7 +346,8 @@ __aicore__ inline void CamMoeCombineNormalA5<TemplateMC2TypeFunc>::CopyBufferToS
         totalTokenCnt = tEnd - tStart;
     }
 
-    // ---------- 发送：遍历本核子区间，保持原有每 token 交错结构（copy + PipeBarrier + status）----------
+    // Send: iterate over this core's sub-ranges, keeping the original per-token interleaved structure (copy +
+    // PipeBarrier + status)
     for (uint32_t si = 0U; si < subRangeNum; ++si) {
         ProcessSendRange(sendRangeOffsetLT(si), sendRangeCntLT(si), sendCostStatsTensor);
     }

--- a/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_a5.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_a5.h
@@ -22,7 +22,6 @@ constexpr uint32_t FLOAT_NUM_PER_ALIGN = 8U;
 constexpr uint8_t DOUBLE_BUFFER = 2;
 constexpr uint32_t BATCH_SRC_INFO_CNT = 128U;  // srcInfo 批处理
 constexpr int64_t CYCLE_TO_TIME = 1000;        // cycle num is converted into a fixed base unit of time, set at 1000
-constexpr int64_t WAIT_TIMEOUT_US = 10 * 1000 * 1000;
 
 template <AscendC::HardEvent event>
 __aicore__ inline void SyncFunc()

--- a/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_multi_round.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_multi_round.h
@@ -138,7 +138,8 @@ private:
     uint32_t startBlockId_{0};
     uint32_t endBlockId_{0};
     uint32_t preRecvCount_{0};
-    uint32_t sendTargetRank_{0};  // 本核发送打点中记录的目标 rank（rank-major 分核后每核固定一个目标 rank）
+    uint32_t sendTargetRank_{0};  // target rank recorded in this core's send profiling (each core has a fixed target
+                                  // rank after rank-major split)
     // recv用到的数据
     uint32_t totalNeedRecvTokenCnt_{0};   // 剩余需要接收的token数，初始化为axisBS_
     uint32_t roundTotalRecvTokenCnt_{0};  // 每一轮所有核需要接收的总token数
@@ -274,7 +275,8 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitR
 
     uint32_t perRankCore = aivNum_ / epWorldSize_;
     if (perRankCore == 0U) {
-        // A < W（核数少于 rank 数）：无法按 rank 分核，降级为按总 token 数切连续段（flat）
+        // A < W (fewer cores than ranks): cannot split by rank, fall back to contiguous segments by total token count
+        // (flat)
         uint32_t selfSendCnt = static_cast<uint32_t>(recvCountLT(moeExpertNum_ - 1));
         uint32_t flatStart = 0, flatEnd = 0, perCoreSendCnt = 0;
         SplitCoreCal(selfSendCnt, perCoreSendCnt, flatStart, flatEnd);
@@ -304,7 +306,7 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitR
         return;
     }
 
-    // ---------- 第一级：按 rank 分核（与单轮 cam_moe_combine_normal A5 一致）----------
+    // Level 1: split cores by rank (consistent with single-round cam_moe_combine_normal A5)
     uint32_t remRankCore = aivNum_ % epWorldSize_;
     uint32_t myRank = 0;
     uint32_t groupStart = 0;
@@ -322,7 +324,8 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitR
     uint32_t k = coreIdx_ - groupStart;
     sendTargetRank_ = myRank;
 
-    // 本核固定只写 rank myRank 的窗口；rank myRank 的 token 总数 T_r = Σ_e blockCount(e, myRank)
+    // This core always writes to the window of rank myRank; total token count T_r of rank myRank = Σ_e blockCount(e,
+    // myRank)
     uint32_t rankTotal = 0;
     for (uint32_t e = 0; e < moeExpertPerRankNum_; ++e) {
         uint32_t blockIdx = e * epWorldSize_ + myRank;
@@ -331,7 +334,7 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitR
         rankTotal += hi - lo;
     }
 
-    // ---------- 第二级：组内按 token 数均分，得到本核 token 区间 [tStart, tEnd) ----------
+    //  Level 2: split evenly by token count within the group to get this core's token range [tStart, tEnd)
     uint32_t perCoreToken = rankTotal / groupSize;
     uint32_t remToken = rankTotal % groupSize;
     uint32_t tStart = perCoreToken * k + (k < remToken ? k : remToken);
@@ -341,14 +344,15 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitR
     }
     needSendTokenCnt_ = tEnd - tStart;
 
-    // 缓冲按最大块数（moeExpertPerRankNum_）预分配，填充时统计实际块数
+    // Pre-allocate buffers by the maximum block count (moeExpertPerRankNum_); count the actual blocks while filling
     uint32_t sendBlockAlignLen = Ceil(moeExpertPerRankNum_ * sizeof(int32_t), UB_32_ALIGN) * UB_32_ALIGN;
     tpipe_->InitBuffer(roundNeedSendCntBuf_, sendBlockAlignLen);
     tpipe_->InitBuffer(roundSendOffsetBuf_, sendBlockAlignLen);
     roundNeedSendCntLT_ = roundNeedSendCntBuf_.Get<uint32_t>();
     roundSendOffsetLT_ = roundSendOffsetBuf_.Get<uint32_t>();
 
-    // 把 [tStart, tEnd) 映射回 myRank 各专家块的子区间（块内为全局 token 索引）
+    // Map [tStart, tEnd) back to sub-ranges of myRank's expert blocks (within a block, indices are global token
+    // indices)
     perCoreBlockNum_ = 0;
     uint32_t consumed = 0;
     for (uint32_t e = 0; e < moeExpertPerRankNum_; ++e) {

--- a/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_multi_round.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_multi_round.h
@@ -67,7 +67,8 @@ private:
     __aicore__ inline void SetStatusBySrcInfo(uint32_t srcRankId, uint32_t srcTokenId, uint32_t srcTopkId);
     __aicore__ inline void ReadBufferAndWeightedSum(uint32_t recvXTokenIdx, uint32_t topkWeightTokenIdx);
     __aicore__ inline void InitRoundSendData();
-    __aicore__ inline void InitTokenBalancedRoundSendDataA5();
+    __aicore__ inline void InitRankMajorRoundSendDataA5();
+    __aicore__ inline void InitSendA5CommonBuffers();
     __aicore__ inline void SetRoundStatus();
     __aicore__ inline void WaitRoundStatus();
     __aicore__ inline void InitRoundRecvData();
@@ -137,6 +138,7 @@ private:
     uint32_t startBlockId_{0};
     uint32_t endBlockId_{0};
     uint32_t preRecvCount_{0};
+    uint32_t sendTargetRank_{0};  // 本核发送打点中记录的目标 rank（rank-major 分核后每核固定一个目标 rank）
     // recv用到的数据
     uint32_t totalNeedRecvTokenCnt_{0};   // 剩余需要接收的token数，初始化为axisBS_
     uint32_t roundTotalRecvTokenCnt_{0};  // 每一轮所有核需要接收的总token数
@@ -258,59 +260,126 @@ __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitB
 }
 
 template <TemplateMC2TypeClass>
-__aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitTokenBalancedRoundSendDataA5()
+__aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitRankMajorRoundSendDataA5()
 {
     uint32_t expertCountLen = moeExpertNum_ * sizeof(int32_t);
     uint32_t expertCountAlignLen = Ceil(expertCountLen, UB_32_ALIGN) * UB_32_ALIGN;
     tpipe_->Reset();
     tpipe_->InitBuffer(tempRecvCountBuf_, expertCountAlignLen);
-    LocalTensor<int32_t> expertEndOffsetLT = tempRecvCountBuf_.Get<int32_t>();
+    LocalTensor<int32_t> recvCountLT = tempRecvCountBuf_.Get<int32_t>();
     const DataCopyExtParams expertCountCopyParams{1U, expertCountLen, 0U, 0U, 0U};
     const DataCopyPadExtParams<int32_t> expertCountPadParams{false, 0U, 0U, 0U};
-    DataCopyPad(expertEndOffsetLT, epRecvCountGM_, expertCountCopyParams, expertCountPadParams);
+    DataCopyPad(recvCountLT, epRecvCountGM_, expertCountCopyParams, expertCountPadParams);
     SyncFunc<HardEvent::MTE2_S>();
 
-    uint32_t selfSendCnt = static_cast<uint32_t>(expertEndOffsetLT(moeExpertNum_ - 1));
-    uint32_t flatStart = 0;
-    uint32_t flatEnd = 0;
-    uint32_t perCoreSendCnt = 0;
-    SplitCoreCal(selfSendCnt, perCoreSendCnt, flatStart, flatEnd);
-    if (perCoreSendCnt == 0) {
+    uint32_t perRankCore = aivNum_ / epWorldSize_;
+    if (perRankCore == 0U) {
+        // A < W（核数少于 rank 数）：无法按 rank 分核，降级为按总 token 数切连续段（flat）
+        uint32_t selfSendCnt = static_cast<uint32_t>(recvCountLT(moeExpertNum_ - 1));
+        uint32_t flatStart = 0, flatEnd = 0, perCoreSendCnt = 0;
+        SplitCoreCal(selfSendCnt, perCoreSendCnt, flatStart, flatEnd);
+        if (perCoreSendCnt == 0) {
+            return;
+        }
+        needSendTokenCnt_ = perCoreSendCnt;
+        preRecvCount_ = flatStart;
+        uint32_t sendBlockAlignLen = Ceil(moeExpertNum_ * sizeof(int32_t), UB_32_ALIGN) * UB_32_ALIGN;
+        tpipe_->InitBuffer(roundNeedSendCntBuf_, sendBlockAlignLen);
+        tpipe_->InitBuffer(roundSendOffsetBuf_, sendBlockAlignLen);
+        roundNeedSendCntLT_ = roundNeedSendCntBuf_.Get<uint32_t>();
+        roundSendOffsetLT_ = roundSendOffsetBuf_.Get<uint32_t>();
+        perCoreBlockNum_ = 0;
+        for (uint32_t blockIdx = 0; blockIdx < moeExpertNum_; ++blockIdx) {
+            uint32_t blockStart = blockIdx == 0 ? 0 : static_cast<uint32_t>(recvCountLT(blockIdx - 1));
+            uint32_t blockEnd = static_cast<uint32_t>(recvCountLT(blockIdx));
+            uint32_t segmentStart = max(flatStart, blockStart);
+            uint32_t segmentEnd = min(flatEnd, blockEnd);
+            if (segmentStart < segmentEnd) {
+                roundSendOffsetLT_(perCoreBlockNum_) = segmentStart;
+                roundNeedSendCntLT_(perCoreBlockNum_) = segmentEnd - segmentStart;
+                ++perCoreBlockNum_;
+            }
+        }
+        InitSendA5CommonBuffers();
         return;
     }
 
-    preRecvCount_ = flatStart;
-    needSendTokenCnt_ = perCoreSendCnt;
-    perCoreBlockNum_ = 0;
-    for (uint32_t expertId = 0; expertId < moeExpertNum_; ++expertId) {
-        uint32_t expertStart = expertId == 0 ? 0 : static_cast<uint32_t>(expertEndOffsetLT(expertId - 1));
-        uint32_t expertEnd = static_cast<uint32_t>(expertEndOffsetLT(expertId));
-        uint32_t segmentStart = max(flatStart, expertStart);
-        uint32_t segmentEnd = min(flatEnd, expertEnd);
-        if (segmentStart < segmentEnd) {
-            ++perCoreBlockNum_;
+    // ---------- 第一级：按 rank 分核（与单轮 cam_moe_combine_normal A5 一致）----------
+    uint32_t remRankCore = aivNum_ % epWorldSize_;
+    uint32_t myRank = 0;
+    uint32_t groupStart = 0;
+    uint32_t groupSize = 0;
+    for (uint32_t r = 0; r < epWorldSize_; ++r) {
+        uint32_t gStart = r * perRankCore + (r < remRankCore ? r : remRankCore);
+        uint32_t gEnd = gStart + perRankCore + (r < remRankCore ? 1U : 0U);
+        if (coreIdx_ >= gStart && coreIdx_ < gEnd) {
+            myRank = r;
+            groupStart = gStart;
+            groupSize = gEnd - gStart;
+            break;
         }
     }
+    uint32_t k = coreIdx_ - groupStart;
+    sendTargetRank_ = myRank;
 
-    uint32_t sendBlockAlignLen = Ceil(perCoreBlockNum_ * sizeof(int32_t), UB_32_ALIGN) * UB_32_ALIGN;
+    // 本核固定只写 rank myRank 的窗口；rank myRank 的 token 总数 T_r = Σ_e blockCount(e, myRank)
+    uint32_t rankTotal = 0;
+    for (uint32_t e = 0; e < moeExpertPerRankNum_; ++e) {
+        uint32_t blockIdx = e * epWorldSize_ + myRank;
+        uint32_t hi = static_cast<uint32_t>(recvCountLT(blockIdx));
+        uint32_t lo = (blockIdx == 0U) ? 0U : static_cast<uint32_t>(recvCountLT(blockIdx - 1));
+        rankTotal += hi - lo;
+    }
+
+    // ---------- 第二级：组内按 token 数均分，得到本核 token 区间 [tStart, tEnd) ----------
+    uint32_t perCoreToken = rankTotal / groupSize;
+    uint32_t remToken = rankTotal % groupSize;
+    uint32_t tStart = perCoreToken * k + (k < remToken ? k : remToken);
+    uint32_t tEnd = tStart + perCoreToken + (k < remToken ? 1U : 0U);
+    if (tStart == tEnd) {
+        return;
+    }
+    needSendTokenCnt_ = tEnd - tStart;
+
+    // 缓冲按最大块数（moeExpertPerRankNum_）预分配，填充时统计实际块数
+    uint32_t sendBlockAlignLen = Ceil(moeExpertPerRankNum_ * sizeof(int32_t), UB_32_ALIGN) * UB_32_ALIGN;
     tpipe_->InitBuffer(roundNeedSendCntBuf_, sendBlockAlignLen);
     tpipe_->InitBuffer(roundSendOffsetBuf_, sendBlockAlignLen);
     roundNeedSendCntLT_ = roundNeedSendCntBuf_.Get<uint32_t>();
     roundSendOffsetLT_ = roundSendOffsetBuf_.Get<uint32_t>();
 
-    uint32_t segmentIndex = 0;
-    for (uint32_t expertId = 0; expertId < moeExpertNum_; ++expertId) {
-        uint32_t expertStart = expertId == 0 ? 0 : static_cast<uint32_t>(expertEndOffsetLT(expertId - 1));
-        uint32_t expertEnd = static_cast<uint32_t>(expertEndOffsetLT(expertId));
-        uint32_t segmentStart = max(flatStart, expertStart);
-        uint32_t segmentEnd = min(flatEnd, expertEnd);
-        if (segmentStart < segmentEnd) {
-            roundSendOffsetLT_(segmentIndex) = segmentStart;
-            roundNeedSendCntLT_(segmentIndex) = segmentEnd - segmentStart;
-            ++segmentIndex;
+    // 把 [tStart, tEnd) 映射回 myRank 各专家块的子区间（块内为全局 token 索引）
+    perCoreBlockNum_ = 0;
+    uint32_t consumed = 0;
+    for (uint32_t e = 0; e < moeExpertPerRankNum_; ++e) {
+        if (consumed >= tEnd) {
+            break;
         }
+        uint32_t blockIdx = e * epWorldSize_ + myRank;
+        uint32_t hi = static_cast<uint32_t>(recvCountLT(blockIdx));
+        uint32_t lo = (blockIdx == 0U) ? 0U : static_cast<uint32_t>(recvCountLT(blockIdx - 1));
+        uint32_t cnt = hi - lo;
+        if (consumed + cnt <= tStart) {
+            consumed += cnt;
+            continue;
+        }
+        uint32_t subLo = lo + ((consumed < tStart) ? (tStart - consumed) : 0U);
+        uint32_t subHi = lo + ((consumed + cnt > tEnd) ? (tEnd - consumed) : cnt);
+        if (subHi > subLo) {
+            roundSendOffsetLT_(perCoreBlockNum_) = subLo;
+            roundNeedSendCntLT_(perCoreBlockNum_) = subHi - subLo;
+            ++perCoreBlockNum_;
+        }
+        consumed += cnt;
     }
+    preRecvCount_ = perCoreBlockNum_ == 0 ? tStart : roundSendOffsetLT_(0);
 
+    InitSendA5CommonBuffers();
+}
+
+template <TemplateMC2TypeClass>
+__aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitSendA5CommonBuffers()
+{
     uint32_t srcInfoLen = static_cast<uint32_t>(BATCH_SRC_INFO_CNT * TOKEN_SRC_INFO_LEN * sizeof(SrcInfoType));
     uint32_t srcInfoAlignLen = Ceil(srcInfoLen, UB_32_ALIGN) * UB_32_ALIGN;
     tpipe_->InitBuffer(srcInfoBuf_, srcInfoAlignLen);
@@ -326,7 +395,7 @@ template <TemplateMC2TypeClass>
 __aicore__ inline void CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitRoundSendData()
 {
 #ifdef __DAV_C310__
-    InitTokenBalancedRoundSendDataA5();
+    InitRankMajorRoundSendDataA5();
     return;
 #endif
     SplitCoreCal(moeExpertNum_, perCoreBlockNum_, startBlockId_,

--- a/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal_a5.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal_a5.h
@@ -808,7 +808,17 @@ __aicore__ inline void CamMoeDispatchNormalA5<CamTypeFunc>::ShareToOutputLongSeq
     recvCountLocalSync.SetFlag(0);
     recvCountLocalSync.WaitFlag(0);
 
-    for (uint32_t i = startStatusId; i < endStatusId; ++i) {
+    for (uint32_t index = startStatusId; index < endStatusId; ++index) {
+        uint64_t expertStart = 0;
+        if (profileEnable_) {
+            expertStart = profileWriter.Now();
+        }
+        // 专家全局索引逻辑：
+        // 1. index % moeExpertNumPerRank：计算当前索引在本rank内的专家偏移量，范围[0, moeExpertNumPerRank-1]
+        // 2. epRankSize * (...)：将专家偏移量转换为跨rank的专家组起始索引（每个rank包含moeExpertNumPerRank个专家）
+        // 3. index / moeExpertNumPerRank：计算当前索引所在的rank偏移量，范围[0, epRankSize-1]
+        // 4. 最终i为专家全局索引，公式等价于：i = 专家组编号 * 总rank数 + 组内rank偏移量
+        uint32_t i = epRankSize * (index % moeExpertNumPerRank) + index / moeExpertNumPerRank;
         preCount = 0;
         if (likely(i != 0)) {
             preCount = recvCountTensor(i - 1);

--- a/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal_a5.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal_a5.h
@@ -810,9 +810,6 @@ __aicore__ inline void CamMoeDispatchNormalA5<CamTypeFunc>::ShareToOutputLongSeq
 
     for (uint32_t index = startStatusId; index < endStatusId; ++index) {
         uint64_t expertStart = 0;
-        if (profileEnable_) {
-            expertStart = profileWriter.Now();
-        }
         // 专家全局索引逻辑：
         // 1. index % moeExpertNumPerRank：计算当前索引在本rank内的专家偏移量，范围[0, moeExpertNumPerRank-1]
         // 2. epRankSize * (...)：将专家偏移量转换为跨rank的专家组起始索引（每个rank包含moeExpertNumPerRank个专家）

--- a/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal_a5.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal_a5.h
@@ -810,11 +810,14 @@ __aicore__ inline void CamMoeDispatchNormalA5<CamTypeFunc>::ShareToOutputLongSeq
 
     for (uint32_t index = startStatusId; index < endStatusId; ++index) {
         uint64_t expertStart = 0;
-        // 专家全局索引逻辑：
-        // 1. index % moeExpertNumPerRank：计算当前索引在本rank内的专家偏移量，范围[0, moeExpertNumPerRank-1]
-        // 2. epRankSize * (...)：将专家偏移量转换为跨rank的专家组起始索引（每个rank包含moeExpertNumPerRank个专家）
-        // 3. index / moeExpertNumPerRank：计算当前索引所在的rank偏移量，范围[0, epRankSize-1]
-        // 4. 最终i为专家全局索引，公式等价于：i = 专家组编号 * 总rank数 + 组内rank偏移量
+        // Expert global index logic:
+        // 1. index % moeExpertNumPerRank: Calculate the expert offset within the current rank, range [0,
+        // moeExpertNumPerRank-1]
+        // 2. epRankSize * (...): Convert the expert offset to a cross-rank expert group start index (each rank contains
+        // moeExpertNumPerRank experts)
+        // 3. index / moeExpertNumPerRank: Calculate the rank offset of the current index, range [0, epRankSize-1]
+        // 4. Final i is the global expert index, formula equivalent to: i = expert group ID * total ranks + rank offset
+        // within group
         uint32_t i = epRankSize * (index % moeExpertNumPerRank) + index / moeExpertNumPerRank;
         preCount = 0;
         if (likely(i != 0)) {

--- a/csrc/deepep/ops/op_kernel/notify_dispatch.h
+++ b/csrc/deepep/ops/op_kernel/notify_dispatch.h
@@ -448,7 +448,7 @@ private:
         totalCntGt.SetGlobalBuffer((__gm__ int32_t *)totalRecvTokens_);
         DataCopyExtParams copyParams{1, static_cast<uint32_t>(1 * sizeof(int32_t)), 0, 0, 0};
         DataCopyPad(totalCntGt, totalCntLt, copyParams);
-        SyncFunc<AscendC::HardEvent::MTE3_MTE2>();
+        SyncFunc<AscendC::HardEvent::MTE3_S>();
     }
 
     __aicore__ inline void BuildRecvCount()
@@ -529,6 +529,9 @@ private:
         if (blockIdx != MAX_BS_CORE) {
             return;
         }
+        pipe.InitBuffer(tmpBuf_, UB_ALIGN_SIZE);
+        LocalTensor<int32_t> maxBsLt = tmpBuf_.Get<int32_t>();
+
         uint32_t singleRankMaxElem = batchRounds * numLocalExperts * sendPerGroup;
         uint32_t singleRankMaxLen = singleRankMaxElem * sizeof(int32_t);
         uint32_t singleRankAlignLen = Ceil(singleRankMaxLen, UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
@@ -572,10 +575,14 @@ private:
             uint32_t tempBs = sendTokensPerRankTensor(srcRank);
             maxBsNum = maxBsNum >= tempBs ? maxBsNum : tempBs;
         }
+        maxBsLt(0) = maxBsNum;
+        SyncFunc<AscendC::HardEvent::S_MTE3>();
+
         GlobalTensor<int32_t> maxBsGt;
         maxBsGt.SetGlobalBuffer((__gm__ int32_t *)maxBs_);
-        maxBsGt.SetValue(0, maxBsNum);
-        DataCacheCleanAndInvalid<int32_t, CacheLine::SINGLE_CACHE_LINE, DcciDst::CACHELINE_OUT>(maxBsGt);
+        DataCopyExtParams copyParams{1, static_cast<uint32_t>(1 * sizeof(int32_t)), 0, 0, 0};
+        DataCopyPad(maxBsGt, maxBsLt, copyParams);
+        SyncFunc<AscendC::HardEvent::MTE3_S>();
     }
 
     __aicore__ inline void BuildRecvTokenPerExp()

--- a/csrc/deepep/ops/op_kernel/notify_dispatch_a5.h
+++ b/csrc/deepep/ops/op_kernel/notify_dispatch_a5.h
@@ -432,7 +432,7 @@ private:
         totalCntGt.SetGlobalBuffer((__gm__ int32_t *)totalRecvTokens_);
         DataCopyExtParams copyParams{1, static_cast<uint32_t>(1 * sizeof(int32_t)), 0, 0, 0};
         DataCopyPad(totalCntGt, totalCntLt, copyParams);
-        SyncFunc<AscendC::HardEvent::MTE3_MTE2>();
+        SyncFunc<AscendC::HardEvent::MTE3_S>();
     }
 
     __aicore__ inline void BuildRecvCount()
@@ -505,6 +505,9 @@ private:
         if (blockIdx != MAX_BS_CORE) {
             return;
         }
+        pipe.InitBuffer(tmpBuf_, UB_ALIGN_SIZE);
+        LocalTensor<int32_t> maxBsLt = tmpBuf_.Get<int32_t>();
+
         uint32_t singleRankMaxElem = batchRounds * numLocalExperts * sendPerGroup;
         uint32_t singleRankAlignLen = Ceil(singleRankMaxElem * sizeof(T), UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
         recvDataAlignLen = rankSize * singleRankAlignLen;
@@ -541,10 +544,13 @@ private:
             uint32_t tempBs = sendTokensPerRankTensor(srcRank);
             maxBsNum = maxBsNum >= tempBs ? maxBsNum : tempBs;
         }
+        maxBsLt(0) = maxBsNum;
+
         GlobalTensor<int32_t> maxBsGt;
         maxBsGt.SetGlobalBuffer((__gm__ int32_t *)maxBs_);
-        maxBsGt.SetValue(0, maxBsNum);
-        DataCacheCleanAndInvalid<int32_t, CacheLine::SINGLE_CACHE_LINE, DcciDst::CACHELINE_OUT>(maxBsGt);
+        DataCopyExtParams copyParams{1, static_cast<uint32_t>(1 * sizeof(int32_t)), 0, 0, 0};
+        DataCopyPad(maxBsGt, maxBsLt, copyParams);
+        SyncFunc<AscendC::HardEvent::MTE3_S>();
     }
 
     __aicore__ inline void BuildRecvTokenPerExp()

--- a/csrc/deepep/ops/op_kernel/notify_dispatch_a5.h
+++ b/csrc/deepep/ops/op_kernel/notify_dispatch_a5.h
@@ -545,6 +545,7 @@ private:
             maxBsNum = maxBsNum >= tempBs ? maxBsNum : tempBs;
         }
         maxBsLt(0) = maxBsNum;
+        SyncFunc<AscendC::HardEvent::S_MTE3>();
 
         GlobalTensor<int32_t> maxBsGt;
         maxBsGt.SetGlobalBuffer((__gm__ int32_t *)maxBs_);

--- a/csrc/deepep/ops2/op_kernel/notify_dispatch.h
+++ b/csrc/deepep/ops2/op_kernel/notify_dispatch.h
@@ -445,7 +445,7 @@ private:
         totalCntGt.SetGlobalBuffer((__gm__ int32_t *)totalRecvTokens_);
         DataCopyExtParams copyParams{1, static_cast<uint32_t>(1 * sizeof(int32_t)), 0, 0, 0};
         DataCopyPad(totalCntGt, totalCntLt, copyParams);
-        SyncFunc<AscendC::HardEvent::MTE3_MTE2>();
+        SyncFunc<AscendC::HardEvent::MTE3_S>();
     }
 
     __aicore__ inline void BuildRecvCount()
@@ -519,6 +519,9 @@ private:
         if (blockIdx != MAX_BS_CORE) {
             return;
         }
+        pipe.InitBuffer(tmpBuf_, UB_ALIGN_SIZE);
+        LocalTensor<int32_t> maxBsLt = tmpBuf_.Get<int32_t>();
+
         uint32_t singleRankMaxElem = batchRounds * numLocalExperts * sendPerGroup;
         uint32_t singleRankMaxLen = singleRankMaxElem * sizeof(int32_t);
         uint32_t singleRankAlignLen = Ceil(singleRankMaxLen, UB_ALIGN_SIZE) * UB_ALIGN_SIZE;
@@ -562,10 +565,14 @@ private:
             uint32_t tempBs = sendTokensPerRankTensor(srcRank);
             maxBsNum = maxBsNum >= tempBs ? maxBsNum : tempBs;
         }
+        maxBsLt(0) = maxBsNum;
+        SyncFunc<AscendC::HardEvent::S_MTE3>();
+
         GlobalTensor<int32_t> maxBsGt;
         maxBsGt.SetGlobalBuffer((__gm__ int32_t *)maxBs_);
-        maxBsGt.SetValue(0, maxBsNum);
-        DataCacheCleanAndInvalid<int32_t, CacheLine::SINGLE_CACHE_LINE, DcciDst::CACHELINE_OUT>(maxBsGt);
+        DataCopyExtParams copyParams{1, static_cast<uint32_t>(1 * sizeof(int32_t)), 0, 0, 0};
+        DataCopyPad(maxBsGt, maxBsLt, copyParams);
+        SyncFunc<AscendC::HardEvent::MTE3_S>();
     }
 
     __aicore__ inline void BuildRecvTokenPerExp()


### PR DESCRIPTION
## Motivation
Performance optimization of the NORMAL operator on A5. relation #730 

## Modifications

1. Dispatch 优化
1a. copyout 循环重排：ShareToOutputLongSeq 循环从 expert-major 改为 rank-major 遍历，每次迭代把 index 换位成全局专家索引 i = epRankSize*(index%moeExpertNumPerRank) + index/moeExpertNumPerRank。每核只读 1~2 个 source rank 的共享内存窗口（原为全部 rank），跨 rank 读局部性改善。

2. Hostbound 优化— deep_ep.cpp
intranode_dispatch 把 max_bs / total_recv_token / recv_tokens_per_expert 三个独立 device tensor 合并为同一块连续 recv_header，notify_dispatch 后仅一次 D2H 读回全部值，real_max_bs / trt / recv_token_per_exp_ptr 全部从 host 缓存取值，消除多次 device→host 同步。该修改对 A5 和 A3 都生效。

3. Combine 和多轮优化
CopyBufferToShareAndSetStatus 发送分核与拷贝重构，解决核间负载不均衡和逐 token 拷贝：
rank-major 两级分核：第一级按 rank 分配核组，第二级组内按 token 数均衡均分（替代原连续段 SplitCoreCal）；A<W 时降级原路径。每个核只写少数几个 rank 的 window，rank 间内存区竞争下降。
epRecvCount 一次性读 UB：E*W 个前缀和整体 DataCopyPad，核内映射 token 区间 → 专家块子区间。
srcInfo 批量拷贝：新增 BATCH_SRC_INFO_CNT=128 + ProcessSendRange，每批一次 DataCopyPad，减少 MTE2 指令数。

## Testing
- A5 precision test pass.

python test_intranode.py --num-processes=8 --num-topk=8 --num-experts=256 --num-tokens=2048
![image.png](https://raw.gitcode.com/user-images/assets/10453718/85f427a9-d466-4d34-bd73-8e5ea773f1de/image.png 'image.png')

python test_intranode.py --num-processes=8 --num-topk=8 --num-experts=256 --num-tokens=4096
![image.png](https://raw.gitcode.com/user-images/assets/10453718/0fa8ca95-3742-4740-b47d-d266044c89ca/image.png 'image.png')

- A3 precision test pass.

python test_intranode.py --num-processes=8 --num-topk=8 --num-experts=256 --num-tokens=2048
![image.png](https://raw.gitcode.com/user-images/assets/10453718/8806c50b-5986-49cf-ab86-8b5f2765effb/image.png 'image.png')

python test_intranode.py --num-processes=8 --num-topk=8 --num-experts=256 --num-tokens=4096
![image.png](https://raw.gitcode.com/user-images/assets/10453718/04bbb75c-bf53-4c90-aace-a9a2ddf5526e/image.png 'image.png')

## Benchmarking and Profiling

config: num_ranks=8, num_experts=256, num_topk=8, hidden_size=7168
A5 DT Performance Comparison: 

> The Ant Moving feature is enabled when the BS exceeds 8k. The configuration is as follows:
export DEEPEP_NORMAL_LONG_SEQ_ROUND=8/16/32
export DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS=2048
export DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ=1

| BS | stage | Indicator | base | optimized | Increase/Decrease Magnitude |
|:---:|:---:|:---:|:---:|:---:|:---:|
| **1024** | dispatch | `dispatch_t` (us) | 1381.58 | 992.42 | **↓ 28.1%** |
| | | `dispatch_b` (GB/s) | 85.29 | 118.09 | **↑ 38.5%** |
| | combine | `combine_t` (us) | 807.93 | 648.11 | **↓ 19.8%** |
| | | `combine_b` (GB/s) | 145.91 | 180.74 | **↑ 23.9%** |
| **2048** | dispatch | `dispatch_t` (us) | 2404.70 | 1485.88 | **↓ 38.2%** |
| | | `dispatch_b` (GB/s) | 97.67 | 158.28 | **↑ 62.0%** |
| | combine | `combine_t` (us) | 1452.11 | 1157.44 | **↓ 20.3%** |
| | | `combine_b` (GB/s) | 161.66 | 203.19 | **↑ 25.7%** |
| **4096** | dispatch | `dispatch_t` (us) | 4352.09 | 2471.12 | **↓ 43.2%** |
| | | `dispatch_b` (GB/s) | 108.56 | 190.12 | **↑ 75.1%** |
| | combine | `combine_t` (us) | 2898.91 | 2205.35 | **↓ 23.9%** |
| | | `combine_b` (GB/s) | 163.05 | 213.04 | **↑ 30.7%** |
| **8192** | dispatch | `dispatch_t` (us) | 8116.72 | 4471.66 | **↓ 44.9%** |
| | | `dispatch_b` (GB/s) | 115.93 | 209.83 | **↑ 81.0%** |
| | combine | `combine_t` (us) | 5670.91 | 4298.52 | **↓ 24.2%** |
| | | `combine_b` (GB/s) | 165.88 | 218.27 | **↑ 31.6%** |
| **16384** | dispatch | `dispatch_t` (us) | 16148.69 | 8788.20 | **↓ 45.6%** |
| | | `dispatch_b` (GB/s) | 116.44 | 213.30 | **↑ 83.2%** |
| | combine | `combine_t` (us) | 11542.53 | 8594.74 | **↓ 25.5%** |
| | | `combine_b` (GB/s) | 162.91 | 218.10 | **↑ 33.9%** |
| **32768** | dispatch | `dispatch_t` (us) | 30876.80 | 17264.90 | **↓ 44.1%** |
| | | `dispatch_b` (GB/s) | 121.66 | 218.05 | **↑ 79.2%** |
| | combine | `combine_t` (us) | 23460.77 | 17351.53 | **↓ 26.0%** |
| | | `combine_b` (GB/s) | 160.11 | 216.97 | **↑ 35.5%** |
| **65536** | dispatch | `dispatch_t` (us) | 62873.44 | 35561.46 | **↓ 43.4%** |
| | | `dispatch_b` (GB/s) | 119.71 | 211.45 | **↑ 76.6%** |
| | combine | `combine_t` (us) | 48365.27 | 34383.48 | **↓ 28.9%** |
| | | `combine_b` (GB/s) | 155.61 | 218.69 | **↑ 40.5%** |

## Checklist

- [x] Format your code.
- [ ] Add unit tests.
- [ ] Update documentation.
- [x] Provide accuracy and speed benchmark results.