### PR TITLE
[NPU] Disable multibuffer for recompute W/U kernel

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/wy_fast.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/wy_fast.py
@@ -143,7 +143,6 @@ def recompute_w_u_fwd_npu(
         BT=BT,
         BK=BK,
         BV=BV,
-        # Avoid intermittent AICore watchdog timeouts with Triton-Ascend on CANN 9.1.
         multibuffer=False,
         num_warps=4,
         num_stages=3,

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/wy_fast.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/wy_fast.py
@@ -143,6 +143,8 @@ def recompute_w_u_fwd_npu(
         BT=BT,
         BK=BK,
         BV=BV,
+        # Avoid intermittent AICore watchdog timeouts with Triton-Ascend on CANN 9.1.
+        multibuffer=False,
         num_warps=4,
         num_stages=3,
     )

--- a/scripts/run_kernel_tests.sh
+++ b/scripts/run_kernel_tests.sh
@@ -164,12 +164,10 @@ esac
 
 # CANN 9.1.0: skip flaky/broken fla tests that only fail on this image.
 # - test_triangular_inverse.py: torch_npu builtin op output mismatch (DTS 20260819-#2)
-# - test_chunk_gdn_triton.py:    intermittent aicore timeout, error 507014 (DTS 20260819-#3)
-# Both still run on CANN 9.0.0 where they pass.
+# It still runs on CANN 9.0.0 where it passes.
 if [[ "${CANN_VERSION:-}" == 9.1* ]]; then
     SKIP_ON_910=(
         test_triangular_inverse.py
-        test_chunk_gdn_triton.py
     )
     FILTERED_TESTS=()
     for t in "${TESTS[@]}"; do


### PR DESCRIPTION
## Summary

- explicitly disable Triton-Ascend multibuffering for `recompute_w_u_fwd_kernel_npu_kernel`
- re-enable `test_chunk_gdn_triton.py` in the CANN 9.1.0 FLA test group
- keep the backend workaround scoped to this kernel launch

## Context

Under CANN 9.1.0, `test_chunk_gdn_triton.py` intermittently hangs for about 10 minutes before `AclrtSynchronizeDeviceWithTimeout` reports error 507014. The affected parameter is:

`H4-D128-mask_p0.5-cu_seqlens[0, 3584, 7168]-torch.float16`

The same CI job can pass on rerun, while CANN 9.0.0 has not reproduced the problem. Device plog identifies `recompute_w_u_fwd_kernel_npu_kernel` as the timed-out AICore task.

Controlled stress on CANN 9.1.0 reproduced the timeout with the default backend setting. With `multibuffer=False`, the target case completed 2 x 100 invocations on each of two physical devices (400 forward launches total) without a timeout. The TTIR is unchanged, while the generated NPUBIN differs, which points to the backend multibuffer path rather than the Triton algorithm.

Now that this launch disables multibuffering, the CANN 9.1.0-specific skip for `test_chunk_gdn_triton.py` is removed. The unrelated `test_triangular_inverse.py` skip remains.

CI examples:
- [CANN 9.1.0 timeout](https://github.com/sgl-project/sgl-kernel-npu/actions/runs/32238943820/job/96025127387?pr=728)
- [successful rerun](https://github.com/sgl-project/sgl-kernel-npu/actions/runs/32323483223/job/96290053181?pr=728)

## Validation

- `python -m py_compile python/sgl_kernel_npu/sgl_kernel_npu/fla/wy_fast.py`
- `bash -n scripts/run_kernel_tests.sh`
- CANN 9.1.0 / 813 image: full `test_chunk_gdn_triton.py`: **30 passed in 62.69s**
- CANN 9.1.0 / 813 image: `CANN_VERSION=9.1.0 bash scripts/run_kernel_tests.sh fla`: **6 test files passed, 0 failed**
- the FLA entrypoint executed `test_chunk_gdn_triton.py` (**30 passed**) and skipped only `test_triangular_inverse.py`
- CANN 9.1.0 / 813 image: captured TP4 `recompute_w_u_fwd_npu` replay, 4 workers x 1000 iterations: **all ranks passed**
- no `507014`, AICore timeout, watchdog timeout, traceback, or runtime-error markers in the validation logs
- post-run NPU health: **OK**