### PR TITLE
[NPU] Optimize GDN indexed state pool I/O

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/chunk.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/chunk.py
@@ -212,11 +212,62 @@ def chunk_gated_delta_rule_fwd(
     initial_state: torch.Tensor,
     output_final_state: bool,
     cu_seqlens: Optional[torch.LongTensor] = None,
+    initial_state_indices: Optional[torch.Tensor] = None,
+    inplace_final_state: bool = False,
 ):
     if _use_mega_gdn():
+        # The AscendC mega kernel currently consumes compact per-request
+        # states. Preserve that backend by doing the legacy transfer here; the
+        # default Triton path below performs true indexed pool I/O.
+        mega_initial_state = initial_state
+        state_indices = None
+        valid_state_indices = None
+        if initial_state is not None and initial_state_indices is not None:
+            num_sequences = (
+                len(cu_seqlens) - 1 if cu_seqlens is not None else q.shape[0]
+            )
+            state_indices = (
+                initial_state_indices[:num_sequences].to(dtype=torch.long).contiguous()
+            )
+            valid_state_indices = (state_indices >= 0) & (
+                state_indices < initial_state.shape[0]
+            )
+            if initial_state.shape[0] == 0:
+                mega_initial_state = initial_state.new_zeros(
+                    num_sequences, *initial_state.shape[1:]
+                )
+            else:
+                safe_state_indices = state_indices.masked_fill(~valid_state_indices, 0)
+                mega_initial_state = initial_state.index_select(0, safe_state_indices)
+                mega_initial_state.masked_fill_(
+                    ~valid_state_indices.view(-1, 1, 1, 1), 0
+                )
         g, o, A, final_state, w, h, v_new = run_mega_chunk_gdn(
-            q, k, v, g, beta, scale, initial_state, output_final_state, cu_seqlens
+            q,
+            k,
+            v,
+            g,
+            beta,
+            scale,
+            mega_initial_state,
+            output_final_state or inplace_final_state,
+            cu_seqlens,
         )
+        if inplace_final_state:
+            if final_state is None:
+                raise RuntimeError(
+                    "mega GDN did not return a final state for in-place update"
+                )
+            valid_slots = state_indices[valid_state_indices]
+            if valid_slots.numel() > 0:
+                initial_state.index_copy_(
+                    0,
+                    valid_slots,
+                    final_state[valid_state_indices].to(initial_state.dtype),
+                )
+            final_state = None
+        elif final_state is not None and valid_state_indices is not None:
+            final_state.masked_fill_(~valid_state_indices.view(-1, 1, 1, 1), 0)
         if SUPPRESS_LEVEL < 3:
             return g, o, A, final_state, None, h, None
         return g, o, A, final_state, w, h, v_new
@@ -241,7 +292,9 @@ def chunk_gated_delta_rule_fwd(
         u=u,
         g=g,
         initial_state=initial_state,
+        initial_state_indices=initial_state_indices,
         output_final_state=output_final_state,
+        inplace_final_state=inplace_final_state,
         cu_seqlens=cu_seqlens,
     )
     o = chunk_fwd_o(
@@ -259,7 +312,7 @@ def chunk_gated_delta_rule_fwd(
         return g, o, A, final_state, w, h, v_new
 
 
-@input_guard
+@input_guard(preserve_when={"initial_state": "inplace_final_state"})
 @torch.compiler.disable
 def chunk_gated_delta_rule_npu(
     q: torch.Tensor,
@@ -273,6 +326,8 @@ def chunk_gated_delta_rule_npu(
     cu_seqlens: Optional[torch.LongTensor] = None,
     head_first: bool = False,
     use_qk_l2norm_in_kernel: bool = False,
+    initial_state_indices: Optional[torch.Tensor] = None,
+    inplace_final_state: bool = False,
 ):
     r"""
     Args:
@@ -293,8 +348,14 @@ def chunk_gated_delta_rule_npu(
             Initial state of shape `[N, H, K, V]` for `N` input sequences.
             For equal-length input sequences, `N` equals the batch size `B`.
             Default: `None`.
+        initial_state_indices (Optional[torch.Tensor]):
+            Slot index for each sequence when ``initial_state`` is a full state
+            pool. When omitted, states are packed in sequence order.
         output_final_state (Optional[bool]):
             Whether to output the final state of shape `[N, H, K, V]`. Default: `False`.
+        inplace_final_state (Optional[bool]):
+            Write final states directly to ``initial_state`` at
+            ``initial_state_indices`` and return ``None`` for the final state.
         cu_seqlens (torch.LongTensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
@@ -367,11 +428,42 @@ def chunk_gated_delta_rule_npu(
                 f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
                 f"Please flatten variable-length inputs before processing."
             )
-        if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
+        if (
+            initial_state is not None
+            and initial_state_indices is None
+            and initial_state.shape[0] != len(cu_seqlens) - 1
+        ):
             raise ValueError(
                 f"The number of initial states is expected to be equal to the number of input sequences, "
                 f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}."
             )
+    num_sequences = len(cu_seqlens) - 1 if cu_seqlens is not None else q.shape[0]
+    if initial_state_indices is not None:
+        if initial_state is None:
+            raise ValueError("initial_state_indices requires initial_state")
+        if (
+            initial_state_indices.ndim != 1
+            or initial_state_indices.numel() < num_sequences
+        ):
+            raise ValueError(
+                "initial_state_indices must be 1D with at least one entry per sequence"
+            )
+        if initial_state_indices.dtype not in (torch.int32, torch.int64):
+            raise ValueError("initial_state_indices must use int32 or int64")
+        if initial_state_indices.device != initial_state.device:
+            raise ValueError(
+                "initial_state_indices and initial_state must be on the same device"
+            )
+    if inplace_final_state and initial_state_indices is None:
+        raise ValueError(
+            "inplace_final_state requires initial_state and initial_state_indices"
+        )
+    if (
+        inplace_final_state
+        and initial_state is not None
+        and not initial_state.is_contiguous()
+    ):
+        raise ValueError("inplace_final_state requires a contiguous initial_state pool")
     if scale is None:
         scale = k.shape[-1] ** -0.5
 
@@ -380,7 +472,17 @@ def chunk_gated_delta_rule_npu(
         k = l2norm_fwd(k)
 
     _, o, _, final_state, _, h, _ = chunk_gated_delta_rule_fwd(
-        q, k, v, g, beta, scale, initial_state, output_final_state, cu_seqlens
+        q,
+        k,
+        v,
+        g,
+        beta,
+        scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        initial_state_indices=initial_state_indices,
+        inplace_final_state=inplace_final_state,
     )
     o = o.to(q.dtype)
     if head_first:

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/chunk_delta_h.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/chunk_delta_h.py
@@ -24,6 +24,9 @@ from sgl_kernel_npu.fla.utils import (
         "STORE_FINAL_STATE": lambda args: args["ht"] is not None,
         "SAVE_NEW_VALUE": lambda args: args["v_new"] is not None,
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "USE_INITIAL_STATE_INDICES": lambda args: args["initial_state_indices"]
+        is not None,
+        "USE_FINAL_STATE_INDICES": lambda args: args["final_state_indices"] is not None,
     }
 )
 @triton.jit(do_not_specialize=["T"])
@@ -36,9 +39,12 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_npu_kernel(
     h,
     h0,
     ht,
+    initial_state_indices,
+    final_state_indices,
     cu_seqlens,
     chunk_offsets,
     T,
+    STATE_POOL_SIZE: tl.constexpr,
     H: tl.constexpr,
     Hg: tl.constexpr,
     K: tl.constexpr,
@@ -49,6 +55,8 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_npu_kernel(
     STORE_FINAL_STATE: tl.constexpr,
     SAVE_NEW_VALUE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
+    USE_INITIAL_STATE_INDICES: tl.constexpr,
+    USE_FINAL_STATE_INDICES: tl.constexpr,
 ):
     i_nh = tl.program_id(1)
     i_n, i_h = i_nh // H, i_nh % H
@@ -82,13 +90,26 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_npu_kernel(
     mask_kv1 = (offs_k < K) & (offs_v1 < V)
     mask_kv2 = (offs_k < K) & (offs_v2 < V)
 
+    initial_state_idx = i_n
+    initial_state_valid = True
+    if USE_INITIAL_STATE_INDICES:
+        initial_state_idx = tl.load(initial_state_indices + i_n).to(tl.int64)
+        initial_state_valid = (initial_state_idx >= 0) & (
+            initial_state_idx < STATE_POOL_SIZE
+        )
+        initial_state_idx = tl.where(initial_state_valid, initial_state_idx, 0)
+
     if USE_INITIAL_STATE:
-        h0_ptr = h0 + i_nh * K * V
+        h0_ptr = h0 + (initial_state_idx * H + i_h) * K * V
         ptr_h0_bv1 = h0_ptr + offs_k * V + offs_v1 * 1
-        b_h1_bv1 += tl.load(ptr_h0_bv1, mask=mask_kv1, other=0.0).to(tl.float32)
+        b_h1_bv1 += tl.load(
+            ptr_h0_bv1, mask=mask_kv1 & initial_state_valid, other=0.0
+        ).to(tl.float32)
 
         ptr_h0_bv2 = h0_ptr + offs_k * V + offs_v2 * 1
-        b_h1_bv2 += tl.load(ptr_h0_bv2, mask=mask_kv2, other=0.0).to(tl.float32)
+        b_h1_bv2 += tl.load(
+            ptr_h0_bv2, mask=mask_kv2 & initial_state_valid, other=0.0
+        ).to(tl.float32)
 
     for i_t in range(NT):
         h_base = h + (boh + i_t) * H * K * V + i_h * K * V
@@ -192,20 +213,35 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_npu_kernel(
         b_h1_bv2 += tl.dot(b_k, b_v_new2)
 
     if STORE_FINAL_STATE:
-        ht_ptr = ht + i_nh * K * V
-        p_ht1_bv1 = tl.make_block_ptr(
-            ht_ptr, (K, V), (V, 1), (0, v_start1), (128, 64), (1, 0)
-        )
-        tl.store(
-            p_ht1_bv1, b_h1_bv1.to(p_ht1_bv1.dtype.element_ty), boundary_check=(0, 1)
-        )
+        final_state_idx = i_n
+        final_state_valid = initial_state_valid
+        if USE_FINAL_STATE_INDICES:
+            final_state_idx = tl.load(final_state_indices + i_n).to(tl.int64)
+            final_state_valid = (
+                final_state_valid
+                & (final_state_idx >= 0)
+                & (final_state_idx < STATE_POOL_SIZE)
+            )
+            final_state_idx = tl.where(final_state_valid, final_state_idx, 0)
+        if final_state_valid:
+            ht_ptr = ht + (final_state_idx * H + i_h) * K * V
+            p_ht1_bv1 = tl.make_block_ptr(
+                ht_ptr, (K, V), (V, 1), (0, v_start1), (128, 64), (1, 0)
+            )
+            tl.store(
+                p_ht1_bv1,
+                b_h1_bv1.to(p_ht1_bv1.dtype.element_ty),
+                boundary_check=(0, 1),
+            )
 
-        p_ht1_bv2 = tl.make_block_ptr(
-            ht_ptr, (K, V), (V, 1), (0, v_start2), (128, 64), (1, 0)
-        )
-        tl.store(
-            p_ht1_bv2, b_h1_bv2.to(p_ht1_bv2.dtype.element_ty), boundary_check=(0, 1)
-        )
+            p_ht1_bv2 = tl.make_block_ptr(
+                ht_ptr, (K, V), (V, 1), (0, v_start2), (128, 64), (1, 0)
+            )
+            tl.store(
+                p_ht1_bv2,
+                b_h1_bv2.to(p_ht1_bv2.dtype.element_ty),
+                boundary_check=(0, 1),
+            )
 
 
 def chunk_gated_delta_rule_fwd_h_npu(
@@ -218,6 +254,8 @@ def chunk_gated_delta_rule_fwd_h_npu(
     chunk_size: int = 64,  # SY: remove this argument and force chunk size 64?
     save_new_value: bool = True,
     cu_seqlens: Optional[torch.LongTensor] = None,
+    initial_state_indices: Optional[torch.Tensor] = None,
+    inplace_final_state: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     B, T, Hg, K, V = *k.shape, u.shape[-1]
     H = u.shape[-2]
@@ -239,9 +277,38 @@ def chunk_gated_delta_rule_fwd_h_npu(
         )
     assert K <= 256, "current kernel does not support head dimension larger than 256."
     h = k.new_empty(B, NT, H, K, V)
-    final_state = (
-        k.new_empty(N, H, K, V, dtype=torch.float32) if output_final_state else None
-    )
+    if initial_state_indices is not None:
+        if initial_state is None:
+            raise ValueError("initial_state_indices requires initial_state")
+        if initial_state_indices.ndim != 1 or initial_state_indices.numel() < N:
+            raise ValueError(
+                "initial_state_indices must be 1D with at least one entry per sequence"
+            )
+        if initial_state_indices.dtype not in (torch.int32, torch.int64):
+            raise ValueError("initial_state_indices must use int32 or int64")
+        if initial_state_indices.device != initial_state.device:
+            raise ValueError(
+                "initial_state_indices and initial_state must be on the same device"
+            )
+
+    if inplace_final_state:
+        if initial_state is None or initial_state_indices is None:
+            raise ValueError(
+                "inplace_final_state requires initial_state and initial_state_indices"
+            )
+        final_state_buffer = initial_state
+        final_state_indices = initial_state_indices
+    else:
+        final_state_buffer = (
+            k.new_zeros(N, H, K, V, dtype=torch.float32)
+            if output_final_state and initial_state_indices is not None
+            else (
+                k.new_empty(N, H, K, V, dtype=torch.float32)
+                if output_final_state
+                else None
+            )
+        )
+        final_state_indices = None
 
     v_new = torch.empty_like(u) if save_new_value else None
     # Pre-transpose tensors outside the kernel to ensure contiguous memory access within the kernel
@@ -259,10 +326,13 @@ def chunk_gated_delta_rule_fwd_h_npu(
         g=g,
         h=h,
         h0=initial_state,
-        ht=final_state,
+        ht=final_state_buffer,
+        initial_state_indices=initial_state_indices,
+        final_state_indices=final_state_indices,
         cu_seqlens=cu_seqlens,
         chunk_offsets=chunk_offsets,
         T=T,
+        STATE_POOL_SIZE=initial_state.shape[0] if initial_state is not None else 0,
         H=H,
         Hg=Hg,
         K=K,
@@ -271,4 +341,8 @@ def chunk_gated_delta_rule_fwd_h_npu(
         num_warps=4,
         num_stages=2,
     )
+    # In indexed in-place mode the caller already owns the updated pool.  Do
+    # not materialize an indexed view merely to satisfy the legacy return
+    # contract; returning None also tells SGLang to skip its IndexPutV2 scatter.
+    final_state = None if inplace_final_state else final_state_buffer
     return h, v_new, final_state

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/utils.py
@@ -4,6 +4,7 @@
 
 import contextlib
 import functools
+import inspect
 import os
 from typing import Any, Callable, Dict, Optional, Tuple
 
@@ -51,18 +52,58 @@ def custom_device_ctx(index: int):
     return torch.npu.device(index)
 
 
-def input_guard(fn: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]:
+def input_guard(
+    fn: Optional[Callable[..., torch.Tensor]] = None,
+    *,
+    preserve_when: Optional[Dict[str, str]] = None,
+) -> Callable[..., torch.Tensor]:
     """
-    A decorator to make sure all input tensors are contiguous and set the device based on input tensors.
+    Make tensor inputs contiguous and select their device context.
+
+    ``preserve_when={"tensor_arg": "bool_arg"}`` preserves the original
+    storage for a tensor only when the named boolean argument is true. This is
+    used by in-place APIs that must never silently update a contiguous copy.
     """
+    if fn is None:
+        return lambda wrapped: input_guard(wrapped, preserve_when=preserve_when)
+
+    preserve_when = preserve_when or {}
+    signature = inspect.signature(fn)
+    positional_names = tuple(signature.parameters)
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
+        def argument_value(name):
+            if name in kwargs:
+                return kwargs[name]
+            try:
+                position = positional_names.index(name)
+            except ValueError:
+                return signature.parameters[name].default
+            if position < len(args):
+                return args[position]
+            return signature.parameters[name].default
+
+        preserved = {
+            tensor_name
+            for tensor_name, condition_name in preserve_when.items()
+            if bool(argument_value(condition_name))
+        }
         contiguous_args = (
-            i if not isinstance(i, torch.Tensor) else i.contiguous() for i in args
+            (
+                value
+                if not isinstance(value, torch.Tensor)
+                or positional_names[i] in preserved
+                else value.contiguous()
+            )
+            for i, value in enumerate(args)
         )
         contiguous_kwargs = {
-            k: (v if not isinstance(v, torch.Tensor) else v.contiguous())
+            k: (
+                v
+                if not isinstance(v, torch.Tensor) or k in preserved
+                else v.contiguous()
+            )
             for k, v in kwargs.items()
         }
 

--- a/tests/python/sgl_kernel_npu/test_chunk_gdn_triton.py
+++ b/tests/python/sgl_kernel_npu/test_chunk_gdn_triton.py
@@ -4,12 +4,14 @@ from typing import Optional
 
 import pytest
 import sgl_kernel_npu  # noqa: F401  registers npu ops before pytestmark
+import sgl_kernel_npu.fla.chunk as chunk_module
 import torch
 import torch.nn.functional as F
 import torch_npu  # noqa: F401  makes torch.ops.npu namespace available
 from sgl_kernel_npu.fla.chunk import (
     chunk_gated_delta_rule_fwd,
     chunk_gated_delta_rule_native,
+    chunk_gated_delta_rule_npu,
 )
 from utils import require_npu_op
 
@@ -177,3 +179,275 @@ def test_chunk_varlen(
 
     assert_close("o", ref, tri, 0.005)
     assert_close("ht", ref_ht, tri_ht, 0.005)
+
+
+def make_indexed_gdn_case(seed, sequence_lengths=(64, 64), pool_size=6):
+    """Build one small varlen case shared by the indexed-state tests."""
+    torch.manual_seed(seed)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+    num_value_heads, num_key_heads, head_dim = 4, 2, 128
+    total_tokens = sum(sequence_lengths)
+    offsets = [0]
+    for length in sequence_lengths:
+        offsets.append(offsets[-1] + length)
+
+    q = torch.randn(
+        1, total_tokens, num_key_heads, head_dim, dtype=torch.bfloat16, device=device
+    )
+    inputs = {
+        "q": q,
+        "k": torch.randn_like(q),
+        "v": torch.randn(
+            1,
+            total_tokens,
+            num_value_heads,
+            head_dim,
+            dtype=torch.bfloat16,
+            device=device,
+        ),
+        "g": F.logsigmoid(
+            torch.randn(
+                1, total_tokens, num_value_heads, dtype=torch.float32, device=device
+            )
+        ),
+        "beta": torch.sigmoid(
+            torch.randn(
+                1,
+                total_tokens,
+                num_value_heads,
+                dtype=torch.bfloat16,
+                device=device,
+            )
+        ),
+        "output_final_state": True,
+        "cu_seqlens": torch.tensor(offsets, dtype=torch.long, device=device),
+    }
+    state_pool = (
+        torch.randn(
+            pool_size,
+            num_value_heads,
+            head_dim,
+            head_dim,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        * 0.01
+    )
+    return inputs, state_pool
+
+
+def test_chunk_varlen_indexed_state_pool_inplace():
+    """Indexed state I/O matches the legacy gather + scatter path exactly."""
+    inputs, initial_pool = make_indexed_gdn_case(1234, pool_size=17)
+    pool_size = initial_pool.shape[0]
+    state_indices = torch.tensor([3, 13], dtype=torch.long, device=device)
+
+    legacy_pool = initial_pool.clone()
+    legacy_out, legacy_final, _ = chunk_gated_delta_rule_npu(
+        **inputs,
+        initial_state=legacy_pool[state_indices],
+        use_qk_l2norm_in_kernel=True,
+    )
+    legacy_pool[state_indices] = legacy_final.to(legacy_pool.dtype)
+
+    direct_pool = initial_pool.clone()
+    direct_out, direct_final, _ = chunk_gated_delta_rule_npu(
+        **inputs,
+        initial_state=direct_pool,
+        initial_state_indices=state_indices,
+        inplace_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+    )
+    torch.npu.synchronize()
+
+    assert direct_final is None
+    torch.testing.assert_close(direct_out, legacy_out, rtol=0, atol=0)
+    torch.testing.assert_close(
+        direct_pool[state_indices], legacy_pool[state_indices], rtol=0, atol=0
+    )
+
+    untouched = torch.ones(pool_size, dtype=torch.bool, device=device)
+    untouched[state_indices] = False
+    torch.testing.assert_close(
+        direct_pool[untouched], initial_pool[untouched], rtol=0, atol=0
+    )
+
+
+def test_chunk_varlen_indexed_state_pool_returns_compact_final_state():
+    """Indexed reads with non-inplace output must write compact final state."""
+    inputs, initial_pool = make_indexed_gdn_case(5678, pool_size=17)
+    state_indices = torch.tensor([3, 13], dtype=torch.long, device=device)
+    initial_pool_before = initial_pool.clone()
+
+    expected_out, expected_final, _ = chunk_gated_delta_rule_npu(
+        **inputs,
+        initial_state=initial_pool[state_indices],
+        use_qk_l2norm_in_kernel=True,
+    )
+    actual_out, actual_final, _ = chunk_gated_delta_rule_npu(
+        **inputs,
+        initial_state=initial_pool,
+        initial_state_indices=state_indices,
+        inplace_final_state=False,
+        use_qk_l2norm_in_kernel=True,
+    )
+    torch.npu.synchronize()
+
+    assert actual_final.shape == (
+        len(state_indices),
+        *initial_pool.shape[1:],
+    )
+    torch.testing.assert_close(actual_out, expected_out, rtol=0, atol=0)
+    torch.testing.assert_close(actual_final, expected_final, rtol=0, atol=0)
+    torch.testing.assert_close(initial_pool, initial_pool_before, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    ("indices", "message"),
+    [
+        (torch.tensor([0], dtype=torch.int64), "at least one entry per sequence"),
+        (torch.tensor([0, 1], dtype=torch.float32), "int32 or int64"),
+    ],
+)
+def test_chunk_varlen_indexed_state_pool_validates_indices(indices, message):
+    inputs, state_pool = make_indexed_gdn_case(9012)
+
+    with pytest.raises(ValueError, match=message):
+        chunk_gated_delta_rule_npu(
+            **inputs,
+            initial_state=state_pool,
+            initial_state_indices=indices.to(device),
+        )
+
+
+@pytest.mark.parametrize("invalid_slot", [-1, 6])
+def test_chunk_varlen_indexed_state_pool_invalid_slots_are_safe(invalid_slot):
+    inputs, state_pool = make_indexed_gdn_case(9012)
+    pool_size = state_pool.shape[0]
+    state_indices = torch.tensor([invalid_slot, 3], dtype=torch.long, device=device)
+    reference_initial = torch.stack([torch.zeros_like(state_pool[0]), state_pool[3]])
+    expected_out, expected_final, _ = chunk_gated_delta_rule_npu(
+        **inputs,
+        initial_state=reference_initial,
+    )
+
+    before = state_pool.clone()
+    actual_out, actual_final, _ = chunk_gated_delta_rule_npu(
+        **inputs,
+        initial_state=state_pool,
+        initial_state_indices=state_indices,
+        inplace_final_state=False,
+    )
+    torch.npu.synchronize()
+    torch.testing.assert_close(actual_out, expected_out, rtol=0, atol=0)
+    torch.testing.assert_close(
+        actual_final[0], torch.zeros_like(actual_final[0]), rtol=0, atol=0
+    )
+    torch.testing.assert_close(actual_final[1], expected_final[1], rtol=0, atol=0)
+    torch.testing.assert_close(state_pool, before, rtol=0, atol=0)
+
+    inplace_pool = before.clone()
+    actual_out, actual_final, _ = chunk_gated_delta_rule_npu(
+        **inputs,
+        initial_state=inplace_pool,
+        initial_state_indices=state_indices,
+        inplace_final_state=True,
+    )
+    torch.npu.synchronize()
+    torch.testing.assert_close(actual_out, expected_out, rtol=0, atol=0)
+    assert actual_final is None
+    torch.testing.assert_close(
+        inplace_pool[3], expected_final[1].to(inplace_pool.dtype), rtol=0, atol=0
+    )
+    untouched = torch.ones(pool_size, dtype=torch.bool, device=device)
+    untouched[3] = False
+    torch.testing.assert_close(
+        inplace_pool[untouched], before[untouched], rtol=0, atol=0
+    )
+
+
+def test_mega_gdn_indexed_state_pool_invalid_slots_are_safe(monkeypatch):
+    monkeypatch.setenv("GDN_USE_MEGA_GDN", "1")
+    state_pool = torch.arange(6 * 1 * 2 * 2, device=device, dtype=torch.bfloat16).view(
+        6, 1, 2, 2
+    )
+    state_indices = torch.tensor([-1, 3], device=device)
+    cu_seqlens = torch.tensor([0, 0, 1], dtype=torch.long, device=device)
+    q = torch.zeros(1, 1, 1, 2, dtype=torch.bfloat16, device=device)
+    v = torch.zeros_like(q)
+    g = torch.zeros(1, 1, 1, dtype=torch.float32, device=device)
+    beta = torch.ones(1, 1, 1, dtype=torch.bfloat16, device=device)
+    produced_final = torch.stack(
+        [torch.full_like(state_pool[0], 11), torch.full_like(state_pool[0], 22)]
+    ).to(torch.float32)
+    gathered_states = []
+
+    def fake_mega(
+        q, k, v, g, beta, scale, initial_state, output_final_state, cu_seqlens
+    ):
+        gathered_states.append(initial_state.clone())
+        return g, v, None, produced_final.clone(), None, None, None
+
+    monkeypatch.setattr(chunk_module, "run_mega_chunk_gdn", fake_mega)
+
+    before = state_pool.clone()
+    _, compact_final, _ = chunk_gated_delta_rule_npu(
+        q,
+        q,
+        v,
+        g,
+        beta,
+        initial_state=state_pool,
+        initial_state_indices=state_indices,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+    )
+
+    torch.testing.assert_close(
+        gathered_states[-1][0], torch.zeros_like(state_pool[0]), rtol=0, atol=0
+    )
+    torch.testing.assert_close(gathered_states[-1][1], state_pool[3], rtol=0, atol=0)
+    torch.testing.assert_close(
+        compact_final[0], torch.zeros_like(compact_final[0]), rtol=0, atol=0
+    )
+    torch.testing.assert_close(compact_final[1], produced_final[1], rtol=0, atol=0)
+    torch.testing.assert_close(state_pool, before, rtol=0, atol=0)
+
+    inplace_pool = before.clone()
+    _, returned_final, _ = chunk_gated_delta_rule_npu(
+        q,
+        q,
+        v,
+        g,
+        beta,
+        initial_state=inplace_pool,
+        initial_state_indices=state_indices,
+        output_final_state=True,
+        inplace_final_state=True,
+        cu_seqlens=cu_seqlens,
+    )
+
+    assert returned_final is None
+    torch.testing.assert_close(
+        inplace_pool[3], produced_final[1].to(inplace_pool.dtype), rtol=0, atol=0
+    )
+    untouched = torch.ones(inplace_pool.shape[0], dtype=torch.bool, device=device)
+    untouched[3] = False
+    torch.testing.assert_close(
+        inplace_pool[untouched], before[untouched], rtol=0, atol=0
+    )
+
+
+def test_chunk_varlen_indexed_inplace_rejects_noncontiguous_state_pool():
+    inputs, state_pool = make_indexed_gdn_case(7890, pool_size=4)
+    # Match the speculative NPU pool layout produced by transpose(-1, -2).
+    state_pool = state_pool.transpose(-1, -2)
+    assert not state_pool.is_contiguous()
+
+    with pytest.raises(ValueError, match="requires a contiguous initial_state"):
+        chunk_gated_delta_rule_npu(
+            **inputs,
+            initial_state=state_pool,
+            initial_state_indices=torch.tensor([0, 1], device=device),
+            inplace_final_state=True,
+        )


### PR DESCRIPTION
## Motivation

SGLang stores GDN recurrent states in a global slot pool. During varlen prefill, the existing NPU path first gathers the active slots into a compact tensor and later scatters the returned final states back into that pool. These state-sized
copies add memory traffic and kernel-launch overhead on every cached prefill.

This change lets the Triton GDN kernel read and update the selected pool slots directly.

## Modifications

- Add optional `initial_state_indices` and `inplace_final_state` arguments to `chunk_gated_delta_rule_npu`. Existing callers retain the old behavior.
- Make the Triton state kernel mask negative and out-of-range slots. Invalid rows use a zero initial state and do not write back to the pool.
- Preserve the caller's state storage in the input-contiguity guard when an in-place update is requested; reject a non-contiguous in-place pool instead of silently updating a temporary contiguous copy.
- Keep the AscendC Mega GDN backend working by gathering a compact state tensor inside its compatibility path and scattering valid final states back only when in-place mode is requested.
- Add focused tests for legacy-equivalent output, in-place updates, compact final-state output, invalid slots, input validation, Mega fallback behavior, and non-contiguous pool rejection.

## Accuracy Tests

On Ascend 910B4-1 with CANN 9.0.0, the complete GDN test file passed:

```text
pytest -q tests/python/sgl_kernel_npu/test_chunk_gdn_triton.py
38 passed
```

The indexed in-place tests compare both output tensors and updated state slots against the legacy gather-plus-scatter path with `rtol=0, atol=0`. Untouched slots are also checked bitwise.

The locally built `sgl-kernel-npu` wheel was additionally used in the full Qwen3.6-27B-W8A8 cached-prefix validation described below; output token IDs matched the legacy configuration.

## Speed Tests and Profiling

Environment: one Ascend 910B4-1, BF16 GDN state, Qwen3.6-27B-W8A8 shapes, 128 suffix tokens, 5 warmups and 15 measured samples. Each comparison performs a bitwise correctness assertion before timing.

| Batch size | Gather/scatter | Indexed in-place | Speedup |
| ---: | ---: | ---: | ---: |
| 1 | 1.1907 ms | 0.9348 ms | 1.274x |
| 8 | 2.5730 ms | 2.2090 ms | 1.165x |
| 32 | 8.0939 ms | 7.0788 ms | 1.143x |

In the single-NPU cached-prefix E2E benchmark (2,048 cached prefix tokens, 128 suffix tokens, one generated token), enabling this path changed median latency from 457.24 ms to 412.11 ms at batch 8 (-9.87%) and from 1508.49 ms to 1434.98 ms at batch 32 (-4.87%).

## Validation

- Affected-file `pre-commit` hooks: passed.
- `git diff --check`: passed.
- Source wheel build for Ascend910B1: passed on the combined kernel snapshot.
- Full official FLA group on the combined snapshot: 7/7 files passed, 195 tests passed and 5 conditionally skipped.