### PR TITLE
[NPU] Fix Mamba conv update numerical consistency

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d.py
@@ -207,41 +207,41 @@ def _causal_conv1d_update_kernel_npu_tiled(
         )
 
         # define history vectors as zeros then load conditionally
-        col0 = tl.zeros((BLOCK_N,), dtype=tl.float16)
-        col1 = tl.zeros((BLOCK_N,), dtype=tl.float16)
-        col2 = tl.zeros((BLOCK_N,), dtype=tl.float16)
-        col3 = tl.zeros((BLOCK_N,), dtype=tl.float16)
-        col4 = tl.zeros((BLOCK_N,), dtype=tl.float16)
+        col0 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+        col1 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+        col2 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+        col3 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+        col4 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
         if KERNEL_WIDTH >= 2:
             col0 = tl.load(
                 prior_tokens + 0 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(tl.float16)
+            ).to(x_ptr.dtype.element_ty)
         if KERNEL_WIDTH >= 3:
             col1 = tl.load(
                 prior_tokens + 1 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(tl.float16)
+            ).to(x_ptr.dtype.element_ty)
         if KERNEL_WIDTH >= 4:
             col2 = tl.load(
                 prior_tokens + 2 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(tl.float16)
+            ).to(x_ptr.dtype.element_ty)
         if KERNEL_WIDTH >= 5:
             col3 = tl.load(
                 prior_tokens + 3 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(tl.float16)
+            ).to(x_ptr.dtype.element_ty)
         if KERNEL_WIDTH >= 6:
             col4 = tl.load(
                 prior_tokens + 4 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(tl.float16)
+            ).to(x_ptr.dtype.element_ty)
 
         # -------------------------
         # STEP 2: chunked state update (replaces original NP2_STATELEN x BLOCK_N big block)
@@ -352,12 +352,9 @@ def _causal_conv1d_update_kernel_npu_tiled(
         x_base_1d = x_base
         o_base_1d = o_ptr + o_offset + idx_feats * stride_o_dim
 
-        # accumulator preload (bias)
-        acc_preload = acc_bias
-
         # compute each token; keep tl.range so varlen can use seqlen_run as runtime trip count (like original)
         for idx_token in tl.range(seqlen_run):
-            acc = acc_preload
+            acc = tl.zeros((BLOCK_N,), dtype=tl.float32)
 
             # same selection logic as original (unrolled by KERNEL_WIDTH)
             matrix_w = w_col0
@@ -368,7 +365,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                     x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                     matrix_x = tl.load(
                         x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                    ).to(tl.float16)
+                    ).to(x_ptr.dtype.element_ty)
                     matrix_w = w_col0
                 elif KERNEL_WIDTH == 2:
                     if j == 1:
@@ -376,7 +373,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(tl.float16)
+                        ).to(x_ptr.dtype.element_ty)
                 elif KERNEL_WIDTH == 3:
                     if j == 1:
                         matrix_w = w_col1
@@ -386,7 +383,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(tl.float16)
+                        ).to(x_ptr.dtype.element_ty)
                 elif KERNEL_WIDTH == 4:
                     if j == 1:
                         matrix_w = w_col1
@@ -399,7 +396,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(tl.float16)
+                        ).to(x_ptr.dtype.element_ty)
                 elif KERNEL_WIDTH == 5:
                     if j == 1:
                         matrix_w = w_col1
@@ -415,7 +412,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(tl.float16)
+                        ).to(x_ptr.dtype.element_ty)
                 elif KERNEL_WIDTH == 6:
                     if j == 1:
                         matrix_w = w_col1
@@ -434,9 +431,16 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(tl.float16)
+                        ).to(x_ptr.dtype.element_ty)
 
                 acc += matrix_x.to(tl.float32) * matrix_w  # [BLOCK_N]
+
+            if HAS_BIAS:
+                acc += acc_bias
+
+            # Persist one BF16 convolution result per token before SiLU, just
+            # like the one-token decode path.
+            acc = acc.to(x_ptr.dtype.element_ty, fp_downcast_rounding="rtne")
 
             # roll history window
             if KERNEL_WIDTH == 2:
@@ -461,6 +465,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                 col4 = matrix_x
 
             if SILU_ACTIVATION:
+                acc = acc.to(tl.float32)
                 acc = acc / (1.0 + tl.exp(-acc))
 
             # store output
@@ -1256,7 +1261,17 @@ def torch_causal_conv1d_update_npu(
     else:
         conv_state_update = hidden_states_new[:, :, -state_len:]
 
-    out = torch.sum(hidden_states_new * weight, dim=-1, keepdim=True)
+    # The speculative Triton kernel performs the convolution in FP32 before
+    # persisting BF16 output. Use the same arithmetic for one-token decode so
+    # enabling speculative decoding does not change model numerics.
+    out = torch.sum(
+        hidden_states_new.to(torch.float32) * weight.to(torch.float32),
+        dim=-1,
+        keepdim=True,
+    )
+    if bias is not None:
+        out = out + bias.to(torch.float32)[None, :, None]
+    out = out.to(hidden_state.dtype)
     if activation in ["silu", "swish"]:
         out = F.silu(out)
     out = out.to(hidden_state.dtype)

--- a/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d.py
@@ -438,8 +438,6 @@ def _causal_conv1d_update_kernel_npu_tiled(
             if HAS_BIAS:
                 acc += acc_bias
 
-            # Persist one FP16 convolution result per token before SiLU, just
-            # like the one-token decode path.
             acc = acc.to(tl.float16, fp_downcast_rounding="rtne")
 
             # roll history window
@@ -1261,9 +1259,6 @@ def torch_causal_conv1d_update_npu(
     else:
         conv_state_update = hidden_states_new[:, :, -state_len:]
 
-    # The speculative Triton kernel performs the convolution in FP32 before
-    # persisting FP16 output. Use the same arithmetic for one-token decode so
-    # enabling speculative decoding does not change model numerics.
     out = torch.sum(
         hidden_states_new.to(torch.float32) * weight.to(torch.float32),
         dim=-1,

--- a/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d.py
@@ -207,41 +207,41 @@ def _causal_conv1d_update_kernel_npu_tiled(
         )
 
         # define history vectors as zeros then load conditionally
-        col0 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
-        col1 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
-        col2 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
-        col3 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
-        col4 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+        col0 = tl.zeros((BLOCK_N,), dtype=tl.float16)
+        col1 = tl.zeros((BLOCK_N,), dtype=tl.float16)
+        col2 = tl.zeros((BLOCK_N,), dtype=tl.float16)
+        col3 = tl.zeros((BLOCK_N,), dtype=tl.float16)
+        col4 = tl.zeros((BLOCK_N,), dtype=tl.float16)
         if KERNEL_WIDTH >= 2:
             col0 = tl.load(
                 prior_tokens + 0 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(x_ptr.dtype.element_ty)
+            ).to(tl.float16)
         if KERNEL_WIDTH >= 3:
             col1 = tl.load(
                 prior_tokens + 1 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(x_ptr.dtype.element_ty)
+            ).to(tl.float16)
         if KERNEL_WIDTH >= 4:
             col2 = tl.load(
                 prior_tokens + 2 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(x_ptr.dtype.element_ty)
+            ).to(tl.float16)
         if KERNEL_WIDTH >= 5:
             col3 = tl.load(
                 prior_tokens + 3 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(x_ptr.dtype.element_ty)
+            ).to(tl.float16)
         if KERNEL_WIDTH >= 6:
             col4 = tl.load(
                 prior_tokens + 4 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(x_ptr.dtype.element_ty)
+            ).to(tl.float16)
 
         # -------------------------
         # STEP 2: chunked state update (replaces original NP2_STATELEN x BLOCK_N big block)
@@ -365,7 +365,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                     x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                     matrix_x = tl.load(
                         x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                    ).to(x_ptr.dtype.element_ty)
+                    ).to(tl.float16)
                     matrix_w = w_col0
                 elif KERNEL_WIDTH == 2:
                     if j == 1:
@@ -373,7 +373,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(x_ptr.dtype.element_ty)
+                        ).to(tl.float16)
                 elif KERNEL_WIDTH == 3:
                     if j == 1:
                         matrix_w = w_col1
@@ -383,7 +383,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(x_ptr.dtype.element_ty)
+                        ).to(tl.float16)
                 elif KERNEL_WIDTH == 4:
                     if j == 1:
                         matrix_w = w_col1
@@ -396,7 +396,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(x_ptr.dtype.element_ty)
+                        ).to(tl.float16)
                 elif KERNEL_WIDTH == 5:
                     if j == 1:
                         matrix_w = w_col1
@@ -412,7 +412,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(x_ptr.dtype.element_ty)
+                        ).to(tl.float16)
                 elif KERNEL_WIDTH == 6:
                     if j == 1:
                         matrix_w = w_col1
@@ -431,16 +431,16 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(x_ptr.dtype.element_ty)
+                        ).to(tl.float16)
 
                 acc += matrix_x.to(tl.float32) * matrix_w  # [BLOCK_N]
 
             if HAS_BIAS:
                 acc += acc_bias
 
-            # Persist one BF16 convolution result per token before SiLU, just
+            # Persist one FP16 convolution result per token before SiLU, just
             # like the one-token decode path.
-            acc = acc.to(x_ptr.dtype.element_ty, fp_downcast_rounding="rtne")
+            acc = acc.to(tl.float16, fp_downcast_rounding="rtne")
 
             # roll history window
             if KERNEL_WIDTH == 2:
@@ -1262,7 +1262,7 @@ def torch_causal_conv1d_update_npu(
         conv_state_update = hidden_states_new[:, :, -state_len:]
 
     # The speculative Triton kernel performs the convolution in FP32 before
-    # persisting BF16 output. Use the same arithmetic for one-token decode so
+    # persisting FP16 output. Use the same arithmetic for one-token decode so
     # enabling speculative decoding does not change model numerics.
     out = torch.sum(
         hidden_states_new.to(torch.float32) * weight.to(torch.float32),

--- a/scripts/run_kernel_tests.sh
+++ b/scripts/run_kernel_tests.sh
@@ -76,7 +76,7 @@ SPECULATIVE_TESTS=(
 MAMBA_TESTS=(
     # test_conv1d_prefill.py  # FAILING: PyTorch 2.10.0 strict schema check
     test_conv1d_update.py
-    # test_mamba_conv.py  # FAILING: varlen conv fp16 swish+bias output mismatch (ratio ~1.0)
+    test_mamba_conv.py
     # test_mamba_state_update.py  # FAILING: move_intermediate_cache strided-dst exact mismatch
 )
 

--- a/tests/python/sgl_kernel_npu/test_conv1d_update.py
+++ b/tests/python/sgl_kernel_npu/test_conv1d_update.py
@@ -10,6 +10,67 @@ logger = logging.getLogger("TestScript")
 torch.manual_seed(42)
 
 
+def test_speculative_bf16_matches_sequential_decode():
+    from sgl_kernel_npu.mamba.causal_conv1d import (
+        causal_conv1d_update_npu,
+        causal_conv1d_update_v2,
+    )
+
+    torch.npu.set_device("npu:0")
+    torch.manual_seed(42)
+    batch_size, steps, dim, width = 1, 4, 1024, 4
+    x = torch.randn(batch_size, steps, dim, device="npu", dtype=torch.bfloat16)
+    weight = torch.randn(dim, width, device="npu", dtype=torch.bfloat16)
+    bias = torch.randn(dim, device="npu", dtype=torch.bfloat16)
+    history = torch.randn(
+        batch_size, width - 1, dim, device="npu", dtype=torch.bfloat16
+    )
+    cache_indices = torch.tensor([0], device="npu", dtype=torch.int32)
+
+    speculative_state = torch.zeros(
+        batch_size,
+        width - 1 + steps - 1,
+        dim,
+        device="npu",
+        dtype=torch.bfloat16,
+    )
+    speculative_state[:, -(width - 1) :] = history
+    speculative_output = causal_conv1d_update_v2(
+        x.clone(),
+        speculative_state,
+        weight.T.contiguous(),
+        bias=bias,
+        activation="silu",
+        conv_state_indices=cache_indices,
+        num_accepted_tokens=torch.tensor([steps], device="npu", dtype=torch.int32),
+        pad_slot_id=-1,
+    )
+
+    sequential_state = history.transpose(1, 2).clone()
+    sequential_output = torch.stack(
+        [
+            causal_conv1d_update_npu(
+                x[:, step].clone(),
+                sequential_state,
+                weight,
+                bias=bias,
+                activation="silu",
+                conv_state_indices=cache_indices,
+            )
+            for step in range(steps)
+        ],
+        dim=1,
+    )
+
+    torch.testing.assert_close(speculative_output, sequential_output, rtol=0, atol=0)
+    torch.testing.assert_close(
+        speculative_state[:, -(width - 1) :],
+        sequential_state.transpose(1, 2),
+        rtol=0,
+        atol=0,
+    )
+
+
 # ==========================================
 # 1. Original SGLang implementation
 # ==========================================

--- a/tests/python/sgl_kernel_npu/test_conv1d_update.py
+++ b/tests/python/sgl_kernel_npu/test_conv1d_update.py
@@ -342,7 +342,7 @@ def test_npu_causal_conv1d_update():
     )
     conv_state_vl = conv_state_init.clone()
     # --- vLLM Execution (CPU/CUDA reference) ---
-    out_vl = vllm_causal_conv1d_update_v3(
+    out_vl, conv_state_vl = vllm_causal_conv1d_update_v3(
         hidden_state=hidden_state,
         conv_state=conv_state_vl,
         weight=weight,
@@ -457,7 +457,10 @@ def test_npu_causal_conv1d_update():
                 f"\\n✅ PASS: Output and state are correctly aligned to torch reference!"
             )
         else:
-            print(f"\\n⚠️  WARNING: Precision below expected threshold")
+            raise AssertionError(
+                f"Precision below expected threshold: output {matched}/{total}, "
+                f"state {state_exact_match}/{state_total}"
+            )
 
         print(f"\n🎉 NPU causal_conv1d_update test passed!")
 
@@ -466,9 +469,15 @@ def test_npu_causal_conv1d_update():
         import traceback
 
         traceback.print_exc()
+        raise
 
 
 if __name__ == "__main__":
+    print("\n" + "=" * 60)
+    print("Running test_speculative_fp16_matches_sequential_decode")
+    print("=" * 60)
+    test_speculative_fp16_matches_sequential_decode()
+
     # print("="*60)
     # print("Running test_correctness_fixed (CPU/CUDA reference)")
     # print("="*60)

--- a/tests/python/sgl_kernel_npu/test_conv1d_update.py
+++ b/tests/python/sgl_kernel_npu/test_conv1d_update.py
@@ -10,7 +10,7 @@ logger = logging.getLogger("TestScript")
 torch.manual_seed(42)
 
 
-def test_speculative_bf16_matches_sequential_decode():
+def test_speculative_fp16_matches_sequential_decode():
     from sgl_kernel_npu.mamba.causal_conv1d import (
         causal_conv1d_update_npu,
         causal_conv1d_update_v2,
@@ -19,12 +19,10 @@ def test_speculative_bf16_matches_sequential_decode():
     torch.npu.set_device("npu:0")
     torch.manual_seed(42)
     batch_size, steps, dim, width = 1, 4, 1024, 4
-    x = torch.randn(batch_size, steps, dim, device="npu", dtype=torch.bfloat16)
-    weight = torch.randn(dim, width, device="npu", dtype=torch.bfloat16)
-    bias = torch.randn(dim, device="npu", dtype=torch.bfloat16)
-    history = torch.randn(
-        batch_size, width - 1, dim, device="npu", dtype=torch.bfloat16
-    )
+    x = torch.randn(batch_size, steps, dim, device="npu", dtype=torch.float16)
+    weight = torch.randn(dim, width, device="npu", dtype=torch.float16)
+    bias = torch.randn(dim, device="npu", dtype=torch.float16)
+    history = torch.randn(batch_size, width - 1, dim, device="npu", dtype=torch.float16)
     cache_indices = torch.tensor([0], device="npu", dtype=torch.int32)
 
     speculative_state = torch.zeros(
@@ -32,7 +30,7 @@ def test_speculative_bf16_matches_sequential_decode():
         width - 1 + steps - 1,
         dim,
         device="npu",
-        dtype=torch.bfloat16,
+        dtype=torch.float16,
     )
     speculative_state[:, -(width - 1) :] = history
     speculative_output = causal_conv1d_update_v2(

--- a/tests/python/sgl_kernel_npu/test_mamba_conv.py
+++ b/tests/python/sgl_kernel_npu/test_mamba_conv.py
@@ -206,7 +206,7 @@ def test_conv_varlen_update(
     state_indexs = torch.Tensor(state_indexs).to(device).long()
 
     x = torch.randn(T, D).to(device, dtype)
-    weight = torch.randn(D, W).to(device, dtype) * 0
+    weight = torch.randn(D, W).to(device, dtype)
     bias = torch.randn(D).to(device, dtype) if has_bias else None
     residual = x.clone() if has_residual else None
     conv_states_ref = torch.randn(T + 1, D, W - 1).to(device, dtype)


### PR DESCRIPTION
## Problem

The Mamba conv update path differed from the reference implementation in several ways:

- sequential execution omitted the convolution bias;
- FP16 execution crossed the activation boundary with different precision;
- the validation test used zero weights, masking numerical mismatches;
- the reference helper's tuple return was not unpacked, and test failures could be swallowed.

## Changes

- Accumulate the convolution and bias in FP32, then cast to FP16 before SiLU.
- Keep input/history values at the intended FP16 boundary.
- Validate with non-zero weights and exact FP16 comparisons.
- Unpack the reference tuple and propagate validation failures.
- Enable `test_mamba_conv.py` in the Mamba PR CI test group.

## Validation

- PR CI at `ba69abb`: `test-mamba-ops` passed on CANN 9.0.0/A3 and CANN 9.1.0/A3.
- Both jobs executed and passed `test_conv1d_update.py` and `test_mamba_conv.py`.
- `test_mamba_conv.py`: 9/9 tests passed on each CANN version.
- Both job logs contain no traceback or swallowed test failure.
- Machine 3 / `sglwmc-723`: Mamba CI collection passed (15/15 before the state-stride test was split to a separate PR).
- Machine 3 / `sglwmc-813`: Mamba CI collection passed (15/15 before the state-stride test was split to a separate PR).
- Earlier focused validation: exact FP16 10/10, non-zero decode 80/80, MTP 10/10, end-to-end 5/5.

## Accuracy
- Aime26 : 29/30, 96.667