### PR TITLE
[fix] compressor: replace defective hand-written tiling cache with ge_helper GetTilingTensor

### DIFF
--- a/csrc/compressor/op_host/compressor.cpp
+++ b/csrc/compressor/op_host/compressor.cpp
@@ -14,10 +14,6 @@
  * \brief host wrapper (ge_helper + direct kernel launch) for the Compressor op.
  */
 #include <cstdio>
-#include <mutex>
-#include <string>
-#include <type_traits>
-#include <unordered_map>
 #include "acl/acl.h"
 #include "kernel_tiling/kernel_tiling.h"
 #include "tiling/platform/platform_ascendc.h"
@@ -32,83 +28,6 @@
 
 namespace sglang {
 namespace npu_kernel {
-
-constexpr uint32_t MAX_CAPTURE_NUM = 1024;
-
-namespace {
-
-struct TilingCache {
-    at::Tensor buffer;
-    std::unordered_map<std::string, uint32_t> slots;
-    uint32_t nextSlot = 0;
-};
-
-template <typename T>
-void AppendTilingKey(std::string &key, const T &value)
-{
-    static_assert(std::is_trivially_copyable_v<T>);
-    key.append(reinterpret_cast<const char *>(&value), sizeof(T));
-}
-
-std::string MakeTilingCacheKey(const optiling::CompressorTilingData &data)
-{
-    std::string key;
-    key.reserve(sizeof(optiling::CompressorTilingData));
-    const auto &base = data.baseParams;
-    AppendTilingKey(key, base.batchSize);
-    AppendTilingKey(key, base.seqSize);
-    AppendTilingKey(key, base.hiddenSize);
-    AppendTilingKey(key, base.headDim);
-    AppendTilingKey(key, base.cmpRatio);
-    AppendTilingKey(key, base.tokenSize);
-    AppendTilingKey(key, base.csSize);
-    AppendTilingKey(key, base.cgSize);
-    AppendTilingKey(key, base.nSize);
-    AppendTilingKey(key, base.usedCoreNum);
-    AppendTilingKey(key, base.ropeHeadDim);
-    AppendTilingKey(key, base.normEps);
-    AppendTilingKey(key, base.reciprocalD);
-    AppendTilingKey(key, base.stateCacheStrideDim0);
-    const auto &page = data.pageAttentionParams;
-    AppendTilingKey(key, page.blockNum);
-    AppendTilingKey(key, page.blockSize);
-    AppendTilingKey(key, page.maxBlockNumPerBatch);
-    const auto &split = data.innerSplitParams;
-    AppendTilingKey(key, split.mBaseSize);
-    AppendTilingKey(key, split.dBaseSize);
-    const auto &ws = data.workspaceParams;
-    AppendTilingKey(key, ws.mm1KvResSize);
-    AppendTilingKey(key, ws.mm1ScoreResSize);
-    AppendTilingKey(key, ws.vec1ResSize);
-    AppendTilingKey(key, ws.vec1TailCacheSize);
-    AppendTilingKey(key, ws.dbWorkspaceRatio);
-    AppendTilingKey(key, data.tilingKey);
-    return key;
-}
-
-bool IsNpuGraphCapturing()
-{
-    aclmdlRICaptureStatus captureStatus = ACL_MODEL_RI_CAPTURE_STATUS_NONE;
-    aclmdlRI model = nullptr;
-    auto stream = c10_npu::getCurrentNPUStream().stream(false);
-    auto status = aclmdlRICaptureGetInfo(stream, &captureStatus, &model);
-    TORCH_CHECK(status == ACL_ERROR_NONE, "compressor: failed to query NPU graph capture status, acl error ", status);
-    return captureStatus == ACL_MODEL_RI_CAPTURE_STATUS_ACTIVE;
-}
-
-std::unordered_map<int64_t, TilingCache> &GetTilingCaches()
-{
-    static std::unordered_map<int64_t, TilingCache> deviceCaches;
-    return deviceCaches;
-}
-
-std::mutex &GetTilingCacheMutex()
-{
-    static std::mutex cacheMutex;
-    return cacheMutex;
-}
-
-}  // namespace
 
 namespace {
 
@@ -239,47 +158,7 @@ HOST_API at::Tensor compressor(const at::Tensor &x, const at::Tensor &wkv, const
         return cmp_kv;
     }
 
-    auto key = MakeTilingCacheKey(tilingData);
-    at::Tensor tilingTensor;
-    if (IsNpuGraphCapturing()) {
-        // ── 入图路径：查缓存，必须命中 ──
-        std::lock_guard<std::mutex> lock(GetTilingCacheMutex());
-        auto &cache = GetTilingCaches()[x.device().index()];
-        TORCH_CHECK(cache.buffer.defined(),
-                    "compressor: run one eager warmup before NPU graph capture to initialize the tiling cache");
-        auto iter = cache.slots.find(key);
-        TORCH_CHECK(iter != cache.slots.end(),
-                    "compressor: the current tiling configuration is not cached; run one eager warmup ...");
-        tilingTensor = cache.buffer.narrow(0, iter->second * tilingSize, tilingSize);
-    } else {
-        // ── 不入图路径：查缓存 → 填缓存 → 满则退回 memcpy（lightning_indexer 风格）──
-        std::lock_guard<std::mutex> lock(GetTilingCacheMutex());
-        auto &cache = GetTilingCaches()[x.device().index()];
-        if (!cache.buffer.defined()) {
-            cache.buffer = at::empty({tilingSize * MAX_CAPTURE_NUM},
-                                     at::TensorOptions().dtype(at::kByte).device(x.options().device()));
-        }
-        auto iter = cache.slots.find(key);
-        if (iter != cache.slots.end()) {
-            tilingTensor = cache.buffer.narrow(0, iter->second * tilingSize, tilingSize);  // 命中复用
-        } else if (cache.nextSlot >= MAX_CAPTURE_NUM) {
-            // 缓存满：退回一次性 memcpy（局部 tensor，避免 static 跨线程/跨设备覆盖）
-            at::Tensor t = at::empty({tilingSize}, at::TensorOptions().dtype(at::kByte).device(x.options().device()));
-            auto status =
-                aclrtMemcpy(t.data_ptr<uint8_t>(), tilingSize, &tilingData, tilingSize, ACL_MEMCPY_HOST_TO_DEVICE);
-            TORCH_CHECK(status == ACL_ERROR_NONE, "compressor: failed to copy tiling data, acl error ", status);
-            tilingTensor = t;
-        } else {
-            // 正常 MISS：填缓存
-            const uint32_t slot = cache.nextSlot;
-            tilingTensor = cache.buffer.narrow(0, slot * tilingSize, tilingSize);
-            auto status = aclrtMemcpy(tilingTensor.data_ptr<uint8_t>(), tilingSize, &tilingData, tilingSize,
-                                      ACL_MEMCPY_HOST_TO_DEVICE);
-            TORCH_CHECK(status == ACL_ERROR_NONE, "compressor: failed to cache tiling data, acl error ", status);
-            cache.slots.emplace(std::move(key), slot);
-            cache.nextSlot++;
-        }
-    }
+    auto tilingTensor = context->GetTilingTensor(tilingData);
 
     // ---- 6) workspace ----
     at::Tensor workspace =

--- a/csrc/utils/ge_helper.h
+++ b/csrc/utils/ge_helper.h
@@ -15,8 +15,6 @@
 #include "tiling/platform/platform_ascendc.h"
 #include "torch_helper.h"
 
-#include <c10/core/InferenceMode.h>
-
 #include <stdexcept>
 
 constexpr ge::DataType SCALAR_TYPE_TO_GE_DATATYPE(at::ScalarType scalarType)
@@ -173,17 +171,14 @@ public:
 private:
     static void CopyTo_(const at::Tensor &destination, const T &tilingData, const std::string &opName)
     {
-        // Upload via torch_npu dispatch (OpCommand) so the H2D copy is ordered on
-        // the same task queue as the surrounding graph / non-blocking ops. A raw
-        // aclrtMemcpy would bypass the queue and break stream ordering in graph mode.
-        auto cpuTiling = at::empty({static_cast<int64_t>(sizeof(T))}, at::kByte);
-        std::memcpy(cpuTiling.data_ptr(), &tilingData, sizeof(T));
-        auto deviceTiling = sglang::npu_kernel::TorchNpuHelper::CopyTensorHostToDevice(cpuTiling);
-        // The cached destination may be an inference tensor (created while the
-        // host ran under InferenceMode), so wrap the in-place update in an
-        // InferenceMode guard to allow it outside an inference context.
-        c10::InferenceMode guard(true);
-        destination.copy_(deviceTiling);
+        // Upload on the torch_npu current stream so the H2D copy is ordered with the
+        // surrounding kernel launches, then sync because the source is a stack object
+        // (an async memcpy would otherwise read freed memory after this returns).
+        auto stream = c10_npu::getCurrentNPUStream().stream(false);
+        auto status = aclrtMemcpyAsync(destination.data_ptr(), sizeof(T), &tilingData, sizeof(T),
+                                       ACL_MEMCPY_HOST_TO_DEVICE, stream);
+        TORCH_CHECK(status == ACL_ERROR_NONE, opName, ": failed to copy tiling data, acl error ", status);
+        aclrtSynchronizeStream(stream);
     }
     struct DeviceCache {
         at::Tensor buffer;

--- a/csrc/utils/ge_helper.h
+++ b/csrc/utils/ge_helper.h
@@ -15,6 +15,8 @@
 #include "tiling/platform/platform_ascendc.h"
 #include "torch_helper.h"
 
+#include <c10/core/InferenceMode.h>
+
 #include <stdexcept>
 
 constexpr ge::DataType SCALAR_TYPE_TO_GE_DATATYPE(at::ScalarType scalarType)
@@ -171,8 +173,17 @@ public:
 private:
     static void CopyTo_(const at::Tensor &destination, const T &tilingData, const std::string &opName)
     {
-        auto status = aclrtMemcpy(destination.data_ptr(), sizeof(T), &tilingData, sizeof(T), ACL_MEMCPY_HOST_TO_DEVICE);
-        TORCH_CHECK(status == ACL_ERROR_NONE, opName, ": failed to copy tiling data, acl error ", status);
+        // Upload via torch_npu dispatch (OpCommand) so the H2D copy is ordered on
+        // the same task queue as the surrounding graph / non-blocking ops. A raw
+        // aclrtMemcpy would bypass the queue and break stream ordering in graph mode.
+        auto cpuTiling = at::empty({static_cast<int64_t>(sizeof(T))}, at::kByte);
+        std::memcpy(cpuTiling.data_ptr(), &tilingData, sizeof(T));
+        auto deviceTiling = sglang::npu_kernel::TorchNpuHelper::CopyTensorHostToDevice(cpuTiling);
+        // The cached destination may be an inference tensor (created while the
+        // host ran under InferenceMode), so wrap the in-place update in an
+        // InferenceMode guard to allow it outside an inference context.
+        c10::InferenceMode guard(true);
+        destination.copy_(deviceTiling);
     }
     struct DeviceCache {
         at::Tensor buffer;


### PR DESCRIPTION
## Summary
The hand-written tiling-upload cache in the compressor host wrapper is buggy. This PR removes it and switches to ge_helper's standard TilingContext::GetTilingTensor(), which backs onto TilingTensorCache<T> with a correct, complete cache key and graph-capture-safe semantics.
## Changes
- csrc/compressor/op_host/compressor.cpp
- Removed the defective hand-written tiling cache: TilingCache, AppendTilingKey, MakeTilingCacheKey, IsNpuGraphCapturing, GetTilingCaches, GetTilingCacheMutex
- Tiling upload now uses context->GetTilingTensor(tilingData)
- Dropped now-unused <mutex> / <string> / <type_traits> / <unordered_map> includes
## Why
The old MakeTilingCacheKey builds the cache key by manually appending selected fields, which is incomplete and can produce wrong cache hits across configurations. ge_helper's TilingTensorCache<T>::Get uses the full serialized tiling data (including padding) as the key and handles:
- cache hit reuse
- NPU graph capture 
- 512-entry cap with one-shot aclrtMemcpy fallback when full
- per-device cache under a mutex

| Model                       | Dataset   | Metric     | Subset   | Num | Score |
|-----------------------------|-----------|------------|----------|-----|-------|
| DeepSeek-V4-Flash-0731-w8a8 | AIME-2026 | Accuracy ↑ | default  | 30  | 93.3% |

| Model                       | Dataset      | Metric     | Subset       | Num | Score |
|-----------------------------|--------------|------------|--------------|-----|-------|
| DeepSeek-V4-Flash-0731-w8a8 | GPQA-Diamond | Accuracy ↑ | gpqa_diamond | 198 | 89.9% |