### PR TITLE
[NPU] align native causal conv1d recurrent numerics

### DIFF
--- a/csrc/causal_conv1d/op_kernel/arch35/causal_conv1d_regbase.h
+++ b/csrc/causal_conv1d/op_kernel/arch35/causal_conv1d_regbase.h
@@ -23,6 +23,7 @@ using namespace AscendC::MicroAPI;
 constexpr uint16_t V_LENGTH = VECTOR_REG_WIDTH / sizeof(float);
 
 constexpr CastTrait castTraitB16ToB32 = {RegLayout::ZERO, SatMode::UNKNOWN, MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
+constexpr CastTrait castTraitB32ToB16 = {RegLayout::ZERO, SatMode::SAT, MaskMergeMode::ZEROING, RoundMode::CAST_RINT};
 
 template <typename T, bool hasActivation>
 __aicore__ inline void ComputeFnRollingOutputRegbase(LocalTensor<T> ring, LocalTensor<float> currF,
@@ -42,6 +43,7 @@ __aicore__ inline void ComputeFnRollingOutputRegbase(LocalTensor<T> ring, LocalT
         RegTensor<float> state0F;
         RegTensor<float> weightF;
         RegTensor<float> tmp;
+        RegTensor<T> roundedInputT;
         MaskReg pregLoop;
         for (uint16_t j = 0; j < colLoopTimes; j++) {
             pregLoop = UpdateMask<float>(dataCount);
@@ -52,6 +54,14 @@ __aicore__ inline void ComputeFnRollingOutputRegbase(LocalTensor<T> ring, LocalT
             Mul(currF, currF, weightF, pregLoop);
             Add(state0F, state0F, currF, pregLoop);
             if constexpr (hasActivation) {
+                if constexpr (!IsSameType<T, float>::value) {
+                    // Match the tensor-dtype checkpoint of BF16/FP16
+                    // convolution before SiLU.  Without this round trip the
+                    // FN rolling prefill path activates the FP32 accumulator,
+                    // while update/decode activates a rounded T value.
+                    Cast<T, float, castTraitB32ToB16>(roundedInputT, state0F, pregLoop);
+                    Cast<float, T, castTraitB16ToB32>(state0F, roundedInputT, pregLoop);
+                }
                 Muls(tmp, state0F, -1.0f, pregLoop);
                 Exp(tmp, tmp, pregLoop);
                 Adds(tmp, tmp, 1.0f, pregLoop);

--- a/csrc/causal_conv1d/op_kernel/causal_conv1d.h
+++ b/csrc/causal_conv1d/op_kernel/causal_conv1d.h
@@ -208,6 +208,8 @@ protected:
     __aicore__ inline void MaybeWriteBackSeqSplitTailChunk(int32_t chunkStart, int32_t chunkLen, int32_t seqStart,
                                                            int32_t seqLen, int32_t cacheIdx, int32_t channelStart,
                                                            int32_t baseDim, int32_t dim);
+    __aicore__ inline void ZeroFnOutputRange(int32_t tokenStart, int32_t tokenEnd, int32_t channelStart,
+                                             int32_t baseDim, int32_t dim);
     __aicore__ inline void ProcessDefault();
     template <int32_t kWindowMode>
     __aicore__ inline void ProcessDefaultByWindowMode();
@@ -472,7 +474,7 @@ __aicore__ inline void CAUSAL_CONV1D_CLASS::RunSeq(int32_t start, int32_t len, i
         }
 
         bool accInitialized = false;
-        if (hasBias) {
+        if (hasBias && !kIsUpdateMode) {
             Adds(accF, biasF, 0.0f, baseDim);
             PipeBarrier<PIPE_V>();
             accInitialized = true;
@@ -492,6 +494,18 @@ __aicore__ inline void CAUSAL_CONV1D_CLASS::RunSeq(int32_t start, int32_t len, i
         }
 
         PipeBarrier<PIPE_V>();
+
+        if constexpr (kIsUpdateMode) {
+            if (hasBias) {
+                // Match PR651/Triton update arithmetic: accumulate every
+                // convolution tap first, then add bias.  Initializing the
+                // accumulator from bias changes the FP32 rounding path; the
+                // resulting rare BF16 one-ULP differences accumulate across
+                // GDN layers and long decode chains.
+                Add(accF, accF, biasF, baseDim);
+                PipeBarrier<PIPE_V>();
+            }
+        }
 
         if (hasActivation) {
             if constexpr (IsSameType<T, float>::value) {
@@ -628,7 +642,7 @@ __aicore__ inline void CAUSAL_CONV1D_CLASS::ComputeFnRollingOutput(int32_t slotC
     PipeBarrier<PIPE_V>();
 
     const bool hasActivation = HasActivation();
-    if (hasActivation) {
+    if (hasActivation && IsSameType<T, float>::value) {
         PipeBarrier<PIPE_V>();
         Silu(currF, state0F, baseDim);
     }
@@ -731,7 +745,18 @@ __aicore__ inline void CAUSAL_CONV1D_CLASS::RunSeqFnRolling(int32_t start, int32
             }
         } else {
             if (hasActivation) {
+#if defined(__CCE_AICORE__) && __CCE_AICORE__ == 310
+                // RegBase rounded the FP32 convolution accumulator to T and
+                // expanded it again before producing currF = SiLU(input).
                 Cast(outSlotT, currF, RoundMode::CAST_RINT, baseDim);
+#else
+                // Use the output buffer as the temporary T checkpoint.  This
+                // mirrors BF16 F.conv1d -> BF16 SiLU instead of applying SiLU
+                // directly to the FP32 accumulator.  The old behavior made
+                // run_mode=0 prefill diverge from run_mode=1 update at every
+                // GDN layer and the error accumulated into garbled decoding.
+                RoundedInputSilu(outSlotT, outSlotT, currF, state0F, baseDim);
+#endif
             } else {
                 Cast(outSlotT, state0F, RoundMode::CAST_RINT, baseDim);
             }

--- a/csrc/causal_conv1d/op_kernel/causal_conv1d.h
+++ b/csrc/causal_conv1d/op_kernel/causal_conv1d.h
@@ -30,6 +30,57 @@ namespace NsCausalConv1d {
 using namespace AscendC;
 using namespace NsCausalConv1dCommon;
 
+template <typename T>
+__aicore__ inline void RoundedInputSilu(LocalTensor<T> dst, LocalTensor<T> roundedInputT,
+                                        LocalTensor<float> roundedInputF, LocalTensor<float> inputF,
+                                        uint32_t dataCount)
+{
+#if defined(__DAV_C220_VEC__)
+    if constexpr (IsSameType<T, bfloat16_t>::value) {
+        set_mask_count();
+        set_vector_mask(0, dataCount);
+        AscendC::CastImpl<bfloat16_t, float, false>(
+            (__ubuf__ bfloat16_t *)roundedInputT.GetPhyAddr(), (__ubuf__ float *)inputF.GetPhyAddr(),
+            RoundMode::CAST_RINT,
+            static_cast<uint64_t>(0), 1,
+            {1, 1, DEFAULT_REPEAT_STRIDE / 2, DEFAULT_REPEAT_STRIDE});
+        PipeBarrier<PIPE_V>();
+        AscendC::CastImpl<float, bfloat16_t, false>(
+            (__ubuf__ float *)roundedInputF.GetPhyAddr(), (__ubuf__ bfloat16_t *)roundedInputT.GetPhyAddr(),
+            RoundMode::CAST_NONE,
+            static_cast<uint64_t>(0), 1,
+            {1, 1, DEFAULT_REPEAT_STRIDE, DEFAULT_REPEAT_STRIDE / 2});
+        PipeBarrier<PIPE_V>();
+
+        const UnaryRepeatParams unaryParams;
+        const BinaryRepeatParams binaryParams;
+        Muls<float, false>(inputF, roundedInputF, -1.0f, MASK_PLACEHOLDER, 1, unaryParams);
+        PipeBarrier<PIPE_V>();
+        Exp<float, false>(inputF, inputF, MASK_PLACEHOLDER, 1, unaryParams);
+        PipeBarrier<PIPE_V>();
+        Adds<float, false>(inputF, inputF, 1.0f, MASK_PLACEHOLDER, 1, unaryParams);
+        PipeBarrier<PIPE_V>();
+        Div<float, false>(inputF, roundedInputF, inputF, MASK_PLACEHOLDER, 1, binaryParams);
+        PipeBarrier<PIPE_V>();
+
+        AscendC::CastImpl<bfloat16_t, float, false>(
+            (__ubuf__ bfloat16_t *)dst.GetPhyAddr(), (__ubuf__ float *)inputF.GetPhyAddr(), RoundMode::CAST_RINT,
+            static_cast<uint64_t>(0), 1,
+            {1, 1, DEFAULT_REPEAT_STRIDE / 2, DEFAULT_REPEAT_STRIDE});
+        set_mask_norm();
+        set_vector_mask(static_cast<uint64_t>(-1), static_cast<uint64_t>(-1));
+        return;
+    }
+#endif
+    Cast(roundedInputT, inputF, RoundMode::CAST_RINT, dataCount);
+    PipeBarrier<PIPE_V>();
+    Cast(roundedInputF, roundedInputT, RoundMode::CAST_NONE, dataCount);
+    PipeBarrier<PIPE_V>();
+    Silu(inputF, roundedInputF, dataCount);
+    PipeBarrier<PIPE_V>();
+    Cast(dst, inputF, RoundMode::CAST_RINT, dataCount);
+}
+
 #define CAUSAL_CONV1D_TEMPLATE_ARGS typename T, uint32_t runModeKey, uint32_t widthKey, uint32_t fnPlanKey
 #define CAUSAL_CONV1D_CLASS CausalConv1d<T, runModeKey, widthKey, fnPlanKey>
 
@@ -398,8 +449,13 @@ __aicore__ inline void CAUSAL_CONV1D_CLASS::RunSeq(int32_t start, int32_t len, i
     LocalTensor<float> &biasF = cl.biasF;
     LocalTensor<float> &accF = cl.accF;
     LocalTensor<float> &tmpF = cl.tmpF;
+    LocalTensor<float> &currF = cl.currF;
     LocalTensor<T> ring = inBuf.Get<T>();
     LocalTensor<T> outT = outBuf.Get<T>();
+    LocalTensor<T> activationInputT;
+    if constexpr (!IsSameType<T, float>::value) {
+        activationInputT = currF.ReinterpretCast<T>();
+    }
     const bool hasBias = HasBias();
     const bool hasActivation = HasActivation();
     for (int32_t t = 0; t < len; ++t) {
@@ -438,7 +494,9 @@ __aicore__ inline void CAUSAL_CONV1D_CLASS::RunSeq(int32_t start, int32_t len, i
         PipeBarrier<PIPE_V>();
 
         if (hasActivation) {
-            Silu(tmpF, accF, baseDim);
+            if constexpr (IsSameType<T, float>::value) {
+                Silu(tmpF, accF, baseDim);
+            }
         }
 
         const int32_t outSlot = t & 1;
@@ -455,7 +513,7 @@ __aicore__ inline void CAUSAL_CONV1D_CLASS::RunSeq(int32_t start, int32_t len, i
             }
         } else {
             if (hasActivation) {
-                Cast(outSlotT, tmpF, RoundMode::CAST_RINT, baseDim);
+                RoundedInputSilu(outSlotT, activationInputT, tmpF, accF, baseDim);
             } else {
                 Cast(outSlotT, accF, RoundMode::CAST_RINT, baseDim);
             }

--- a/csrc/causal_conv1d/op_kernel/causal_conv1d_fn_tasks.h
+++ b/csrc/causal_conv1d/op_kernel/causal_conv1d_fn_tasks.h
@@ -187,6 +187,32 @@ __aicore__ inline void CAUSAL_CONV1D_CLASS::MaybeWriteBackSeqSplitTailChunk(int3
 }
 
 template <CAUSAL_CONV1D_TEMPLATE_ARGS>
+__aicore__ inline void CAUSAL_CONV1D_CLASS::ZeroFnOutputRange(int32_t tokenStart, int32_t tokenEnd,
+                                                              int32_t channelStart, int32_t baseDim, int32_t dim)
+{
+    if (tokenEnd <= tokenStart) {
+        return;
+    }
+
+    // Varlen scheduler/page alignment can leave physical rows after the last
+    // query_start_loc entry.  PR651 returns zeros for those rows.  The native
+    // kernel previously left empty_like() storage untouched, so allocator
+    // contents entered the downstream recurrent path.  Clear only the ranges
+    // this channel task did not process; doing it in the same AscendC launch
+    // also avoids a host-side zero-fill racing the kernel stream.
+    LocalTensor<T> zero = inBuf.Get<T>();
+    Duplicate(zero, static_cast<T>(0), baseDim);
+    SetFlag<HardEvent::V_MTE3>(stateShiftVToMte3Event_);
+    WaitFlag<HardEvent::V_MTE3>(stateShiftVToMte3Event_);
+    for (int32_t token = tokenStart; token < tokenEnd; ++token) {
+        const int64_t outOffset = static_cast<int64_t>(token) * dim + channelStart;
+        DataCopy(yGm[outOffset], zero, baseDim);
+    }
+    SetFlag<HardEvent::MTE3_V>(stateWritebackMte3ToVEvent_);
+    WaitFlag<HardEvent::MTE3_V>(stateWritebackMte3ToVEvent_);
+}
+
+template <CAUSAL_CONV1D_TEMPLATE_ARGS>
 __aicore__ inline void CAUSAL_CONV1D_CLASS::PrefetchInitStatesToWorkspace(int32_t channelStart, int32_t baseDimSize)
 {
     if (tilingData_->hasInitStateWorkspace == 0) {
@@ -289,6 +315,7 @@ __aicore__ inline void CAUSAL_CONV1D_CLASS::ProcessVarlenTokenTiled()
 
         int32_t cacheIdx = 0;
         if (!ResolveSeqCacheIndex(seq, hasCacheIndices, cacheIdx)) {
+            ZeroFnOutputRange(cursor, tileEnd, blockTask.channelStart, blockTask.baseDimSize, dim);
             cursor = tileEnd;
             ++seq;
             continue;
@@ -300,6 +327,10 @@ __aicore__ inline void CAUSAL_CONV1D_CLASS::ProcessVarlenTokenTiled()
 
         cursor = tileEnd;
         ++seq;
+    }
+
+    if (isVarlenMode && cursor < blockTask.tokenEnd) {
+        ZeroFnOutputRange(cursor, blockTask.tokenEnd, blockTask.channelStart, blockTask.baseDimSize, dim);
     }
 }
 

--- a/csrc/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule_kernel.cpp
+++ b/csrc/recurrent_gated_delta_rule/op_kernel/recurrent_gated_delta_rule_kernel.cpp
@@ -433,6 +433,14 @@ private:
         uint32_t ktShape[2] = {1, alignK_};
         uint32_t deltaShape[2] = {curSingleV, 1};
 
+        out_empty_Attn.wait();
+        if (seq_i > seq0) {
+            // Decode persists BF16 state between tokens. Match that round-trip
+            // during multi-token verification before advancing the recurrence.
+            Cast(stateInUb, stateOutLocal, AscendC::RoundMode::CAST_NONE, alignK_ * curSingleV);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+
         {
             uint64_t gbOffset = head_i + (seq_i - seq0) * NV_;
             gama_ = hasGama_ ? gamaLocal.GetValue(gbOffset) : 1;
@@ -489,8 +497,6 @@ private:
                                            curSingleV, {1, 0, 1, 16, 1, 0});
             AscendC::PipeBarrier<PIPE_V>();
         }
-
-        out_empty_Attn.wait();
 
         Cast(stateOutLocal, stateInUb, AscendC::RoundMode::CAST_RINT, alignK_ * curSingleV);
 

--- a/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d.py
@@ -207,41 +207,41 @@ def _causal_conv1d_update_kernel_npu_tiled(
         )
 
         # define history vectors as zeros then load conditionally
-        col0 = tl.zeros((BLOCK_N,), dtype=tl.float16)
-        col1 = tl.zeros((BLOCK_N,), dtype=tl.float16)
-        col2 = tl.zeros((BLOCK_N,), dtype=tl.float16)
-        col3 = tl.zeros((BLOCK_N,), dtype=tl.float16)
-        col4 = tl.zeros((BLOCK_N,), dtype=tl.float16)
+        col0 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+        col1 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+        col2 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+        col3 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+        col4 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
         if KERNEL_WIDTH >= 2:
             col0 = tl.load(
                 prior_tokens + 0 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(tl.float16)
+            ).to(x_ptr.dtype.element_ty)
         if KERNEL_WIDTH >= 3:
             col1 = tl.load(
                 prior_tokens + 1 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(tl.float16)
+            ).to(x_ptr.dtype.element_ty)
         if KERNEL_WIDTH >= 4:
             col2 = tl.load(
                 prior_tokens + 2 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(tl.float16)
+            ).to(x_ptr.dtype.element_ty)
         if KERNEL_WIDTH >= 5:
             col3 = tl.load(
                 prior_tokens + 3 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(tl.float16)
+            ).to(x_ptr.dtype.element_ty)
         if KERNEL_WIDTH >= 6:
             col4 = tl.load(
                 prior_tokens + 4 * stride_conv_state_tok,
                 mask=lane_active & mask_w,
                 other=0.0,
-            ).to(tl.float16)
+            ).to(x_ptr.dtype.element_ty)
 
         # -------------------------
         # STEP 2: chunked state update (replaces original NP2_STATELEN x BLOCK_N big block)
@@ -352,12 +352,9 @@ def _causal_conv1d_update_kernel_npu_tiled(
         x_base_1d = x_base
         o_base_1d = o_ptr + o_offset + idx_feats * stride_o_dim
 
-        # accumulator preload (bias)
-        acc_preload = acc_bias
-
         # compute each token; keep tl.range so varlen can use seqlen_run as runtime trip count (like original)
         for idx_token in tl.range(seqlen_run):
-            acc = acc_preload
+            acc = tl.zeros((BLOCK_N,), dtype=tl.float32)
 
             # same selection logic as original (unrolled by KERNEL_WIDTH)
             matrix_w = w_col0
@@ -368,7 +365,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                     x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                     matrix_x = tl.load(
                         x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                    ).to(tl.float16)
+                    ).to(x_ptr.dtype.element_ty)
                     matrix_w = w_col0
                 elif KERNEL_WIDTH == 2:
                     if j == 1:
@@ -376,7 +373,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(tl.float16)
+                        ).to(x_ptr.dtype.element_ty)
                 elif KERNEL_WIDTH == 3:
                     if j == 1:
                         matrix_w = w_col1
@@ -386,7 +383,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(tl.float16)
+                        ).to(x_ptr.dtype.element_ty)
                 elif KERNEL_WIDTH == 4:
                     if j == 1:
                         matrix_w = w_col1
@@ -399,7 +396,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(tl.float16)
+                        ).to(x_ptr.dtype.element_ty)
                 elif KERNEL_WIDTH == 5:
                     if j == 1:
                         matrix_w = w_col1
@@ -415,7 +412,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(tl.float16)
+                        ).to(x_ptr.dtype.element_ty)
                 elif KERNEL_WIDTH == 6:
                     if j == 1:
                         matrix_w = w_col1
@@ -434,9 +431,18 @@ def _causal_conv1d_update_kernel_npu_tiled(
                         x_ptrs_1d = x_base_1d + idx_token * stride_x_token
                         matrix_x = tl.load(
                             x_ptrs_1d, mask=lane_active & mask_w, other=0.0
-                        ).to(tl.float16)
+                        ).to(x_ptr.dtype.element_ty)
 
                 acc += matrix_x.to(tl.float32) * matrix_w  # [BLOCK_N]
+
+            if HAS_BIAS:
+                acc += acc_bias
+
+            # Persist one BF16 convolution result per token before SiLU, just
+            # like the one-token decode path.
+            acc = acc.to(
+                x_ptr.dtype.element_ty, fp_downcast_rounding="rtne"
+            )
 
             # roll history window
             if KERNEL_WIDTH == 2:
@@ -461,6 +467,7 @@ def _causal_conv1d_update_kernel_npu_tiled(
                 col4 = matrix_x
 
             if SILU_ACTIVATION:
+                acc = acc.to(tl.float32)
                 acc = acc / (1.0 + tl.exp(-acc))
 
             # store output
@@ -1256,7 +1263,17 @@ def torch_causal_conv1d_update_npu(
     else:
         conv_state_update = hidden_states_new[:, :, -state_len:]
 
-    out = torch.sum(hidden_states_new * weight, dim=-1, keepdim=True)
+    # The speculative Triton kernel performs the convolution in FP32 before
+    # persisting BF16 output. Use the same arithmetic for one-token decode so
+    # enabling speculative decoding does not change model numerics.
+    out = torch.sum(
+        hidden_states_new.to(torch.float32) * weight.to(torch.float32),
+        dim=-1,
+        keepdim=True,
+    )
+    if bias is not None:
+        out = out + bias.to(torch.float32)[None, :, None]
+    out = out.to(hidden_state.dtype)
     if activation in ["silu", "swish"]:
         out = F.silu(out)
     out = out.to(hidden_state.dtype)

--- a/python/sgl_kernel_npu/sgl_kernel_npu/mamba/mamba_state_update_triton.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/mamba/mamba_state_update_triton.py
@@ -89,7 +89,7 @@ def move_intermediate_cache(
     dst_indices_tensor,
     src_indices_tensor,
     last_steps_tensor,
-    h_block_size=2,
+    h_block_size=1,
 ):
     """
     Move intermediate cache to SSM states using Triton kernel.
@@ -138,7 +138,8 @@ def move_intermediate_cache(
         dim_v=V,
         dim_k=K,
         num_layers=L,
-        H_BLOCK_SIZE=h_block_size,  # Process 2 h elements per block
+        # Keep the 128x128 state tile within the A2 192 KiB UB.
+        H_BLOCK_SIZE=h_block_size,
         BLOCK_V=triton.next_power_of_2(V),  # Block size for dim_v
         BLOCK_K=triton.next_power_of_2(K),  # Block size for dim_k
     )

--- a/tests/python/sgl_kernel_npu/test_causal_conv1d_chunk_chain.py
+++ b/tests/python/sgl_kernel_npu/test_causal_conv1d_chunk_chain.py
@@ -1,0 +1,89 @@
+"""Production-length chunked-prefill regression for the native causal conv1d.
+
+This mirrors the Qwen3.6 TP=2 path: a four-tap convolution over 4096 local
+channels with the state deliberately reused across chunks.  It covers both
+the radix-aligned 16384/12672/128 chain and the no-radix 16384/12800 chain.
+"""
+
+import torch
+
+import sgl_kernel_npu  # noqa: F401 - registers torch.ops.npu.causal_conv1d
+from sgl_kernel_npu.mamba.causal_conv1d import causal_conv1d_fn_npu
+
+
+@torch.no_grad()
+def test_qwen36_production_chunk_chain_exact():
+    device = torch.device("npu")
+    dtype = torch.bfloat16
+    dim = 4096
+    width = 4
+    cache_slot = 3
+    num_cache_lines = 8
+
+    chunk_chains = {
+        "radix": [(16384, 16384), (12672, 12672), (128, 67)],
+        "no_radix": [(16384, 16384), (12800, 12739)],
+    }
+
+    for chain_name, chunks in chunk_chains.items():
+        torch.manual_seed(20260823)
+        weight_native = (
+            torch.randn((width, dim), device=device, dtype=dtype) * 0.02
+        )
+        bias = torch.randn((dim,), device=device, dtype=dtype) * 0.02
+        native_state = torch.zeros(
+            (num_cache_lines, width - 1, dim), device=device, dtype=dtype
+        )
+        reference_state = native_state.transpose(1, 2).contiguous()
+        cache_indices = torch.tensor(
+            [cache_slot], device=device, dtype=torch.int32
+        )
+
+        for chunk_id, (physical_len, valid_len) in enumerate(chunks):
+            x = (
+                torch.randn((physical_len, dim), device=device, dtype=dtype)
+                * 0.02
+            )
+            query_start_loc = torch.tensor(
+                [0, valid_len], device=device, dtype=torch.int32
+            )
+            has_initial_state = torch.tensor(
+                [chunk_id != 0], device=device, dtype=torch.bool
+            )
+
+            native_out = torch.ops.npu.causal_conv1d(
+                x,
+                weight_native,
+                conv_states=native_state,
+                bias=bias,
+                query_start_loc=query_start_loc,
+                cache_indices=cache_indices,
+                has_initial_state=has_initial_state,
+                activation_mode=1,
+                pad_slot_id=-1,
+                run_mode=0,
+            )
+            reference_out = causal_conv1d_fn_npu(
+                x.transpose(0, 1).contiguous(),
+                weight_native.transpose(0, 1).contiguous(),
+                bias=bias,
+                query_start_loc=query_start_loc,
+                cache_indices=cache_indices,
+                has_initial_state=has_initial_state,
+                conv_states=reference_state,
+                activation="silu",
+                pad_slot_id=-1,
+            ).transpose(0, 1)
+            torch.npu.synchronize()
+
+            assert torch.equal(native_out[:valid_len], reference_out[:valid_len]), (
+                f"{chain_name} chunk {chunk_id} valid output differs: max_abs="
+                f"{(native_out[:valid_len].float() - reference_out[:valid_len].float()).abs().max().item()}"
+            )
+            assert torch.equal(
+                native_state[cache_slot],
+                reference_state[cache_slot].transpose(0, 1),
+            ), f"{chain_name} chunk {chunk_id} state differs"
+            assert torch.count_nonzero(native_out[valid_len:]).item() == 0, (
+                f"{chain_name} chunk {chunk_id} physical tail was not zeroed"
+            )

--- a/tests/python/sgl_kernel_npu/test_causal_conv1d_dtype_checkpoint.py
+++ b/tests/python/sgl_kernel_npu/test_causal_conv1d_dtype_checkpoint.py
@@ -1,0 +1,511 @@
+import argparse
+
+import torch
+import torch.nn.functional as F
+
+import sgl_kernel_npu  # noqa: F401 - registers torch.ops.npu.causal_conv1d
+from sgl_kernel_npu.mamba.causal_conv1d import causal_conv1d_update_v2
+
+
+def _device_int64(values):
+    out = torch.empty(len(values), device="npu", dtype=torch.int64)
+    for index, value in enumerate(values):
+        out[index] = value
+    return out
+
+
+def _device_bool(values):
+    out = torch.empty(len(values), device="npu", dtype=torch.bool)
+    for index, value in enumerate(values):
+        out[index] = value
+    return out
+
+
+def _reference_prefill(
+    x,
+    weight,
+    bias,
+    conv_states,
+    query_start_loc,
+    cache_indices,
+    has_initial_state,
+):
+    """PR651/PyTorch semantics: BF16 conv result, then BF16 SiLU."""
+    width, dim = weight.shape
+    history = width - 1
+    outputs = []
+    for sequence in range(cache_indices.numel()):
+        start = int(query_start_loc[sequence].item())
+        end = int(query_start_loc[sequence + 1].item())
+        cache_index = int(cache_indices[sequence].item())
+        if bool(has_initial_state[sequence].item()):
+            prefix = conv_states[cache_index, :history]
+        else:
+            prefix = torch.zeros(
+                (history, dim), device=x.device, dtype=x.dtype
+            )
+        segment = x[start:end]
+        full = torch.cat((prefix, segment), dim=0)
+        convolution = F.conv1d(
+            full.transpose(0, 1).unsqueeze(0),
+            weight.transpose(0, 1).unsqueeze(1),
+            bias=bias,
+            groups=dim,
+        )
+        outputs.append(F.silu(convolution).squeeze(0).transpose(0, 1))
+        conv_states[cache_index, :history] = full[-history:]
+    return torch.cat(outputs, dim=0)
+
+
+def _assert_exact(label, actual, expected):
+    torch.npu.synchronize()
+    equal = actual == expected
+    exact = int(equal.sum().item())
+    total = equal.numel()
+    max_abs = float((actual.float() - expected.float()).abs().max().item())
+    print(f"{label}: exact={exact}/{total}, max_abs={max_abs}")
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def _reference_update(
+    x,
+    weight,
+    bias,
+    conv_states,
+    query_start_loc,
+    cache_indices,
+    num_accepted_tokens=None,
+):
+    width, dim = weight.shape
+    history = width - 1
+    outputs = []
+    for sequence in range(cache_indices.numel()):
+        start = int(query_start_loc[sequence].item())
+        end = int(query_start_loc[sequence + 1].item())
+        cache_index = int(cache_indices[sequence].item())
+        segment = x[start:end]
+        if num_accepted_tokens is None:
+            offset = 0
+        else:
+            offset = int(num_accepted_tokens[sequence].item()) - 1
+            offset = max(0, min(offset, conv_states.shape[1] - history))
+        prefix = conv_states[cache_index, offset : offset + history].clone()
+        full = torch.cat((prefix, segment), dim=0)
+        convolution = F.conv1d(
+            full.transpose(0, 1).unsqueeze(0),
+            weight.transpose(0, 1).unsqueeze(1),
+            bias=bias,
+            groups=dim,
+        )
+        outputs.append(F.silu(convolution).squeeze(0).transpose(0, 1))
+
+        if num_accepted_tokens is None:
+            conv_states[cache_index, :history] = full[-history:]
+        else:
+            # Width four speculative state layout: retain the two history
+            # values after the accepted-token offset, then append all draft
+            # inputs.  This mirrors WriteBackStateSpec.
+            conv_states[cache_index, :2] = prefix[1:3]
+            conv_states[cache_index, 2 : 2 + segment.shape[0]] = segment
+    return torch.cat(outputs, dim=0)
+
+
+def run_prefill_chain(dim, lengths, use_bias):
+    torch.manual_seed(20260823)
+    dtype = torch.bfloat16
+    width = 4
+    weight = torch.randn((width, dim), device="npu", dtype=dtype)
+    bias = (
+        torch.randn((dim,), device="npu", dtype=dtype) if use_bias else None
+    )
+    native_state = torch.randn((8, width - 1, dim), device="npu", dtype=dtype)
+    reference_state = native_state.clone()
+    cache_indices = _device_int64([3])
+
+    for chunk_index, length in enumerate(lengths):
+        x = torch.randn((length, dim), device="npu", dtype=dtype)
+        query_start_loc = _device_int64([0, length])
+        has_initial_state = _device_bool([chunk_index != 0])
+
+        expected = _reference_prefill(
+            x,
+            weight,
+            bias,
+            reference_state,
+            query_start_loc,
+            cache_indices,
+            has_initial_state,
+        )
+        actual = torch.ops.npu.causal_conv1d(
+            x,
+            weight,
+            native_state,
+            bias=bias,
+            query_start_loc=query_start_loc,
+            cache_indices=cache_indices,
+            has_initial_state=has_initial_state,
+            activation_mode=1,
+            pad_slot_id=-1,
+            run_mode=0,
+        )
+        _assert_exact(f"prefill-output-{chunk_index}-{length}", actual, expected)
+        _assert_exact(
+            f"prefill-state-{chunk_index}-{length}",
+            native_state,
+            reference_state,
+        )
+
+
+def run_padded_prefill_tail(dim, padded_length, valid_length, use_bias):
+    """Varlen padding must be deterministic zeros, like PR651.
+
+    Scheduler/page alignment can pass 128 physical rows while query_start_loc
+    marks only 67 real tokens.  Downstream GDN code retains the physical shape,
+    so leaving the remaining rows from empty_like() uninitialized injects stale
+    allocator data into the recurrent path.
+    """
+    assert 0 < valid_length < padded_length
+    torch.manual_seed(20260828)
+    dtype = torch.bfloat16
+    width = 4
+    weight = torch.randn((width, dim), device="npu", dtype=dtype)
+    bias = torch.randn((dim,), device="npu", dtype=dtype) if use_bias else None
+    native_state = torch.randn(
+        (8, width - 1, dim), device="npu", dtype=dtype
+    )
+    reference_state = native_state.clone()
+    x = torch.randn((padded_length, dim), device="npu", dtype=dtype)
+    query_start_loc = _device_int64([0, valid_length])
+    cache_indices = _device_int64([3])
+    has_initial_state = _device_bool([False])
+
+    expected_valid = _reference_prefill(
+        x[:valid_length],
+        weight,
+        bias,
+        reference_state,
+        _device_int64([0, valid_length]),
+        cache_indices,
+        has_initial_state,
+    )
+
+    # Encourage empty_like() to reuse a visibly non-zero allocator block.
+    poison = torch.full_like(x, 17.0)
+    del poison
+    actual = torch.ops.npu.causal_conv1d(
+        x,
+        weight,
+        native_state,
+        bias=bias,
+        query_start_loc=query_start_loc,
+        cache_indices=cache_indices,
+        has_initial_state=has_initial_state,
+        activation_mode=1,
+        pad_slot_id=-1,
+        run_mode=0,
+    )
+    torch.npu.synchronize()
+
+    _assert_exact("padded-prefill-valid", actual[:valid_length], expected_valid)
+    _assert_exact("padded-prefill-state", native_state, reference_state)
+    expected_padding = torch.zeros_like(actual[valid_length:])
+    _assert_exact("padded-prefill-zero-tail", actual[valid_length:], expected_padding)
+
+
+def run_decode_chain(dim, steps, use_bias):
+    torch.manual_seed(20260824)
+    dtype = torch.bfloat16
+    width = 4
+    batch = 2
+    weight = torch.randn((width, dim), device="npu", dtype=dtype)
+    bias = (
+        torch.randn((dim,), device="npu", dtype=dtype) if use_bias else None
+    )
+    native_state = torch.randn((8, width - 1, dim), device="npu", dtype=dtype)
+    reference_state = native_state.clone()
+    query_start_loc = _device_int64([0, 1, 2])
+    cache_indices = _device_int64([2, 5])
+
+    for step in range(steps):
+        x = torch.randn((batch, dim), device="npu", dtype=dtype)
+        expected = _reference_update(
+            x,
+            weight,
+            bias,
+            reference_state,
+            query_start_loc,
+            cache_indices,
+        )
+        actual = torch.ops.npu.causal_conv1d(
+            x,
+            weight,
+            native_state,
+            bias=bias,
+            query_start_loc=query_start_loc,
+            cache_indices=cache_indices,
+            activation_mode=1,
+            pad_slot_id=-1,
+            run_mode=1,
+        )
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        torch.testing.assert_close(native_state, reference_state, rtol=0, atol=0)
+    _assert_exact(f"decode-output-after-{steps}", actual, expected)
+    _assert_exact(f"decode-state-after-{steps}", native_state, reference_state)
+
+
+def run_speculative_update(dim, use_bias):
+    torch.manual_seed(20260825)
+    dtype = torch.bfloat16
+    width = 4
+    batch = 2
+    draft_tokens = 4
+    weight = torch.randn((width, dim), device="npu", dtype=dtype)
+    bias = (
+        torch.randn((dim,), device="npu", dtype=dtype) if use_bias else None
+    )
+    native_state = torch.randn((8, 120, dim), device="npu", dtype=dtype)
+    reference_state = native_state.clone()
+    x = torch.randn((batch * draft_tokens, dim), device="npu", dtype=dtype)
+    query_start_loc = _device_int64([0, draft_tokens, 2 * draft_tokens])
+    cache_indices = _device_int64([1, 6])
+    num_accepted_tokens = torch.empty(batch, device="npu", dtype=torch.int32)
+    num_accepted_tokens[0] = 4
+    num_accepted_tokens[1] = 2
+
+    expected = _reference_update(
+        x,
+        weight,
+        bias,
+        reference_state,
+        query_start_loc,
+        cache_indices,
+        num_accepted_tokens=num_accepted_tokens,
+    )
+    actual = torch.ops.npu.causal_conv1d(
+        x,
+        weight,
+        native_state,
+        bias=bias,
+        query_start_loc=query_start_loc,
+        cache_indices=cache_indices,
+        num_accepted_tokens=num_accepted_tokens,
+        activation_mode=1,
+        pad_slot_id=-1,
+        run_mode=1,
+    )
+    _assert_exact("speculative-output", actual, expected)
+    _assert_exact("speculative-state", native_state, reference_state)
+
+
+def run_speculative_graph_replay(dim, steps, use_bias):
+    """Keep update outputs/state bit-exact across repeated NPU graph replays."""
+    torch.manual_seed(20260826)
+    dtype = torch.bfloat16
+    width = 4
+    batch = 1
+    draft_tokens = 4
+    weight = torch.randn((width, dim), device="npu", dtype=dtype)
+    bias = (
+        torch.randn((dim,), device="npu", dtype=dtype) if use_bias else None
+    )
+    state_len = width - 1 + draft_tokens - 1
+    initial_state = torch.randn(
+        (8, state_len, dim), device="npu", dtype=dtype
+    )
+    native_state = initial_state.clone()
+    reference_state = initial_state.clone()
+    staging_x = torch.empty(
+        (batch * draft_tokens, dim), device="npu", dtype=dtype
+    )
+    query_start_loc = _device_int64([0, draft_tokens])
+    cache_indices = _device_int64([3])
+    num_accepted_tokens = torch.empty(batch, device="npu", dtype=torch.int32)
+    num_accepted_tokens[0] = draft_tokens
+
+    graph = torch.npu.NPUGraph()
+    capture_stream = torch.npu.Stream()
+    with torch.npu.graph(graph, stream=capture_stream, auto_dispatch_capture=True):
+        graph_output = torch.ops.npu.causal_conv1d(
+            staging_x,
+            weight,
+            native_state,
+            bias=bias,
+            query_start_loc=query_start_loc,
+            cache_indices=cache_indices,
+            num_accepted_tokens=num_accepted_tokens,
+            activation_mode=1,
+            pad_slot_id=-1,
+            run_mode=1,
+        )
+    torch.npu.synchronize()
+
+    # Capture executes the graph once.  Restore the fixed-address state buffer
+    # so the replay chain and the eager reference start from identical bytes.
+    native_state.copy_(initial_state)
+    torch.npu.synchronize()
+
+    for step in range(steps):
+        x = torch.randn((batch * draft_tokens, dim), device="npu", dtype=dtype)
+        staging_x.copy_(x)
+        expected = causal_conv1d_update_v2(
+            x=x.view(1, draft_tokens, dim).contiguous(),
+            conv_state=reference_state,
+            weight=weight,
+            bias=bias,
+            activation="silu",
+            conv_state_indices=cache_indices,
+            num_accepted_tokens=num_accepted_tokens,
+            pad_slot_id=-1,
+            validate_data=False,
+        ).view(draft_tokens, dim)
+
+        # Exercise allocator reuse around the address of the temporary tiling
+        # Tensor that existed only while the graph was captured.
+        allocator_pressure = [
+            torch.empty(4096, device="npu", dtype=torch.uint8) for _ in range(32)
+        ]
+        del allocator_pressure
+        graph.replay()
+        torch.npu.synchronize()
+
+        torch.testing.assert_close(graph_output, expected, rtol=0, atol=0)
+        torch.testing.assert_close(native_state, reference_state, rtol=0, atol=0)
+
+        accepted_step = step % draft_tokens
+        _rollback_speculative_state(
+            native_state, 3, accepted_step, draft_tokens
+        )
+        _rollback_speculative_state(
+            reference_state, 3, accepted_step, draft_tokens
+        )
+
+    _assert_exact(f"graph-output-after-{steps}", graph_output, expected)
+    _assert_exact(f"graph-state-after-{steps}", native_state, reference_state)
+
+
+def _rollback_speculative_state(state, cache_index, accepted_step, draft_tokens):
+    """Mirror conv_state_rollback after target verification."""
+    shift = (draft_tokens - 1) - accepted_step
+    if shift > 0:
+        state[cache_index, shift:] = state[cache_index, :-shift].clone()
+
+
+def run_speculative_against_triton(dim, steps, use_bias):
+    """Compare the AscendC update directly with the known-good PR651 path.
+
+    Production target verification always passes draft_tokens as the accepted
+    count to causal_conv1d, then rolls the six-slot conv window back to the
+    actually accepted step.  Cycling that rollback step exposes state errors
+    which a single fixed-accept invocation cannot see.
+    """
+    torch.manual_seed(20260827)
+    dtype = torch.bfloat16
+    width = 4
+    draft_tokens = 4
+    state_len = width - 1 + draft_tokens - 1
+    cache_index = 3
+
+    weight = torch.randn((width, dim), device="npu", dtype=dtype)
+    bias = torch.randn((dim,), device="npu", dtype=dtype) if use_bias else None
+    initial_state = torch.randn(
+        (8, state_len, dim), device="npu", dtype=dtype
+    )
+    native_state = initial_state.clone()
+    triton_state = initial_state.clone()
+    query_start_loc = _device_int64([0, draft_tokens])
+    cache_indices = _device_int64([cache_index])
+    num_accepted_tokens = torch.full(
+        (1,), draft_tokens, device="npu", dtype=torch.int32
+    )
+
+    for step in range(steps):
+        x = torch.randn((draft_tokens, dim), device="npu", dtype=dtype)
+        native_output = torch.ops.npu.causal_conv1d(
+            x,
+            weight,
+            native_state,
+            bias=bias,
+            query_start_loc=query_start_loc,
+            cache_indices=cache_indices,
+            num_accepted_tokens=num_accepted_tokens,
+            activation_mode=1,
+            pad_slot_id=-1,
+            run_mode=1,
+        )
+        triton_output = causal_conv1d_update_v2(
+            x=x.view(1, draft_tokens, dim).contiguous(),
+            conv_state=triton_state,
+            weight=weight,
+            bias=bias,
+            activation="silu",
+            conv_state_indices=cache_indices,
+            num_accepted_tokens=num_accepted_tokens,
+            pad_slot_id=-1,
+            validate_data=False,
+        ).view(draft_tokens, dim)
+
+        torch.npu.synchronize()
+        try:
+            torch.testing.assert_close(
+                native_output, triton_output, rtol=0, atol=0
+            )
+            torch.testing.assert_close(native_state, triton_state, rtol=0, atol=0)
+        except AssertionError:
+            _assert_exact(f"triton-output-first-mismatch-{step}", native_output, triton_output)
+            _assert_exact(f"triton-state-first-mismatch-{step}", native_state, triton_state)
+            raise
+
+        accepted_step = step % draft_tokens
+        _rollback_speculative_state(
+            native_state, cache_index, accepted_step, draft_tokens
+        )
+        _rollback_speculative_state(
+            triton_state, cache_index, accepted_step, draft_tokens
+        )
+
+    _assert_exact(f"triton-output-after-{steps}", native_output, triton_output)
+    _assert_exact(f"triton-state-after-{steps}", native_state, triton_state)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--dim", type=int, default=2048)
+    parser.add_argument(
+        "--lengths", type=int, nargs="+", default=[257, 129, 67]
+    )
+    parser.add_argument("--no-bias", action="store_true")
+    parser.add_argument("--decode-steps", type=int, default=32)
+    parser.add_argument("--graph-steps", type=int, default=64)
+    parser.add_argument("--triton-steps", type=int, default=256)
+    parser.add_argument("--only-triton", action="store_true")
+    parser.add_argument("--only-padded-tail", action="store_true")
+    parser.add_argument("--padded-length", type=int, default=128)
+    parser.add_argument("--valid-length", type=int, default=67)
+    args = parser.parse_args()
+    torch.npu.set_device(f"npu:{args.device}")
+    use_bias = not args.no_bias
+    if args.only_padded_tail:
+        run_padded_prefill_tail(
+            args.dim,
+            args.padded_length,
+            args.valid_length,
+            use_bias=use_bias,
+        )
+        return
+    if args.only_triton:
+        run_speculative_against_triton(
+            args.dim, args.triton_steps, use_bias=use_bias
+        )
+        return
+    run_prefill_chain(args.dim, args.lengths, use_bias=use_bias)
+    run_decode_chain(args.dim, args.decode_steps, use_bias=use_bias)
+    run_speculative_update(args.dim, use_bias=use_bias)
+    run_speculative_graph_replay(args.dim, args.graph_steps, use_bias=use_bias)
+    run_speculative_against_triton(
+        args.dim, args.triton_steps, use_bias=use_bias
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/sgl_kernel_npu/test_conv1d_prefill.py
+++ b/tests/python/sgl_kernel_npu/test_conv1d_prefill.py
@@ -134,6 +134,13 @@ def reference_causal_conv1d(
         acc = sum(x_ext[j : j + length] * weight_fp32[j] for j in range(width))
         if bias_fp32 is not None:
             acc = acc + bias_fp32
+
+        # torch.nn.functional.conv1d returns the convolution result in the
+        # input dtype.  SGLang applies SiLU to that BF16/FP16 tensor, so the
+        # dtype checkpoint must happen before activation.  Keeping acc in
+        # FP32 through SiLU hides the prefill/update mismatch that corrupts
+        # long chained GDN execution.
+        acc = acc.to(x.dtype)
         if activation_mode:
             acc = F.silu(acc)
 

--- a/tests/python/sgl_kernel_npu/test_conv1d_update.py
+++ b/tests/python/sgl_kernel_npu/test_conv1d_update.py
@@ -10,6 +10,73 @@ logger = logging.getLogger("TestScript")
 torch.manual_seed(42)
 
 
+def test_speculative_bf16_matches_sequential_decode():
+    from sgl_kernel_npu.mamba.causal_conv1d import (
+        causal_conv1d_update_npu,
+        causal_conv1d_update_v2,
+    )
+
+    torch.npu.set_device("npu:0")
+    torch.manual_seed(42)
+    batch_size, steps, dim, width = 1, 4, 1024, 4
+    x = torch.randn(
+        batch_size, steps, dim, device="npu", dtype=torch.bfloat16
+    )
+    weight = torch.randn(dim, width, device="npu", dtype=torch.bfloat16)
+    bias = torch.randn(dim, device="npu", dtype=torch.bfloat16)
+    history = torch.randn(
+        batch_size, width - 1, dim, device="npu", dtype=torch.bfloat16
+    )
+    cache_indices = torch.tensor([0], device="npu", dtype=torch.int32)
+
+    speculative_state = torch.zeros(
+        batch_size,
+        width - 1 + steps - 1,
+        dim,
+        device="npu",
+        dtype=torch.bfloat16,
+    )
+    speculative_state[:, -(width - 1) :] = history
+    speculative_output = causal_conv1d_update_v2(
+        x.clone(),
+        speculative_state,
+        weight.T.contiguous(),
+        bias=bias,
+        activation="silu",
+        conv_state_indices=cache_indices,
+        num_accepted_tokens=torch.tensor(
+            [steps], device="npu", dtype=torch.int32
+        ),
+        pad_slot_id=-1,
+    )
+
+    sequential_state = history.transpose(1, 2).clone()
+    sequential_output = torch.stack(
+        [
+            causal_conv1d_update_npu(
+                x[:, step].clone(),
+                sequential_state,
+                weight,
+                bias=bias,
+                activation="silu",
+                conv_state_indices=cache_indices,
+            )
+            for step in range(steps)
+        ],
+        dim=1,
+    )
+
+    torch.testing.assert_close(
+        speculative_output, sequential_output, rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        speculative_state[:, -(width - 1) :],
+        sequential_state.transpose(1, 2),
+        rtol=0,
+        atol=0,
+    )
+
+
 # ==========================================
 # 1. Original SGLang implementation
 # ==========================================

--- a/tests/python/sgl_kernel_npu/test_mamba_state_update.py
+++ b/tests/python/sgl_kernel_npu/test_mamba_state_update.py
@@ -162,3 +162,32 @@ def test_move_intermediate_cache(
     )
 
     assert_close("move_cache", dst_cache, dst_cache_clone, 1e-3)
+
+
+@torch.no_grad
+def test_move_intermediate_cache_a2_real_shape():
+    """Compile and validate the Qwen3.6 state tile without overflowing A2 UB."""
+    torch.manual_seed(42)
+    # UB usage depends on H/V/K; keep the outer dimensions small for this regression.
+    L, S, D, H, V, K = 1, 4, 4, 8, 128, 128
+    dst_cache = torch.randn(L, S, H, V, K, device=device, dtype=torch.bfloat16)
+    expected = dst_cache.clone()
+    src_cache = torch.randn(
+        L, S, D, H, V, K, device=device, dtype=torch.bfloat16
+    )
+    dst_indices = torch.tensor([0, 3], device=device, dtype=torch.int32)
+    src_indices = torch.tensor([0, 1], device=device, dtype=torch.int32)
+    last_steps = torch.tensor([0, 3], device=device, dtype=torch.int32)
+    expected[:, dst_indices.to(torch.int64)] = src_cache[
+        :, src_indices.to(torch.int64), last_steps.to(torch.int64)
+    ]
+
+    move_intermediate_cache(
+        dst_cache,
+        src_cache,
+        dst_indices,
+        src_indices,
+        last_steps,
+    )
+
+    assert_close("move_cache_a2_real_shape", expected, dst_cache, 1e-3)

--- a/tests/python/sgl_kernel_npu/test_recurrent_gated_delta_rule.py
+++ b/tests/python/sgl_kernel_npu/test_recurrent_gated_delta_rule.py
@@ -406,6 +406,80 @@ class TestCase:
             return False
 
 
+def test_mtp_matches_sequential_decode():
+    """MTP must preserve the per-token BF16 state round-trip of decode."""
+    torch.npu.set_device("npu:0")
+    torch.manual_seed(42)
+    batch_size, steps, nk, nv, dk, dv = 1, 4, 4, 8, 128, 128
+
+    q = torch.rand(
+        batch_size, steps, nk, dk, dtype=torch.bfloat16, device="npu"
+    )
+    k = torch.rand_like(q)
+    v = torch.rand(
+        batch_size, steps, nv, dv, dtype=torch.bfloat16, device="npu"
+    )
+    mix_qkv = torch.cat(
+        [q.flatten(2), k.flatten(2), v.flatten(2)], dim=-1
+    ).contiguous()
+    beta = torch.rand(
+        batch_size, steps, nv, dtype=torch.bfloat16, device="npu"
+    )
+    g = -torch.rand(batch_size, steps, nv, dtype=torch.float32, device="npu")
+    initial_state = torch.rand(
+        batch_size, nv, dv, dk, dtype=torch.bfloat16, device="npu"
+    )
+    scale = dk**-0.5
+
+    intermediate = torch.empty(
+        batch_size, steps, nv, dv, dk, dtype=torch.bfloat16, device="npu"
+    )
+    mtp_output = torch.ops.npu.recurrent_gated_delta_rule(
+        mix_qkv,
+        initial_state.clone(),
+        beta=beta,
+        scale=scale,
+        actual_seq_lengths=torch.tensor([steps], dtype=torch.int32, device="npu"),
+        ssm_state_indices=torch.arange(
+            steps, dtype=torch.int32, device="npu"
+        ).view(1, steps),
+        nk=nk,
+        nv=nv,
+        intermediate_state=intermediate.view(-1, nv, dv, dk),
+        cache_indices=torch.tensor([0], dtype=torch.int32, device="npu"),
+        num_accepted_tokens=torch.tensor([1], dtype=torch.int32, device="npu"),
+        g=g,
+    )
+
+    sequential_state = initial_state.clone()
+    sequential_outputs = []
+    sequential_states = []
+    one = torch.tensor([1], dtype=torch.int32, device="npu")
+    state_index = torch.zeros((1, 1), dtype=torch.int32, device="npu")
+    for step in range(steps):
+        sequential_outputs.append(
+            torch.ops.npu.recurrent_gated_delta_rule(
+                mix_qkv[:, step : step + 1],
+                sequential_state,
+                beta=beta[:, step : step + 1],
+                scale=scale,
+                actual_seq_lengths=one,
+                ssm_state_indices=state_index,
+                nk=nk,
+                nv=nv,
+                g=g[:, step : step + 1],
+            )
+        )
+        sequential_states.append(sequential_state[0].clone())
+
+    torch.testing.assert_close(
+        mtp_output, torch.cat(sequential_outputs, dim=1), rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        intermediate[0], torch.stack(sequential_states), rtol=0, atol=0
+    )
+
+
 def compatible_cases():
     """Defines the matrix of test cases to be executed."""
     res = []


### PR DESCRIPTION
Summary: extend PR #651 so native AscendC causal_conv1d matches the known-good BF16 recurrent semantics. The kernel checkpoints BF16 before SiLU, adds update bias after all taps, and zeroes physical varlen tail rows in the same launch. Regression coverage compares production Qwen3.6 prefill, decode, speculative update, graph replay, and padded tails against the PR651 path. Validation: machine 152 radix cold/hot 5 of 5 and no-radix 2 of 2 produced the same stopped output with NEXTN enabled; machine 3 validation is pending because its SSH endpoint is currently unreachable.