### PR TITLE
[NPU] Add fused Mamba slot copy

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/mamba/mamba_state_update_triton.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/mamba/mamba_state_update_triton.py
@@ -146,6 +146,57 @@ def move_intermediate_cache(
     return ssm_states
 
 
+def copy_mamba_slots(
+    states: torch.Tensor,
+    src_indices: torch.Tensor,
+    dst_indices: torch.Tensor,
+    h_block_size: int = 2,
+):
+    """Copy full recurrent-state slots in one indexed NPU kernel.
+
+    ``states`` uses the standard contiguous ``[layers, slots, H, V, K]``
+    layout. Source and destination slot sets must be disjoint: unlike PyTorch's
+    gather-then-scatter expression this kernel reads and writes the pool in one
+    pass, so cross-pair overlap would race. Radix-cache copy-on-write satisfies
+    this invariant by copying checkpoints into freshly allocated active slots.
+
+    The implementation reuses the verified intermediate-state mover by exposing
+    the source pool through a length-one draft-step view. No state-sized gather
+    or temporary tensor is materialized.
+    """
+    if states.ndim != 5:
+        raise ValueError(f"states must be 5D [L, S, H, V, K], got {states.ndim}D")
+    if src_indices.ndim != 1 or dst_indices.ndim != 1:
+        raise ValueError("src_indices and dst_indices must be 1D")
+    if src_indices.numel() != dst_indices.numel():
+        raise ValueError("src_indices and dst_indices must have the same length")
+    if src_indices.dtype not in (torch.int32, torch.int64):
+        raise ValueError("src_indices must use int32 or int64")
+    if dst_indices.dtype not in (torch.int32, torch.int64):
+        raise ValueError("dst_indices must use int32 or int64")
+    if src_indices.device != states.device or dst_indices.device != states.device:
+        raise ValueError(
+            "src_indices, dst_indices, and states must be on the same device"
+        )
+    if src_indices.numel() == 0 or states.numel() == 0:
+        return states
+    if not states[0, 0].is_contiguous():
+        raise ValueError("each Mamba state slot must be contiguous")
+
+    # The mover loads indices as ptr + row and does not accept index strides.
+    src_indices = src_indices.contiguous()
+    dst_indices = dst_indices.contiguous()
+    zero_steps = torch.zeros_like(src_indices, dtype=torch.int32)
+    return move_intermediate_cache(
+        states,
+        states.unsqueeze(2),
+        dst_indices,
+        src_indices,
+        zero_steps,
+        h_block_size=h_block_size,
+    )
+
+
 @triton.jit
 def move_cache_dynamic_last_kernel_h_block_kda(
     dst_cache_ptr,

--- a/tests/python/sgl_kernel_npu/test_mamba_state_update.py
+++ b/tests/python/sgl_kernel_npu/test_mamba_state_update.py
@@ -5,10 +5,82 @@ import pytest
 import torch
 from sgl_kernel_npu.mamba.mamba_state_update_triton import (
     conv_state_rollback,
+    copy_mamba_slots,
     move_intermediate_cache,
 )
 
 device = "npu"
+
+
+@torch.no_grad
+def test_copy_mamba_slots():
+    torch.manual_seed(7)
+    states = torch.randn(3, 17, 4, 16, 16, device=device, dtype=torch.bfloat16)
+    original = states.clone()
+    src = torch.tensor([2, 5, 9], device=device, dtype=torch.int32)
+    dst = torch.tensor([11, 13, 15], device=device, dtype=torch.int32)
+
+    expected = original.clone()
+    expected[:, dst.to(torch.long)] = expected[:, src.to(torch.long)]
+    copy_mamba_slots(states, src, dst)
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(states, expected, rtol=0, atol=0)
+    untouched = torch.ones(states.shape[1], dtype=torch.bool, device=device)
+    untouched[dst.to(torch.long)] = False
+    torch.testing.assert_close(
+        states[:, untouched], original[:, untouched], rtol=0, atol=0
+    )
+
+
+@torch.no_grad
+def test_copy_mamba_slots_accepts_noncontiguous_indices():
+    torch.manual_seed(8)
+    states = torch.randn(2, 17, 3, 8, 8, device=device, dtype=torch.bfloat16)
+    original = states.clone()
+    src = torch.tensor([2, 0, 5, 0, 9, 0], device=device, dtype=torch.int32)[::2]
+    dst = torch.tensor([11, 0, 13, 0, 15, 0], device=device, dtype=torch.int64)[::2]
+    assert not src.is_contiguous()
+    assert not dst.is_contiguous()
+
+    expected = original.clone()
+    expected[:, dst.to(torch.long)] = expected[:, src.to(torch.long)]
+    copy_mamba_slots(states, src, dst)
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(states, expected, rtol=0, atol=0)
+
+
+@torch.no_grad
+@pytest.mark.parametrize(
+    ("src_factory", "dst_factory", "message"),
+    [
+        (
+            lambda: torch.tensor([0, 1], device=device, dtype=torch.int32),
+            lambda: torch.tensor([2], device=device, dtype=torch.int32),
+            "same length",
+        ),
+        (
+            lambda: torch.tensor([0, 1], device=device, dtype=torch.float32),
+            lambda: torch.tensor([2, 3], device=device, dtype=torch.int32),
+            "src_indices must use int32 or int64",
+        ),
+        (
+            lambda: torch.tensor([0, 1], device=device, dtype=torch.int32),
+            lambda: torch.tensor([2, 3], device=device, dtype=torch.float32),
+            "dst_indices must use int32 or int64",
+        ),
+        (
+            lambda: torch.tensor([0, 1], device=device, dtype=torch.int32),
+            lambda: torch.tensor([2, 3], device="cpu", dtype=torch.int32),
+            "must be on the same device",
+        ),
+    ],
+)
+def test_copy_mamba_slots_validates_inputs(src_factory, dst_factory, message):
+    states = torch.empty(2, 4, 2, 8, 8, device=device, dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match=message):
+        copy_mamba_slots(states, src_factory(), dst_factory())
 
 
 def get_abs_err(x, y):


### PR DESCRIPTION
## Motivation

SGLang copies complete Mamba recurrent-state slots for radix-cache copy-on-write and checkpoint tracking. Expressing this as PyTorch advanced indexing creates a large temporary gather before the destination write. For Qwen3.6-27B, that temporary can span all recurrent layers and dominates these bookkeeping paths.

## Modifications

- Add `copy_mamba_slots(states, src_indices, dst_indices)`.
- Reuse the existing `move_intermediate_cache` Triton kernel through a length-one draft-step view, so the state moves directly between pool slots without a state-sized temporary.
- Accept `int32` and `int64` indices and make non-contiguous index vectors contiguous before launch.
- Validate rank, index lengths, dtypes, devices, and per-slot layout.
- Document the API invariant that source and destination slot sets must be disjoint. The intended SGLang COW and tracking callers satisfy this invariant.
- Add focused correctness and validation tests.

## Accuracy Tests

On Ascend 910B4-1 with CANN 9.0.0:

```text
pytest -q tests/python/sgl_kernel_npu/test_mamba_state_update.py -k copy_mamba_slots
6 passed, 12 deselected
```

The tests compare the entire state pool against PyTorch gather-plus-scatter with `rtol=0, atol=0`, including untouched slots and non-contiguous index inputs.

The helper was also exercised by Qwen3.6-27B-W8A8 cached-prefix E2E tests. All measured requests reported the expected cache hit and produced the same output token IDs as the non-fused configuration.

## Speed Tests and Profiling

One Ascend 910B4-1, BF16 state, 5 warmups and 15 measured samples; a bitwise correctness assertion runs before timing.

| Use case and shape | PyTorch indexing | Fused copy | Speedup |
| --- | ---: | ---: | ---: |
| COW, `[48, 161, 48, 128, 128]`, 8 slots | 32.7664 ms | 2.4084 ms | 13.605x |
| Tracking, `[161, 48, 128, 128]`, 8 slots | 0.5579 ms | 0.1300 ms | 4.292x |

## Validation

- Affected-file `pre-commit` hooks: passed.
- `git diff --check`: passed.
- Source wheel build for Ascend910B1: passed on the combined kernel snapshot.
- Full official FLA group on the combined snapshot: 7/7 files passed, 195 tests passed and 5 conditionally skipped.

## API constraint

The fused kernel intentionally does not perform an always-on host-side overlap or bounds check because converting device values to Python would synchronize the hot path. Callers must provide valid, pairwise-disjoint source and destination slot sets.
