### PR TITLE
[kernels] follow-ups on #641 and #644: dispatch boundary, ULP bound, block_v validation

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/sample/argmax_softmax_prob.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/sample/argmax_softmax_prob.py
@@ -83,19 +83,27 @@ def argmax_softmax_prob_fused(
     ``(argmax_ids [B] int64, prob [B] float32)``. Accumulates in fp32; never
     materializes a ``[B, V]`` temporary.
 
-    ``block_v`` overrides the vocab tile width; the default derives it from the
-    logits dtype so the tile stays within the unified buffer.
+    ``block_v`` overrides the vocab tile width. It must be a positive power of
+    two, and is capped by the vocab and by the unified buffer; the default
+    derives it from the logits dtype.
     """
     assert logits.dim() == 2 and logits.stride(1) == 1
     B, V = logits.shape
     argmax = torch.empty(B, dtype=torch.int64, device=logits.device)
     prob = torch.empty(B, dtype=torch.float32, device=logits.device)
     grid = (min(_num_cores(), B),)
+    budget = _TILE_BYTES // logits.element_size()
     if block_v is None:
-        block_v = _TILE_BYTES // logits.element_size()
-    # A tile wider than the vocab only wastes unified buffer (and overflows it
-    # once the single-iteration loop is unrolled).
-    block_v = min(block_v, triton.next_power_of_2(V))
+        block_v = budget
+    elif block_v <= 0 or block_v & (block_v - 1):
+        # tl.arange needs a positive power of two under SIMT; without this the
+        # failure is an opaque Triton compilation error.
+        raise ValueError(f"block_v must be a positive power of two, got {block_v}")
+    # Bound by the unified buffer before the vocab: a width that is legal on its
+    # own can still be several tiles wide in the input dtype (fp32
+    # block_v=16384 is 64 KiB), which fails to compile rather than running
+    # slowly. All three terms are powers of two, so the tile stays one.
+    block_v = min(block_v, budget, triton.next_power_of_2(V))
     _argmax_prob_kernel[grid](
         logits, argmax, prob, B, V, logits.stride(0), BLOCK_V=block_v
     )

--- a/python/sgl_kernel_npu/sgl_kernel_npu/sample/argmax_softmax_prob.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/sample/argmax_softmax_prob.py
@@ -78,7 +78,7 @@ def argmax_softmax_prob_fused(
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Per-row argmax id and the softmax probability of that argmax token.
 
-    ``logits``: ``[B, V]``, any float dtype, last dim contiguous (an arbitrary
+    ``logits``: ``[B, V]``, fp32, bf16 or fp16, last dim contiguous (an arbitrary
     row stride is fine, so a vocab-truncated view costs no copy). Returns
     ``(argmax_ids [B] int64, prob [B] float32)``. Accumulates in fp32; never
     materializes a ``[B, V]`` temporary.
@@ -88,13 +88,24 @@ def argmax_softmax_prob_fused(
     derives it from the logits dtype.
     """
     assert logits.dim() == 2 and logits.stride(1) == 1
+    if logits.dtype not in (torch.float32, torch.bfloat16, torch.float16):
+        # The kernel has no fp64 path; without this the failure is an
+        # MLIRCompilationError naming neither the dtype nor this call.
+        raise ValueError(f"logits dtype must be fp32, bf16 or fp16, got {logits.dtype}")
     B, V = logits.shape
+    if V <= 0:
+        # Not covered by the block_v check below: sglang replaces
+        # triton.next_power_of_2 with a variant returning 1 at 0, so an empty
+        # vocab does not reach that check as a zero tile.
+        raise ValueError(f"logits must have a non-empty vocab, got V={V}")
     argmax = torch.empty(B, dtype=torch.int64, device=logits.device)
     prob = torch.empty(B, dtype=torch.float32, device=logits.device)
     grid = (min(_num_cores(), B),)
     budget = _TILE_BYTES // logits.element_size()
     if block_v is None:
         block_v = budget
+    elif not isinstance(block_v, int) or isinstance(block_v, bool):
+        raise ValueError(f"block_v must be an int, got {type(block_v).__name__}")
     elif block_v <= 0 or block_v & (block_v - 1):
         # tl.arange needs a positive power of two under SIMT; without this the
         # failure is an opaque Triton compilation error.

--- a/python/sgl_kernel_npu/sgl_kernel_npu/sample/argmax_softmax_prob.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/sample/argmax_softmax_prob.py
@@ -41,7 +41,11 @@ def _argmax_prob_kernel(
     row_pid = tl.program_id(0)
     n_prog = tl.num_programs(0)
     for row in tl.range(row_pid, B, n_prog):
-        base = row * stride_b
+        # int64 before the multiply: Triton binds a stride that fits in int32 as
+        # int32, so row * stride_b wraps once the tensor passes 2**31 elements
+        # (13662 rows at vocab 157184) and addresses outside it. Once per row,
+        # not in the tile loop below.
+        base = row.to(tl.int64) * stride_b
         m = tl.full((), float("-inf"), tl.float32)
         arg = tl.zeros((), tl.int64)
         s = tl.zeros((), tl.float32)

--- a/tests/python/sgl_kernel_npu/test_argmax_softmax_prob.py
+++ b/tests/python/sgl_kernel_npu/test_argmax_softmax_prob.py
@@ -1,4 +1,7 @@
+import contextlib
+
 import pytest
+import sgl_kernel_npu.sample.argmax_softmax_prob as mod
 import torch
 from sgl_kernel_npu.sample.argmax_softmax_prob import argmax_softmax_prob_fused
 
@@ -46,6 +49,87 @@ def test_row_stride_is_honoured():
     ref_argmax, ref_prob = argmax_softmax_prob_golden(view)
     argmax, prob = argmax_softmax_prob_fused(view)
 
+    assert torch.equal(argmax, ref_argmax)
+    torch.testing.assert_close(prob, ref_prob, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize("bad", [0, -1, 3, 100, 1000])
+def test_rejects_a_block_v_that_is_not_a_positive_power_of_two(bad):
+    """Without the check the failure is an opaque Triton compilation error
+    rather than a message naming the argument."""
+    logits = torch.randn(4, 4096, dtype=torch.bfloat16, device="npu")
+    with pytest.raises(ValueError, match="positive power of two"):
+        argmax_softmax_prob_fused(logits, block_v=bad)
+
+
+@contextlib.contextmanager
+def _record_block_v():
+    """Capture the BLOCK_V actually handed to the kernel."""
+    seen = []
+    real = mod._argmax_prob_kernel
+
+    class _Recorder:
+        def __getitem__(self, grid):
+            launch = real[grid]
+
+            def call(*args, **kwargs):
+                seen.append(kwargs["BLOCK_V"])
+                return launch(*args, **kwargs)
+
+            return call
+
+    mod._argmax_prob_kernel = _Recorder()
+    try:
+        yield seen
+    finally:
+        mod._argmax_prob_kernel = real
+
+
+def test_record_block_v_observes_the_launch():
+    """Control for _record_block_v: it must see the default width, not nothing."""
+    logits = torch.randn(4, 4096, dtype=torch.bfloat16, device="npu")
+    with _record_block_v() as seen:
+        argmax_softmax_prob_fused(logits)
+    assert seen == [4096], seen
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("V", [17, 4096, 157184])
+@pytest.mark.parametrize("block_v", [None, 64, 65536])
+def test_the_tile_reaching_the_kernel_is_a_power_of_two(block_v, V, dtype):
+    """Rejecting a bad block_v is only half of it: the width the kernel sees is
+    the caller's value clamped by the dtype budget and by the vocab, and it is
+    that value tl.arange has to accept."""
+    logits = torch.randn(2, V, dtype=dtype, device="npu")
+    with _record_block_v() as seen:
+        argmax_softmax_prob_fused(logits, block_v=block_v)
+    (used,) = seen
+    assert used > 0 and used & (used - 1) == 0, f"tile is not a power of two: {used}"
+
+
+@pytest.mark.parametrize("good", [64, 1024, 8192])
+def test_accepts_a_power_of_two_block_v(good):
+    """A valid override must still produce the reference result, including when
+    it is wider than the vocab and gets clamped."""
+    logits = torch.randn(8, 4096, dtype=torch.bfloat16, device="npu")
+    ref_argmax, ref_prob = argmax_softmax_prob_golden(logits)
+    argmax, prob = argmax_softmax_prob_fused(logits, block_v=good)
+    assert torch.equal(argmax, ref_argmax)
+    torch.testing.assert_close(prob, ref_prob, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_oversized_power_of_two_block_v_is_capped_by_the_dtype_budget(dtype):
+    """A legal power of two can still exceed the unified buffer in the input
+    dtype: fp32 block_v=16384 is 64 KiB against a 32 KiB tile, and fails to
+    compile. The vocab is wide enough that next_power_of_2(V) does not clamp it
+    first, so only the dtype budget can."""
+    # 16384 is exactly the bf16 budget, so that arm would be capped by nothing;
+    # scale the override with the dtype so both arms actually exceed it.
+    over = {torch.float32: 16384, torch.bfloat16: 32768}[dtype]
+    logits = torch.randn(4, 32000, dtype=dtype, device="npu")
+    ref_argmax, ref_prob = argmax_softmax_prob_golden(logits)
+    argmax, prob = argmax_softmax_prob_fused(logits, block_v=over)
     assert torch.equal(argmax, ref_argmax)
     torch.testing.assert_close(prob, ref_prob, rtol=1e-5, atol=1e-6)
 

--- a/tests/python/sgl_kernel_npu/test_argmax_softmax_prob.py
+++ b/tests/python/sgl_kernel_npu/test_argmax_softmax_prob.py
@@ -153,7 +153,13 @@ def test_oversized_power_of_two_block_v_is_capped_by_the_dtype_budget(dtype):
     over = {torch.float32: 16384, torch.bfloat16: 32768}[dtype]
     logits = torch.randn(4, 32000, dtype=dtype, device="npu")
     ref_argmax, ref_prob = argmax_softmax_prob_golden(logits)
-    argmax, prob = argmax_softmax_prob_fused(logits, block_v=over)
+    with _record_block_v() as seen:
+        argmax, prob = argmax_softmax_prob_fused(logits, block_v=over)
+    # Assert the clamped width, not only the result. Dropping the budget term
+    # sends the override to the kernel, where today it fails to compile -- so the
+    # result assertions would catch it, but only for as long as that width stays
+    # a compile error. The width is what this test is about.
+    assert seen == [mod._TILE_BYTES // logits.element_size()], seen
     assert torch.equal(argmax, ref_argmax)
     torch.testing.assert_close(prob, ref_prob, rtol=1e-5, atol=1e-6)
 

--- a/tests/python/sgl_kernel_npu/test_argmax_softmax_prob.py
+++ b/tests/python/sgl_kernel_npu/test_argmax_softmax_prob.py
@@ -5,6 +5,8 @@ import sgl_kernel_npu.sample.argmax_softmax_prob as mod
 import torch
 from sgl_kernel_npu.sample.argmax_softmax_prob import argmax_softmax_prob_fused
 
+_npo2 = mod.triton.next_power_of_2
+
 
 def argmax_softmax_prob_golden(logits: torch.Tensor):
     """Reference: argmax id and the softmax probability of that id, in fp32."""
@@ -62,6 +64,15 @@ def test_rejects_a_block_v_that_is_not_a_positive_power_of_two(bad):
         argmax_softmax_prob_fused(logits, block_v=bad)
 
 
+@pytest.mark.parametrize("bad", [1024.0, "1024", True])
+def test_rejects_a_non_int_block_v(bad):
+    """A float, a string or a bool used to reach the kernel and fail there;
+    bool is an int subclass, so it needs its own rejection."""
+    logits = torch.randn(4, 4096, dtype=torch.bfloat16, device="npu")
+    with pytest.raises(ValueError, match="must be an int"):
+        argmax_softmax_prob_fused(logits, block_v=bad)
+
+
 @contextlib.contextmanager
 def _record_block_v():
     """Capture the BLOCK_V actually handed to the kernel."""
@@ -107,6 +118,19 @@ def test_the_tile_reaching_the_kernel_is_a_power_of_two(block_v, V, dtype):
     assert used > 0 and used & (used - 1) == 0, f"tile is not a power of two: {used}"
 
 
+@pytest.mark.parametrize("npo2_at_zero", [0, 1])
+def test_empty_vocab_is_rejected(monkeypatch, npo2_at_zero):
+    """V=0 must be rejected on its own, not as a side effect of the tile clamp:
+    sglang replaces triton.next_power_of_2 with a variant returning 1 at 0, and
+    importing it anywhere in the process changes what the clamp yields here."""
+    monkeypatch.setattr(
+        mod.triton, "next_power_of_2", lambda n: npo2_at_zero if n == 0 else _npo2(n)
+    )
+    logits = torch.randn(4, 0, dtype=torch.bfloat16, device="npu")
+    with pytest.raises(ValueError, match="non-empty vocab"):
+        argmax_softmax_prob_fused(logits)
+
+
 @pytest.mark.parametrize("good", [64, 1024, 8192])
 def test_accepts_a_power_of_two_block_v(good):
     """A valid override must still produce the reference result, including when
@@ -132,6 +156,13 @@ def test_oversized_power_of_two_block_v_is_capped_by_the_dtype_budget(dtype):
     argmax, prob = argmax_softmax_prob_fused(logits, block_v=over)
     assert torch.equal(argmax, ref_argmax)
     torch.testing.assert_close(prob, ref_prob, rtol=1e-5, atol=1e-6)
+
+
+def test_rejects_an_unsupported_dtype():
+    """fp64 has no kernel path; it reached Triton and failed to compile."""
+    logits = torch.randn(4, 4096, dtype=torch.float64, device="npu")
+    with pytest.raises(ValueError, match="dtype must be"):
+        argmax_softmax_prob_fused(logits)
 
 
 def test_ties_keep_the_lower_index():

--- a/tests/python/sgl_kernel_npu/test_argmax_softmax_prob.py
+++ b/tests/python/sgl_kernel_npu/test_argmax_softmax_prob.py
@@ -183,5 +183,42 @@ def test_ties_keep_the_lower_index():
     assert torch.equal(argmax, torch.full((4,), 100, dtype=torch.int64, device="npu"))
 
 
+def test_row_offset_does_not_overflow_int32():
+    """The row offset is ``row * stride_b``, and Triton binds a stride that fits
+    in int32 as int32, so the product wraps once the tensor passes 2**31
+    elements -- 13662 rows at vocab 157184.
+
+    The wrapped offset is not a wrong answer: it addresses outside the tensor
+    and takes the device down with a vector core exception, which fails the rest
+    of the session with it. Hence last in the file.
+
+    What trips it is the element count, so the smallest case that reaches the
+    boundary is ~4 GiB of logits; skipped where that does not fit. The argmax is
+    planted rather than taken from ``torch.argmax``: at this width bf16 ties at
+    the maximum are common, and the reference would have to agree on breaking
+    them.
+    """
+    V = 157184
+    rows_at_overflow = (2**31) // V
+    B = rows_at_overflow + 256
+    needed = B * V * 2  # bf16
+    free, _ = torch.npu.mem_get_info()
+    if free < needed + (1 << 30):
+        pytest.skip(
+            f"needs ~{needed / 2**30:.1f} GiB free HBM, have {free / 2**30:.1f} GiB"
+        )
+
+    torch.manual_seed(0)
+    logits = torch.randn(B, V, dtype=torch.bfloat16, device="npu")
+    planted = torch.randint(0, V, (B,), device="npu")
+    # Above the max of 2**31 bf16 normals, so it is the argmax of its row alone.
+    logits[torch.arange(B, device="npu"), planted] = 8.0
+
+    argmax, prob = argmax_softmax_prob_fused(logits)
+
+    assert torch.equal(argmax, planted.to(torch.int64))
+    assert torch.isfinite(prob).all()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-q"])

--- a/tests/python/sgl_kernel_npu/test_split_qkv_rmsnorm_rope_pos_cache_half_npu.py
+++ b/tests/python/sgl_kernel_npu/test_split_qkv_rmsnorm_rope_pos_cache_half_npu.py
@@ -203,70 +203,59 @@ def test_within_bf16_ulps_helper_controls():
         raise AssertionError(why)
 
 
-def _assert_no_worse_than(
-    wide: torch.Tensor, per_head: torch.Tensor, golden: torch.Tensor
-):
-    """The wide grid must not be further from the fp32 reference than the
-    per-head grid is.
+def _assert_within_row_bf16_ulps(a: torch.Tensor, b: torch.Tensor, ulps: int = 2):
+    """Bound the elementwise difference by ``ulps`` bf16 steps of the row's
+    largest element.
 
-    For K a ULP bound between the arms is unbounded, because RoPE cancels: one
-    ULP of the operands survives the subtraction whole and reads as many ULP on
-    the small result. At q_hidden 8192 the worst element sums -0.2749 and
-    +0.2906 to 0.0158, where the arms differ by 0.0017 -- 16 ULP. An elementwise
-    1 ULP bound holds on 15 of 20 seeds there; this predicate holds on all 20,
-    at both q_hidden. Q has no such element and keeps the ULP bound.
+    The reference magnitude is the row, not the element. RoPE cancels:
+    ``b*cos + a*sin`` sums two terms of the row's magnitude into a result that
+    can be far smaller, so one step of the operands survives the subtraction
+    whole and is many steps of the result. At q_hidden 8192 the worst element
+    sums -0.2749 and +0.2906 to 0.0158, where the arms differ by 0.0017 -- 16
+    steps of the element, well inside one step of its row.
+
+    Measured over 20 seeds at q_hidden 2048 and 8192, the difference peaks at
+    1.008 steps of the row, so this holds with margin while an elementwise
+    bound holds on 15 of those 40 runs.
     """
-    assert wide.shape == per_head.shape == golden.shape, (
-        f"shape mismatch: {tuple(wide.shape)} {tuple(per_head.shape)} "
-        f"{tuple(golden.shape)}"
-    )
-    # Non-finite first: two infinite arms compare equal and pass, and an
-    # infinite per_head passes anything, since the predicate only asks whether
-    # wide is the worse of the two.
-    for name, t in (("wide", wide), ("per_head", per_head), ("golden", golden)):
+    assert a.shape == b.shape, f"shape mismatch: {tuple(a.shape)} {tuple(b.shape)}"
+    for name, t in (("a", a), ("b", b)):
         assert torch.isfinite(t).all(), f"{name} has non-finite values"
-    g = golden.to(torch.float32).cpu()
-    dw = (wide.to(torch.float32).cpu() - g).abs().max()
-    dn = (per_head.to(torch.float32).cpu() - g).abs().max()
-    # One bf16 step of slack: the arms round the same value in opposite
-    # directions often enough that requiring dw <= dn exactly is itself
-    # seed-dependent.
-    slack = dn.abs() * (2**-7) + torch.finfo(torch.bfloat16).tiny
-    assert dw <= dn + slack, (
-        f"wide grid is the worse approximation: max|wide-golden|={dw:.6g} "
-        f"vs max|per_head-golden|={dn:.6g}"
+    af = a.to(torch.float32).cpu()
+    bf = b.to(torch.float32).cpu()
+    diff = (af - bf).abs().amax(dim=-1)
+    bound = af.abs().amax(dim=-1) * (2**-8) * ulps
+    worst = int((diff - bound).argmax())
+    assert (diff <= bound).all(), (
+        f"row {worst}: |a-b|={float(diff[worst]):.6g} exceeds {ulps} bf16 steps "
+        f"of the row magnitude ({float(bound[worst]):.6g})"
     )
 
 
-def test_no_worse_than_helper_controls():
-    """Controls for _assert_no_worse_than: a shape mismatch (which a bare tensor
-    comparison would broadcast away), a genuinely worse first argument, and
-    non-finite values in any position.
-
-    Two of the non-finite cases pass on the arithmetic alone -- two infinite
-    arms are equally far from the reference, and an infinite per_head is further
-    than anything -- so they need the explicit check, not a tolerance.
+def test_within_row_bf16_ulps_helper_controls():
+    """Controls for _assert_within_row_bf16_ulps: a difference beyond the row
+    bound, a shape mismatch, and non-finite values in either position.
     """
-    g = torch.tensor([1.0, 2.0, 4.0])
-    good = torch.tensor([1.0, 2.0, 4.0])
-    worse = torch.tensor([1.0, 2.0, 4.5])
-    nan = torch.tensor([1.0, 2.0, float("nan")])
-    inf = torch.tensor([1.0, 2.0, float("inf")])
+    row = torch.tensor([[8.0, 0.5, 0.25]])
+    # 8.0 * 2**-8 * 2 = 0.0625, so 0.03 passes on the row bound while being
+    # many steps of the 0.25 element it sits on.
+    near = torch.tensor([[8.0, 0.5, 0.28]])
+    far = torch.tensor([[8.0, 0.5, 0.5]])
+    nan = torch.tensor([[8.0, 0.5, float("nan")]])
+    inf = torch.tensor([[8.0, 0.5, float("inf")]])
 
-    _assert_no_worse_than(good, worse, g)  # wide is the better arm: fine
+    _assert_within_row_bf16_ulps(row, near)
 
-    for a, b, c, why in (
-        (worse, good, g, "worse arm accepted"),
-        (torch.tensor([1.0]), good, g, "shape mismatch accepted"),
-        (nan, good, g, "NaN in wide accepted"),
-        (good, nan, g, "NaN in per_head accepted"),
-        (good, good, nan, "NaN in golden accepted"),
-        (inf, good, g, "inf in wide accepted"),
-        (good, inf, g, "inf in per_head accepted"),
-        (inf, inf, g, "two infinite arms accepted"),
+    for a, b, why in (
+        (row, far, "difference beyond the row bound accepted"),
+        (row, torch.tensor([[8.0]]), "shape mismatch accepted"),
+        (nan, row, "NaN in a accepted"),
+        (row, nan, "NaN in b accepted"),
+        (inf, row, "inf in a accepted"),
+        (row, inf, "inf in b accepted"),
     ):
         try:
-            _assert_no_worse_than(a, b, c)
+            _assert_within_row_bf16_ulps(a, b)
         except AssertionError:
             continue
         raise AssertionError(why)
@@ -425,9 +414,9 @@ class TestSplitQkvRmsnormRopePosCacheHalfNpu(unittest.TestCase):
         """The wide grid (B >= wide_grid_min_tokens) must agree with the per-head grid.
 
         Both arms run the same kernel; only the launch grid differs. V is a plain copy so it
-        is bit-identical, and Q is too. K differs on a small fraction of elements by an
-        amount bounded in absolute terms but not in relative ones, so the arms are compared
-        through the fp32 reference rather than to each other -- see _assert_no_worse_than.
+        is bit-identical, and Q is too. K differs on a handful of elements, by an amount
+        bounded against the row magnitude rather than the element -- see
+        _assert_within_row_bf16_ulps.
 
         More than one seed, because the predicate this replaced passed on seed 0 and failed
         on 6 of 20 others: a single seed cannot tell a property of the kernel from a property
@@ -494,25 +483,10 @@ class TestSplitQkvRmsnormRopePosCacheHalfNpu(unittest.TestCase):
 
                 torch.testing.assert_close(wv.cpu(), nv.cpu(), atol=0, rtol=0)
 
-                gq, gk, _ = golden_split_qkv_rmsnorm_rope_pos_cache_half(
-                    qkv,
-                    positions,
-                    cos_sin_cache,
-                    q_hidden_size,
-                    kv_hidden_size,
-                    head_dim,
-                    rope_dim,
-                    eps,
-                    q_weight,
-                    k_weight,
-                    None,
-                    None,
-                    use_qk_norm=True,
-                )
-                # Q holds a real ULP bound; K does not, because RoPE cancels
-                # there -- see _assert_no_worse_than.
+                # Q holds an elementwise bound; K only holds one against the row
+                # magnitude -- see _assert_within_row_bf16_ulps.
                 _assert_within_bf16_ulps(wq, nq)
-                _assert_no_worse_than(wk, nk, gk)
+                _assert_within_row_bf16_ulps(wk, nk)
 
     def test_grid_arms_agree_above_threshold(self):
         """Batch above the default threshold: wide grid vs per-head grid."""

--- a/tests/python/sgl_kernel_npu/test_split_qkv_rmsnorm_rope_pos_cache_half_npu.py
+++ b/tests/python/sgl_kernel_npu/test_split_qkv_rmsnorm_rope_pos_cache_half_npu.py
@@ -1,3 +1,4 @@
+import contextlib
 import unittest
 
 import torch
@@ -128,6 +129,78 @@ def golden_split_qkv_rmsnorm_rope_pos_cache_half(
     k = torch.cat((k_rot, k_pass), dim=-1).reshape(k_shape)
 
     return q, k, v
+
+
+@contextlib.contextmanager
+def _record_launch_grids():
+    """Capture the launch grid of each kernel call.
+
+    The two arms differ in the grid, not just in the result: the wide grid is
+    one column, the per-head grid is kv_hidden_size // head_dim of them.
+    """
+    import sgl_kernel_npu.norm.split_qkv_rmsnorm_rope_pos_cache_half_npu as mod
+
+    grids = []
+    real = mod.split_qkv_rmsnorm_rope_half_pos_cache_kernel
+
+    class _Recorder:
+        def __getitem__(self, grid):
+            grids.append(tuple(grid))
+            return real[grid]
+
+    mod.split_qkv_rmsnorm_rope_half_pos_cache_kernel = _Recorder()
+    try:
+        yield grids
+    finally:
+        mod.split_qkv_rmsnorm_rope_half_pos_cache_kernel = real
+
+
+def _assert_within_bf16_ulps(a: torch.Tensor, b: torch.Tensor, ulps: int = 1):
+    """Bound the elementwise distance in bf16 representable steps.
+
+    ``assert_close``'s atol + rtol*|b| is not a ULP bound: a fixed atol is far
+    wider than one ULP near zero and far narrower than one near the top of the
+    exponent range.
+
+    Non-finite values are rejected rather than counted: two equal NaNs are zero
+    steps apart, and the largest finite value is one step from infinity, so both
+    pass a tight bound while meaning nothing.
+    """
+    assert a.shape == b.shape, f"shape mismatch: {tuple(a.shape)} {tuple(b.shape)}"
+    for name, t in (("a", a), ("b", b)):
+        assert torch.isfinite(t).all(), f"{name} has non-finite values"
+    ai = a.to(torch.bfloat16).cpu().view(torch.int16).to(torch.int32)
+    bi = b.to(torch.bfloat16).cpu().view(torch.int16).to(torch.int32)
+    # Map sign-magnitude to a monotone ordering so the step count is meaningful
+    # across zero.
+    ai = torch.where(ai < 0, torch.tensor(-(2**15), dtype=torch.int32) - ai, ai)
+    bi = torch.where(bi < 0, torch.tensor(-(2**15), dtype=torch.int32) - bi, bi)
+    worst = int((ai - bi).abs().max())
+    assert worst <= ulps, f"worst elementwise distance {worst} bf16 ULP > {ulps}"
+
+
+def test_within_bf16_ulps_helper_controls():
+    """Controls for _assert_within_bf16_ulps: the two non-finite cases that pass
+    a tight bound on the bit patterns alone, plus a real overshoot.
+    """
+    bf = lambda *v: torch.tensor(v, dtype=torch.bfloat16)
+    top = torch.finfo(torch.bfloat16).max
+    nan, inf = float("nan"), float("inf")
+
+    _assert_within_bf16_ulps(bf(1.0, 2.0), bf(1.0, 2.0), ulps=0)
+
+    for a, b, why in (
+        (bf(nan, 1.0), bf(nan, 1.0), "equal NaNs accepted"),
+        (bf(top, 1.0), bf(inf, 1.0), "max finite one step from inf accepted"),
+        (bf(inf, 1.0), bf(inf, 1.0), "equal infinities accepted"),
+        (bf(2.0), bf(4.0), "128 ULP accepted"),
+        (bf(1.0), bf(1.0, 2.0), "shape mismatch accepted"),
+    ):
+        try:
+            _assert_within_bf16_ulps(a, b)
+        except AssertionError:
+            continue
+        raise AssertionError(why)
 
 
 def _assert_close_fp32(
@@ -282,13 +355,13 @@ class TestSplitQkvRmsnormRopePosCacheHalfNpu(unittest.TestCase):
         """The wide grid (B >= wide_grid_min_tokens) must agree with the per-head grid.
 
         Both arms run the same kernel; only the launch grid differs. V is a plain copy so it
-        is bit-identical; Q/K RMSNorm reduces over head_dim either way, so any difference is a
-        reassociation worth at most one bf16 ULP (relative 2**-7). Measured: Q and V are
-        bit-identical, K differs on < 0.001% of elements by exactly 1 ULP.
+        is bit-identical; Q and K are bounded in bf16 ULP.
+
         """
         eps = 1e-6
         max_pos = 2048
         rope_theta = 10000.0
+
         torch.manual_seed(0)
 
         qkv = torch.randn(
@@ -321,13 +394,27 @@ class TestSplitQkvRmsnormRopePosCacheHalfNpu(unittest.TestCase):
                 wide_grid_min_tokens=wide_grid_min_tokens,
             )
 
-        nq, nk, nv = run(bsz + 1)  # per-head grid
-        wq, wk, wv = run(0)  # wide grid
+        with _record_launch_grids() as grids:
+            nq, nk, nv = run(bsz + 1)  # per-head grid
+            wq, wk, wv = run(0)  # wide grid
+
+        # Agreement alone is not enough: if the width check rejects this
+        # q_hidden_size, both calls fall back and trivially match. Compare the
+        # launches instead of hard-coding n_cols > 1 for the per-head arm --
+        # with a single KV head (kv_hidden_size == head_dim) that arm is also
+        # one column, and the two calls would be the same launch.
+        assert kv_hidden_size > head_dim, (
+            "the arms are indistinguishable at one KV head; pick a case with "
+            "kv_hidden_size > head_dim"
+        )
+        assert len(grids) == 2, f"expected two launches, saw {grids}"
+        assert grids[0] != grids[1], f"both calls took the same grid: {grids[0]}"
+        assert grids[1][1] == 1, f"second call should be the wide grid: {grids[1]}"
 
         torch.testing.assert_close(wv.cpu(), nv.cpu(), atol=0, rtol=0)
-        one_bf16_ulp = 2**-7
-        _assert_close_fp32(wq, nq, atol=1e-6, rtol=one_bf16_ulp)
-        _assert_close_fp32(wk, nk, atol=1e-6, rtol=one_bf16_ulp)
+
+        _assert_within_bf16_ulps(wq, nq)
+        _assert_within_bf16_ulps(wk, nk)
 
     def test_grid_arms_agree_above_threshold(self):
         """Batch above the default threshold: wide grid vs per-head grid."""
@@ -337,6 +424,33 @@ class TestSplitQkvRmsnormRopePosCacheHalfNpu(unittest.TestCase):
             kv_hidden_size=512,
             head_dim=128,
             rope_dim=64,
+        )
+
+    def test_dispatch_boundary_q_hidden_8192(self):
+        """q_hidden_size == _WIDE_GRID_MAX_Q_HIDDEN: the last width that takes
+        the wide grid. This guards the comparison, not the constant -- turning
+        `<=` into `<` silently sends both arms down the per-head path, where
+        they agree for the wrong reason. Widening the constant is caught by the
+        12288 case below instead."""
+        self._run_case_grid_arms(
+            bsz=1024,
+            q_hidden_size=8192,
+            kv_hidden_size=1024,
+            head_dim=128,
+            rope_dim=64,
+        )
+
+    def test_dispatch_boundary_q_hidden_12288_falls_back(self):
+        """One step past the boundary: the per-head grid has to carry it. 12288
+        raises MLIRCompilationError on the wide grid, so a regression that drops
+        the width check fails here rather than in a deployment."""
+        self._run_case_graph(
+            bsz=1024,
+            q_hidden_size=12288,
+            kv_hidden_size=1024,
+            head_dim=128,
+            rope_dim=64,
+            use_qk_norm=True,
         )
 
     def test_wide_grid_vs_golden(self):

--- a/tests/python/sgl_kernel_npu/test_split_qkv_rmsnorm_rope_pos_cache_half_npu.py
+++ b/tests/python/sgl_kernel_npu/test_split_qkv_rmsnorm_rope_pos_cache_half_npu.py
@@ -516,14 +516,26 @@ class TestSplitQkvRmsnormRopePosCacheHalfNpu(unittest.TestCase):
         """One step past the boundary: the per-head grid has to carry it. 12288
         raises MLIRCompilationError on the wide grid, so a regression that drops
         the width check fails here rather than in a deployment."""
-        self._run_case_graph(
-            bsz=1024,
-            q_hidden_size=12288,
-            kv_hidden_size=1024,
-            head_dim=128,
-            rope_dim=64,
-            use_qk_norm=True,
-        )
+        kv_hidden_size, head_dim = 1024, 128
+        with _record_launch_grids() as grids:
+            self._run_case_graph(
+                bsz=1024,
+                q_hidden_size=12288,
+                kv_hidden_size=kv_hidden_size,
+                head_dim=head_dim,
+                rope_dim=64,
+                use_qk_norm=True,
+            )
+        # Assert the branch, not the absence of a crash. Today a wide-grid launch
+        # at this width raises MLIRCompilationError, so the fallback is load
+        # bearing; the moment it compiles -- a wider constant, a newer toolchain
+        # -- "falls back" becomes a claim nothing here checks. Same reason the
+        # 8192 case records grids.
+        expected_n_cols = kv_hidden_size // head_dim
+        assert grids, "no launch recorded"
+        assert all(
+            grid[1] == expected_n_cols for grid in grids
+        ), f"expected the per-head grid ({expected_n_cols} columns), saw {grids}"
 
     def test_wide_grid_vs_golden(self):
         """Batch above the default threshold takes the wide grid; still matches golden."""

--- a/tests/python/sgl_kernel_npu/test_split_qkv_rmsnorm_rope_pos_cache_half_npu.py
+++ b/tests/python/sgl_kernel_npu/test_split_qkv_rmsnorm_rope_pos_cache_half_npu.py
@@ -203,6 +203,75 @@ def test_within_bf16_ulps_helper_controls():
         raise AssertionError(why)
 
 
+def _assert_no_worse_than(
+    wide: torch.Tensor, per_head: torch.Tensor, golden: torch.Tensor
+):
+    """The wide grid must not be further from the fp32 reference than the
+    per-head grid is.
+
+    For K a ULP bound between the arms is unbounded, because RoPE cancels: one
+    ULP of the operands survives the subtraction whole and reads as many ULP on
+    the small result. At q_hidden 8192 the worst element sums -0.2749 and
+    +0.2906 to 0.0158, where the arms differ by 0.0017 -- 16 ULP. An elementwise
+    1 ULP bound holds on 15 of 20 seeds there; this predicate holds on all 20,
+    at both q_hidden. Q has no such element and keeps the ULP bound.
+    """
+    assert wide.shape == per_head.shape == golden.shape, (
+        f"shape mismatch: {tuple(wide.shape)} {tuple(per_head.shape)} "
+        f"{tuple(golden.shape)}"
+    )
+    # Non-finite first: two infinite arms compare equal and pass, and an
+    # infinite per_head passes anything, since the predicate only asks whether
+    # wide is the worse of the two.
+    for name, t in (("wide", wide), ("per_head", per_head), ("golden", golden)):
+        assert torch.isfinite(t).all(), f"{name} has non-finite values"
+    g = golden.to(torch.float32).cpu()
+    dw = (wide.to(torch.float32).cpu() - g).abs().max()
+    dn = (per_head.to(torch.float32).cpu() - g).abs().max()
+    # One bf16 step of slack: the arms round the same value in opposite
+    # directions often enough that requiring dw <= dn exactly is itself
+    # seed-dependent.
+    slack = dn.abs() * (2**-7) + torch.finfo(torch.bfloat16).tiny
+    assert dw <= dn + slack, (
+        f"wide grid is the worse approximation: max|wide-golden|={dw:.6g} "
+        f"vs max|per_head-golden|={dn:.6g}"
+    )
+
+
+def test_no_worse_than_helper_controls():
+    """Controls for _assert_no_worse_than: a shape mismatch (which a bare tensor
+    comparison would broadcast away), a genuinely worse first argument, and
+    non-finite values in any position.
+
+    Two of the non-finite cases pass on the arithmetic alone -- two infinite
+    arms are equally far from the reference, and an infinite per_head is further
+    than anything -- so they need the explicit check, not a tolerance.
+    """
+    g = torch.tensor([1.0, 2.0, 4.0])
+    good = torch.tensor([1.0, 2.0, 4.0])
+    worse = torch.tensor([1.0, 2.0, 4.5])
+    nan = torch.tensor([1.0, 2.0, float("nan")])
+    inf = torch.tensor([1.0, 2.0, float("inf")])
+
+    _assert_no_worse_than(good, worse, g)  # wide is the better arm: fine
+
+    for a, b, c, why in (
+        (worse, good, g, "worse arm accepted"),
+        (torch.tensor([1.0]), good, g, "shape mismatch accepted"),
+        (nan, good, g, "NaN in wide accepted"),
+        (good, nan, g, "NaN in per_head accepted"),
+        (good, good, nan, "NaN in golden accepted"),
+        (inf, good, g, "inf in wide accepted"),
+        (good, inf, g, "inf in per_head accepted"),
+        (inf, inf, g, "two infinite arms accepted"),
+    ):
+        try:
+            _assert_no_worse_than(a, b, c)
+        except AssertionError:
+            continue
+        raise AssertionError(why)
+
+
 def _assert_close_fp32(
     a: torch.Tensor, b: torch.Tensor, atol: float, rtol: float = 5e-3
 ):
@@ -351,70 +420,99 @@ class TestSplitQkvRmsnormRopePosCacheHalfNpu(unittest.TestCase):
         kv_hidden_size: int,
         head_dim: int,
         rope_dim: int,
+        seeds=(0, 3, 7, 14),
     ):
         """The wide grid (B >= wide_grid_min_tokens) must agree with the per-head grid.
 
         Both arms run the same kernel; only the launch grid differs. V is a plain copy so it
-        is bit-identical; Q and K are bounded in bf16 ULP.
+        is bit-identical, and Q is too. K differs on a small fraction of elements by an
+        amount bounded in absolute terms but not in relative ones, so the arms are compared
+        through the fp32 reference rather than to each other -- see _assert_no_worse_than.
 
+        More than one seed, because the predicate this replaced passed on seed 0 and failed
+        on 6 of 20 others: a single seed cannot tell a property of the kernel from a property
+        of the sample. Each seed here is one the old predicate failed on, except 0.
         """
         eps = 1e-6
         max_pos = 2048
         rope_theta = 10000.0
 
-        torch.manual_seed(0)
+        for seed in seeds:
+            with self.subTest(seed=seed):
+                torch.manual_seed(seed)
 
-        qkv = torch.randn(
-            bsz,
-            q_hidden_size + kv_hidden_size * 2,
-            dtype=self.dtype,
-            device=self.device,
-        )
-        positions = torch.randint(
-            0, max_pos, (bsz,), dtype=torch.int64, device=self.device
-        )
-        cos_sin_cache = _make_cos_sin_cache(
-            max_pos, rope_dim, rope_theta, torch.float32, self.device
-        )
-        q_weight = torch.randn(head_dim, dtype=self.dtype, device=self.device)
-        k_weight = torch.randn(head_dim, dtype=self.dtype, device=self.device)
+                qkv = torch.randn(
+                    bsz,
+                    q_hidden_size + kv_hidden_size * 2,
+                    dtype=self.dtype,
+                    device=self.device,
+                )
+                positions = torch.randint(
+                    0, max_pos, (bsz,), dtype=torch.int64, device=self.device
+                )
+                cos_sin_cache = _make_cos_sin_cache(
+                    max_pos, rope_dim, rope_theta, torch.float32, self.device
+                )
+                q_weight = torch.randn(head_dim, dtype=self.dtype, device=self.device)
+                k_weight = torch.randn(head_dim, dtype=self.dtype, device=self.device)
 
-        def run(wide_grid_min_tokens: int):
-            return split_qkv_rmsnorm_rope_pos_cache_half_npu(
-                qkv,
-                positions,
-                cos_sin_cache,
-                q_hidden_size,
-                kv_hidden_size,
-                head_dim,
-                eps=eps,
-                q_weight=q_weight,
-                k_weight=k_weight,
-                rope_dim=rope_dim,
-                wide_grid_min_tokens=wide_grid_min_tokens,
-            )
+                def run(wide_grid_min_tokens: int):
+                    return split_qkv_rmsnorm_rope_pos_cache_half_npu(
+                        qkv,
+                        positions,
+                        cos_sin_cache,
+                        q_hidden_size,
+                        kv_hidden_size,
+                        head_dim,
+                        eps=eps,
+                        q_weight=q_weight,
+                        k_weight=k_weight,
+                        rope_dim=rope_dim,
+                        wide_grid_min_tokens=wide_grid_min_tokens,
+                    )
 
-        with _record_launch_grids() as grids:
-            nq, nk, nv = run(bsz + 1)  # per-head grid
-            wq, wk, wv = run(0)  # wide grid
+                with _record_launch_grids() as grids:
+                    nq, nk, nv = run(bsz + 1)  # per-head grid
+                    wq, wk, wv = run(0)  # wide grid
 
-        # Agreement alone is not enough: if the width check rejects this
-        # q_hidden_size, both calls fall back and trivially match. Compare the
-        # launches instead of hard-coding n_cols > 1 for the per-head arm --
-        # with a single KV head (kv_hidden_size == head_dim) that arm is also
-        # one column, and the two calls would be the same launch.
-        assert kv_hidden_size > head_dim, (
-            "the arms are indistinguishable at one KV head; pick a case with "
-            "kv_hidden_size > head_dim"
-        )
-        assert len(grids) == 2, f"expected two launches, saw {grids}"
-        assert grids[0] != grids[1], f"both calls took the same grid: {grids[0]}"
-        assert grids[1][1] == 1, f"second call should be the wide grid: {grids[1]}"
+                # Agreement alone is not enough: if the width check rejects this
+                # q_hidden_size, both calls fall back and trivially match. Compare the
+                # launches instead of hard-coding n_cols > 1 for the per-head arm --
+                # with a single KV head (kv_hidden_size == head_dim) that arm is also
+                # one column, and the two calls would be the same launch.
+                assert kv_hidden_size > head_dim, (
+                    "the arms are indistinguishable at one KV head; pick a case with "
+                    "kv_hidden_size > head_dim"
+                )
+                assert len(grids) == 2, f"expected two launches, saw {grids}"
+                assert (
+                    grids[0] != grids[1]
+                ), f"both calls took the same grid: {grids[0]}"
+                assert (
+                    grids[1][1] == 1
+                ), f"second call should be the wide grid: {grids[1]}"
 
-        torch.testing.assert_close(wv.cpu(), nv.cpu(), atol=0, rtol=0)
+                torch.testing.assert_close(wv.cpu(), nv.cpu(), atol=0, rtol=0)
 
-        _assert_within_bf16_ulps(wq, nq)
-        _assert_within_bf16_ulps(wk, nk)
+                gq, gk, _ = golden_split_qkv_rmsnorm_rope_pos_cache_half(
+                    qkv,
+                    positions,
+                    cos_sin_cache,
+                    q_hidden_size,
+                    kv_hidden_size,
+                    head_dim,
+                    rope_dim,
+                    eps,
+                    q_weight,
+                    k_weight,
+                    None,
+                    None,
+                    use_qk_norm=True,
+                )
+                # Q holds a real ULP bound; K does not, because RoPE cancels
+                # there -- see _assert_no_worse_than.
+                _assert_within_bf16_ulps(wq, nq)
+                _assert_no_worse_than(wk, nk, gk)
 
     def test_grid_arms_agree_above_threshold(self):
         """Batch above the default threshold: wide grid vs per-head grid."""


### PR DESCRIPTION
Two follow-ups raised in review of #641 and #644.

## #644 — validate the vocab tile width

`tl.arange` needs a positive power of two, and `min(block_v, next_power_of_2(V))` only bounded the value from above. `block_v=0`, `3` or `1000` reached the kernel and failed inside the Triton compiler, where the message names neither the argument nor the constraint. They are now rejected with a `ValueError`, along with a non-int (`True` is an `int` subclass, so it needs its own arm) and an fp64 `logits`.

Bounding from above is also not enough on its own: a legal power of two can still be several tiles wide in the input dtype — fp32 `block_v=16384` is 64 KiB against a 32 KiB tile — which fails to compile rather than running slowly. The clamp is `min(block_v, budget, next_power_of_2(V))`, budget first.

An empty vocab gets its own check rather than riding the clamp: sglang replaces `triton.next_power_of_2` with a variant returning 1 at 0, so under sglang `V=0` ran at `BLOCK_V=1` — no error, garbage out.

Cases added for every rejected value, for valid overrides including one wider than the vocab so the clamp stays covered, and for the width that actually reaches the kernel: the launch is recorded and pinned to the dtype budget. Without that, the budget term was guarded only by the compile failure it prevents, so a budget that is wrong but still compiles passed unnoticed.

## #641 — dispatch boundary and the ULP bound

`split_qkv_rmsnorm_rope_pos_cache_half` takes the wide launch grid when `q_hidden_size <= _WIDE_GRID_MAX_Q_HIDDEN` (8192). That constant came from a compile probe, and the widest case under test was 6144, so neither side of the cutoff was exercised. Adds:

- `q_hidden_size = 8192` — the last width the wide grid takes;
- `q_hidden_size = 12288` — must fall back to the per-head grid. It raises `MLIRCompilationError` on the wide grid, so widening the cutoff fails here rather than at run time.

Both cases record the launch grids and assert the branch they claim. Agreement alone is not evidence: if the width check rejects the case, both arms fall back and match for the wrong reason, and "falls back" is a claim nothing checks. That is also why the per-head arm is identified by comparing the two launches rather than by `n_cols > 1` — with a single KV head, both arms are one column.

The two grid arms were compared with `atol=1e-6` plus `rtol=2**-7` and described as a 1 BF16 ULP bound. `assert_close` adds the two terms, so that admits much more than one ULP near zero and fewer than one near the top of the exponent range. Replaced with a count of steps between the bf16 bit patterns, mapped through sign-magnitude so it stays meaningful across zero, with non-finite values rejected rather than counted — two equal NaNs are zero steps apart and the largest finite value is one step from infinity, so both would pass a tight bound while meaning nothing.

That bound holds elementwise for Q, and for K only against the row's magnitude. RoPE cancels: `b*cos + a*sin` sums two terms of the row's magnitude into a result that can be far smaller, so one step of the operands survives whole and is many steps of the result. At `q_hidden` 8192 the worst element sums -0.2749 and +0.2906 to 0.0158, where the arms differ by 16 steps of the element and well under one step of its row.

The single seed was the weaker half: the old predicate passed on seed 0 and failed on 6 of 20 others, so the arms case runs four seeds, three of them ones it used to fail.

## Tests

Run on 910B3:

| File | Result |
| --- | --- |
| `tests/python/sgl_kernel_npu/test_argmax_softmax_prob.py` | 47 passed |
| `tests/python/sgl_kernel_npu/test_split_qkv_rmsnorm_rope_pos_cache_half_npu.py` | 9 passed |

Each new assertion was checked against the mutation it guards. Two that the previous round would have missed: halving the dtype budget — a wrong width that still compiles and still computes the right answer — now fails on the width; and widening `_WIDE_GRID_MAX_Q_HIDDEN` to 16384 fails the 12288 case, today with `MLIRCompilationError` and, once that width ever compiles, on the recorded grid.
