### PR TITLE
[test](deepep): cover zero-token layout on idle ranks

### DIFF
--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -133,6 +133,12 @@ jobs:
           HCCL_BUFFSIZE: 4065
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=4
+      - name: Run zero-token layout regression
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 4065
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_zero_token_layout.py
       - name: Run test intranode for big bs
         timeout-minutes: 10
         env:

--- a/tests/python/deepep/test_zero_token_layout.py
+++ b/tests/python/deepep/test_zero_token_layout.py
@@ -1,0 +1,90 @@
+import argparse
+import os
+
+import deep_ep
+import torch
+import torch.distributed as dist
+import torch_npu  # noqa: F401
+
+
+NUM_EXPERTS = 256
+NUM_TOPK = 8
+
+
+def run_rank(local_rank: int, world_size: int) -> None:
+    torch.npu.set_device(local_rank)
+    dist.init_process_group(
+        backend="hccl",
+        init_method=f"tcp://{os.environ['MASTER_ADDR']}:{os.environ['MASTER_PORT']}",
+        rank=local_rank,
+        world_size=world_size,
+    )
+    group = dist.new_group(list(range(world_size)))
+
+    try:
+        buffer = deep_ep.Buffer(
+            group,
+            int(2e9),
+            0,
+            low_latency_mode=False,
+            num_qps_per_rank=1,
+        )
+
+        # Match SGLang's DP-attention idle path: only one DP rank owns a token,
+        # while every idle rank still participates in DeepEP layout generation.
+        num_tokens = 1 if local_rank == 0 else 0
+        if num_tokens:
+            topk_idx = torch.arange(
+                NUM_TOPK, dtype=torch.int64, device="npu"
+            ).reshape(1, NUM_TOPK)
+        else:
+            topk_idx = torch.empty(
+                (0, NUM_TOPK), dtype=torch.int64, device="npu"
+            )
+
+        (
+            num_tokens_per_rank,
+            num_tokens_per_rdma_rank,
+            num_tokens_per_expert,
+            is_token_in_rank,
+            _,
+        ) = buffer.get_dispatch_layout(topk_idx, NUM_EXPERTS)
+
+        assert num_tokens_per_rdma_rank is None
+        assert tuple(num_tokens_per_rank.shape) == (world_size,)
+        assert tuple(is_token_in_rank.shape) == (num_tokens, world_size)
+
+        expected_routes = NUM_TOPK if num_tokens else 0
+        assert int(num_tokens_per_expert.sum().item()) == expected_routes
+        if num_tokens == 0:
+            assert int(num_tokens_per_rank.sum().item()) == 0
+            assert is_token_in_rank.numel() == 0
+
+        print(
+            f"rank={local_rank} num_tokens={num_tokens} layout passed",
+            flush=True,
+        )
+        dist.barrier(group=group)
+    finally:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Test zero-token DeepEP layouts")
+    parser.add_argument(
+        "--num-processes",
+        type=int,
+        default=16,
+        help="Number of local ranks to spawn (default: 16)",
+    )
+    args = parser.parse_args()
+
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29567")
+    os.environ.setdefault("DEEP_USE_MODE", "default")
+    torch.multiprocessing.spawn(
+        run_rank,
+        args=(args.num_processes,),
+        nprocs=args.num_processes,
+        join=True,
+    )


### PR DESCRIPTION
## Motivation

PR #735 fixed get_dispatch_layout to accept zero-token source ranks, which are valid when DP/EP load is imbalanced. The functional change is already merged, but the repository does not retain an automated regression for the idle-rank layout that triggered the SGLang failure.

## Modification

- Add a 16-rank DeepEP layout regression matching the SGLang DP-attention idle path.
- Give rank 0 one token and ranks 1-15 contiguous topk_idx tensors with shape (0, 8).
- Validate layout shapes and route counts for both active and idle ranks.
- Run the regression in the existing A3 PR matrix for CANN 9.0.0 and 9.1.0.

## Testing

Static checks performed locally:

- python3 -m py_compile tests/python/deepep/test_zero_token_layout.py
- Parsed .github/workflows/pr-test-deepep-npu.yml with PyYAML
- git diff --check

The same 16-rank zero-token path and Kimi K2.6 3k5/1k5/50ms workload passed end-to-end with kernel 2026.8.18 plus the #735-equivalent patch:

- CANN 9.0.0: https://github.com/Ascend/sglang/actions/runs/32551752743
- CANN 9.1.0: https://github.com/Ascend/sglang/actions/runs/32553738086

This branch was not run locally because the local environment has no Ascend NPU; the added PR CI step provides the repository-native runtime validation.