### PR TITLE
[NPU] Preserve physical Mamba state storage semantics

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/mamba/mamba_state_update_triton.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/mamba/mamba_state_update_triton.py
@@ -417,10 +417,6 @@ def conv_state_rollback(
     state_indices = state_indices.to(torch.int32).contiguous()
     step_indices = step_indices.to(torch.int32).contiguous()
 
-    # Ensure conv_states is contiguous
-    if not conv_states.is_contiguous():
-        conv_states = conv_states.contiguous()
-
     # Grid over all requests
     grid = (num_requests,)
 

--- a/tests/python/sgl_kernel_npu/test_mamba_state_update.py
+++ b/tests/python/sgl_kernel_npu/test_mamba_state_update.py
@@ -102,6 +102,33 @@ def test_conv_state_rollback(
     assert_close("conv_state", gt_states, result_states, 1e-3)
 
 
+@torch.no_grad
+def test_conv_state_rollback_updates_noncontiguous_view_in_place():
+    L, S, D, W, N = 2, 5, 4, 6, 64
+    storage = torch.arange(L * S * N * W, device=device, dtype=torch.int64).reshape(
+        L, S, N, W
+    )
+    storage = (storage % 2048).to(torch.bfloat16)
+    conv_states = storage.transpose(-1, -2)
+    assert not conv_states.is_contiguous()
+
+    expected_storage = storage.clone()
+    expected = expected_storage.transpose(-1, -2)
+    original = expected.clone()
+    state_indices = torch.tensor([0, 2, 4], device=device, dtype=torch.int32)
+    step_indices = torch.tensor([0, 2, 3], device=device, dtype=torch.int32)
+    for state_idx, step_idx in zip(state_indices.tolist(), step_indices.tolist()):
+        shift = (D - 1) - step_idx
+        if shift > 0:
+            expected[:, state_idx, shift:] = original[:, state_idx, :-shift]
+
+    result = conv_state_rollback(conv_states, state_indices, step_indices, D)
+
+    assert result.data_ptr() == conv_states.data_ptr()
+    assert result.stride() == conv_states.stride()
+    assert torch.equal(storage, expected_storage)
+
+
 @pytest.mark.parametrize(
     ("L", "S", "D", "H", "V", "K", "num_valid", "dtype"),
     [
@@ -206,8 +233,8 @@ def test_move_intermediate_cache_copies_every_v_tile(V: int):
 
 
 @torch.no_grad
-def test_move_intermediate_cache_mask_and_destination_strides():
-    """Masked rows stay unchanged and destination H/V/K strides are honored."""
+def test_move_intermediate_cache_mask_and_physical_layout():
+    """Masked rows stay unchanged and state data is copied in physical order."""
     L, S, D, H, V, K = 2, 4, 3, 2, 128, 16
     src_cache = torch.randn(L, S, D, H, V, K, device=device, dtype=torch.bfloat16)
 
@@ -220,14 +247,14 @@ def test_move_intermediate_cache_mask_and_destination_strides():
     )
     dst_cache = dst_storage.transpose(-1, -2)
     assert not dst_cache.is_contiguous()
-    expected = dst_cache.clone()
+    expected_storage = dst_storage.clone()
 
     dst_indices = torch.tensor([0, 3, 5], device=device, dtype=torch.int32)
     src_indices = torch.tensor([1, 2, 3], device=device, dtype=torch.int32)
     last_steps = torch.tensor([2, -1, 0], device=device, dtype=torch.int32)
-    expected[:, dst_indices[[0, 2]].long()] = src_cache[
+    expected_storage[:, dst_indices[[0, 2]].long()] = src_cache[
         :, src_indices[[0, 2]].long(), last_steps[[0, 2]].long()
-    ]
+    ].reshape(L, 2, H, K, V)
 
     move_intermediate_cache(
         dst_cache,
@@ -237,5 +264,5 @@ def test_move_intermediate_cache_mask_and_destination_strides():
         last_steps,
     )
 
-    assert torch.equal(dst_cache, expected)
-    assert torch.all(dst_cache[:, dst_indices[1].long()] == -7)
+    assert torch.equal(dst_storage, expected_storage)
+    assert torch.all(dst_storage[:, dst_indices[1].long()] == -7)


### PR DESCRIPTION
## Problem

The NPU GDN speculative path exposes `ssm_states` as a `transpose(-1, -2)` view, but `torch.ops.npu.recurrent_gated_delta_rule` consumes the recurrent state through its raw `data_ptr()` and does not receive tensor strides. The transpose is therefore an ABI/layout shim, not a request for a logical PyTorch assignment.

Making the generic GDN mover honor destination H/V/K strides applies a second physical transpose. That corrupts recurrent state and produces gibberish in Qwen3.6-35B-A3B NEXTN decoding. This also happens with `--disable-radix-cache`: disabling Radix selects `ChunkCache`, but MTP verification still commits intermediate Mamba state.

The same module had a second strided-state bug in `conv_state_rollback`: it captured strides from the caller's view, replaced the tensor with a contiguous copy, then launched with the stale strides. The runtime ignores the helper's return value, so a non-contiguous state pool was not updated in place.

## Changes

- Preserve the source's dense physical per-slot order in the generic GDN `move_intermediate_cache`; do not apply destination logical H/V/K strides.
- Keep the KDA-specific mover stride-aware because it has a different explicit contract.
- Retain fixed 64-element V tiling so V dimensions above 64 are fully copied.
- Validate cache layout, dtype/device, metadata rank/type, and block size before launch.
- Ignore negative and out-of-range source, destination, and draft indices in the device kernel.
- Make metadata tensors contiguous before linear pointer indexing.
- Make `conv_state_rollback` update the caller's original view in place using its real strides.
- Mask rollback dimensions with a power-of-two Triton block, supporting non-power-of-two hidden sizes.
- Add rollback slot/step bounds checks and consistent Python-side validation.
- Re-enable `test_mamba_state_update.py` in the Mamba CI collection.

## Validation

Machine 3:

- `sglwmc-723` / CANN 9.0: `test_mamba_state_update.py` — **16 passed**.
- `sglwmc-813` / CANN 9.1: `test_mamba_state_update.py` — **16 passed**.
- Coverage includes contiguous destinations, physical storage behind a transposed view, V=65/128/129, invalid metadata, non-contiguous in-place rollback, and hidden size 65.

Qwen3.6-35B-A3B A/B on NPU 8/9, TP=2, NEXTN 3 steps / 4 draft tokens, `--disable-radix-cache`, same deterministic 1024-token inclusion-exclusion request:

- A (this change): HTTP 200, 6.338 s, coherent calculation, accept rate 0.88–0.98, about 162–175 tok/s.
- B (container's original physical-flat mover): HTTP 200, 6.261 s, accept rate 0.86–0.98, about 161–178 tok/s.
- `message`, `finish_reason`, and `usage` were exactly equal between A and B. Both stopped at the configured 1024-token limit; neither produced corrupted text.

Local checks:

- Black 24.10.0 formatting passed.
- Python compile check passed.
- `git diff --check` passed.