### PR TITLE
[NPU] Fix causal_conv1d prefill schema tests

### DIFF
--- a/csrc/causal_conv1d/op_host/causal_conv1d.cpp
+++ b/csrc/causal_conv1d/op_host/causal_conv1d.cpp
@@ -268,6 +268,7 @@ HOST_API at::Tensor causal_conv1d_impl(const at::Tensor &x, const at::Tensor &we
 
     TORCH_CHECK(x.dim() == 2 || x.dim() == 3, "x must be 2D or 3D tensor");
     TORCH_CHECK(weight.dim() == 2, "weight must be 2D tensor");
+    TORCH_CHECK(conv_states.dim() == 3, "conv_states must be 3D tensor");
 
     const at::ScalarType dtype = x.scalar_type();
     TORCH_CHECK(dtype == at::kBFloat16 || dtype == at::kHalf, "Only BF16 and FP16 are supported");
@@ -280,6 +281,8 @@ HOST_API at::Tensor causal_conv1d_impl(const at::Tensor &x, const at::Tensor &we
 
     int64_t dim = (x.dim() == 2) ? x.size(1) : x.size(2);
     int64_t width = weight.size(0);
+    TORCH_CHECK(weight.size(1) == dim, "weight.shape[1] must equal dim");
+    TORCH_CHECK(conv_states.size(2) == dim, "conv_states.shape[2] must equal dim");
     TORCH_CHECK(width >= MIN_WIDTH && width <= MAX_WIDTH, "Only support width in [2,4]");
 
     int64_t inputMode = (x.dim() == 2) ? 0 : 1;

--- a/csrc/pytorch_extensions.cpp
+++ b/csrc/pytorch_extensions.cpp
@@ -177,7 +177,7 @@ TORCH_LIBRARY_FRAGMENT(npu, m)
     m.def("triangular_inverse(Tensor x) -> Tensor");
 
     m.def(
-        "causal_conv1d(Tensor x, Tensor weight, Tensor conv_states, Tensor? bias=None, "
+        "causal_conv1d(Tensor x, Tensor weight, Tensor(a!) conv_states, Tensor? bias=None, "
         "Tensor? query_start_loc=None, Tensor? cache_indices=None, Tensor? has_initial_state=None, "
         "Tensor? num_accepted_tokens=None, int activation_mode=0, int pad_slot_id=-1, "
         "int run_mode=0) -> Tensor");

--- a/scripts/run_kernel_tests.sh
+++ b/scripts/run_kernel_tests.sh
@@ -74,7 +74,7 @@ SPECULATIVE_TESTS=(
 )
 
 MAMBA_TESTS=(
-    # test_conv1d_prefill.py  # FAILING: PyTorch 2.10.0 strict schema check
+    test_conv1d_prefill.py
     test_conv1d_update.py
     test_mamba_conv.py
     # test_mamba_state_update.py  # FAILING: move_intermediate_cache strided-dst exact mismatch

--- a/tests/python/sgl_kernel_npu/test_conv1d_prefill.py
+++ b/tests/python/sgl_kernel_npu/test_conv1d_prefill.py
@@ -1,5 +1,5 @@
 import argparse
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Iterable, Optional
 
 import sgl_kernel_npu  # noqa: F401  registers npu ops before pytestmark
@@ -29,15 +29,20 @@ class CaseConfig:
     lengths: Optional[list[int]] = None
     cache_indices: Optional[list[int]] = None
     has_initial_state: Optional[list[bool]] = None
+    query_start_loc_dtype: torch.dtype = torch.int32
 
 
-def make_query_start_loc(lengths: Iterable[int], device: torch.device) -> torch.Tensor:
+def make_query_start_loc(
+    lengths: Iterable[int],
+    device: torch.device,
+    dtype: torch.dtype = torch.int32,
+) -> torch.Tensor:
     qsl = [0]
     for length in lengths:
         qsl.append(qsl[-1] + int(length))
     if device.type == "cpu":
-        return torch.tensor(qsl, device="cpu", dtype=torch.int32)
-    out = torch.empty((len(qsl),), device=device, dtype=torch.int32)
+        return torch.tensor(qsl, device="cpu", dtype=dtype)
+    out = torch.empty((len(qsl),), device=device, dtype=dtype)
     for idx, value in enumerate(qsl):
         out[idx] = int(value)
     return out
@@ -58,18 +63,6 @@ def make_device_int_tensor(values: Iterable[int], device: torch.device) -> torch
     if device.type == "cpu":
         return torch.tensor(values, device="cpu", dtype=torch.int32)
     out = torch.empty((len(values),), device=device, dtype=torch.int32)
-    for idx, value in enumerate(values):
-        out[idx] = int(value)
-    return out
-
-
-def make_device_long_tensor(
-    values: Iterable[int], device: torch.device
-) -> torch.Tensor:
-    values = list(values)
-    if device.type == "cpu":
-        return torch.tensor(values, device="cpu", dtype=torch.int64)
-    out = torch.empty((len(values),), device=device, dtype=torch.int64)
     for idx, value in enumerate(values):
         out[idx] = int(value)
     return out
@@ -171,7 +164,9 @@ def make_case_tensors(case: CaseConfig, device: torch.device, pad_slot_id: int):
         device=device,
         dtype=case.dtype,
     )
-    query_start_loc = make_query_start_loc(lengths, device)
+    query_start_loc = make_query_start_loc(
+        lengths, device, dtype=case.query_start_loc_dtype
+    )
     cache_indices = make_device_int_tensor(case.cache_indices, device)
     if device.type == "cpu":
         has_initial_state = make_host_bool_tensor(case.has_initial_state)
@@ -217,7 +212,9 @@ def run_positive_case(
     weight = weight_cpu.to(device=device)
     bias = bias_cpu.to(device=device) if bias_cpu is not None else None
     conv_states_npu = conv_states_cpu.to(device=device)
-    query_start_loc = make_query_start_loc(lengths, device)
+    query_start_loc = make_query_start_loc(
+        lengths, device, dtype=case.query_start_loc_dtype
+    )
     cache_indices = make_device_int_tensor(case.cache_indices, device)
     has_initial_state = make_device_bool_tensor(case.has_initial_state, device)
 
@@ -292,47 +289,63 @@ def expect_failure(name: str, fn, expected_substrings: tuple[str, ...]):
 
 
 def run_negative_cases(device: torch.device, dtype: torch.dtype, pad_slot_id: int):
-    dim = 4096
-    x = torch.randn((2, 4, dim), device=device, dtype=dtype)
-    weight = torch.randn((4, dim), device=device, dtype=dtype)
-    conv_states = torch.randn((8, 5, dim), device=device, dtype=dtype)
-    query_start_loc = make_device_int_tensor([0, 4, 8], device)
-    cache_indices = make_device_int_tensor([0, 3], device)
-    has_initial_state = make_device_bool_tensor([True, False], device)
-    bias = torch.randn((dim,), device=device, dtype=dtype)
+    base_case = CaseConfig(
+        name="negative_case_inputs",
+        dtype=dtype,
+        dim=4096,
+        width=4,
+        state_len=5,
+        num_cache_lines=8,
+        activation_mode=False,
+        use_bias=True,
+        input_mode="3d",
+        batch=2,
+        seq_len=4,
+        cache_indices=[0, 3],
+        has_initial_state=[True, False],
+    )
+    (
+        x,
+        weight,
+        bias,
+        conv_states,
+        query_start_loc,
+        cache_indices,
+        has_initial_state,
+    ) = make_case_tensors(base_case, device, pad_slot_id)
 
-    # The registered host implementation currently supports widths 2 through 4.
+    unsupported_width_case = replace(
+        base_case, name="unsupported_width", width=5
+    )
+    (
+        unsupported_x,
+        unsupported_weight,
+        unsupported_bias,
+        unsupported_conv_states,
+        unsupported_query_start_loc,
+        unsupported_cache_indices,
+        unsupported_has_initial_state,
+    ) = make_case_tensors(unsupported_width_case, device, pad_slot_id)
+
+    # The native prefill kernel defines MAX_WIDTH=4, so 5 is the first invalid width.
     expect_failure(
         "unsupported_width",
         lambda: torch.ops.npu.causal_conv1d(
-            x,
-            torch.randn((5, dim), device=device, dtype=dtype),
-            conv_states,
-            bias=bias,
-            query_start_loc=query_start_loc,
-            cache_indices=cache_indices,
-            has_initial_state=has_initial_state,
+            unsupported_x,
+            unsupported_weight,
+            unsupported_conv_states,
+            bias=unsupported_bias,
+            query_start_loc=unsupported_query_start_loc,
+            cache_indices=unsupported_cache_indices,
+            has_initial_state=unsupported_has_initial_state,
         ),
         ("width in [2,4]",),
     )
 
-    # The current kernel tiles the channel axis, so dim=3072 is valid.
-    dim3072 = torch.ops.npu.causal_conv1d(
-        torch.randn((2, 4, 3072), device=device, dtype=dtype),
-        torch.randn((4, 3072), device=device, dtype=dtype),
-        torch.randn((8, 5, 3072), device=device, dtype=dtype),
-        bias=torch.randn((3072,), device=device, dtype=dtype),
-        query_start_loc=query_start_loc,
-        cache_indices=cache_indices,
-        has_initial_state=has_initial_state,
-    )
-    assert dim3072.shape[-1] == 3072, "causal_conv1d should support dim=3072"
-    print("[PASS] supports_dim_3072")
-
     expect_failure(
         "missing_query_start_loc_for_varlen",
         lambda: torch.ops.npu.causal_conv1d(
-            x.reshape(-1, dim),
+            x.reshape(-1, base_case.dim),
             weight,
             conv_states,
             bias=bias,
@@ -360,7 +373,11 @@ def run_negative_cases(device: torch.device, dtype: torch.dtype, pad_slot_id: in
         "dtype_mismatch_weight",
         lambda: torch.ops.npu.causal_conv1d(
             x,
-            torch.randn((4, dim), device="cpu", dtype=torch.float32).to(device=device),
+            torch.randn(
+                (base_case.width, base_case.dim),
+                device="cpu",
+                dtype=torch.float32,
+            ).to(device=device),
             conv_states,
             bias=bias,
             query_start_loc=query_start_loc,
@@ -369,19 +386,6 @@ def run_negative_cases(device: torch.device, dtype: torch.dtype, pad_slot_id: in
         ),
         ("dtype must match",),
     )
-
-    int64_query_start_loc_out = torch.ops.npu.causal_conv1d(
-        x,
-        weight,
-        conv_states.clone(),
-        bias=bias,
-        query_start_loc=make_device_long_tensor([0, 4, 8], device),
-        cache_indices=cache_indices,
-        has_initial_state=has_initial_state,
-    )
-    torch.npu.synchronize()
-    assert int64_query_start_loc_out.shape == x.shape
-    print("[PASS] supports_int64_query_start_loc")
 
 
 def main():
@@ -506,6 +510,37 @@ def main():
             lengths=[3, 5, 1, 4],
             cache_indices=[1, 6, args.pad_slot_id, 11],
             has_initial_state=[True, True, False, True],
+        ),
+        CaseConfig(
+            name="dense3d_dim3072",
+            dtype=torch.bfloat16,
+            dim=3072,
+            width=4,
+            state_len=5,
+            num_cache_lines=8,
+            activation_mode=False,
+            use_bias=True,
+            input_mode="3d",
+            batch=2,
+            seq_len=4,
+            cache_indices=[0, 3],
+            has_initial_state=[True, False],
+        ),
+        CaseConfig(
+            name="dense3d_int64_query_start_loc",
+            dtype=torch.bfloat16,
+            dim=1024,
+            width=4,
+            state_len=5,
+            num_cache_lines=8,
+            activation_mode=False,
+            use_bias=True,
+            input_mode="3d",
+            batch=2,
+            seq_len=4,
+            cache_indices=[1, 5],
+            has_initial_state=[True, False],
+            query_start_loc_dtype=torch.int64,
         ),
     ]
 

--- a/tests/python/sgl_kernel_npu/test_conv1d_prefill.py
+++ b/tests/python/sgl_kernel_npu/test_conv1d_prefill.py
@@ -314,9 +314,7 @@ def run_negative_cases(device: torch.device, dtype: torch.dtype, pad_slot_id: in
         has_initial_state,
     ) = make_case_tensors(base_case, device, pad_slot_id)
 
-    unsupported_width_case = replace(
-        base_case, name="unsupported_width", width=5
-    )
+    unsupported_width_case = replace(base_case, name="unsupported_width", width=5)
     (
         unsupported_x,
         unsupported_weight,

--- a/tests/python/sgl_kernel_npu/test_conv1d_prefill.py
+++ b/tests/python/sgl_kernel_npu/test_conv1d_prefill.py
@@ -237,11 +237,11 @@ def run_positive_case(
         x,
         weight,
         conv_states_npu,
-        query_start_loc,
-        cache_indices,
-        has_initial_state,
         bias=bias,
-        activation_mode=case.activation_mode,
+        query_start_loc=query_start_loc,
+        cache_indices=cache_indices,
+        has_initial_state=has_initial_state,
+        activation_mode=int(case.activation_mode),
         pad_slot_id=pad_slot_id,
     )
     torch.npu.synchronize()
@@ -301,45 +301,45 @@ def run_negative_cases(device: torch.device, dtype: torch.dtype, pad_slot_id: in
     has_initial_state = make_device_bool_tensor([True, False], device)
     bias = torch.randn((dim,), device=device, dtype=dtype)
 
-    # width 65 would need RS=128 (does not fit UB); widths 2..64 are all supported
-    # (any K, routed to the RS = roundUpToPow2(K) variant), so 65 is the first reject.
+    # The registered host implementation currently supports widths 2 through 4.
     expect_failure(
         "unsupported_width",
         lambda: torch.ops.npu.causal_conv1d(
             x,
-            torch.randn((65, dim), device=device, dtype=dtype),
+            torch.randn((5, dim), device=device, dtype=dtype),
             conv_states,
-            query_start_loc,
-            cache_indices,
-            has_initial_state,
             bias=bias,
+            query_start_loc=query_start_loc,
+            cache_indices=cache_indices,
+            has_initial_state=has_initial_state,
         ),
-        ("2..64", "width"),
+        ("width in [2,4]",),
     )
 
-    # NOTE: the previous AscendC kernel only supported a fixed set of dims
-    # (e.g. 1024/4096/8192) and rejected others such as 3072. The PTO kernel is
-    # generic over `dim` (it tiles the channel axis), so dim=3072 is now a valid
-    # case rather than an error; correctness across arbitrary dims is covered by
-    # the positive cases and the fp32-reference sweep.
+    # The current kernel tiles the channel axis, so dim=3072 is valid.
     dim3072 = torch.ops.npu.causal_conv1d(
         torch.randn((2, 4, 3072), device=device, dtype=dtype),
         torch.randn((4, 3072), device=device, dtype=dtype),
         torch.randn((8, 5, 3072), device=device, dtype=dtype),
-        query_start_loc,
-        cache_indices,
-        has_initial_state,
         bias=torch.randn((3072,), device=device, dtype=dtype),
+        query_start_loc=query_start_loc,
+        cache_indices=cache_indices,
+        has_initial_state=has_initial_state,
     )
-    assert dim3072.shape[-1] == 3072, "PTO causal_conv1d should support dim=3072"
-    print("[PASS] supports_dim_3072 (PTO kernel is generic over dim)")
+    assert dim3072.shape[-1] == 3072, "causal_conv1d should support dim=3072"
+    print("[PASS] supports_dim_3072")
 
     expect_failure(
-        "missing_required_query_start_loc",
+        "missing_query_start_loc_for_varlen",
         lambda: torch.ops.npu.causal_conv1d(
-            x, weight, conv_states, cache_indices, has_initial_state
+            x.reshape(-1, dim),
+            weight,
+            conv_states,
+            bias=bias,
+            cache_indices=cache_indices,
+            has_initial_state=has_initial_state,
         ),
-        ("missing", "expected at most", "arguments"),
+        ("query_start_loc must have at least 2 elements",),
     )
 
     expect_failure(
@@ -348,10 +348,10 @@ def run_negative_cases(device: torch.device, dtype: torch.dtype, pad_slot_id: in
             x,
             weight,
             torch.randn((8, 5, 2048), device=device, dtype=dtype),
-            query_start_loc,
-            cache_indices,
-            has_initial_state,
             bias=bias,
+            query_start_loc=query_start_loc,
+            cache_indices=cache_indices,
+            has_initial_state=has_initial_state,
         ),
         ("conv_states.shape[2]", "must equal dim"),
     )
@@ -362,27 +362,26 @@ def run_negative_cases(device: torch.device, dtype: torch.dtype, pad_slot_id: in
             x,
             torch.randn((4, dim), device="cpu", dtype=torch.float32).to(device=device),
             conv_states,
-            query_start_loc,
-            cache_indices,
-            has_initial_state,
             bias=bias,
+            query_start_loc=query_start_loc,
+            cache_indices=cache_indices,
+            has_initial_state=has_initial_state,
         ),
         ("dtype must match",),
     )
 
-    expect_failure(
-        "dtype_mismatch_query_start_loc",
-        lambda: torch.ops.npu.causal_conv1d(
-            x,
-            weight,
-            conv_states,
-            make_device_long_tensor([0, 4, 8], device),
-            cache_indices,
-            has_initial_state,
-            bias=bias,
-        ),
-        ("query_start_loc dtype must be int32",),
+    int64_query_start_loc_out = torch.ops.npu.causal_conv1d(
+        x,
+        weight,
+        conv_states.clone(),
+        bias=bias,
+        query_start_loc=make_device_long_tensor([0, 4, 8], device),
+        cache_indices=cache_indices,
+        has_initial_state=has_initial_state,
     )
+    torch.npu.synchronize()
+    assert int64_query_start_loc_out.shape == x.shape
+    print("[PASS] supports_int64_query_start_loc")
 
 
 def main():
@@ -507,144 +506,6 @@ def main():
             lengths=[3, 5, 1, 4],
             cache_indices=[1, 6, args.pad_slot_id, 11],
             has_initial_state=[True, True, False, True],
-        ),
-        CaseConfig(
-            name="dense3d_width5_bias_act",
-            dtype=torch.bfloat16,
-            dim=2048,
-            width=5,
-            state_len=5,
-            num_cache_lines=12,
-            activation_mode=True,
-            use_bias=True,
-            input_mode="3d",
-            batch=2,
-            seq_len=9,
-            cache_indices=[0, 6],
-            has_initial_state=[True, True],
-        ),
-        CaseConfig(
-            name="varlen2d_width8_fp16_act",
-            dtype=torch.float16,
-            dim=6144,
-            width=8,
-            state_len=8,
-            num_cache_lines=16,
-            activation_mode=True,
-            use_bias=True,
-            input_mode="2d",
-            batch=3,
-            lengths=[10, 4, 7],
-            cache_indices=[2, 9, 14],
-            has_initial_state=[True, False, True],
-        ),
-        CaseConfig(
-            name="dense3d_width16_bias_act",
-            dtype=torch.bfloat16,
-            dim=2048,
-            width=16,
-            state_len=16,
-            num_cache_lines=8,
-            activation_mode=True,
-            use_bias=True,
-            input_mode="3d",
-            batch=2,
-            seq_len=20,
-            cache_indices=[0, 4],
-            has_initial_state=[True, False],
-        ),
-        CaseConfig(
-            name="dense3d_width32_fp16_act",
-            dtype=torch.float16,
-            dim=2048,
-            width=32,
-            state_len=32,
-            num_cache_lines=8,
-            activation_mode=True,
-            use_bias=False,
-            input_mode="3d",
-            batch=2,
-            seq_len=40,
-            cache_indices=[1, 5],
-            has_initial_state=[True, True],
-        ),
-        CaseConfig(
-            name="varlen2d_width64_bias_act",
-            dtype=torch.bfloat16,
-            dim=2048,
-            width=64,
-            state_len=64,
-            num_cache_lines=8,
-            activation_mode=True,
-            use_bias=True,
-            input_mode="2d",
-            batch=2,
-            lengths=[70, 50],
-            cache_indices=[0, 3],
-            has_initial_state=[True, False],
-        ),
-        # Non-power-of-two widths: K is passed at runtime and routed to the
-        # RS = roundUpToPow2(K) variant, so these exercise K < RS in each RS group
-        # (7->rs8, 12->rs16, 24->rs32, 48->rs64). widths 3 and 5 above cover rs4/rs8.
-        CaseConfig(
-            name="dense3d_width7_fp16_bias_act",
-            dtype=torch.float16,
-            dim=2048,
-            width=7,
-            state_len=7,
-            num_cache_lines=12,
-            activation_mode=True,
-            use_bias=True,
-            input_mode="3d",
-            batch=2,
-            seq_len=12,
-            cache_indices=[0, 5],
-            has_initial_state=[True, False],
-        ),
-        CaseConfig(
-            name="varlen2d_width12_bias_act",
-            dtype=torch.bfloat16,
-            dim=2048,
-            width=12,
-            state_len=12,
-            num_cache_lines=10,
-            activation_mode=True,
-            use_bias=True,
-            input_mode="2d",
-            batch=2,
-            lengths=[20, 14],
-            cache_indices=[0, 4],
-            has_initial_state=[True, True],
-        ),
-        CaseConfig(
-            name="dense3d_width24_fp16_act",
-            dtype=torch.float16,
-            dim=2048,
-            width=24,
-            state_len=24,
-            num_cache_lines=8,
-            activation_mode=True,
-            use_bias=False,
-            input_mode="3d",
-            batch=2,
-            seq_len=30,
-            cache_indices=[1, 5],
-            has_initial_state=[True, True],
-        ),
-        CaseConfig(
-            name="varlen2d_width48_bias_act",
-            dtype=torch.bfloat16,
-            dim=2048,
-            width=48,
-            state_len=48,
-            num_cache_lines=8,
-            activation_mode=True,
-            use_bias=True,
-            input_mode="2d",
-            batch=2,
-            lengths=[60, 50],
-            cache_indices=[0, 3],
-            has_initial_state=[True, False],
         ),
     ]
 


### PR DESCRIPTION
## Summary

- pass every optional causal_conv1d argument by keyword so the test matches the current schema and does not trigger the PyTorch 2.10 duplicate-argument assertion
- declare conv_states as mutable in the operator schema and reject invalid state/weight shapes in the host implementation
- drive successful contract coverage through CaseConfig, including dim=3072 and int64 query_start_loc, with independent state for every case
- align width coverage with the native prefill kernel and re-enable test_conv1d_prefill.py in the Mamba test group

## Width boundary

The native prefill implementation in csrc/causal_conv1d defines MAX_WIDTH=4, so width=5 is its first invalid boundary. PR #736 fixes the Python/Triton causal_conv1d_update path and does not change the native causal_conv1d prefill width limit. The stale width 5-64 positive cases came from the earlier PTO implementation and are removed here.

## Testing

- rebased onto main at 146153e, which contains #736
- rebuilt wheel and passed python3 tests/python/sgl_kernel_npu/test_conv1d_prefill.py in machine 3 container sglwmc-91-813 (CANN 9.1 / Python 3.12)
- rebuilt wheel and passed python3 tests/python/sgl_kernel_npu/test_conv1d_prefill.py in machine 3 container sglwmc-9-723 (CANN 9.0 / Python 3.11)
- reran the CaseConfig refactor in both containers; all positive and negative cases passed
- git diff --check, Python syntax check, and Bash syntax check passed