### PR TITLE
Lightning indexer v2 implementation

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -58,6 +58,8 @@ set(OP_SRCS
     ${PROJECT_OP_SRC_BASE}/sparse_attn_sharedkv_metadata/op_host/sparse_attn_sharedkv_metadata.cpp
     ${PROJECT_OP_SRC_BASE}/sparse_attention_score/op_host/sparse_attention_score.cpp
     ${PROJECT_OP_SRC_BASE}/sparse_attention_score/op_host/tiling/sparse_attention_score_tiling.cpp
+    ${PROJECT_OP_SRC_BASE}/lightning_indexer_v2/op_host/lightning_indexer_v2.cpp
+    ${PROJECT_OP_SRC_BASE}/lightning_indexer_v2/op_host/tiling/lightning_indexer_v2_tiling.cpp
     )
 # A3-only host sources
 if(SGL_KERNEL_ENABLE_A3_ONLY_OPS)
@@ -193,6 +195,34 @@ if(BUILD_CATLASS_MODULE)
     set(CATLASS_WORKSPACE_KERNEL_TARGETS catlass_workspace_kernel)
 endif()
 
+# lightning_indexer_v2 gets its own AscendC target: it needs the upstream
+# per-op compile options (see vllm-ascend op_host/CMakeLists.txt), which in
+# AscendC apply to the whole target.
+ascendc_library(lightning_indexer_v2_kernel STATIC
+    ${PROJECT_OP_SRC_BASE}/lightning_indexer_v2/op_kernel/lightning_indexer_v2_kernel.cpp
+)
+ascendc_include_directories(lightning_indexer_v2_kernel PRIVATE
+    ${PROJECT_OP_SRC_BASE}/lightning_indexer_v2/op_kernel
+    ${PROJECT_OP_SRC_BASE}/utils/kernel
+)
+ascendc_compile_definitions(lightning_indexer_v2_kernel PRIVATE
+    -DHAVE_WORKSPACE
+    -DHAVE_TILING
+)
+ascendc_compile_options(lightning_indexer_v2_kernel PRIVATE
+    --cce-auto-sync=off
+    -Wno-deprecated-declarations
+    -mllvm
+    -cce-vf-remove-membar=false
+)
+# Upstream (vllm-ascend op_host/CMakeLists.txt) also passes
+#     -mllvm -cce-aicore-hoist-movemask=false
+# but CANN 9.1.0's bisheng rejects it as an unknown argument on both the A2/A3
+# and the Ascend950 toolchains, so it is dropped here. Upstream presumably
+# builds against a CANN version that has the option. If a future CANN adds it
+# back, restore it: it disables movemask hoisting, and upstream turning it off
+# suggests the optimisation is unwanted for this kernel.
+
 # Dedicated A3-only kernel targets. Keep these separate from workspace_kernel:
 # their compiler definitions/options apply to the whole AscendC target.
 set(A3_ONLY_KERNEL_TARGETS)
@@ -240,6 +270,7 @@ add_library(${OP_PLUGIN_NAME} SHARED ${OP_SRCS})
 
 target_link_libraries(${OP_PLUGIN_NAME} PRIVATE
         ${A3_ONLY_KERNEL_TARGETS}
+        lightning_indexer_v2_kernel
         workspace_kernel
         no_workspace_kernel
         ${CATLASS_WORKSPACE_KERNEL_TARGETS}
@@ -272,6 +303,8 @@ target_include_directories(${OP_PLUGIN_NAME} PRIVATE
         ${PROJECT_OP_SRC_BASE}/sparse_attn_sharedkv/op_host
         ${PROJECT_OP_SRC_BASE}/sparse_attention_score/op_host
         ${PROJECT_OP_SRC_BASE}/sparse_attention_score/op_host/tiling
+        ${PROJECT_OP_SRC_BASE}/lightning_indexer_v2/op_host
+        ${PROJECT_OP_SRC_BASE}/lightning_indexer_v2/op_host/tiling
         ${TORCH_DIR}/include
         ${TORCH_DIR}/include/torch/csrc/api/include
         ${TORCH_NPU_DIR}/include

--- a/csrc/lightning_indexer_v2/README.md
+++ b/csrc/lightning_indexer_v2/README.md
@@ -1,0 +1,111 @@
+# torch.ops.npu.lightning_indexer_v2
+
+## Origin
+
+Ported from `vllm-ascend/csrc/attention/lightning_indexer`. It is a newer revision of the
+kernel behind [`lightning_indexer`](../lightning_indexer/README.md), which remains in the
+tree unchanged; the two ops are independent.
+
+Compared to `lightning_indexer` this version adds:
+
+- an **arch35** kernel path for <term>Ascend 950PR/950DT</term> (VF top-k), alongside the
+  existing **arch22** path for <term>Atlas A2/A3</term>. `lightning_indexer` is A3-only;
+  `lightning_indexer_v2` is therefore *not* gated on `SGL_KERNEL_ENABLE_A3_ONLY_OPS`.
+- an optional second output **`sparse_values`** (`return_values`).
+- **fp32 `weights`** while `query`/`key` stay fp16/bf16 (upstream `DT_W_FLAG`).
+- the `pre_tokens` / `next_tokens` attributes.
+
+## Product Support Status
+
+| Product                                                    | Supported |
+| ---------------------------------------------------------- | :-------: |
+| <term>Ascend 950PR / Ascend 950DT</term>                     |     √     |
+| <term>Atlas A3 Training/Inference Product Series</term>      |     √     |
+| <term>Atlas A2 Training/Inference Product Series</term>      |     √     |
+
+## Function Description
+
+`LightningIndexer` computes the Top-$k$ positions corresponding to each token. For an Index
+Query $Q_{index}\in\R^{g\times d}$ corresponding to a certain token, given the context Index
+Key $K_{index}\in\R^{S_{k}\times d},W\in\R^{g\times 1}$, where $g$ is the group size for GQA,
+$d$ is the dimension of each head, and $S_{k}$ is the context length:
+
+$$
+Indices=\text{Top-}k\left\{[1]_{1\times g}@\left[(W@[1]_{1\times S_{k}})\odot\text{ReLU}\left(Q_{index}@K_{index}^T\right)\right]\right\}
+$$
+
+## Function Prototype
+
+```
+torch.ops.npu.lightning_indexer_v2(
+    query, key, weights,
+    actual_seq_lengths_query=None, actual_seq_lengths_key=None, block_table=None,
+    layout_query='BSND', layout_key='BSND',
+    sparse_count=2048, sparse_mode=3,
+    pre_tokens=None, next_tokens=None, return_values=False,
+) -> (Tensor, Tensor)
+```
+
+Returns `(sparse_indices, sparse_values)`. When `return_values` is `False`, `sparse_values`
+is an empty tensor.
+
+## Parameter Description
+
+Dimension meanings: B (Batch Size), S (Sequence Length), H (Head Size), N (Head Num),
+D (Head Dim, D=H/N), T (cumulative sum of sequence lengths across the batch). S1/N1 refer to
+`query`, S2/N2 to `key`.
+
+- **query** (`Tensor`): required, contiguous, ND. `bfloat16` or `float16`.
+- **key** (`Tensor`): required, contiguous, ND. `bfloat16` or `float16`. When `layout_key` is
+  `'PA_BSND'` the shape is `[block_count, block_size, N2, D]`.
+- **weights** (`Tensor`): required, contiguous, ND. Same dtype as `query`, **or** `float32`.
+- **actual_seq_lengths_query** (`Tensor`, optional): `int32`, 1-D of length B. Required when
+  `layout_query` is `'TND'`, where each element is the prefix sum of tokens up to and
+  including that batch (non-decreasing, non-negative), and its length defines B.
+- **actual_seq_lengths_key** (`Tensor`, optional): `int32`, 1-D of length B.
+- **block_table** (`Tensor`, optional): `int32`, ND. Required for PageAttention; 2-D, first
+  dim B, second dim at least maxBlockNumPerSeq.
+- **layout_query** (`str`, optional): `'BSND'` or `'TND'`. Default `'BSND'`.
+- **layout_key** (`str`, optional): `'PA_BSND'`, `'BSND'` or `'TND'`. Default `'BSND'`.
+  Outside PageAttention it must equal `layout_query`.
+- **sparse_count** (`int`, optional): number of positions kept by the topK phase, 1-2048.
+- **sparse_mode** (`int`, optional): `0` (defaultMask) or `3` (rightDownCausal). Default `3`.
+- **pre_tokens** / **next_tokens** (`int`, optional): currently only `INT64_MAX` is accepted,
+  matching upstream.
+- **return_values** (`bool`, optional): also return the Top-$k$ scores. Default `False`.
+
+## Return Value
+
+- **sparse_indices** (`Tensor`): `int32`, ND.
+- **sparse_values** (`Tensor`): same dtype as `query`, ND. Empty when `return_values=False`.
+
+## Constraints
+
+- Inference scenarios; graph mode supported.
+- N in `query` supports 64, N in `key` supports 1.
+- D of `query` and `key` must both be 128.
+- `query` and `key` must share a dtype; `weights` matches it or is `float32`.
+- `block_size` must be a multiple of 16, up to 1024.
+
+## Port notes
+
+The upstream sources are reused as close to verbatim as practical so they stay diffable
+against `vllm-ascend`. The deviations are:
+
+| Upstream | Here | Why |
+| --- | --- | --- |
+| `ASCENDC_TPL_ARGS_DECL` / `GET_TPL_TILING_KEY` codegen | `op_kernel/lightning_indexer_v2_tiling_key.h` + an explicit `switch` in the kernel entry | sgl-kernel-npu emits a single kernel binary, so the template combinations upstream lists in `ASCENDC_TPL_SEL` are expanded by hand. |
+| `BEGIN_TILING_DATA_DEF(LITilingData)` | POD in `op_host/tiling/lightning_indexer_v2_tiling_data.h` | No CANN op-project codegen; the struct is shared by host and device. |
+| `err/ops_err.h` (`OP_CHECK_IF`, `OP_LOGE`, ...) | `op_host/tiling/lightning_indexer_v2_ops_compat.h` | Those macros only exist inside a CANN op project. The shim maps them onto `TORCH_CHECK`, which keeps the ~800 lines of tiling checks byte-identical to upstream. |
+| `aclnn` + `EXEC_NPU_CMD` | `EXEC_KERNEL_CMD` + `ge_helper` | This repo uses kernel-direct-launch, not a registered CANN operator. |
+| `context->SetBlockDim/SetTilingKey/GetRawTilingData` | carried in the tiling POD | Not available on the `ge_helper::TilingContext` shim. |
+| `CeilDiv(T, T)` | `CeilDiv(T1, T2)` | CANN 9.1.0's kernel headers have no second `CeilDiv` overload, so mixed-type calls in the service layer fail to deduce. |
+| `-mllvm -cce-aicore-hoist-movemask=false` applied unconditionally | applied only for `Ascend950*` | The A2/A3 bisheng rejects the flag as an unknown argument. |
+| — | host-only `EVENT_ID4..7` fallbacks in `lightning_indexer_v2_common.h` | The `--cce-host-only` stub pass defines no aicore target macros, so the compiler builtins `EVENT_ID4..7` are missing there. |
+
+Namespaces are nested under `sglang::npu_kernel::liv2` (device) and `sglang::LIV2Host`
+(host) so nothing collides with the older `lightning_indexer` op in the same library.
+
+## Usage Example
+
+See [test_lightning_indexer_v2.py](../../tests/python/sgl_kernel_npu/test_lightning_indexer_v2.py).

--- a/csrc/lightning_indexer_v2/op_host/lightning_indexer_v2.cpp
+++ b/csrc/lightning_indexer_v2/op_host/lightning_indexer_v2.cpp
@@ -1,0 +1,192 @@
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. See LICENSE in the root of
+ * the software repository for the full text of the License.
+ */
+
+/*!
+ * \file lightning_indexer_v2.cpp
+ * \brief torch.ops.npu.lightning_indexer_v2 的 host 侧入口。
+ */
+
+#include <string>
+#include <tuple>
+
+#include "acl/acl.h"
+#include "kernel_tiling/kernel_tiling.h"
+#include "tiling/platform/platform_ascendc.h"
+
+#include "common.h"
+#include "defines.h"
+#include "ge_helper.h"
+#include "torch_helper.h"
+
+#include "lightning_indexer_v2_def.h"
+#include "tiling/lightning_indexer_v2_tiling.h"
+#include "../op_kernel/lightning_indexer_v2_tiling_key.h"
+
+#include "aclrtlaunch_lightning_indexer_v2.h"
+
+namespace sglang::LIV2Host {
+
+using namespace ge_helper;
+
+constexpr int SIZE = 8;
+constexpr int DIM_0 = 0;
+constexpr int DIM_1 = 1;
+constexpr int DIM_2 = 2;
+
+// tilingKey 的 dtype 段必须与 lightning_indexer_v2_tiling_key.h 中的常量一致。
+static_assert(GE_DATATYPE_TO_KEY(ge::DT_FLOAT16) == SGL_LI_V2_DT_FP16, "SGL_LI_V2_DT_FP16 mismatch");
+static_assert(GE_DATATYPE_TO_KEY(ge::DT_BF16) == SGL_LI_V2_DT_BF16, "SGL_LI_V2_DT_BF16 mismatch");
+static_assert(GE_DATATYPE_TO_KEY(ge::DT_INT32) == SGL_LI_V2_DT_INT32, "SGL_LI_V2_DT_INT32 mismatch");
+// layout 段必须与 LICommon::LI_LAYOUT / DataLayout 一致。
+static_assert(static_cast<uint32_t>(DataLayout::BSND) == SGL_LI_V2_LAYOUT_BSND, "BSND layout code mismatch");
+static_assert(static_cast<uint32_t>(DataLayout::TND) == SGL_LI_V2_LAYOUT_TND, "TND layout code mismatch");
+static_assert(static_cast<uint32_t>(DataLayout::BnBsND) == SGL_LI_V2_LAYOUT_PA_BSND, "PA_BSND layout code mismatch");
+
+// 输出 shape 规则与上游 lightning_indexer_torch_adpt.h 保持一致。
+inline std::tuple<at::Tensor, at::Tensor> ConstructOutputTensors(const at::Tensor &query, const at::Tensor &key,
+                                                                 int64_t sparseCount, const std::string &queryLayout,
+                                                                 const std::string &keyLayout, bool returnValues)
+{
+    for (size_t i = 0; i < query.sizes().size(); i++) {
+        TORCH_CHECK(query.size(i) > 0, "All values within query shape should be greater than 0, but shape[", i,
+                    "] is ", query.size(i));
+    }
+    for (size_t i = 0; i < key.sizes().size(); i++) {
+        TORCH_CHECK(key.size(i) > 0, "All values within key shape should be greater than 0, but shape[", i, "] is ",
+                    key.size(i));
+    }
+    TORCH_CHECK(sparseCount > 0, "sparse count should be greater than 0, but now is ", sparseCount);
+
+    at::SmallVector<int64_t, SIZE> outputSize;
+    if (queryLayout == "BSND") {
+        outputSize = {query.size(DIM_0), query.size(DIM_1), key.size(DIM_2), sparseCount};
+    } else {
+        int nDimIndex = (keyLayout == "TND") ? DIM_1 : DIM_2;
+        outputSize = {query.size(DIM_0), key.size(nDimIndex), sparseCount};
+    }
+
+    at::Tensor sparseIndices = at::empty(outputSize, query.options().dtype(at::kInt));
+    // returnValues 为 false 时 kernel 仍需要一个合法地址，这里给一个空 tensor。
+    at::Tensor sparseValues = returnValues ? at::empty(outputSize, query.options()) : at::empty({0}, query.options());
+    return {sparseIndices, sparseValues};
+}
+
+inline at::Tensor OptionalOrEmpty(const c10::optional<at::Tensor> &tensor, const at::Tensor &like)
+{
+    return tensor.has_value()
+               ? tensor.value()
+               : at::empty({1}, at::TensorOptions().dtype(at::kInt).device(like.options().device()));
+}
+
+}  // namespace sglang::LIV2Host
+
+namespace sglang {
+namespace npu_kernel {
+
+HOST_API std::tuple<at::Tensor, at::Tensor> lightning_indexer_v2(
+    const at::Tensor &query, const at::Tensor &key, const at::Tensor &weights,
+    const c10::optional<at::Tensor> &actual_seq_lengths_query,
+    const c10::optional<at::Tensor> &actual_seq_lengths_key, const c10::optional<at::Tensor> &block_table,
+    c10::optional<c10::string_view> layout_query, c10::optional<c10::string_view> layout_key,
+    c10::optional<int64_t> sparse_count, c10::optional<int64_t> sparse_mode, c10::optional<int64_t> pre_tokens,
+    c10::optional<int64_t> next_tokens, c10::optional<bool> return_values)
+{
+    using namespace LIV2Host;
+
+    TORCH_CHECK(query.numel() > 0, "Tensor query is empty.");
+    TORCH_CHECK(key.numel() > 0, "Tensor key is empty.");
+    TORCH_CHECK(weights.numel() > 0, "Tensor weights is empty.");
+
+    LightningIndexerV2 indexer("lightning_indexer_v2");
+    auto context = std::make_shared<TilingContext>("lightning_indexer_v2");
+    TORCH_CHECK(context != nullptr, "TilingContext is null");
+
+    std::string layoutQuery(indexer.GetAttr(ATTR_QUERY_LAYOUT_INDEX).GetString());
+    std::string layoutKey(indexer.GetAttr(ATTR_KEY_LAYOUT_INDEX).GetString());
+    int64_t sparseCount = std::any_cast<int32_t>(indexer.GetAttr(ATTR_SPARSE_COUNT_INDEX).GetValue());
+    bool returnValues = std::any_cast<bool>(indexer.GetAttr(ATTR_RETURN_VALUE_INDEX).GetValue());
+
+    if (layout_query.has_value()) {
+        layoutQuery = std::string(layout_query.value());
+        indexer.SetAttrStr("layout_query", layoutQuery);
+    }
+    if (layout_key.has_value()) {
+        layoutKey = std::string(layout_key.value());
+        indexer.SetAttrStr("layout_key", layoutKey);
+    }
+    if (sparse_count.has_value()) {
+        sparseCount = sparse_count.value();
+        indexer.SetAttrAny("sparse_count", static_cast<int32_t>(sparseCount));
+    }
+    if (sparse_mode.has_value()) {
+        indexer.SetAttrAny("sparse_mode", static_cast<int32_t>(sparse_mode.value()));
+    }
+    if (pre_tokens.has_value()) {
+        indexer.SetAttrAny("pre_tokens", static_cast<int64_t>(pre_tokens.value()));
+    }
+    if (next_tokens.has_value()) {
+        indexer.SetAttrAny("next_tokens", static_cast<int64_t>(next_tokens.value()));
+    }
+    if (return_values.has_value()) {
+        returnValues = return_values.value();
+        indexer.SetAttrAny("return_values", returnValues);
+    }
+
+    auto outputs = ConstructOutputTensors(query, key, sparseCount, layoutQuery, layoutKey, returnValues);
+    at::Tensor sparseIndices = std::get<0>(outputs);
+    at::Tensor sparseValues = std::get<1>(outputs);
+
+    auto qScalarType = query.scalar_type();
+    indexer.SetToContext(context, qScalarType);
+    // weights 允许为 fp32 而 query/key 为 fp16/bf16（上游的 DT_W_FLAG 档位），
+    // 该组合无法由 SetToContext 的单一下标表达，这里按实际 tensor 修正。
+    context->OverrideInputDataType(WEIGTHS_INDEX, SCALAR_TYPE_TO_GE_DATATYPE(weights.scalar_type()));
+
+    context->RegisterTensor(query, true);
+    context->RegisterTensor(key, true);
+    context->RegisterTensor(weights, true);
+    context->RegisterTensor(actual_seq_lengths_query, true);
+    context->RegisterTensor(actual_seq_lengths_key, true);
+    context->RegisterTensor(block_table, true);
+    context->RegisterTensor(sparseIndices, false);
+    context->RegisterTensor(sparseValues, false);
+
+    LITilingInfo liInfo;
+    LIInfoParser parser(context.get());
+    TORCH_CHECK(parser.ParseAndCheck(liInfo) == ge::GRAPH_SUCCESS,
+                "lightning_indexer_v2 ParseAndCheck failed: ", LastOpError());
+
+    LightningIndexerTiling liTiling(context.get());
+    TORCH_CHECK(liTiling.DoTiling(&liInfo) == ge::GRAPH_SUCCESS,
+                "lightning_indexer_v2 DoTiling failed: ", LastOpError());
+    const LITilingData &tilingData = liTiling.GetTilingData();
+
+    at::Tensor tilingTensor = context->GetTilingTensor(tilingData);
+
+    at::Tensor actualSeqLengthsQuery = OptionalOrEmpty(actual_seq_lengths_query, query);
+    at::Tensor actualSeqLengthsKey = OptionalOrEmpty(actual_seq_lengths_key, query);
+    at::Tensor blockTable = OptionalOrEmpty(block_table, query);
+
+    size_t workspaceSize = context->GetWorkspaceSize();
+    auto workspace = at::empty({static_cast<int64_t>(workspaceSize)},
+                               at::TensorOptions().dtype(at::kByte).device(query.options().device()));
+
+    // EXEC_KERNEL_CMD 会把 blockdim 实参直接展开到 lambda 的捕获列表里，
+    // 因此只能传一个普通变量名，不能传 tilingData.usedCoreNum 这样的表达式。
+    auto blockDim = tilingData.usedCoreNum;
+    EXEC_KERNEL_CMD(lightning_indexer_v2, blockDim, query, key, weights, actualSeqLengthsQuery, actualSeqLengthsKey,
+                    blockTable, sparseIndices, sparseValues, workspace, tilingTensor);
+
+    return {sparseIndices, sparseValues};
+}
+
+}  // namespace npu_kernel
+}  // namespace sglang

--- a/csrc/lightning_indexer_v2/op_host/lightning_indexer_v2_def.h
+++ b/csrc/lightning_indexer_v2/op_host/lightning_indexer_v2_def.h
@@ -1,0 +1,81 @@
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. See LICENSE in the root of
+ * the software repository for the full text of the License.
+ */
+
+/*!
+ * \file lightning_indexer_v2_def.h
+ * \brief
+ */
+#ifndef SGL_LI_V2_DEF_H
+#define SGL_LI_V2_DEF_H
+#include <cstdint>
+#include "ge_helper.h"
+
+namespace sglang {
+namespace LIV2Host {
+using namespace ge_helper;
+
+// 与上游 op_host/lightning_indexer_def.cpp 对应。
+// 上游 weights 的 dtype 列表为 {BF16, FP16, FLOAT, FLOAT}，靠框架按四元组选档；
+// ge_helper::OpDef 只能按 query 的 dtype 选出一个下标，因此这里 weights 仍按
+// {BF16, FP16} 声明，fp32 weights 由 launcher 调用
+// TilingContext::OverrideInputDataType() 修正（见 lightning_indexer_v2.cpp）。
+class LightningIndexerV2 : public OpDef
+{
+public:
+    explicit LightningIndexerV2(const char *name) : OpDef(name)
+    {
+        this->Input("query")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("key")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("weights")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("actual_seq_lengths_query")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("actual_seq_lengths_key")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("block_table")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Output("sparse_indices").ParamType(REQUIRED).DataTypeList({ge::DT_INT32}).FormatList({ge::FORMAT_ND});
+        this->Output("sparse_values")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16})
+            .FormatList({ge::FORMAT_ND});
+        this->Attr("layout_query").AttrType(OPTIONAL).String("BSND");
+        this->Attr("layout_key").AttrType(OPTIONAL).String("BSND");
+        this->Attr("sparse_count").AttrType(OPTIONAL).Int(2048);  // 2048:默认值，筛选前2048
+        this->Attr("sparse_mode").AttrType(OPTIONAL).Int(3);      // 3:默认值，只计算下三角
+        this->Attr("pre_tokens").AttrType(OPTIONAL).Int64(INT64_MAX);
+        this->Attr("next_tokens").AttrType(OPTIONAL).Int64(INT64_MAX);
+        this->Attr("return_values").AttrType(OPTIONAL).Bool(false);
+    }
+};
+}  // namespace LIV2Host
+}  // namespace sglang
+#endif  // SGL_LI_V2_DEF_H

--- a/csrc/lightning_indexer_v2/op_host/tiling/lightning_indexer_v2_ops_compat.h
+++ b/csrc/lightning_indexer_v2/op_host/tiling/lightning_indexer_v2_ops_compat.h
@@ -1,0 +1,80 @@
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. See LICENSE in the root of
+ * the software repository for the full text of the License.
+ */
+
+/*!
+ * \file lightning_indexer_v2_ops_compat.h
+ * \brief CANN 算子工程日志/校验宏在 sgl-kernel-npu 中的替身。
+ *
+ * 上游 tiling 代码依赖 ops 仓的 err/ops_err.h (OP_CHECK_IF / OP_LOGE / ...)，
+ * 该头文件只在 CANN 算子工程内可见。这里提供等价实现，使得 tiling 主体逻辑
+ * 可以逐字复用、便于后续与上游对比同步：
+ *   - OP_LOGE  记录一条格式化后的错误信息（不抛出），供随后的检查/返回使用；
+ *   - OP_CHECK_IF 在条件成立时记录信息并通过 TORCH_CHECK 抛出；
+ *   - OP_LOGI / OP_LOGW 为空实现。
+ */
+#ifndef SGL_LI_V2_OPS_COMPAT_H
+#define SGL_LI_V2_OPS_COMPAT_H
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <map>
+#include <string>
+
+#include "torch_helper.h"
+
+namespace sglang {
+namespace LIV2Host {
+
+inline std::string &LastOpErrorRef()
+{
+    thread_local std::string lastError;
+    return lastError;
+}
+
+inline const std::string &LastOpError()
+{
+    return LastOpErrorRef();
+}
+
+template <typename... Args>
+inline void RecordOpError(const char *opName, const char *fmt, Args... args)
+{
+    char buf[1024];
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#pragma GCC diagnostic ignored "-Wformat-security"
+    const int written = std::snprintf(buf, sizeof(buf), fmt, args...);
+#pragma GCC diagnostic pop
+    const std::string message =
+        (written > 0) ? std::string(buf, std::min(static_cast<size_t>(written), sizeof(buf) - 1)) : std::string(fmt);
+    LastOpErrorRef() = std::string(opName != nullptr ? opName : "LightningIndexerV2") + ": " + message;
+}
+
+}  // namespace LIV2Host
+}  // namespace sglang
+
+#define OP_LOGE(opName, ...) ::sglang::LIV2Host::RecordOpError((opName), __VA_ARGS__)
+#define OPS_REPORT_VECTOR_INNER_ERR(opName, ...) ::sglang::LIV2Host::RecordOpError((opName), __VA_ARGS__)
+#define OP_LOGI(...) ((void)0)
+#define OP_LOGW(...) ((void)0)
+
+// 上游用法: OP_CHECK_IF(cond, OP_LOGE(...), return ge::GRAPH_FAILED);
+// 这里改为直接抛出，retExpr 不再需要（保留形参以维持调用点原样）。
+#define OP_CHECK_IF(cond, logExpr, retExpr)                          \
+    do {                                                             \
+        if (cond) {                                                  \
+            (logExpr);                                               \
+            TORCH_CHECK(false, ::sglang::LIV2Host::LastOpError());   \
+        }                                                            \
+    } while (0)
+
+#endif  // SGL_LI_V2_OPS_COMPAT_H

--- a/csrc/lightning_indexer_v2/op_host/tiling/lightning_indexer_v2_tiling.cpp
+++ b/csrc/lightning_indexer_v2/op_host/tiling/lightning_indexer_v2_tiling.cpp
@@ -1,0 +1,805 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file lightning_indexer_tiling.cpp
+ * \brief
+ */
+
+#include "lightning_indexer_v2_tiling.h"
+#include "../../op_kernel/lightning_indexer_v2_tiling_key.h"
+
+using namespace ge;
+using namespace AscendC;
+using std::map;
+using std::string;
+namespace sglang::LIV2Host {
+// --------------------------LIInfoParser类成员函数定义-------------------------------------
+ge::graphStatus LIInfoParser::CheckRequiredInOutExistence() const
+{
+    OP_CHECK_IF(opParamInfo_.query.shape == nullptr, OP_LOGE(opName_, "Shape of tensor query is nullptr"),
+               return ge::GRAPH_FAILED);
+    OP_CHECK_IF(opParamInfo_.query.desc == nullptr, OP_LOGE(opName_, "Desc of tensor query is nullptr"),
+               return ge::GRAPH_FAILED);
+    OP_CHECK_IF(opParamInfo_.key.shape == nullptr, OP_LOGE(opName_, "Shape of tensor k is nullptr"),
+               return ge::GRAPH_FAILED);
+    OP_CHECK_IF(opParamInfo_.key.desc == nullptr, OP_LOGE(opName_, "Desc of tensor k is nullptr"),
+               return ge::GRAPH_FAILED);
+    OP_CHECK_IF(opParamInfo_.weights.shape == nullptr, OP_LOGE(opName_, "Shape of tensor value is nullptr"),
+               return ge::GRAPH_FAILED);
+    OP_CHECK_IF(opParamInfo_.weights.desc == nullptr, OP_LOGE(opName_, "Desc of tensor value is nullptr"),
+               return ge::GRAPH_FAILED);
+    OP_CHECK_IF(opParamInfo_.attenOut.shape == nullptr, OP_LOGE(opName_, "Shape of tensor output is nullptr"),
+               return ge::GRAPH_FAILED);
+    OP_CHECK_IF(opParamInfo_.attenOut.desc == nullptr, OP_LOGE(opName_, "Desc of tensor output is nullptr"),
+               return ge::GRAPH_FAILED);
+    OP_CHECK_IF(opParamInfo_.valuesOut.shape == nullptr, OP_LOGE(opName_, "Shape of tensor output values is nullptr"),
+               return ge::GRAPH_FAILED);
+    OP_CHECK_IF(opParamInfo_.valuesOut.desc == nullptr, OP_LOGE(opName_, "Desc of tensor output values is nullptr"),
+               return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::CheckRequiredAttrExistence() const
+{
+    OP_CHECK_IF(opParamInfo_.layOut == nullptr, OP_LOGE(opName_, "attr layout_query is nullptr"),
+               return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(opParamInfo_.layOutKey == nullptr, OP_LOGE(opName_, "attr layout_key is nullptr"),
+               return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(opParamInfo_.sparseCount == nullptr, OP_LOGE(opName_, "attr sparse_count is nullptr"),
+               return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF(opParamInfo_.sparseMode == nullptr, OP_LOGE(opName_, "attr sparse_mode is nullptr"),
+               return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::CheckRequiredParaExistence() const
+{
+    if (CheckRequiredInOutExistence() != ge::GRAPH_SUCCESS || CheckRequiredAttrExistence() != ge::GRAPH_SUCCESS) {
+        return ge::GRAPH_FAILED;
+    }
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::GetOpName()
+{
+    if (context_->GetNodeName() == nullptr) {
+        OP_LOGE("LightningIndexer", "opName got from TilingContext is nullptr");
+        return ge::GRAPH_FAILED;
+    }
+    opName_ = context_->GetNodeName();
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::GetNpuInfo()
+{
+    // kernel-direct-launch 下没有 GE 传入的 PlatFormInfos，改用平台单例。
+    auto ascendcPlatform = *platform_ascendc::PlatformAscendCManager::GetInstance();
+    uint32_t aivNum = ascendcPlatform.GetCoreNumAiv();
+    uint32_t aicNum = ascendcPlatform.GetCoreNumAic();
+    OP_CHECK_IF(aicNum == 0 || aivNum == 0, OP_LOGE(opName_, "num of core obtained is 0."), return GRAPH_FAILED);
+
+    socVersion_ = ascendcPlatform.GetSocVersion();
+    if ((socVersion_ != platform_ascendc::SocVersion::ASCEND910B) &&
+        (socVersion_ != platform_ascendc::SocVersion::ASCEND910_93) &&
+        (socVersion_ != platform_ascendc::SocVersion::ASCEND950)) {
+        OP_LOGE(opName_, "SOC Version[%d] is not support.", static_cast<int32_t>(socVersion_));
+        return GRAPH_FAILED;
+    }
+    OP_CHECK_IF(context_->GetWorkspaceSizes(1) == nullptr, OP_LOGE(opName_, "workSpaceSize got from ge is nullptr"),
+               return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+void LIInfoParser::GetOptionalInputParaInfo()
+{
+    opParamInfo_.actualSeqLengthsQ.tensor = context_->GetOptionalInputTensor(ACTUAL_SEQ_Q_INDEX);
+    opParamInfo_.actualSeqLengthsQ.desc = context_->GetOptionalInputDesc(ACTUAL_SEQ_Q_INDEX);
+    opParamInfo_.actualSeqLengths.tensor = context_->GetOptionalInputTensor(ACTUAL_SEQ_K_INDEX);
+    opParamInfo_.actualSeqLengths.desc = context_->GetOptionalInputDesc(ACTUAL_SEQ_K_INDEX);
+    opParamInfo_.blockTable.tensor = context_->GetOptionalInputTensor(BLOCK_TABLE_INDEX);
+    opParamInfo_.blockTable.desc = context_->GetOptionalInputDesc(BLOCK_TABLE_INDEX);
+}
+
+void LIInfoParser::GetInputParaInfo()
+{
+    opParamInfo_.query.desc = context_->GetInputDesc(QUERY_INDEX);
+    opParamInfo_.query.shape = context_->GetInputShape(QUERY_INDEX);
+    opParamInfo_.key.desc = context_->GetInputDesc(KEY_INDEX);
+    opParamInfo_.key.shape = context_->GetInputShape(KEY_INDEX);
+    opParamInfo_.weights.desc = context_->GetInputDesc(WEIGTHS_INDEX);
+    opParamInfo_.weights.shape = context_->GetInputShape(WEIGTHS_INDEX);
+    GetOptionalInputParaInfo();
+}
+
+void LIInfoParser::GetOutputParaInfo()
+{
+    opParamInfo_.attenOut.desc = context_->GetOutputDesc(LIGHTNING_INDEXER);
+    opParamInfo_.attenOut.shape = context_->GetOutputShape(LIGHTNING_INDEXER);
+    opParamInfo_.valuesOut.desc = context_->GetOutputDesc(LIGHTNING_VALUES);
+    opParamInfo_.valuesOut.shape = context_->GetOutputShape(LIGHTNING_VALUES);
+}
+
+ge::graphStatus LIInfoParser::GetAndCheckAttrParaInfo()
+{
+    auto attrs = context_->GetAttrs();
+    OP_CHECK_IF(attrs == nullptr, OPS_REPORT_VECTOR_INNER_ERR(context_->GetNodeName(), "attrs got from ge is nullptr"),
+               return ge::GRAPH_FAILED);
+    OP_LOGI(context_->GetNodeName(), "GetAndCheckAttrParaInfo start");
+    opParamInfo_.layOut = attrs->GetStr(ATTR_QUERY_LAYOUT_INDEX);
+    opParamInfo_.layOutKey = attrs->GetStr(ATTR_KEY_LAYOUT_INDEX);
+    opParamInfo_.sparseCount = attrs->GetAttrPointer<int32_t>(ATTR_SPARSE_COUNT_INDEX);
+    opParamInfo_.sparseMode = attrs->GetAttrPointer<int32_t>(ATTR_SPARSE_MODE_INDEX);
+    opParamInfo_.preTokens = attrs->GetAttrPointer<int64_t>(ATTR_PRE_TOKENS_INDEX);
+    opParamInfo_.nextTokens = attrs->GetAttrPointer<int64_t>(ATTR_NEXT_TOKENS_INDEX);
+    opParamInfo_.returnValue = attrs->GetAttrPointer<bool>(ATTR_RETURN_VALUE_INDEX);
+    if (opParamInfo_.layOut != nullptr) {
+        OP_LOGI(context_->GetNodeName(), "layout_query is:%s", opParamInfo_.layOut);
+    }
+    if (opParamInfo_.layOutKey != nullptr) {
+        OP_LOGI(context_->GetNodeName(), "layout_key is:%s", opParamInfo_.layOutKey);
+    }
+    if (opParamInfo_.sparseCount != nullptr) {
+        OP_LOGI(context_->GetNodeName(), "selscted count is:%d", *opParamInfo_.sparseCount);
+    }
+    if (opParamInfo_.sparseMode != nullptr) {
+        OP_LOGI(context_->GetNodeName(), "sparse mode is:%d", *opParamInfo_.sparseMode);
+    }
+    if (opParamInfo_.preTokens != nullptr) {
+        OP_LOGI(context_->GetNodeName(), "pre tokens is:%d", *opParamInfo_.preTokens);
+    }
+    if (opParamInfo_.nextTokens != nullptr) {
+        OP_LOGI(context_->GetNodeName(), "next tokens is:%d", *opParamInfo_.nextTokens);
+    }
+    if (opParamInfo_.returnValue != nullptr) {
+        OP_LOGI(context_->GetNodeName(), "return value is:%d", *opParamInfo_.returnValue);
+    }
+    OP_LOGI(context_->GetNodeName(), "GetAndCheckAttrParaInfo end");
+    OP_CHECK_IF(
+        ((std::string(opParamInfo_.layOutKey) != "PA_BSND")
+        && (std::string(opParamInfo_.layOut) != std::string(opParamInfo_.layOutKey))),
+        OP_LOGE(opName_, "under non-PA conditions, layout_query and layout_key should be equal."),
+        return ge::GRAPH_FAILED);
+    OP_CHECK_IF(
+        ((std::string(opParamInfo_.layOutKey) != "PA_BSND") && (std::string(opParamInfo_.layOutKey) != "BSND")
+        && (std::string(opParamInfo_.layOutKey) != "TND")),
+        OP_LOGE(opName_, "input attr layout_key only supported PA_BSND, BSND or TND"), return ge::GRAPH_FAILED);
+    OP_CHECK_IF(((std::string(opParamInfo_.layOut) != "BSND") && (std::string(opParamInfo_.layOut) != "TND")),
+               OP_LOGE(opName_, "input attr layout_query only supported BSND or TND."), return ge::GRAPH_FAILED);
+    OP_CHECK_IF((!((*opParamInfo_.sparseCount > 0) && (*opParamInfo_.sparseCount <= SPARSE_LIMIT)) &&
+                     *opParamInfo_.sparseCount % 1024 != 0),
+                     OP_LOGE(opName_, "input attr sparse_count must > 0 and <= 8192. And when sparse_count > 2048, sparse_count must be an integer multiple of 1024."),
+                     return ge::GRAPH_FAILED);
+    OP_CHECK_IF(!((*opParamInfo_.sparseMode == 0) || (*opParamInfo_.sparseMode == SPARSE_MODE_LOWER)),
+               OP_LOGE(opName_, "input attr sparse_mode only supported 0 or 3."), return ge::GRAPH_FAILED);
+    OP_CHECK_IF(*opParamInfo_.preTokens != INT64_MAX,
+               OP_LOGE(opName_, "input attr pre_tokens only supported INT64_MAX."), return ge::GRAPH_FAILED);
+    OP_CHECK_IF(*opParamInfo_.nextTokens != INT64_MAX,
+               OP_LOGE(opName_, "input attr nextTokens only supported INT64_MAX."), return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::GetOpParaInfo()
+{
+    GetInputParaInfo();
+    GetOutputParaInfo();
+    if (ge::GRAPH_SUCCESS != GetAndCheckAttrParaInfo()) {
+        return ge::GRAPH_FAILED;
+    }
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::GetAndCheckInOutDataType()
+{
+    inputQType_ = opParamInfo_.query.desc->GetDataType();
+    inputKType_ = opParamInfo_.key.desc->GetDataType();
+    weightsType_ = opParamInfo_.weights.desc->GetDataType();
+    outputType_ = opParamInfo_.attenOut.desc->GetDataType();
+    valuesOutType_ = opParamInfo_.valuesOut.desc->GetDataType();
+
+    bool inDTypeAllEqual = (inputQType_ == inputKType_);
+    OP_CHECK_IF(!inDTypeAllEqual,
+            OP_LOGE(opName_, "The data types of the input query and key must be the same."),
+            return ge::GRAPH_FAILED);
+    OP_CHECK_IF(((inputQType_ != ge::DT_FLOAT16) && (inputQType_ != ge::DT_BF16)),
+               OP_LOGE(opName_, "The data types of the input query, key must be float16 or bfloat16."),
+               return ge::GRAPH_FAILED);
+    if (socVersion_ == platform_ascendc::SocVersion::ASCEND950) {
+        OP_CHECK_IF((inputQType_ != weightsType_),
+                OP_LOGE(opName_, "The data types of the input query, key, and weights must be the same."),
+                return ge::GRAPH_FAILED);
+    } else {
+        if (weightsType_ != ge::DT_FLOAT) {
+            OP_CHECK_IF((inputQType_ != weightsType_),
+                    OP_LOGE(opName_, "The data types of the input query, key, and weights must be the same."),
+                    return ge::GRAPH_FAILED);
+        } else {
+            OP_CHECK_IF((weightsType_ != ge::DT_FLOAT),
+                OP_LOGE(opName_, "The data types of the input weights must be float32."),
+                return ge::GRAPH_FAILED);
+        }
+    }
+    OP_CHECK_IF(outputType_ != ge::DT_INT32,
+               OP_LOGE(opName_, "The data types of the output sparse_indices must be int32."),
+               return ge::GRAPH_FAILED);
+    OP_CHECK_IF(valuesOutType_ != inputQType_,
+               OP_LOGE(opName_, "The data types of the output sparse_values must be same as inputQType."),
+               return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::GetQueryKeyAndOutLayout()
+{
+    // 获取query,key的Layout基准值
+    const map<string, DataLayout> layoutMap = {
+        {"BSND", DataLayout::BSND},
+        {"TND", DataLayout::TND},
+        {"PA_BSND", DataLayout::BnBsND}
+    };
+
+    std::string layout(opParamInfo_.layOut);
+    auto it = layoutMap.find(layout);
+    if (it != layoutMap.end()) {
+        qLayout_ = it->second;
+    }
+
+    std::string layoutKey(opParamInfo_.layOutKey);
+    auto itKey = layoutMap.find(layoutKey);
+    if (itKey != layoutMap.end()) {
+        kLayout_ = itKey->second;
+    }
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::GetAndCheckOptionalInput()
+{
+    if (kLayout_ == DataLayout::BnBsND) {
+        OP_CHECK_IF(opParamInfo_.blockTable.tensor == nullptr,
+                   OP_LOGE(opName_, "when layout_key is PA_BSND, input block_table must not be null"),
+                   return ge::GRAPH_FAILED);
+        OP_CHECK_IF(
+            opParamInfo_.actualSeqLengths.tensor == nullptr,
+            OP_LOGE(opName_, "when layout_key is PA_BSND, input actual_seq_lengths_key must not be null"),
+            return ge::GRAPH_FAILED);
+        OP_CHECK_IF(opParamInfo_.blockTable.desc->GetDataType() != ge::DT_INT32,
+                   OP_LOGE(opName_, "input block_table data type only support int32"), return ge::GRAPH_FAILED);
+    } else if (kLayout_ == DataLayout::TND) {
+        OP_CHECK_IF(opParamInfo_.actualSeqLengths.tensor == nullptr,
+                   OP_LOGE(opName_, "when layout_key is TND, input actual_seq_lengths_key must not be null"),
+                   return ge::GRAPH_FAILED);
+    }
+    OP_CHECK_IF(opParamInfo_.actualSeqLengths.tensor != nullptr &&
+               opParamInfo_.actualSeqLengths.desc->GetDataType() != ge::DT_INT32,
+                   OP_LOGE(opName_, "input actual_seq_lengths_key data type only support int32"),
+                   return ge::GRAPH_FAILED);
+    OP_CHECK_IF(opParamInfo_.actualSeqLengths.tensor != nullptr &&
+                   opParamInfo_.actualSeqLengths.desc->GetDataType() != ge::DT_INT32,
+               OP_LOGE(opName_, "input actual_seq_lengths_key data type only support int32"),
+               return ge::GRAPH_FAILED);
+    if (qLayout_ == DataLayout::TND) {
+        OP_CHECK_IF(opParamInfo_.actualSeqLengthsQ.tensor == nullptr,
+                   OP_LOGE(opName_, "when layout_query is TND, input actual_seq_lengths_query must not be null"),
+                   return ge::GRAPH_FAILED);
+    }
+    OP_CHECK_IF(opParamInfo_.actualSeqLengthsQ.tensor != nullptr &&
+                   opParamInfo_.actualSeqLengthsQ.desc->GetDataType() != ge::DT_INT32,
+               OP_LOGE(opName_, "input actual_seq_lengths_query data type only support int32"),
+               return ge::GRAPH_FAILED);
+    OP_CHECK_IF(kLayout_ != DataLayout::BnBsND && opParamInfo_.blockTable.tensor != nullptr,
+                   OP_LOGE(opName_, "when key layout is not PA_BSND, input block_table must be null"),
+                   return ge::GRAPH_FAILED);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::CheckShapeDim()
+{
+    OP_CHECK_IF((opParamInfo_.blockTable.tensor != nullptr) &&
+                   (opParamInfo_.blockTable.tensor->GetStorageShape().GetDimNum() != DIM_NUM_TWO),
+               OP_LOGE(opName_, "the dim num of block_table's shape should be 2"), return ge::GRAPH_FAILED);
+
+    uint32_t kShapeDim = opParamInfo_.key.shape->GetStorageShape().GetDimNum();
+    uint32_t qShapeDim = opParamInfo_.query.shape->GetStorageShape().GetDimNum();
+    uint32_t weightsShapeDim = opParamInfo_.weights.shape->GetStorageShape().GetDimNum();
+    uint32_t outShapeDim = opParamInfo_.attenOut.shape->GetStorageShape().GetDimNum();
+    uint32_t valuesOutShapeDim = opParamInfo_.valuesOut.shape->GetStorageShape().GetDimNum();
+    uint32_t qExpectShapeDim = DIM_NUM_FOUR;
+    uint32_t kExpectShapeDim = DIM_NUM_FOUR;
+    if (qLayout_ == DataLayout::TND) {
+        qExpectShapeDim = DIM_NUM_THREE;
+    }
+    if (kLayout_ == DataLayout::TND) {
+        kExpectShapeDim = DIM_NUM_THREE;
+    }
+    OP_CHECK_IF(kShapeDim != kExpectShapeDim,
+               OP_LOGE(opName_, "the dim num of key's shape should be %u, but now is %u", kExpectShapeDim, kShapeDim),
+               return ge::GRAPH_FAILED);
+    OP_CHECK_IF(qShapeDim != qExpectShapeDim,
+               OP_LOGE(opName_, "the dim num of query's shape should be %u, but now is %u",
+                qExpectShapeDim, qShapeDim),
+               return ge::GRAPH_FAILED);
+    OP_CHECK_IF(outShapeDim != qExpectShapeDim,
+               OP_LOGE(opName_, "the dim num of sparse_indices's shape should be %u, but now is %u",
+                qExpectShapeDim, outShapeDim),
+               return ge::GRAPH_FAILED);
+    OP_CHECK_IF(valuesOutShapeDim != qExpectShapeDim && (*opParamInfo_.returnValue),
+               OP_LOGE(opName_, "the dim num of sparse_values's shape should be %u, but now is %u",
+                qExpectShapeDim, valuesOutShapeDim),
+               return ge::GRAPH_FAILED);
+    OP_CHECK_IF(!(weightsShapeDim == qExpectShapeDim - 1),
+               OP_LOGE(opName_, "the dim num of weights's shape should be %u, but now is %u", qExpectShapeDim - 1,
+                weightsShapeDim),
+               return ge::GRAPH_FAILED);
+    if (opParamInfo_.valuesOut.shape->GetStorageShape().GetShapeSize() != 0 && !(*opParamInfo_.returnValue)) {
+        OP_LOGW(opName_, "when returnValue is false, valuesOut must be null.");
+    }
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::GetN1Size()
+{
+    if (qLayout_ == DataLayout::BSND) {
+        n1Size_ = static_cast<uint32_t>(opParamInfo_.query.shape->GetStorageShape().GetDim(DIM_IDX_TWO));
+    } else {
+        // TND
+        n1Size_ = static_cast<uint32_t>(opParamInfo_.query.shape->GetStorageShape().GetDim(1));
+    }
+    OP_LOGI(context_->GetNodeName(), "n1Size is %d", n1Size_);
+
+    OP_CHECK_IF(n1Size_ > QUERY_HEAD_NUM_LIMIT, OP_LOGE(opName_, "N1 is %u, but N1 must be no greater than %u.",
+                n1Size_, QUERY_HEAD_NUM_LIMIT), return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::GetActualSeqLenSize(uint32_t &size, const gert::Tensor *tensor,
+                                                  const std::string &actualSeqLenName) const
+{
+    size = static_cast<uint32_t>(tensor->GetShapeSize());
+    if (size <= 0) {
+        OP_LOGE(opName_, "%s's shape size is %u, it should be greater than 0.", actualSeqLenName.c_str(), size);
+        return ge::GRAPH_FAILED;
+    }
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::GetAndCheckN2Size()
+{
+    uint32_t n2Index = (kLayout_ == DataLayout::TND) ? DIM_IDX_ONE : DIM_IDX_TWO;
+    n2Size_ = static_cast<uint32_t>(opParamInfo_.key.shape->GetStorageShape().GetDim(n2Index));
+    OP_LOGI(context_->GetNodeName(), "n2Size_ is %d", n2Size_);
+    OP_CHECK_IF(n2Size_ != 1, OP_LOGE(opName_, "key shape[%u] is numhead, only support 1.", n2Index),
+    return ge::GRAPH_FAILED);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::GetGSize()
+{
+    if (n1Size_ % n2Size_ != 0) {
+        OP_LOGE(opName_, "input query's head_num %u can not be a multiple of key's head_num %u.", n1Size_, n2Size_);
+        return ge::GRAPH_FAILED;
+    }
+    gSize_ = n1Size_ / n2Size_;
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::GetBatchSize()
+{
+    // 获取B基准值
+    // 1、非TND/NTD时, 以query的batch_size维度为基准;
+    // 2、TND/NTD时, actual_seq_lens_q必须传入, 以actual_seq_lens_q数组的长度为B轴大小
+    if ((qLayout_ == DataLayout::TND)) {
+        return GetActualSeqLenSize(bSize_, opParamInfo_.actualSeqLengthsQ.tensor, "input actual_seq_lengths_query");
+    } else { // BSND
+        bSize_ = opParamInfo_.query.shape->GetStorageShape().GetDim(0);
+        return ge::GRAPH_SUCCESS;
+    }
+}
+
+ge::graphStatus LIInfoParser::GetHeadDim()
+{
+    // 以query的D维度为基准
+    uint32_t dIndex = DIM_IDX_TWO;
+    // 根据layout确定D维度在shape中的位置
+    switch (qLayout_) {
+        case DataLayout::TND:
+            // TND格式: [Total, N, D] -> D是第2维(索引2)
+            dIndex = DIM_IDX_TWO;
+            break;
+        case DataLayout::BSND:
+            // BSND格式: [Batch, SeqLen, N, D] -> D是第3维(索引3)
+            dIndex = DIM_IDX_THREE;
+            break;
+        default:
+            OP_LOGE(opName_, "unsupported layout for getting head dim.");
+            return ge::GRAPH_FAILED;
+    }
+    headDim_ = opParamInfo_.query.shape->GetStorageShape().GetDim(dIndex);
+    OP_CHECK_IF(headDim_ != HEAD_DIM_LIMIT, OP_LOGE(opName_, "input query's last dim head_dim only support 128."),
+               return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::GetS1Size()
+{
+    if (qLayout_ == DataLayout::BSND) {
+        s1Size_ = opParamInfo_.query.shape->GetStorageShape().GetDim(1);
+    }
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::GetAndCheckBlockSize()
+{
+    blockSize_ = static_cast<uint32_t>(opParamInfo_.key.shape->GetStorageShape().GetDim(1));
+    OP_LOGI(context_->GetNodeName(), "blockSize_ is %d", blockSize_);
+
+    OP_CHECK_IF(((blockSize_ % 16 != 0) || (blockSize_ == 0) || (blockSize_ > 1024)),
+               OP_LOGE(opName_, "input key's block_size must be a multiple of 16 and belong to (0, 1024]."),
+               return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::CheckBlockCount()
+{
+    int32_t blockCount_ = static_cast<uint32_t>(opParamInfo_.key.shape->GetStorageShape().GetDim(0));
+    OP_CHECK_IF((blockCount_ == 0),
+                OP_LOGE(opName_, "input key's block_count cannot be 0."),
+                return ge::GRAPH_FAILED);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::GetS2SizeForPageAttention()
+{
+    if (GetAndCheckBlockSize() != ge::GRAPH_SUCCESS) {
+        return ge::GRAPH_FAILED;
+    }
+    if (CheckBlockCount() != ge::GRAPH_SUCCESS) {
+        return ge::GRAPH_FAILED;
+    }
+    maxBlockNumPerBatch_ = opParamInfo_.blockTable.tensor->GetStorageShape().GetDim(1);
+    s2Size_ = maxBlockNumPerBatch_ * blockSize_;
+    OP_LOGI(context_->GetNodeName(), "maxBlockNumPerBatch_ is %d, blockSize_ is %d, s2Size_ is %d",
+              maxBlockNumPerBatch_, blockSize_, s2Size_);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::GetS2Size()
+{
+    // 获取S2基准值
+    // 1、BATCH_CONTINUOUS时, 从key的S轴获取
+    // 3、PAGE_ATTENTION时, S2 = block_table.dim1 * block_size
+    if (kLayout_ == DataLayout::BnBsND) {
+        return GetS2SizeForPageAttention();
+    } else if (kLayout_ == DataLayout::TND) {
+        s2Size_ = opParamInfo_.key.shape->GetStorageShape().GetDim(0);
+    } else if (kLayout_ == DataLayout::BSND) {
+        s2Size_ = opParamInfo_.key.shape->GetStorageShape().GetDim(1);
+    }
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::ValidateInputShapesMatchQtnd()
+{
+    // -----------------------check BatchSize-------------------
+    // bSize_ 来源于act_seq_q
+    if (kLayout_ == DataLayout::TND) {
+        OP_CHECK_IF(
+        (opParamInfo_.actualSeqLengths.tensor->GetShapeSize() != bSize_),
+            OP_LOGE(opName_,
+                "TND case input actual_seq_lengths_query, actual_seq_lengths_key are %u, %ld respectively, they must be same.",
+                bSize_, opParamInfo_.actualSeqLengths.tensor->GetShapeSize()),
+            return ge::GRAPH_FAILED);
+    } else { // kLayout_ PA_BSND
+        OP_CHECK_IF(
+        (opParamInfo_.actualSeqLengths.tensor->GetShapeSize() != bSize_) ||
+                (opParamInfo_.blockTable.tensor->GetStorageShape().GetDim(0) != bSize_),
+            OP_LOGE(
+                opName_,
+                "TND case input actual_seq_lengths_query, actual_seq_lengths_key, block_table dim 0 are %u, %ld, %ld respectively, they must be same.",
+                bSize_, opParamInfo_.actualSeqLengths.tensor->GetShapeSize(),
+                opParamInfo_.blockTable.tensor->GetStorageShape().GetDim(0)),
+            return ge::GRAPH_FAILED);
+    }
+    // -----------------------check T-------------------
+    uint32_t qTsize = opParamInfo_.query.shape->GetStorageShape().GetDim(0);
+    OP_CHECK_IF((opParamInfo_.weights.shape->GetStorageShape().GetDim(0) != qTsize) ||
+                (opParamInfo_.attenOut.shape->GetStorageShape().GetDim(0) != qTsize),
+                OP_LOGE(opName_, "TND case input query, weights and sparse_indices dim 0 are %u, %ld, %ld respectively, they must be same.",
+                    qTsize, opParamInfo_.weights.shape->GetStorageShape().GetDim(0),
+                    opParamInfo_.attenOut.shape->GetStorageShape().GetDim(0)),
+                return ge::GRAPH_FAILED);
+
+    OP_CHECK_IF((opParamInfo_.valuesOut.shape->GetStorageShape().GetDim(0) != qTsize &&
+                (*opParamInfo_.returnValue)),
+                OP_LOGE(opName_, "TND case input query and sparse_values dim 0 are %u, %ld respectively, they must be same.",
+                    qTsize, opParamInfo_.valuesOut.shape->GetStorageShape().GetDim(0)),
+                return ge::GRAPH_FAILED);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::ValidateInputShapesMatchQbsnd()
+{
+    // -----------------------check BatchSize-------------------
+    // bSize_ 来源于query
+    if (kLayout_ == DataLayout::BnBsND) {
+        OP_CHECK_IF((opParamInfo_.blockTable.tensor->GetStorageShape().GetDim(0) != bSize_) ||
+                    (opParamInfo_.actualSeqLengths.tensor->GetShapeSize() != bSize_),
+                OP_LOGE(opName_, "BSND case input query, actual_seq_lengths_key, block_table dim 0 are %u, %ld, %ld respectively, they must be same.",
+                    bSize_, opParamInfo_.actualSeqLengths.tensor->GetShapeSize(),
+                    opParamInfo_.blockTable.tensor->GetStorageShape().GetDim(0)),
+                return ge::GRAPH_FAILED);
+    } else if (kLayout_ == DataLayout::BSND) {
+        OP_CHECK_IF(opParamInfo_.key.shape->GetStorageShape().GetDim(0) != bSize_,
+                OP_LOGE(opName_, "BSND case input query, key dim 0 are %u, %ld respectively, they must be same.",
+                    bSize_, opParamInfo_.key.shape->GetStorageShape().GetDim(0)),
+                return ge::GRAPH_FAILED);
+        OP_CHECK_IF((opParamInfo_.actualSeqLengths.tensor != nullptr) &&
+                    (opParamInfo_.actualSeqLengths.tensor->GetShapeSize() != bSize_),
+                OP_LOGE(opName_, "BSND case input query, actual_seq_lengths_key dim 0 are %u, %ld respectively, they must be same.",
+                    bSize_, opParamInfo_.actualSeqLengths.tensor->GetShapeSize()),
+                return ge::GRAPH_FAILED);
+    }
+    OP_CHECK_IF((opParamInfo_.weights.shape->GetStorageShape().GetDim(0) != bSize_) ||
+                (opParamInfo_.attenOut.shape->GetStorageShape().GetDim(0) != bSize_),
+                OP_LOGE(opName_, "BSND case input query, weight and sparse_indices dim 0 are %u, %ld, %ld respectively, they must be same.",
+                    bSize_, opParamInfo_.weights.shape->GetStorageShape().GetDim(0),
+                    opParamInfo_.attenOut.shape->GetStorageShape().GetDim(0)),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF((opParamInfo_.valuesOut.shape->GetStorageShape().GetDim(0) != bSize_  &&
+                (*opParamInfo_.returnValue)),
+                OP_LOGE(opName_, "BSND case input query, sparse_values dim 0 are %u, %ld respectively, they must be same.",
+                    bSize_, opParamInfo_.valuesOut.shape->GetStorageShape().GetDim(0)),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF((opParamInfo_.actualSeqLengthsQ.tensor != nullptr) &&
+                   (opParamInfo_.actualSeqLengthsQ.tensor->GetShapeSize() != bSize_),
+                OP_LOGE(opName_, "BSND case input query, actual_seq_lengths_query dim 0 are %u, %ld respectively, they must be same",
+                    bSize_, opParamInfo_.actualSeqLengthsQ.tensor->GetShapeSize()),
+                return ge::GRAPH_FAILED);
+    // -----------------------check S1-------------------
+    OP_CHECK_IF((opParamInfo_.weights.shape->GetStorageShape().GetDim(1) != s1Size_) ||
+                (opParamInfo_.attenOut.shape->GetStorageShape().GetDim(1) != s1Size_),
+                OP_LOGE(opName_, "BSND case input query, weight and sparse_indices dim 1 are %u, %ld, %ld, they must be same.",
+                    s1Size_, opParamInfo_.weights.shape->GetStorageShape().GetDim(1),
+                    opParamInfo_.attenOut.shape->GetStorageShape().GetDim(1)),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF((opParamInfo_.valuesOut.shape->GetStorageShape().GetDim(1) != s1Size_ &&
+                (*opParamInfo_.returnValue)),
+                OP_LOGE(opName_, "BSND case input query and sparse_values dim 1 are %u, %ld, they must be same.",
+                    s1Size_, opParamInfo_.valuesOut.shape->GetStorageShape().GetDim(1)),
+                return ge::GRAPH_FAILED);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus LIInfoParser::ValidateInputShapesMatch()
+{
+    /*
+    TND:
+    query [T,N1,D],
+    key [BlockNum,BlockSize,N2,D],
+    weight [T,N1],
+    block_table [BatchSize, BatchMaxBlockNum],
+    act_seq_k [BatchSize]
+    act_seq_q [BatchSize],
+    out [T,N2,topk]
+    ----------------------
+    BSND:
+    query [BatchSize,S1,N1,D],
+    key [BlockNum,BlockSize,N2,D],
+    weight [BatchSize,S1,N1],
+    block_table [BatchSize, BatchMaxBlockNum],
+    act_seq_k [BatchSize]
+    act_seq_q [BatchSize] 可选
+    out [BatchSize,S1,N2,topk]
+    */
+    uint32_t queryWeightsN1Dim = 1;
+    uint32_t outN2Dim = 1;
+    if (qLayout_ == DataLayout::TND) {
+        if (ValidateInputShapesMatchQtnd() != ge::GRAPH_SUCCESS) {
+            return ge::GRAPH_FAILED;
+        }
+    } else { // qLayout_ BSND
+        if (ValidateInputShapesMatchQbsnd() != ge::GRAPH_SUCCESS) {
+            return ge::GRAPH_FAILED;
+        }
+        queryWeightsN1Dim = DIM_IDX_TWO;
+        outN2Dim = DIM_IDX_TWO;
+    }
+    // -----------------------check N1-------------------
+    OP_CHECK_IF((opParamInfo_.weights.shape->GetStorageShape().GetDim(queryWeightsN1Dim) != n1Size_),
+               OP_LOGE(opName_, "input query, weight shape dim N1 must be same."), return ge::GRAPH_FAILED);
+    // -----------------------check D-------------------
+    uint32_t keyDDim = kLayout_ == DataLayout::TND ? DIM_IDX_TWO : DIM_IDX_THREE;
+    OP_CHECK_IF((opParamInfo_.key.shape->GetStorageShape().GetDim(keyDDim) != headDim_),
+               OP_LOGE(opName_, "input query, key shape last dim must be same."), return ge::GRAPH_FAILED);
+    // -----------------------check N2-------------------
+    OP_CHECK_IF((opParamInfo_.attenOut.shape->GetStorageShape().GetDim(outN2Dim) != n2Size_),
+               OP_LOGE(opName_, "input query and output sparse_indices shape n2 dim must be same,"
+                       "but now they are %u, %ld respectively.",
+                       n2Size_, opParamInfo_.attenOut.shape->GetStorageShape().GetDim(outN2Dim)),
+               return ge::GRAPH_FAILED);
+    OP_CHECK_IF((opParamInfo_.valuesOut.shape->GetStorageShape().GetDim(outN2Dim) != n2Size_ &&
+                (*opParamInfo_.returnValue)),
+               OP_LOGE(opName_, "input query and sparse_values shape n2 dim must be same,"
+                       "but now they are %u, %ld respectively.",
+                       n2Size_, opParamInfo_.valuesOut.shape->GetStorageShape().GetDim(outN2Dim)),
+               return ge::GRAPH_FAILED);
+    // -----------------------check sparse_count-------------------
+    OP_CHECK_IF((opParamInfo_.attenOut.shape->GetStorageShape().GetDim(outN2Dim + 1) != *opParamInfo_.sparseCount),
+               OP_LOGE(opName_, "output sparse_indices shape last dim must be same as attr sparse_count,"
+                       "but now they are %u, %ld respectively.", *opParamInfo_.sparseCount,
+                       opParamInfo_.attenOut.shape->GetStorageShape().GetDim(outN2Dim + 1)),
+               return ge::GRAPH_FAILED);
+    OP_CHECK_IF((opParamInfo_.valuesOut.shape->GetStorageShape().GetDim(outN2Dim + 1) != *opParamInfo_.sparseCount &&
+                (*opParamInfo_.returnValue)),
+               OP_LOGE(opName_, "output sparse_values shape last dim must be same as attr sparse_count,"
+                       "but now they are %u, %ld respectively.", *opParamInfo_.sparseCount,
+                       opParamInfo_.valuesOut.shape->GetStorageShape().GetDim(outN2Dim + 1)),
+               return ge::GRAPH_FAILED);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+void LIInfoParser::GenerateInfo(LITilingInfo &liInfo)
+{
+    liInfo.opName = opName_;
+    liInfo.opParamInfo = opParamInfo_;
+    liInfo.socVersion = socVersion_;
+
+    liInfo.bSize = bSize_;
+    liInfo.n1Size = n1Size_;
+    liInfo.n2Size = n2Size_;
+    liInfo.s1Size = s1Size_;
+    liInfo.s2Size = s2Size_;
+    liInfo.gSize = gSize_;
+
+    liInfo.inputQType = inputQType_;
+    liInfo.inputKType = inputKType_;
+    liInfo.weightsType = weightsType_;
+    liInfo.outputType = outputType_;
+
+    liInfo.blockSize = blockSize_;
+    liInfo.maxBlockNumPerBatch = maxBlockNumPerBatch_;
+
+    std::string layOutKeyStr(opParamInfo_.layOutKey);
+    liInfo.pageAttentionFlag = layOutKeyStr == "PA_BSND" ? true : false;
+    liInfo.sparseMode = *opParamInfo_.sparseMode;
+    liInfo.sparseCount = *opParamInfo_.sparseCount;
+    liInfo.preTokens = *opParamInfo_.preTokens;
+    liInfo.nextTokens = *opParamInfo_.nextTokens;
+    liInfo.returnValue = *opParamInfo_.returnValue;
+
+    liInfo.inputQLayout = qLayout_;
+    liInfo.inputKLayout = kLayout_;
+}
+
+ge::graphStatus LIInfoParser::ParseAndCheck(LITilingInfo &liInfo)
+{
+    if (ge::GRAPH_SUCCESS != GetOpName() || ge::GRAPH_SUCCESS != GetNpuInfo() || ge::GRAPH_SUCCESS != GetOpParaInfo() ||
+        ge::GRAPH_SUCCESS != CheckRequiredParaExistence()) {
+        return ge::GRAPH_FAILED;
+    }
+
+    if (ge::GRAPH_SUCCESS != GetAndCheckInOutDataType() || ge::GRAPH_SUCCESS != GetQueryKeyAndOutLayout() ||
+        ge::GRAPH_SUCCESS != GetAndCheckOptionalInput()) {
+        return ge::GRAPH_FAILED;
+    }
+
+    if (ge::GRAPH_SUCCESS != CheckShapeDim() || ge::GRAPH_SUCCESS != GetN1Size() ||
+        ge::GRAPH_SUCCESS != GetAndCheckN2Size() || ge::GRAPH_SUCCESS != GetGSize()) {
+        return ge::GRAPH_FAILED;
+    }
+
+    if (ge::GRAPH_SUCCESS != GetBatchSize() || ge::GRAPH_SUCCESS != GetS1Size() || ge::GRAPH_SUCCESS != GetHeadDim() ||
+        ge::GRAPH_SUCCESS != GetS2Size()) {
+        return ge::GRAPH_FAILED;
+    }
+    if (ge::GRAPH_SUCCESS != ValidateInputShapesMatch()) {
+        return ge::GRAPH_FAILED;
+    }
+
+    GenerateInfo(liInfo);
+
+    return ge::GRAPH_SUCCESS;
+}
+
+// --------------------------LightningIndexerTiling类成员函数定义-----------------------
+ge::graphStatus LightningIndexerTiling::DoTiling(LITilingInfo *tilingInfo)
+{
+    // -------------set blockdim-----------------
+    // blockDim 通过 tilingData.usedCoreNum 回传给 launcher（见 lightning_indexer_v2.cpp）。
+    auto ascendcPlatform = *platform_ascendc::PlatformAscendCManager::GetInstance();
+    uint32_t aivNum = ascendcPlatform.GetCoreNumAiv();
+    uint32_t aicNum = ascendcPlatform.GetCoreNumAic();
+    uint32_t blockDim = ascendcPlatform.CalcTschBlockDim(aivNum, aicNum, aivNum);
+
+    // -------------set workspacesize-----------------
+    constexpr uint32_t MM1_RES_ELEM_SIZE = 4;         // 4: fp32
+    constexpr uint32_t DOUBLE_BUFFER = 2;             // 双Buffer
+    constexpr uint32_t M_BASE_SIZE = 512;             // m轴基本块大小
+    constexpr uint32_t S2_BASE_SIZE = 512;            // S2轴基本块大小
+    constexpr uint32_t V1_RES_ELEM_SIZE = 4;          // 4: int32
+    constexpr uint32_t V1_RES_ELEM_TYPE = 2;          // 保留Index和Value 2种数据
+    constexpr uint32_t V1_DECODE_PARAM_ELEM_SIZE = 8; // 8: int64
+    constexpr uint32_t V1_DECODE_PARAM_NUM = 16;      // Decode参数个数
+    constexpr uint32_t V1_DECODE_DATA_NUM = 2;        // Decode每个核需要存储头和尾部两块数据
+    constexpr uint32_t S1_BASE_SIZE = 8;              // S1轴基本块的大小
+    constexpr uint32_t TOPK_MAX_SIZE = 2048;          // TopK选取个数
+    // 上游在此叠加 GetLibApiWorkSpaceSize()；ge_helper::TilingContext::SetWorkspaceSizes()
+    // 已经把系统 workspace 计入，这里只统计算子自身需要的部分。
+    uint32_t workspaceSize = 0;
+    // 主流程需Workspace大小
+    if (tilingInfo->socVersion == platform_ascendc::SocVersion::ASCEND950) {
+        constexpr uint32_t s1BaseSize = 4;
+        constexpr uint32_t s2BaseSize = 128;
+        workspaceSize +=
+            s1BaseSize * ((tilingInfo->s2Size + s2BaseSize - 1) / s2BaseSize) * s2BaseSize * sizeof(uint16_t) * aicNum;
+    } else {
+        constexpr uint32_t mm1ResSize = M_BASE_SIZE * S2_BASE_SIZE;
+        workspaceSize += mm1ResSize * MM1_RES_ELEM_SIZE * DOUBLE_BUFFER * aicNum;
+        // Decode流程(LD)需要Workspace大小
+        // 临时存储Decode中间结果大小: 2(头/尾)*8(s1Base)*2(idx/value)*2048(K)*sizeof(int32)*24=6M
+        workspaceSize +=
+            V1_DECODE_DATA_NUM * S1_BASE_SIZE * V1_RES_ELEM_TYPE * TOPK_MAX_SIZE * V1_RES_ELEM_SIZE * aicNum;
+        // 临时存储Decode中间参数信息大小: 2(头/尾)*8(s1Base)*16(paramNum)*sizeof(int64_t)*24=48k
+        workspaceSize +=
+            V1_DECODE_DATA_NUM * S1_BASE_SIZE * V1_DECODE_PARAM_NUM * V1_DECODE_PARAM_ELEM_SIZE * aicNum;
+    }
+    context_->SetWorkspaceSizes(workspaceSize);
+
+    // -------------set tilingkey-----------------
+    // 上游用 GET_TPL_TILING_KEY 生成框架分发用的 key；这里生成 device 侧 switch
+    // 使用的 key，编码见 lightning_indexer_v2_tiling_key.h。
+    uint32_t inputQType = GE_DATATYPE_TO_KEY(tilingInfo->inputQType);
+    uint32_t inputKType = GE_DATATYPE_TO_KEY(tilingInfo->inputKType);
+    uint32_t outputType = GE_DATATYPE_TO_KEY(tilingInfo->outputType);
+    uint32_t pageAttentionFlag = static_cast<uint32_t>(tilingInfo->pageAttentionFlag);
+    uint32_t inputQLayout = static_cast<uint32_t>(tilingInfo->inputQLayout);
+    uint32_t inputKLayout = static_cast<uint32_t>(tilingInfo->inputKLayout);
+    uint32_t weightTypeFlag = (tilingInfo->weightsType == ge::DT_FLOAT) ? 1U : 0U;
+    uint32_t tilingKey = SGL_LI_V2_TILING_KEY(inputQType, inputKType, outputType, weightTypeFlag, pageAttentionFlag,
+                                              inputQLayout, inputKLayout);
+
+    // -------------set tilingdata-----------------
+    tilingData_.preTokens = tilingInfo->preTokens;
+    tilingData_.nextTokens = tilingInfo->nextTokens;
+    tilingData_.bSize = tilingInfo->bSize;
+    tilingData_.n2Size = tilingInfo->n2Size;
+    tilingData_.gSize = tilingInfo->gSize;
+    tilingData_.s1Size = tilingInfo->s1Size;
+    tilingData_.s2Size = static_cast<uint32_t>(tilingInfo->s2Size);
+    tilingData_.sparseCount = tilingInfo->sparseCount;
+    tilingData_.usedCoreNum = blockDim;
+    tilingData_.blockSize = static_cast<uint32_t>(tilingInfo->blockSize);
+    tilingData_.maxBlockNumPerBatch = tilingInfo->maxBlockNumPerBatch;
+    tilingData_.sparseMode = tilingInfo->sparseMode;
+    tilingData_.returnValue = static_cast<uint32_t>(tilingInfo->returnValue);
+    tilingData_.tilingKey = tilingKey;
+
+    return ge::GRAPH_SUCCESS;
+}
+
+const LITilingData &LightningIndexerTiling::GetTilingData() const
+{
+    return tilingData_;
+}
+
+}  // namespace sglang::LIV2Host

--- a/csrc/lightning_indexer_v2/op_host/tiling/lightning_indexer_v2_tiling.h
+++ b/csrc/lightning_indexer_v2/op_host/tiling/lightning_indexer_v2_tiling.h
@@ -1,0 +1,227 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file lightning_indexer_tiling.h
+ * \brief
+ */
+
+#ifndef SGL_LI_V2_LIGHTNING_INDEXER_TILING_H_
+#define SGL_LI_V2_LIGHTNING_INDEXER_TILING_H_
+
+#include "tiling/platform/platform_ascendc.h"
+#include "tiling/tiling_api.h"
+#include "platform/platform_info.h"
+
+#include "ge_helper.h"
+#include "lightning_indexer_v2_ops_compat.h"
+#include "lightning_indexer_v2_tiling_data.h"
+
+namespace sglang::LIV2Host {
+using ge_helper::TilingContext;
+
+// ------------------公共定义--------------------------
+struct TilingRequiredParaInfo {
+    const gert::CompileTimeTensorDesc *desc;
+    const gert::StorageShape *shape;
+};
+
+struct TilingOptionalParaInfo {
+    const gert::CompileTimeTensorDesc *desc;
+    const gert::Tensor *tensor;
+};
+
+enum class DataLayout : uint32_t {
+    BSND = 0,
+    TND = 1,
+    BnBsND = 2
+};
+
+// ------------------算子原型索引常量定义----------------
+// Inputs Index
+constexpr uint32_t QUERY_INDEX = 0;
+constexpr uint32_t KEY_INDEX = 1;
+constexpr uint32_t WEIGTHS_INDEX = 2;
+constexpr uint32_t ACTUAL_SEQ_Q_INDEX = 3;
+constexpr uint32_t ACTUAL_SEQ_K_INDEX = 4;
+constexpr uint32_t BLOCK_TABLE_INDEX = 5;
+//Outputs Index
+constexpr uint32_t LIGHTNING_INDEXER = 0;
+constexpr uint32_t LIGHTNING_VALUES = 1;
+// Attributes Index
+constexpr uint32_t ATTR_QUERY_LAYOUT_INDEX = 0;
+constexpr uint32_t ATTR_KEY_LAYOUT_INDEX = 1;
+constexpr uint32_t ATTR_SPARSE_COUNT_INDEX = 2;
+constexpr uint32_t ATTR_SPARSE_MODE_INDEX = 3;
+constexpr uint32_t ATTR_PRE_TOKENS_INDEX = 4;
+constexpr uint32_t ATTR_NEXT_TOKENS_INDEX = 5;
+constexpr uint32_t ATTR_RETURN_VALUE_INDEX = 6;
+// Dim Index
+constexpr uint32_t DIM_IDX_ONE = 1;
+constexpr uint32_t DIM_IDX_TWO = 2;
+constexpr uint32_t DIM_IDX_THREE = 3;
+// Dim Num
+constexpr uint32_t DIM_NUM_TWO = 2;
+constexpr uint32_t DIM_NUM_THREE = 3;
+constexpr uint32_t DIM_NUM_FOUR = 4;
+// 入参限制常量
+constexpr uint32_t HEAD_DIM_LIMIT = 128;
+constexpr uint32_t SPARSE_LIMIT = 2048;
+constexpr uint32_t SPARSE_MODE_LOWER = 3;
+constexpr uint32_t QUERY_HEAD_NUM_LIMIT = 64;
+
+// -----------算子TilingData定义---------------
+// 见 lightning_indexer_v2_tiling_data.h：上游的 BEGIN_TILING_DATA_DEF 依赖 CANN
+// 算子工程的代码生成，这里改为 host/device 共用的 POD 结构体 LITilingData。
+
+// -----------算子CompileInfo定义-------------------
+struct LICompileInfo {};
+
+// -----------算子Tiling入参结构体定义---------------
+struct LiParaInfo {
+    TilingRequiredParaInfo query = {nullptr, nullptr};
+    TilingRequiredParaInfo key = {nullptr, nullptr};
+    TilingRequiredParaInfo weights = {nullptr, nullptr};
+    TilingOptionalParaInfo actualSeqLengthsQ = {nullptr, nullptr};
+    TilingOptionalParaInfo actualSeqLengths = {nullptr, nullptr};
+    TilingOptionalParaInfo blockTable = {nullptr, nullptr};
+    TilingRequiredParaInfo attenOut = {nullptr, nullptr};
+    TilingRequiredParaInfo valuesOut = {nullptr, nullptr};
+
+    const char *layOut = nullptr;
+    const char *layOutKey = nullptr;
+    const int32_t *blockSize = nullptr;
+    const int32_t *sparseMode = nullptr;
+    const int32_t *sparseCount = nullptr;
+    const int64_t *preTokens = nullptr;
+    const int64_t *nextTokens = nullptr;
+    const bool *returnValue = nullptr;
+};
+
+// -----------算子Tiling入参信息类---------------
+class LITilingInfo {
+public:
+    const char *opName = nullptr;
+    LiParaInfo opParamInfo;
+    // Base Param
+    platform_ascendc::SocVersion socVersion = platform_ascendc::SocVersion::ASCEND910B;
+    uint32_t bSize = 0;
+    uint32_t n1Size = 0;
+    uint32_t n2Size = 0;
+    uint32_t s1Size = 0;
+    int64_t s2Size = 0;
+    uint32_t qkHeadDim = 0;
+    uint32_t gSize = 0;
+    // PageAttention
+    bool pageAttentionFlag = false;
+    int32_t blockSize = 0;
+    uint32_t maxBlockNumPerBatch = 0;
+    // Mask
+    int32_t sparseMode = 0;
+    // Others Flag
+    uint32_t sparseCount = 0;
+    int64_t preTokens = INT64_MAX;
+    int64_t nextTokens = INT64_MAX;
+    bool returnValue = false;
+    // DType
+    ge::DataType inputQType = ge::DT_FLOAT16;
+    ge::DataType inputKType = ge::DT_FLOAT16;
+    ge::DataType weightsType = ge::DT_FLOAT16;
+    ge::DataType outputType = ge::DT_INT32;
+    // Layout
+    DataLayout inputQLayout = DataLayout::BSND;
+    DataLayout inputKLayout = DataLayout::BnBsND;
+};
+
+// -----------算子Tiling入参信息解析及Check类---------------
+class LIInfoParser {
+public:
+    explicit LIInfoParser(ge_helper::TilingContext *context) : context_(context)
+    {
+    }
+    ~LIInfoParser() = default;
+
+    ge::graphStatus CheckRequiredInOutExistence() const;
+    ge::graphStatus CheckRequiredAttrExistence() const;
+    ge::graphStatus CheckRequiredParaExistence() const;
+    ge::graphStatus GetActualSeqLenSize(uint32_t &size, const gert::Tensor *tensor,
+                                        const std::string &actualSeqLenName) const;
+    ge::graphStatus GetOpName();
+    ge::graphStatus GetNpuInfo();
+    void GetOptionalInputParaInfo();
+    void GetInputParaInfo();
+    void GetOutputParaInfo();
+    ge::graphStatus GetAndCheckAttrParaInfo();
+    ge::graphStatus GetOpParaInfo();
+    ge::graphStatus ValidateInputShapesMatchQbsnd();
+    ge::graphStatus ValidateInputShapesMatchQtnd();
+    ge::graphStatus ValidateInputShapesMatch();
+    ge::graphStatus GetAndCheckInOutDataType();
+    ge::graphStatus GetBatchSize();
+    ge::graphStatus GetHeadDim();
+    ge::graphStatus GetS1Size();
+    ge::graphStatus GetAndCheckOptionalInput();
+    ge::graphStatus CheckShapeDim();
+    ge::graphStatus GetAndCheckBlockSize();
+    ge::graphStatus CheckBlockCount();
+    ge::graphStatus GetS2SizeForPageAttention();
+    ge::graphStatus GetS2Size();
+    ge::graphStatus GetQueryKeyAndOutLayout();
+    ge::graphStatus GetN1Size();
+    ge::graphStatus GetAndCheckN2Size();
+    ge::graphStatus GetGSize();
+    ge::graphStatus GetAttenMaskInfo();
+    ge::graphStatus GetActualSeqInfo();
+    void GenerateInfo(LITilingInfo &liInfo);
+    ge::graphStatus ParseAndCheck(LITilingInfo &liInfo);
+
+public:
+    ge_helper::TilingContext *context_ = nullptr;
+    const char *opName_;
+    LiParaInfo opParamInfo_;
+
+    // BaseParams
+    uint32_t bSize_ = 0;
+    uint32_t n1Size_ = 0;
+    uint32_t n2Size_ = 0;
+    uint32_t gSize_ = 0;
+    uint32_t s1Size_ = 0;
+    int64_t s2Size_ = 0;
+    uint32_t headDim_ = 0;
+    // Layout
+    DataLayout qLayout_ = DataLayout::BSND;
+    DataLayout kLayout_ = DataLayout::BnBsND;
+    // PageAttention
+    uint32_t maxBlockNumPerBatch_ = 0;
+    int32_t blockSize_ = 0;
+    platform_ascendc::SocVersion socVersion_ = platform_ascendc::SocVersion::ASCEND910B;
+    ge::DataType inputQType_ = ge::DT_FLOAT16;
+    ge::DataType inputKType_ = ge::DT_FLOAT16;
+    ge::DataType weightsType_ = ge::DT_FLOAT16;
+    ge::DataType blockTableType_ = ge::DT_FLOAT16;
+    ge::DataType inputKRopeType_ = ge::DT_FLOAT16;
+    ge::DataType outputType_ = ge::DT_FLOAT16;
+    ge::DataType valuesOutType_ = ge::DT_FLOAT16;
+};
+
+// ---------------算子Tiling类---------------
+class LightningIndexerTiling {
+public:
+    explicit LightningIndexerTiling(ge_helper::TilingContext *context) : context_(context){};
+    ge::graphStatus DoTiling(LITilingInfo *tilingInfo);
+    const LITilingData &GetTilingData() const;
+
+private:
+    ge_helper::TilingContext *context_ = nullptr;
+    LITilingData tilingData_;
+};
+
+}  // namespace sglang::LIV2Host
+#endif // SGL_LI_V2_LIGHTNING_INDEXER_TILING_H_

--- a/csrc/lightning_indexer_v2/op_host/tiling/lightning_indexer_v2_tiling_data.h
+++ b/csrc/lightning_indexer_v2/op_host/tiling/lightning_indexer_v2_tiling_data.h
@@ -1,0 +1,48 @@
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. See LICENSE in the root of
+ * the software repository for the full text of the License.
+ */
+
+/*!
+ * \file lightning_indexer_v2_tiling_data.h
+ * \brief Shared host/device tiling struct for the lightning_indexer_v2 op.
+ */
+#ifndef SGL_LI_V2_TILING_DATA_H
+#define SGL_LI_V2_TILING_DATA_H
+#include <cstdint>
+
+namespace sglang {
+namespace LIV2Host {
+
+// -----------算子TilingData定义---------------
+// 与上游 CANN 版本的 BEGIN_TILING_DATA_DEF(LITilingData) 字段一一对应。
+// 这里不使用 #pragma pack: preTokens/nextTokens 为 64bit，设备侧按自然对齐读取。
+// 64bit 字段前置，保证 host 与 device 侧布局一致且无隐式填充歧义。
+struct LITilingData {
+    int64_t preTokens = 0;
+    int64_t nextTokens = 0;
+    uint32_t bSize = 0U;
+    uint32_t n2Size = 0U;
+    uint32_t gSize = 0U;
+    uint32_t s1Size = 0U;
+    uint32_t s2Size = 0U;
+    uint32_t sparseCount = 0U;
+    uint32_t usedCoreNum = 0U;
+    uint32_t blockSize = 0U;
+    uint32_t maxBlockNumPerBatch = 0U;
+    uint32_t sparseMode = 0U;
+    uint32_t returnValue = 0U;
+    uint32_t tilingKey = 0U;
+};
+
+static_assert(sizeof(LITilingData) == 64, "LITilingData layout changed unexpectedly");
+
+}  // namespace LIV2Host
+}  // namespace sglang
+#endif  // SGL_LI_V2_TILING_DATA_H

--- a/csrc/lightning_indexer_v2/op_kernel/arch22/lightning_indexer_kernel.h
+++ b/csrc/lightning_indexer_v2/op_kernel/arch22/lightning_indexer_kernel.h
@@ -1,0 +1,695 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+/*!
+ * \file lightning_indexer_kernel.h
+ * \brief
+ */
+
+#ifndef SGL_LI_V2_LIGHTNING_INDEXER_KERNEL_H
+#define SGL_LI_V2_LIGHTNING_INDEXER_KERNEL_H
+
+#include "kernel_operator.h"
+#include "kernel_operator_list_tensor_intf.h"
+#include "kernel_tiling/kernel_tiling.h"
+#include "lib/matmul_intf.h"
+#include "lib/matrix/matmul/tiling.h"
+#include "../lightning_indexer_v2_common.h"
+#include "lightning_indexer_service_vector.h"
+#include "lightning_indexer_service_cube.h"
+
+namespace sglang::npu_kernel::liv2 {
+
+namespace LIKernel {
+using namespace LICommon;
+using namespace LIServiceVec;
+using namespace matmul;
+using AscendC::CacheMode;
+using AscendC::CrossCoreSetFlag;
+using AscendC::CrossCoreWaitFlag;
+
+// 由于S2循环前，RunInfo还没有赋值，使用TempLoopInfo临时存放B、N、S1轴相关的信息；同时减少重复计算
+struct TempLoopInfo {
+    uint32_t bN2Idx = 0;
+    uint32_t bIdx = 0U;
+    uint32_t n2Idx = 0U;
+    uint32_t gS1Idx = 0U;
+    uint32_t gS1LoopEnd = 0U;      // gS1方向循环的结束Idx
+    uint32_t s2LoopEnd = 0U;       // S2方向循环的结束Idx
+    uint32_t actS1Size = 1ULL;     // 当前Batch循环处理的S1轴的实际大小
+    uint32_t actS2Size = 0ULL;
+    bool curActSeqLenIsZero = false;
+    bool needDealActS1LessThanS1 = false; // S1的实际长度小于shape的S1长度时，是否需要清理输出
+    uint32_t actMBaseSize = 0U;    // m轴(gS1)方向实际大小
+    uint32_t mBasicSizeTail = 0U;  // gS1方向循环的尾基本块大小
+    uint32_t s2BasicSizeTail = 0U; // S2方向循环的尾基本块大小
+};
+
+template <typename LIT>
+class LightningIndexerKernel {
+public:
+    __aicore__ inline LightningIndexerKernel(){};
+    __aicore__ inline void Init(__gm__ uint8_t *query, __gm__ uint8_t *key, __gm__ uint8_t *weights,
+                                __gm__ uint8_t *actualSeqLengthsQ, __gm__ uint8_t *actualSeqLengths,
+                                __gm__ uint8_t *blockTable, __gm__ uint8_t *sparseIndices, __gm__ uint8_t *sparseValues,
+                                __gm__ uint8_t *workspace, const LITilingData *__restrict tiling, TPipe *tPipe);
+    __aicore__ inline void Process();
+
+    // =================================类型定义区=================================
+    static constexpr bool DT_W_FLAG = LIT::weightsTypeFlag;
+    using Q_T = typename LIT::queryType;
+    using K_T = typename LIT::keyType;
+    using OUT_T = typename LIT::outputType;
+    static constexpr bool PAGE_ATTENTION = LIT::pageAttention;
+    static constexpr LI_LAYOUT LAYOUT_T = LIT::layout;
+    static constexpr LI_LAYOUT K_LAYOUT_T = LIT::keyLayout;
+    // 编译期条件选择模板第二个参数的类型，直接声明W_T
+    // 第一个模板参数：固定为Q_T；第二个模板参数：编译期选float/void
+    using W_T = typename LightningIndexerTypeTraits<Q_T,
+                                                typename std::conditional<DT_W_FLAG, float, void>::type>::weightsType;
+
+    using MM1_OUT_T = float;
+
+    LightningIndexerServiceCube<LIT> matmulService;
+    LightningIndexerServiceVector<LIT> vectorService;
+
+    // =================================常量区=================================
+    static constexpr uint32_t SYNC_C1_V1_FLAG = 4;
+    static constexpr uint32_t SYNC_V1_C1_FLAG = 5;
+
+    static constexpr uint32_t M_BASE_SIZE = 512;
+    static constexpr uint32_t S2_BASE_SIZE = 512;
+    static constexpr uint32_t HEAD_DIM = 128;
+    static constexpr uint32_t K_HEAD_NUM = 1;
+    static constexpr uint32_t GM_ALIGN_BYTES = 512;
+    static constexpr uint32_t SPARSE_COUNT_8K = 8192;
+    static constexpr uint32_t BLOCK_CUBE_SIZE = 16;
+
+    static constexpr int64_t LD_PREFETCH_LEN = 2;
+    // for workspace double
+    static constexpr uint32_t WS_DOUBLE = 2;
+
+protected:
+    TPipe *pipe = nullptr;
+
+    // offset
+    uint64_t queryCoreOffset = 0ULL;
+    uint64_t keyCoreOffset = 0ULL;
+    uint64_t weightsCoreOffset = 0ULL;
+    uint64_t indiceOutCoreOffset = 0ULL;
+
+    // ================================Global Buffer区=================================
+    GlobalTensor<Q_T> queryGm;
+    GlobalTensor<K_T> keyGm;
+    GlobalTensor<W_T> weightsGm;
+
+    GlobalTensor<int32_t> indiceOutGm;
+    GlobalTensor<K_T> valueOutGm;
+    GlobalTensor<int32_t> blockTableGm;
+
+    GlobalTensor<uint32_t> actualSeqLengthsGmQ;
+    GlobalTensor<uint32_t> actualSeqLengthsGm;
+    // workspace
+    GlobalTensor<MM1_OUT_T> mm1ResGm;  // 存放S
+    GlobalTensor<float> vec1ResGm;     // 存放TopK计算中间结果
+    GlobalTensor<int64_t> vec1ParamGm; // 存放LD参数信息
+
+    // ================================类成员变量====================================
+    // aic、aiv核信息
+    uint32_t tmpBlockIdx = 0U;
+    uint32_t aiCoreIdx = 0U;
+    uint32_t usedCoreNum = 0U;
+
+    LICommon::ConstInfo constInfo{};
+    TempLoopInfo tempLoopInfo{};
+    LICommon::SplitCoreInfo splitCoreInfo{};
+
+    // ================================Init functions==================================
+    __aicore__ inline void InitTilingData(const LITilingData *__restrict tilingData);
+    __aicore__ inline void InitBuffers();
+    __aicore__ inline void InitActualSeqLen(__gm__ uint8_t *actualSeqLengthsQ, __gm__ uint8_t *actualSeqLengths);
+    // ================================Split Core================================
+    __aicore__ inline void SplitCore(uint32_t curCoreIdx, uint32_t &coreNum, LICommon::SplitCoreInfo &info);
+    __aicore__ inline uint32_t GetS2BaseBlockNumOnMask(uint32_t s1gIdx, uint32_t actS1Size, uint32_t actS2Size);
+    __aicore__ inline uint32_t GetTotalBaseBlockNum();
+    // ================================Process functions================================
+    __aicore__ inline void ProcessMain();
+    __aicore__ inline void ProcessBaseBlock(uint32_t loop, uint64_t s2LoopIdx, LICommon::RunInfo &runInfo);
+    __aicore__ inline void ProcessDecode();
+    __aicore__ inline void ProcessInvalid();
+    // ================================Params Calc=====================================
+    __aicore__ inline void CalcGS1LoopParams(uint32_t bN2Idx);
+    __aicore__ inline void GetBN2Idx(uint32_t bN2Idx);
+    __aicore__ inline uint32_t GetActualSeqLen(uint32_t bIdx, uint32_t actualLenDims, bool isAccumSeq,
+                                               GlobalTensor<uint32_t> &actualSeqLengthsGm, uint32_t defaultSeqLen);
+    __aicore__ inline void GetS1S2ActualSeqLen(uint32_t bIdx, uint32_t &actS1Size, uint32_t &actS2Size);
+    __aicore__ inline void CalcS2LoopParams(uint32_t bN2LoopIdx, uint32_t gS1LoopIdx);
+    __aicore__ inline void CalcRunInfo(uint32_t loop, uint32_t s2LoopIdx, LICommon::RunInfo &runInfo);
+    __aicore__ inline void DealActSeqLenIsZero(uint32_t bIdx, uint32_t n2Idx, uint32_t s1Start);
+};
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::InitTilingData(const LITilingData *__restrict tilingData)
+{
+    usedCoreNum = tilingData->usedCoreNum;
+    constInfo.batchSize = tilingData->bSize;
+    constInfo.qHeadNum = constInfo.gSize = tilingData->gSize;
+    constInfo.kSeqSize = tilingData->s2Size;
+    constInfo.qSeqSize = tilingData->s1Size;
+    constInfo.attenMaskFlag = (tilingData->sparseMode == 3);
+    constInfo.kCacheBlockSize = tilingData->blockSize;
+    constInfo.maxBlockNumPerBatch = tilingData->maxBlockNumPerBatch;
+    constInfo.sparseCount = tilingData->sparseCount;
+    constInfo.preTokens = tilingData->preTokens;
+    constInfo.nextTokens = tilingData->nextTokens;
+    constInfo.returnValue = tilingData->returnValue;
+
+    constInfo.outputLayout = LAYOUT_T; // 输出和输入形状一致
+    if (LAYOUT_T == LI_LAYOUT::TND) {
+        constInfo.isAccumSeqS1 = true;
+    }
+    if (K_LAYOUT_T == LI_LAYOUT::TND) {
+        constInfo.isAccumSeqS2 = true;
+    }
+
+    constInfo.kHeadNum = K_HEAD_NUM;
+    constInfo.headDim = HEAD_DIM;
+    constInfo.s2BaseSize = S2_BASE_SIZE;
+    constInfo.isSparseCountOver2K = (constInfo.sparseCount <= BASE_TOPK) ? false : true;
+
+    constInfo.s1BaseSize = constInfo.isSparseCountOver2K ? SPARSE_COUNT_8K / constInfo.sparseCount * 2 : 8;
+    constInfo.mBaseSize = constInfo.s1BaseSize * constInfo.gSize;
+    constInfo.mBaseSizeAlign = LICommon::Align(constInfo.mBaseSize, BLOCK_CUBE_SIZE);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::InitBuffers()
+{
+    if ASCEND_IS_AIV {
+        vectorService.InitBuffers(pipe);
+    } else {
+        matmulService.InitBuffers(pipe);
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::InitActualSeqLen(__gm__ uint8_t *actualSeqLengthsQ,
+                                                        __gm__ uint8_t *actualSeqLengths)
+{
+    if (actualSeqLengthsQ == nullptr) {
+        constInfo.actualLenQDims = 0;
+    } else {
+        constInfo.actualLenQDims = constInfo.batchSize;
+        actualSeqLengthsGmQ.SetGlobalBuffer((__gm__ uint32_t *)actualSeqLengthsQ, constInfo.actualLenQDims);
+    }
+    if (actualSeqLengths == nullptr) {
+        constInfo.actualLenDims = 0;
+    } else {
+        constInfo.actualLenDims = constInfo.batchSize;
+        actualSeqLengthsGm.SetGlobalBuffer((__gm__ uint32_t *)actualSeqLengths, constInfo.actualLenDims);
+    }
+}
+
+template <typename LIT>
+__aicore__ inline uint32_t LightningIndexerKernel<LIT>::GetActualSeqLen(uint32_t bIdx,
+                                                           uint32_t actualLenDims, bool isAccumSeq,
+                                                           GlobalTensor<uint32_t> &actualSeqLengthsGm,
+                                                           uint32_t defaultSeqLen)
+{
+    if (actualLenDims == 0) {
+        return defaultSeqLen;
+    } else if (isAccumSeq && bIdx > 0) {
+        return actualSeqLengthsGm.GetValue(bIdx) - actualSeqLengthsGm.GetValue(bIdx - 1);
+    } else {
+        return actualSeqLengthsGm.GetValue(bIdx);
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::GetS1S2ActualSeqLen(uint32_t bIdx,
+                                                         uint32_t &actS1Size, uint32_t &actS2Size)
+{
+    actS1Size = GetActualSeqLen(bIdx, constInfo.actualLenQDims, constInfo.isAccumSeqS1, actualSeqLengthsGmQ,
+                                constInfo.qSeqSize);
+    actS2Size =
+        GetActualSeqLen(bIdx, constInfo.actualLenDims, constInfo.isAccumSeqS2, actualSeqLengthsGm, constInfo.kSeqSize);
+}
+
+template <typename LIT>
+__aicore__ inline uint32_t LightningIndexerKernel<LIT>::GetS2BaseBlockNumOnMask(uint32_t s1gIdx, uint32_t actS1Size,
+                                                                   uint32_t actS2Size)
+{
+    if (actS2Size == 0) {
+        return 0;
+    }
+    uint32_t s1Offset = constInfo.s1BaseSize * s1gIdx;
+    int32_t validS2LenBase = static_cast<int32_t>(actS2Size) - static_cast<int32_t>(actS1Size);
+    int32_t validS2Len = s1Offset + validS2LenBase + constInfo.s1BaseSize;
+    validS2Len = Min(validS2Len, static_cast<int32_t>(actS2Size));
+    validS2Len = Max(validS2Len, 1);
+    return (validS2Len + constInfo.s2BaseSize - 1) / constInfo.s2BaseSize;
+}
+
+template <typename LIT>
+__aicore__ inline uint32_t LightningIndexerKernel<LIT>::GetTotalBaseBlockNum()
+{
+    uint32_t totalBlockNum = 0;
+    uint32_t actS1Size, actS2Size;
+    uint32_t s1GBaseNum, s2BaseNum;
+    for (uint32_t bIdx = 0; bIdx < constInfo.batchSize; bIdx++) {
+        GetS1S2ActualSeqLen(bIdx, actS1Size, actS2Size);
+        s1GBaseNum = CeilDiv(actS1Size, constInfo.s1BaseSize);
+        if (!constInfo.attenMaskFlag) {
+            s2BaseNum = constInfo.isSparseCountOver2K
+                      ? (actS2Size > 0 ? 1 : 0)
+                      : CeilDiv(actS2Size, constInfo.s2BaseSize);
+            totalBlockNum += s1GBaseNum * s2BaseNum * constInfo.kHeadNum;
+            continue;
+        }
+        for (uint32_t s1gIdx = 0; s1gIdx < s1GBaseNum; s1gIdx++) {
+            s2BaseNum = constInfo.isSparseCountOver2K
+                      ? (actS2Size > 0 ? 1 : 0)
+                      : GetS2BaseBlockNumOnMask(s1gIdx, actS1Size, actS2Size);
+            totalBlockNum += s2BaseNum * constInfo.kHeadNum;
+        }
+    }
+    return totalBlockNum;
+}
+
+// 多核版本，双闭区间
+template <typename LIT>
+__aicore__ void inline LightningIndexerKernel<LIT>::SplitCore(uint32_t curCoreIdx,
+                                                         uint32_t &coreNum, LICommon::SplitCoreInfo &info)
+{
+    // 计算每个核最少处理的块数, 剩余的部分前面的核每个核多处理一块
+    uint32_t totalBlockNum = GetTotalBaseBlockNum();
+    uint32_t minBlockPerCore = totalBlockNum / coreNum;
+    uint32_t deal1MoreBlockCoreNum = totalBlockNum % coreNum;
+    uint32_t coreIdx = 0;
+    uint32_t lastGS1RemainBlockCnt = 0;
+    uint32_t coreDealBlockCnt = coreIdx < deal1MoreBlockCoreNum ? minBlockPerCore + 1 : minBlockPerCore;
+    coreNum = minBlockPerCore == 0 ? deal1MoreBlockCoreNum : coreNum;
+
+    bool findLastCoreEnd = true;
+    uint32_t actS1Size, actS2Size;
+    uint32_t s1GBaseNum, s2BaseNum, s2Loop;
+    for (uint32_t bN2Idx = 0; bN2Idx < constInfo.batchSize * constInfo.kHeadNum; bN2Idx++) {
+        uint32_t bIdx = bN2Idx / constInfo.kHeadNum;
+        if (bN2Idx % constInfo.kHeadNum == 0) {
+            GetS1S2ActualSeqLen(bIdx, actS1Size, actS2Size);
+            s1GBaseNum = CeilDiv(actS1Size, constInfo.s1BaseSize);
+            s2BaseNum = CeilDiv(actS2Size, constInfo.s2BaseSize);
+        }
+        if constexpr (LAYOUT_T == LI_LAYOUT::BSND) {
+            if (findLastCoreEnd && (s1GBaseNum == 0U || s2BaseNum == 0U)) {
+                info.bN2Start = bN2Idx;
+                info.gS1Start = 0;
+                info.s2Start = 0;
+                findLastCoreEnd = false;
+            }
+        }
+        for (uint32_t gS1Idx = 0; gS1Idx < s1GBaseNum; gS1Idx++) {
+            if (constInfo.attenMaskFlag) {
+                s2BaseNum = GetS2BaseBlockNumOnMask(gS1Idx, actS1Size, actS2Size);
+            }
+            if (findLastCoreEnd && s2BaseNum == 0U) {
+                info.bN2Start = bN2Idx;
+                info.gS1Start = gS1Idx;
+                info.s2Start = 0;
+                findLastCoreEnd = false;
+            }
+            s2Loop = constInfo.isSparseCountOver2K ? (actS2Size > 0 ? 1 : 0) : s2BaseNum;
+            for (uint32_t s2Idx = 0; s2Idx < s2Loop;) {
+                if (findLastCoreEnd) {
+                    info.bN2Start = bN2Idx;
+                    info.gS1Start = gS1Idx;
+                    info.s2Start = s2Idx;
+                    findLastCoreEnd = false;
+                }
+                uint32_t s2RemainBaseNum = s2Loop - s2Idx;
+                if (lastGS1RemainBlockCnt + s2RemainBaseNum >= coreDealBlockCnt) {
+                    info.bN2End = bN2Idx;
+                    info.gS1End = gS1Idx;
+                    info.s2End = constInfo.isSparseCountOver2K
+                               ? s2BaseNum - 1
+                               : s2Idx + coreDealBlockCnt - lastGS1RemainBlockCnt - 1;
+
+                    if (coreIdx == curCoreIdx) {
+                        // S2被切N核，那么只有第一个核需要处理LD，其他核不用
+                        if (s2Idx == 0 && info.s2End + 1 < s2BaseNum) {
+                            info.isLD = true;
+                        }
+                        // 最后一个核处理的不是最后一个Batch，表明后面的Batch为空块(S2=0), 调整终点坐标以便清理输出
+                        if (coreIdx == coreNum - 1 && info.bN2End != constInfo.batchSize -1) {
+                            info.bN2End = constInfo.batchSize -1;
+                            info.gS1End = 0;
+                            info.s2End = 0;
+                        }
+                        return;
+                    }
+                    coreIdx++;
+                    findLastCoreEnd = true;
+                    s2Idx = info.s2End + 1;
+                    lastGS1RemainBlockCnt = 0;
+                    coreDealBlockCnt = coreIdx < deal1MoreBlockCoreNum ? minBlockPerCore + 1 : minBlockPerCore;
+                } else {
+                    lastGS1RemainBlockCnt += s2RemainBaseNum;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::DealActSeqLenIsZero(uint32_t bIdx, uint32_t n2Idx, uint32_t s1Start)
+{
+    if ASCEND_IS_AIV {
+        if (constInfo.outputLayout == LI_LAYOUT::TND) {
+            uint32_t tSize = actualSeqLengthsGmQ.GetValue(constInfo.batchSize - 1);
+            uint32_t tBase = bIdx == 0 ? 0 : actualSeqLengthsGmQ.GetValue(bIdx - 1);
+            uint32_t s1Count = tempLoopInfo.actS1Size;
+
+            for (uint32_t s1Idx = s1Start; s1Idx < s1Count; s1Idx++) {
+                uint64_t indiceOutOffset =
+                    (tBase + s1Idx) * constInfo.kHeadNum * constInfo.sparseCount + // T轴、s1轴偏移
+                    n2Idx * constInfo.sparseCount;                                 // N2轴偏移
+                vectorService.CleanInvalidOutput(indiceOutOffset);
+            }
+        } else if (constInfo.outputLayout == LI_LAYOUT::BSND) {
+            for (uint32_t s1Idx = s1Start; s1Idx < constInfo.qSeqSize; s1Idx++) {
+                // B,S1,N2,K
+                uint64_t indiceOutOffset = bIdx * constInfo.qSeqSize * constInfo.kHeadNum * constInfo.sparseCount +
+                                           s1Idx * constInfo.kHeadNum * constInfo.sparseCount + // B轴、S1轴偏移
+                                           n2Idx * constInfo.sparseCount;                       // N2轴偏移
+                vectorService.CleanInvalidOutput(indiceOutOffset);
+            }
+        }
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::Init(__gm__ uint8_t *query,
+                                            __gm__ uint8_t *key, __gm__ uint8_t *weights,
+                                            __gm__ uint8_t *actualSeqLengthsQ, __gm__ uint8_t *actualSeqLengths,
+                                            __gm__ uint8_t *blockTable, __gm__ uint8_t *sparseIndices,
+                                            __gm__ uint8_t *sparseValues,
+                                            __gm__ uint8_t *workspace, const LITilingData *__restrict tiling,
+                                            TPipe *tPipe)
+{
+    if ASCEND_IS_AIV {
+        tmpBlockIdx = GetBlockIdx(); // vec:0-47
+        aiCoreIdx = tmpBlockIdx / 2;
+    } else {
+        tmpBlockIdx = GetBlockIdx(); // cube:0-23
+        aiCoreIdx = tmpBlockIdx;
+    }
+
+    InitTilingData(tiling);
+    InitActualSeqLen(actualSeqLengthsQ, actualSeqLengths);
+
+    // 计算分核
+    SplitCore(aiCoreIdx, usedCoreNum, splitCoreInfo);
+
+    pipe = tPipe;
+    // workspace 内存排布
+    // |mm1ResGm(存S)|vec1ResGm(存LD中间结果)|vec1ParamGm(存LD参数)
+    // |Core0_mm1ResDB0-Core0_mm1ResDB1-Core1_mm1ResDB0....Core23_mm1ResDB0-Core23_mm1ResDB1|Core0_vec1Res...
+    uint64_t offset = 0;
+
+    // mm1开DoubleBuffer
+    uint64_t singleCoreMm1ResSize = WS_DOUBLE * constInfo.mBaseSizeAlign * constInfo.s2BaseSize * sizeof(MM1_OUT_T);
+    mm1ResGm.SetGlobalBuffer((__gm__ MM1_OUT_T *)(workspace + offset + aiCoreIdx * singleCoreMm1ResSize));
+    offset += GetBlockNum() * singleCoreMm1ResSize;
+
+    // ld流程需要ws大小: [aicnum, 2, CeilDiv(constInfo.mBaseSize, constInfo.gSize), topkOut_*2]
+    // (aic, 8, 2, 2, 2048)
+    // (aic, s1_cube, 头尾, idx/value, K)
+    vec1ResGm.SetGlobalBuffer((__gm__ float *)(workspace + offset));
+    offset += GetBlockNum() * constInfo.s1BaseSize * WS_DOUBLE * WS_DOUBLE * BASE_TOPK * sizeof(float);
+
+    // (aic, 8, 2, 16)
+    // (aic, s1_cube, 头尾，16ele)
+    vec1ParamGm.SetGlobalBuffer((__gm__ int64_t *)(workspace + offset));
+    offset += GetBlockNum() * constInfo.s1BaseSize * WS_DOUBLE * LD_PARAM_NUM * sizeof(int64_t);
+
+    if ASCEND_IS_AIV {
+        vectorService.InitParams(constInfo, tiling);
+        indiceOutGm.SetGlobalBuffer((__gm__ int32_t *)sparseIndices);
+        valueOutGm.SetGlobalBuffer((__gm__ K_T *)sparseValues);
+        weightsGm.SetGlobalBuffer((__gm__ W_T *)weights);
+        vectorService.InitVec1GlobalTensor(mm1ResGm, vec1ResGm, vec1ParamGm, weightsGm, indiceOutGm, valueOutGm);
+    } else {
+        matmulService.InitParams(constInfo);
+        queryGm.SetGlobalBuffer((__gm__ Q_T *)query);
+        if constexpr (PAGE_ATTENTION) {
+            blockTableGm.SetGlobalBuffer((__gm__ int32_t *)blockTable);
+        }
+        keyGm.SetGlobalBuffer((__gm__ K_T *)key);
+        matmulService.InitMm1GlobalTensor(blockTableGm, keyGm, queryGm, mm1ResGm);
+    }
+    InitBuffers();
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::GetBN2Idx(uint32_t bN2Idx)
+{
+    tempLoopInfo.bN2Idx = bN2Idx;
+    tempLoopInfo.bIdx = bN2Idx / constInfo.kHeadNum;
+    tempLoopInfo.n2Idx = bN2Idx % constInfo.kHeadNum;
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::CalcS2LoopParams(uint32_t bN2LoopIdx, uint32_t gS1LoopIdx)
+{
+    tempLoopInfo.gS1Idx = gS1LoopIdx;
+    tempLoopInfo.actMBaseSize = constInfo.mBaseSize;
+    uint32_t remainedGS1Size = tempLoopInfo.actS1Size * constInfo.gSize - tempLoopInfo.gS1Idx * constInfo.mBaseSize;
+    if (remainedGS1Size <= constInfo.mBaseSize && remainedGS1Size > 0) {
+        tempLoopInfo.actMBaseSize = tempLoopInfo.mBasicSizeTail;
+    }
+
+    bool isEnd = (bN2LoopIdx == splitCoreInfo.bN2End) && (gS1LoopIdx == splitCoreInfo.gS1End);
+    uint32_t s2BlockNum;
+    if (constInfo.attenMaskFlag) {
+        s2BlockNum = GetS2BaseBlockNumOnMask(gS1LoopIdx, tempLoopInfo.actS1Size, tempLoopInfo.actS2Size);
+    } else {
+        s2BlockNum = (tempLoopInfo.actS2Size + constInfo.s2BaseSize - 1) / constInfo.s2BaseSize;
+    }
+    tempLoopInfo.s2LoopEnd = isEnd ? splitCoreInfo.s2End : s2BlockNum - 1;
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::CalcGS1LoopParams(uint32_t bN2LoopIdx)
+{
+    GetBN2Idx(bN2LoopIdx);
+    GetS1S2ActualSeqLen(tempLoopInfo.bIdx, tempLoopInfo.actS1Size, tempLoopInfo.actS2Size);
+    if ((tempLoopInfo.actS2Size == 0) || (tempLoopInfo.actS1Size == 0)) {
+        tempLoopInfo.curActSeqLenIsZero = true;
+        return;
+    }
+    tempLoopInfo.curActSeqLenIsZero = false;
+    tempLoopInfo.s2BasicSizeTail = tempLoopInfo.actS2Size % constInfo.s2BaseSize;
+    tempLoopInfo.s2BasicSizeTail =
+        (tempLoopInfo.s2BasicSizeTail == 0) ? constInfo.s2BaseSize : tempLoopInfo.s2BasicSizeTail;
+    tempLoopInfo.mBasicSizeTail = (tempLoopInfo.actS1Size * constInfo.gSize) % constInfo.mBaseSize;
+    tempLoopInfo.mBasicSizeTail =
+        (tempLoopInfo.mBasicSizeTail == 0) ? constInfo.mBaseSize : tempLoopInfo.mBasicSizeTail;
+
+    uint32_t gS1SplitNum = (tempLoopInfo.actS1Size * constInfo.gSize + constInfo.mBaseSize - 1) / constInfo.mBaseSize;
+    tempLoopInfo.gS1LoopEnd = (bN2LoopIdx == splitCoreInfo.bN2End) ? splitCoreInfo.gS1End : gS1SplitNum - 1;
+    if constexpr (LAYOUT_T == LI_LAYOUT::BSND) {
+        if (tempLoopInfo.gS1LoopEnd == gS1SplitNum - 1 && constInfo.qSeqSize > tempLoopInfo.actS1Size) {
+            tempLoopInfo.needDealActS1LessThanS1 = true;
+        }
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::CalcRunInfo(uint32_t loop,
+                                                         uint32_t s2LoopIdx, LICommon::RunInfo &runInfo)
+{
+    runInfo.loop = loop;
+    runInfo.bIdx = tempLoopInfo.bIdx;
+    runInfo.gS1Idx = tempLoopInfo.gS1Idx;
+    runInfo.s2Idx = s2LoopIdx;
+    runInfo.bN2Idx = tempLoopInfo.bN2Idx;
+
+    runInfo.actS1Size = tempLoopInfo.actS1Size;
+    runInfo.actS2Size = tempLoopInfo.actS2Size;
+    // 计算实际基本块size
+    runInfo.actMBaseSize = tempLoopInfo.actMBaseSize;
+    runInfo.actualSingleProcessSInnerSize = constInfo.s2BaseSize;
+    uint32_t s2SplitNum = (tempLoopInfo.actS2Size + constInfo.s2BaseSize - 1) / constInfo.s2BaseSize;
+    if (runInfo.s2Idx == s2SplitNum - 1) {
+        runInfo.actualSingleProcessSInnerSize = tempLoopInfo.s2BasicSizeTail;
+    }
+    runInfo.actualSingleProcessSInnerSizeAlign =
+        LICommon::Align((uint32_t)runInfo.actualSingleProcessSInnerSize, LICommon::ConstInfo::BUFFER_SIZE_BYTE_32B);
+
+    runInfo.isFirstS2InnerLoop = s2LoopIdx == splitCoreInfo.s2Start;
+    runInfo.isLastS2InnerLoop = s2LoopIdx == tempLoopInfo.s2LoopEnd;
+    runInfo.isAllLoopEnd = (runInfo.bN2Idx == splitCoreInfo.bN2End) && (runInfo.gS1Idx == splitCoreInfo.gS1End) &&
+                           (runInfo.s2Idx == splitCoreInfo.s2End);
+
+    if (runInfo.isFirstS2InnerLoop) {
+        uint64_t actualSeqQPrefixSum;
+        uint64_t actualSeqKPrefixSum;
+        if constexpr (LAYOUT_T == LI_LAYOUT::TND) {
+            actualSeqQPrefixSum = (runInfo.bIdx <= 0) ? 0 : actualSeqLengthsGmQ.GetValue(runInfo.bIdx - 1);
+            actualSeqKPrefixSum = (runInfo.bIdx <= 0) ? 0 : actualSeqLengthsGm.GetValue(runInfo.bIdx - 1);
+        } else { // BSND
+            actualSeqQPrefixSum = (runInfo.bIdx <= 0) ? 0 : runInfo.bIdx * constInfo.qSeqSize;
+            actualSeqKPrefixSum = (runInfo.bIdx <= 0) ? 0 : runInfo.bIdx * constInfo.kSeqSize;
+        }
+        uint64_t tndBIdxOffset = actualSeqQPrefixSum * constInfo.qHeadNum * constInfo.headDim;
+        uint64_t tndKeyBIdxOffset = actualSeqKPrefixSum * constInfo.kHeadNum * constInfo.headDim;
+        // B,S1,N1(N2,G),D
+        queryCoreOffset = tndBIdxOffset + runInfo.gS1Idx * constInfo.mBaseSize * constInfo.headDim;
+        keyCoreOffset = tndKeyBIdxOffset + runInfo.n2Idx * constInfo.headDim;
+        // B,S1,N1(N2,G)/T,N1(N2,G)
+        weightsCoreOffset = actualSeqQPrefixSum * constInfo.qHeadNum + runInfo.n2Idx * constInfo.gSize;
+        // B,S1,N2,k/T,N2,k
+        indiceOutCoreOffset = actualSeqQPrefixSum * constInfo.kHeadNum * constInfo.sparseCount +
+                              runInfo.n2Idx * constInfo.sparseCount;
+    }
+    runInfo.tensorQueryOffset = queryCoreOffset;
+    runInfo.tensorKeyOffset = keyCoreOffset + runInfo.s2Idx * constInfo.s2BaseSize * constInfo.kHeadNum
+    * constInfo.headDim;
+    runInfo.tensorWeightsOffset = weightsCoreOffset;
+    runInfo.indiceOutOffset = indiceOutCoreOffset;
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::Process()
+{
+    if (usedCoreNum == 0) {
+        // 没有计算任务，直接清理输出
+        ProcessInvalid();
+        return;
+    }
+    ProcessMain();
+    ProcessDecode();
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::ProcessInvalid()
+{
+    if ASCEND_IS_AIV {
+        uint32_t aivCoreNum = GetBlockNum() * 2; // 2 means c:v = 1:2
+        uint64_t totalOutputSize =
+            constInfo.batchSize * constInfo.qSeqSize * constInfo.kHeadNum * constInfo.sparseCount;
+        uint64_t singleCoreSize =
+            LICommon::Align((totalOutputSize + aivCoreNum - 1) / aivCoreNum, GM_ALIGN_BYTES / sizeof(OUT_T));
+        uint64_t baseSize = tmpBlockIdx * singleCoreSize;
+        if (baseSize < totalOutputSize) {
+            uint64_t dealSize =
+                (baseSize + singleCoreSize <= totalOutputSize) ? singleCoreSize : totalOutputSize - baseSize;
+            GlobalTensor<OUT_T> output = indiceOutGm[baseSize];
+            AscendC::InitGlobalMemory(output, dealSize, constInfo.INVALID_IDX);
+            if (constInfo.returnValue) {
+                event_t eventIDMTE3ToV = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE3_V));
+                SetFlag<HardEvent::MTE3_V>(eventIDMTE3ToV);
+                WaitFlag<HardEvent::MTE3_V>(eventIDMTE3ToV);
+
+                GlobalTensor<uint16_t> valueOutGmTmp;
+                valueOutGmTmp.SetGlobalBuffer((__gm__ uint16_t *)valueOutGm.GetPhyAddr());
+                GlobalTensor<uint16_t> valueOut = valueOutGmTmp[baseSize];
+
+                uint16_t negInf = 0;
+                if constexpr(std::is_same<K_T, float16_t>::value) {
+                    negInf = 0xFC00;
+                } else {
+                    negInf = 0xFF80;
+                }
+                AscendC::InitGlobalMemory(valueOut, dealSize, negInf);
+            }
+        }
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::ProcessMain()
+{
+    if (aiCoreIdx >= usedCoreNum) {
+        // 无任务核直接返回
+        return;
+    }
+
+    if ASCEND_IS_AIV {
+        vectorService.AllocEventID();
+        CrossCoreSetFlag<LICommon::ConstInfo::FIA_SYNC_MODE2, PIPE_MTE2>(constInfo.syncV1C1);
+        CrossCoreSetFlag<LICommon::ConstInfo::FIA_SYNC_MODE2, PIPE_MTE2>(constInfo.syncV1C1);
+    } else {
+        matmulService.AllocEventID();
+    }
+
+    LICommon::RunInfo runInfo;
+    uint32_t gloop = 0;
+    for (uint32_t bN2LoopIdx = splitCoreInfo.bN2Start; bN2LoopIdx <= splitCoreInfo.bN2End; bN2LoopIdx++) {
+        CalcGS1LoopParams(bN2LoopIdx);
+        if (tempLoopInfo.curActSeqLenIsZero) {
+            DealActSeqLenIsZero(tempLoopInfo.bIdx, tempLoopInfo.n2Idx, 0U);
+            continue;
+        }
+        for (uint32_t gS1LoopIdx = splitCoreInfo.gS1Start; gS1LoopIdx <= tempLoopInfo.gS1LoopEnd; gS1LoopIdx++) {
+            CalcS2LoopParams(bN2LoopIdx, gS1LoopIdx);
+            for (int s2LoopIdx = splitCoreInfo.s2Start; s2LoopIdx <= tempLoopInfo.s2LoopEnd; s2LoopIdx++) {
+                ProcessBaseBlock(gloop, s2LoopIdx, runInfo);
+                ++gloop;
+            }
+            splitCoreInfo.s2Start = 0;
+        }
+        if (tempLoopInfo.needDealActS1LessThanS1) {
+            DealActSeqLenIsZero(tempLoopInfo.bIdx, tempLoopInfo.n2Idx, tempLoopInfo.actS1Size);
+        }
+        splitCoreInfo.gS1Start = 0;
+    }
+
+    if ASCEND_IS_AIV {
+        vectorService.FreeEventID();
+    } else {
+        matmulService.FreeEventID();
+        CrossCoreWaitFlag(constInfo.syncV1C1);
+        CrossCoreWaitFlag(constInfo.syncV1C1);
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::ProcessBaseBlock(uint32_t loop,
+                                                         uint64_t s2LoopIdx, LICommon::RunInfo &runInfo)
+{
+    CalcRunInfo(loop, s2LoopIdx, runInfo);
+    if ASCEND_IS_AIC {
+        CrossCoreWaitFlag(constInfo.syncV1C1);
+        matmulService.ComputeMm1(runInfo);
+        CrossCoreSetFlag<LICommon::ConstInfo::FIA_SYNC_MODE2, PIPE_FIX>(constInfo.syncC1V1);
+    } else {
+        CrossCoreWaitFlag(constInfo.syncC1V1);
+        vectorService.ProcessVec(runInfo);
+        CrossCoreSetFlag<LICommon::ConstInfo::FIA_SYNC_MODE2, PIPE_MTE2>(constInfo.syncV1C1);
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::ProcessDecode()
+{
+    if ASCEND_IS_AIV {
+        vectorService.InitLDBuffers(pipe);
+        ICachePreLoad(LD_PREFETCH_LEN);
+        SyncAll();
+        if (splitCoreInfo.isLD) {
+            vectorService.ProcessLD();
+        }
+    }
+}
+} // namespace LIKernel
+}  // namespace sglang::npu_kernel::liv2
+#endif // SGL_LI_V2_LIGHTNING_INDEXER_KERNEL_H

--- a/csrc/lightning_indexer_v2/op_kernel/arch22/lightning_indexer_service_cube.h
+++ b/csrc/lightning_indexer_v2/op_kernel/arch22/lightning_indexer_service_cube.h
@@ -1,0 +1,428 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+/*!
+ * \file lightning_indexer_service_cube.h
+ * \brief use 5 buffer for matmul l1, better pipeline
+ */
+#ifndef SGL_LI_V2_LIGHTNING_INDEXER_SERVICE_CUBE_H
+#define SGL_LI_V2_LIGHTNING_INDEXER_SERVICE_CUBE_H
+
+#include "kernel_operator.h"
+#include "kernel_operator_list_tensor_intf.h"
+#include "kernel_tiling/kernel_tiling.h"
+#include "lib/matmul_intf.h"
+#include "lib/matrix/matmul/tiling.h"
+#include "../lightning_indexer_v2_common.h"
+
+namespace sglang::npu_kernel::liv2 {
+
+namespace LIKernel {
+using namespace LICommon;
+template <typename LIT>
+class LightningIndexerServiceCube {
+public:
+    using Q_T = typename LIT::queryType;
+    using K_T = typename LIT::keyType;
+
+    __aicore__ inline LightningIndexerServiceCube(){};
+    __aicore__ inline void InitBuffers(TPipe *pipe);
+    __aicore__ inline void InitMm1GlobalTensor(const GlobalTensor<int32_t> &blkTableGm, const GlobalTensor<K_T> &keyGm,
+                                               const GlobalTensor<Q_T> &queryGm, const GlobalTensor<float> &mm1ResGm);
+    __aicore__ inline void InitParams(const ConstInfo &constInfo);
+    __aicore__ inline void AllocEventID();
+    __aicore__ inline void FreeEventID();
+    __aicore__ inline void ComputeMm1(const LICommon::RunInfo &runInfo);
+
+    static constexpr IsResetLoad3dConfig LOAD3DV2_CONFIG = {true, true}; // isSetFMatrix isSetPadding;
+    static constexpr uint64_t KEY_BUF_NUM = 3;
+    static constexpr uint64_t QUERY_BUF_NUM = 2;
+    static constexpr uint64_t L0_BUF_NUM = 2;
+
+    static constexpr uint32_t KEY_MTE1_MTE2_EVENT = EVENT_ID2;
+    static constexpr uint32_t QUERY_MTE1_MTE2_EVENT = EVENT_ID5;         // KEY_MTE1_MTE2_EVENT + KEY_BUF_NUM;
+    static constexpr uint32_t M_MTE1_EVENT = EVENT_ID3;
+
+    static constexpr uint32_t MTE2_MTE1_EVENT = EVENT_ID2;
+    static constexpr uint32_t MTE1_M_EVENT = EVENT_ID2;
+
+    static constexpr uint64_t M_BASIC_BLOCK = 256;
+    static constexpr uint64_t D_BASIC_BLOCK = 128;
+    static constexpr uint64_t S2_BASIC_BLOCK = 256;
+
+    static constexpr uint64_t M_BASIC_BLOCK_L0 = 128;
+    static constexpr uint64_t D_BASIC_BLOCK_L0 = 128;
+    static constexpr uint64_t S2_BASIC_BLOCK_L0 = 128;
+
+    static constexpr uint64_t QUERY_BUFFER_OFFSET = M_BASIC_BLOCK * D_BASIC_BLOCK;
+    static constexpr uint64_t KEY_BUFFER_OFFSET = S2_BASIC_BLOCK * D_BASIC_BLOCK;
+    static constexpr uint64_t L0AB_BUFFER_OFFSET = M_BASIC_BLOCK_L0 * D_BASIC_BLOCK_L0;
+    static constexpr uint64_t L0C_BUFFER_OFFSET = M_BASIC_BLOCK_L0 * S2_BASIC_BLOCK_L0;
+
+protected:
+    __aicore__ inline void Fixp(uint64_t s1gGmOffset, uint64_t s2GmOffset, uint64_t s1gL0RealSize,
+                                uint64_t s2L0RealSize, const LICommon::RunInfo &runInfo);
+    __aicore__ inline void ComuteL0c(uint64_t s1gL0RealSize, uint64_t s2L0RealSize, const LICommon::RunInfo &runInfo);
+    __aicore__ inline void LoadKeyToL0b(uint64_t s2L0Offset, uint64_t s2L1RealSize, uint64_t s2L0RealSize,
+                                        const LICommon::RunInfo &runInfo);
+    __aicore__ inline void LoadQueryToL0a(uint64_t s1gL1Offset, uint64_t s1gL0Offset, uint64_t s1gL1RealSize,
+                                          uint64_t s1gL0RealSize, const LICommon::RunInfo &runInfo);
+    __aicore__ inline void QueryNd2Nz(uint64_t s1gL1RealSize, uint64_t s1gL1Offset, const LICommon::RunInfo &runInfo);
+    __aicore__ inline void KeyNd2Nz(uint64_t s2L1RealSize, uint64_t s2GmOffset, const LICommon::RunInfo &runInfo);
+    __aicore__ inline void KeyNd2NzForPA(uint64_t s2L1RealSize, uint64_t s2GmOffset, const LICommon::RunInfo &runInfo);
+    GlobalTensor<int32_t> blkTableGm_;
+    GlobalTensor<K_T> keyGm_;
+    GlobalTensor<Q_T> queryGm_;
+    GlobalTensor<float> mm1ResGm_;
+
+    TBuf<TPosition::A1> bufQL1_;
+    LocalTensor<Q_T> queryL1_;
+    TBuf<TPosition::B1> bufKeyL1_;
+    LocalTensor<K_T> keyL1_;
+
+    TBuf<TPosition::A2> bufQL0_;
+    LocalTensor<Q_T> queryL0_;
+    TBuf<TPosition::B2> bufKeyL0_;
+    LocalTensor<K_T> keyL0_;
+
+    TBuf<TPosition::CO1> bufL0C_;
+    LocalTensor<float> cL0_;
+
+    uint64_t keyL1BufIdx_ = 0;
+    uint64_t queryL1Mte2BufIdx_ = 0;
+    uint64_t queryL1Mte1BufIdx_ = 0;
+    uint64_t l0BufIdx_ = 0;
+
+    ConstInfo constInfo_;
+
+private:
+    static constexpr bool PAGE_ATTENTION = LIT::pageAttention;
+};
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::InitParams(const ConstInfo &constInfo)
+{
+    constInfo_ = constInfo;
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::InitBuffers(TPipe *pipe)
+{
+    pipe->InitBuffer(bufQL1_, QUERY_BUF_NUM * M_BASIC_BLOCK * D_BASIC_BLOCK * sizeof(Q_T));
+    queryL1_ = bufQL1_.Get<Q_T>();
+    pipe->InitBuffer(bufKeyL1_, KEY_BUF_NUM * S2_BASIC_BLOCK * D_BASIC_BLOCK * sizeof(K_T));
+    keyL1_ = bufKeyL1_.Get<K_T>();
+
+    pipe->InitBuffer(bufQL0_, L0_BUF_NUM * M_BASIC_BLOCK_L0 * D_BASIC_BLOCK_L0 * sizeof(Q_T));
+    queryL0_ = bufQL0_.Get<Q_T>();
+    pipe->InitBuffer(bufKeyL0_, L0_BUF_NUM * D_BASIC_BLOCK_L0 * S2_BASIC_BLOCK_L0 * sizeof(K_T));
+    keyL0_ = bufKeyL0_.Get<K_T>();
+
+    pipe->InitBuffer(bufL0C_, L0_BUF_NUM * M_BASIC_BLOCK_L0 * S2_BASIC_BLOCK_L0 * sizeof(float));
+    cL0_ = bufL0C_.Get<float>();
+}
+
+template <typename LIT>
+__aicore__ inline void
+LightningIndexerServiceCube<LIT>::InitMm1GlobalTensor(const GlobalTensor<int32_t> &blkTableGm,
+                                   const GlobalTensor<K_T> &keyGm,
+                                   const GlobalTensor<Q_T> &queryGm, const GlobalTensor<float> &mm1ResGm)
+{
+    blkTableGm_ = blkTableGm;
+    keyGm_ = keyGm;
+    queryGm_ = queryGm;
+    mm1ResGm_ = mm1ResGm;
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::ComputeMm1(const LICommon::RunInfo &runInfo)
+{
+    uint64_t s2GmBaseOffset = runInfo.s2Idx * constInfo_.s2BaseSize;
+    uint64_t s1gProcessSize = runInfo.actMBaseSize;
+    uint64_t s2ProcessSize = runInfo.actualSingleProcessSInnerSize;
+    for (uint64_t s2GmOffset = 0; s2GmOffset < s2ProcessSize; s2GmOffset += S2_BASIC_BLOCK) {
+        WaitFlag<HardEvent::MTE1_MTE2>(KEY_MTE1_MTE2_EVENT + keyL1BufIdx_ % KEY_BUF_NUM);
+        uint64_t s2L1RealSize =
+            s2GmOffset + S2_BASIC_BLOCK > s2ProcessSize ? s2ProcessSize - s2GmOffset : S2_BASIC_BLOCK;
+        if (PAGE_ATTENTION) {
+            KeyNd2NzForPA(s2L1RealSize, s2GmBaseOffset + s2GmOffset, runInfo);
+        }else {
+            KeyNd2Nz(s2L1RealSize, s2GmOffset, runInfo);
+        }
+
+        SetFlag<HardEvent::MTE2_MTE1>(MTE2_MTE1_EVENT);
+        WaitFlag<HardEvent::MTE2_MTE1>(MTE2_MTE1_EVENT);
+        // s1gProcessSize当前必定不会超过2倍的s1g basic block
+        for (uint64_t s1gGmOffset = 0; s1gGmOffset < s1gProcessSize; s1gGmOffset += M_BASIC_BLOCK) {
+            uint64_t s1gL1RealSize =
+                s1gGmOffset + M_BASIC_BLOCK > s1gProcessSize ? s1gProcessSize - s1gGmOffset : M_BASIC_BLOCK;
+            if (runInfo.isFirstS2InnerLoop && s2GmOffset == 0) {
+                queryL1Mte2BufIdx_++;
+                queryL1Mte1BufIdx_ = queryL1Mte2BufIdx_;
+                WaitFlag<HardEvent::MTE1_MTE2>(QUERY_MTE1_MTE2_EVENT + queryL1Mte2BufIdx_ % QUERY_BUF_NUM);
+                QueryNd2Nz(s1gL1RealSize, s1gGmOffset, runInfo);
+                SetFlag<HardEvent::MTE2_MTE1>(MTE2_MTE1_EVENT);
+                WaitFlag<HardEvent::MTE2_MTE1>(MTE2_MTE1_EVENT);
+            } else {
+                queryL1Mte1BufIdx_ =
+                    queryL1Mte2BufIdx_ - (CeilDiv(s1gProcessSize, M_BASIC_BLOCK) - 1 - (s1gGmOffset > 0));
+            }
+            for (uint64_t s2L1Offset = 0; s2L1Offset < s2L1RealSize; s2L1Offset += S2_BASIC_BLOCK_L0) {
+                uint64_t s2L0RealSize =
+                    s2L1Offset + S2_BASIC_BLOCK_L0 > s2L1RealSize ? s2L1RealSize - s2L1Offset : S2_BASIC_BLOCK_L0;
+                for (uint64_t s1gL1Offset = 0; s1gL1Offset < s1gL1RealSize; s1gL1Offset += M_BASIC_BLOCK_L0) {
+                    WaitFlag<HardEvent::M_MTE1>(M_MTE1_EVENT + l0BufIdx_ % L0_BUF_NUM);
+                    uint64_t s1gL0RealSize =
+                        s1gL1Offset + M_BASIC_BLOCK_L0 > s1gL1RealSize ? s1gL1RealSize - s1gL1Offset : M_BASIC_BLOCK_L0;
+                    LoadQueryToL0a(s1gGmOffset, s1gL1Offset, s1gL1RealSize, s1gL0RealSize, runInfo);
+                    LoadKeyToL0b(s2L1Offset, s2L1RealSize, s2L0RealSize, runInfo);
+
+                    SetFlag<HardEvent::MTE1_M>(MTE1_M_EVENT);
+                    WaitFlag<HardEvent::MTE1_M>(MTE1_M_EVENT);
+
+                    ComuteL0c(s1gL0RealSize, s2L0RealSize, runInfo);
+
+                    SetFlag<HardEvent::M_MTE1>(M_MTE1_EVENT + l0BufIdx_ % L0_BUF_NUM);
+
+                    Fixp(s1gGmOffset + s1gL1Offset, s2GmOffset + s2L1Offset, s1gL0RealSize, s2L0RealSize, runInfo);
+                    l0BufIdx_++;
+                }
+            }
+            if (s2GmOffset + S2_BASIC_BLOCK >= s2ProcessSize && runInfo.isLastS2InnerLoop) {
+                SetFlag<HardEvent::MTE1_MTE2>(QUERY_MTE1_MTE2_EVENT + queryL1Mte1BufIdx_ % QUERY_BUF_NUM);
+            }
+        }
+
+        SetFlag<HardEvent::MTE1_MTE2>(KEY_MTE1_MTE2_EVENT + keyL1BufIdx_ % KEY_BUF_NUM);
+        keyL1BufIdx_++;
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::KeyNd2Nz(uint64_t s2L1RealSize, uint64_t s2GmOffset,
+                                                    const LICommon::RunInfo &runInfo)
+{
+    uint64_t s2L1Offset = 0;
+    while (s2L1Offset < s2L1RealSize) {
+        uint64_t keyGmOffset = runInfo.tensorKeyOffset + (s2GmOffset + s2L1Offset) * constInfo_.headDim;
+        // 搬运按照S2_BASIC_BLOCK_L0*D_BASIC_BLOCK_L0的方式在l1上排布, 方便后续mte1
+        // 根据s2的offset判断当前属于前一个L0分型还是后一个L0分型，暂时只支持两个分型
+        uint64_t s2Mte2Size = (s2L1RealSize <= S2_BASIC_BLOCK_L0 || s2L1Offset >= S2_BASIC_BLOCK_L0) ?
+                                  s2L1RealSize - s2L1Offset :
+                                  S2_BASIC_BLOCK_L0 - s2L1Offset;
+
+        Nd2NzParams nd2nzPara;
+        nd2nzPara.ndNum = 1;
+        nd2nzPara.nValue = s2Mte2Size; // 行数
+        nd2nzPara.dValue = constInfo_.headDim;
+        nd2nzPara.srcDValue = constInfo_.headDim;
+        nd2nzPara.dstNzC0Stride = s2L1Offset >= S2_BASIC_BLOCK_L0 ?
+                                      CeilAlign(s2L1RealSize - S2_BASIC_BLOCK_L0, (uint64_t)BLOCK_CUBE) :
+                                      (s2L1RealSize > S2_BASIC_BLOCK_L0 ?
+                                           S2_BASIC_BLOCK_L0 :
+                                           CeilAlign(s2L1RealSize, (uint64_t)BLOCK_CUBE)); // 对齐到16 单位block
+        nd2nzPara.dstNzNStride = 1;
+        nd2nzPara.srcNdMatrixStride = 0;
+        nd2nzPara.dstNzMatrixStride = 0;
+        DataCopy(keyL1_[(keyL1BufIdx_ % KEY_BUF_NUM) * KEY_BUFFER_OFFSET +
+                        (s2L1Offset >= S2_BASIC_BLOCK_L0 ?
+                             S2_BASIC_BLOCK_L0 * D_BASIC_BLOCK_L0 + (s2L1Offset - S2_BASIC_BLOCK_L0) * BLOCK_CUBE :
+                             s2L1Offset * BLOCK_CUBE)],
+                 keyGm_[keyGmOffset], nd2nzPara);
+
+        s2L1Offset += s2Mte2Size;
+    }
+}
+
+// blkNum, blkSize, N2, D
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::KeyNd2NzForPA(uint64_t s2L1RealSize, uint64_t s2GmOffset,
+                                                    const LICommon::RunInfo &runInfo)
+{
+    uint64_t s2L1Offset = 0;
+    while (s2L1Offset < s2L1RealSize) {
+        uint64_t s2BlkId = (s2L1Offset + s2GmOffset) / constInfo_.kCacheBlockSize;
+        uint64_t s2BlkOffset = (s2L1Offset + s2GmOffset) % constInfo_.kCacheBlockSize;
+        uint64_t keyGmOffset = blkTableGm_.GetValue(runInfo.bIdx * constInfo_.maxBlockNumPerBatch + s2BlkId) *
+                                   constInfo_.kCacheBlockSize * constInfo_.kHeadNum * constInfo_.headDim +
+                               s2BlkOffset * constInfo_.headDim;
+        // 搬运按照S2_BASIC_BLOCK_L0*D_BASIC_BLOCK_L0的方式在l1上排布, 方便后续mte1
+        // 根据s2的offset判断当前属于前一个L0分型还是后一个L0分型，暂时只支持两个分型
+        uint64_t s2Mte2Size = (s2L1RealSize <= S2_BASIC_BLOCK_L0 || s2L1Offset >= S2_BASIC_BLOCK_L0) ?
+                                  s2L1RealSize - s2L1Offset :
+                                  S2_BASIC_BLOCK_L0 - s2L1Offset;
+        s2Mte2Size = s2BlkOffset + s2Mte2Size >= constInfo_.kCacheBlockSize ? constInfo_.kCacheBlockSize - s2BlkOffset :
+                                                                              s2Mte2Size;
+        Nd2NzParams nd2nzPara;
+        nd2nzPara.ndNum = 1;
+        nd2nzPara.nValue = s2Mte2Size; // 行数
+        nd2nzPara.dValue = constInfo_.headDim;
+        nd2nzPara.srcDValue = constInfo_.headDim;
+        nd2nzPara.dstNzC0Stride = s2L1Offset >= S2_BASIC_BLOCK_L0 ?
+                                      CeilAlign(s2L1RealSize - S2_BASIC_BLOCK_L0, (uint64_t)BLOCK_CUBE) :
+                                      (s2L1RealSize > S2_BASIC_BLOCK_L0 ?
+                                           S2_BASIC_BLOCK_L0 :
+                                           CeilAlign(s2L1RealSize, (uint64_t)BLOCK_CUBE)); // 对齐到16 单位block
+        nd2nzPara.dstNzNStride = 1;
+        nd2nzPara.srcNdMatrixStride = 0;
+        nd2nzPara.dstNzMatrixStride = 0;
+        DataCopy(keyL1_[(keyL1BufIdx_ % KEY_BUF_NUM) * KEY_BUFFER_OFFSET +
+                        (s2L1Offset >= S2_BASIC_BLOCK_L0 ?
+                             S2_BASIC_BLOCK_L0 * D_BASIC_BLOCK_L0 + (s2L1Offset - S2_BASIC_BLOCK_L0) * BLOCK_CUBE :
+                             s2L1Offset * BLOCK_CUBE)],
+                 keyGm_[keyGmOffset], nd2nzPara);
+
+        s2L1Offset += s2Mte2Size;
+    }
+}
+
+// batch, s1, n2, g, d
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::QueryNd2Nz(uint64_t s1gL1RealSize, uint64_t s1gGmOffset,
+                                                 const LICommon::RunInfo &runInfo)
+{
+    Nd2NzParams nd2nzPara;
+    nd2nzPara.ndNum = 1;
+    nd2nzPara.nValue = s1gL1RealSize; // 行数
+    nd2nzPara.dValue = constInfo_.headDim;
+    nd2nzPara.srcDValue = constInfo_.headDim;
+    nd2nzPara.dstNzC0Stride = CeilAlign(s1gL1RealSize, (uint64_t)BLOCK_CUBE); // 对齐到16 单位block
+    nd2nzPara.dstNzNStride = 1;
+    nd2nzPara.srcNdMatrixStride = 0;
+    nd2nzPara.dstNzMatrixStride = 0;
+    // 默认一块buf最多放两份
+    DataCopy(queryL1_[(queryL1Mte2BufIdx_ % QUERY_BUF_NUM) * QUERY_BUFFER_OFFSET],
+             queryGm_[runInfo.tensorQueryOffset + s1gGmOffset * constInfo_.headDim], nd2nzPara);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::LoadQueryToL0a(uint64_t s1gGmOffset,
+                                                     uint64_t s1gL1Offset, uint64_t s1gL1RealSize,
+                                                     uint64_t s1gL0RealSize, const LICommon::RunInfo &runInfo)
+{
+    LoadData3DParamsV2<Q_T> loadData3DParams;
+    // SetFmatrixParams
+    loadData3DParams.l1H = CeilDiv(s1gL1RealSize, BLOCK_CUBE); // Hin=M1=8
+    loadData3DParams.l1W = BLOCK_CUBE;                         // Win=M0
+    loadData3DParams.channelSize = constInfo_.headDim;         // Cin=K
+
+    loadData3DParams.padList[0] = 0;
+    loadData3DParams.padList[1] = 0;
+    loadData3DParams.padList[2] = 0;
+    loadData3DParams.padList[3] = 255; // 尾部数据不影响滑窗的结果
+
+    // SetLoadToA0Params
+    loadData3DParams.mExtension = CeilAlign(s1gL0RealSize, BLOCK_CUBE); // M height维度目的
+    loadData3DParams.kExtension = constInfo_.headDim;                   // K width维度目的
+    loadData3DParams.mStartPt = s1gL1Offset;
+    loadData3DParams.kStartPt = 0;
+    loadData3DParams.strideW = 1;
+    loadData3DParams.strideH = 1;
+    loadData3DParams.filterW = 1;
+    loadData3DParams.filterSizeW = (1 >> 8) & 255;
+    loadData3DParams.filterH = 1;
+    loadData3DParams.filterSizeH = (1 >> 8) & 255;
+    loadData3DParams.dilationFilterW = 1;
+    loadData3DParams.dilationFilterH = 1;
+    loadData3DParams.enTranspose = 0;
+    loadData3DParams.fMatrixCtrl = 0;
+
+    LoadData<Q_T, LOAD3DV2_CONFIG>(queryL0_[(l0BufIdx_ % L0_BUF_NUM) * L0AB_BUFFER_OFFSET],
+                                   queryL1_[(queryL1Mte1BufIdx_ % QUERY_BUF_NUM) * QUERY_BUFFER_OFFSET],
+                                   loadData3DParams);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::LoadKeyToL0b(uint64_t s2L1Offset,
+                                                   uint64_t s2L1RealSize, uint64_t s2L0RealSize,
+                                                   const LICommon::RunInfo &runInfo)
+{
+    uint64_t keyL1Offset = s2L1Offset >= S2_BASIC_BLOCK_L0 ? S2_BASIC_BLOCK_L0 * D_BASIC_BLOCK_L0 : 0;
+    LoadData2DParams loadData2DParams;
+    loadData2DParams.startIndex = 0;
+    loadData2DParams.repeatTimes = CeilDiv(s2L0RealSize, BLOCK_CUBE) * CeilDiv(constInfo_.headDim, BLOCK_CUBE);
+    loadData2DParams.srcStride = 1;
+    loadData2DParams.dstGap = 0;
+    loadData2DParams.ifTranspose = false;
+    LoadData(keyL0_[(l0BufIdx_ % L0_BUF_NUM) * L0AB_BUFFER_OFFSET],
+             keyL1_[(keyL1BufIdx_ % KEY_BUF_NUM) * KEY_BUFFER_OFFSET + keyL1Offset], loadData2DParams);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::ComuteL0c(uint64_t s1gL0RealSize, uint64_t s2L0RealSize,
+                                                const LICommon::RunInfo &runInfo)
+{
+    MmadParams mmadParams;
+    mmadParams.m = CeilAlign(s1gL0RealSize, BLOCK_CUBE);
+    mmadParams.n = s2L0RealSize;
+    mmadParams.k = constInfo_.headDim;
+    mmadParams.cmatrixInitVal = true;
+    mmadParams.cmatrixSource = false;
+    mmadParams.unitFlag = 0b11;
+    Mmad(cL0_[(l0BufIdx_ % L0_BUF_NUM) * L0C_BUFFER_OFFSET], queryL0_[(l0BufIdx_ % L0_BUF_NUM) * L0AB_BUFFER_OFFSET],
+         keyL0_[(l0BufIdx_ % L0_BUF_NUM) * L0AB_BUFFER_OFFSET], mmadParams);
+    if ((mmadParams.m / 16) * (mmadParams.n / 16) < 10) {
+        PipeBarrier<PIPE_M>();
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::Fixp(uint64_t s1gGmOffset,
+                                           uint64_t s2GmOffset, uint64_t s1gL0RealSize,
+                                           uint64_t s2L0RealSize, const LICommon::RunInfo &runInfo)
+{
+    AscendC::DataCopyCO12DstParams intriParams;
+    intriParams.mSize = CeilAlign(s1gL0RealSize, BLOCK_CUBE);
+    intriParams.nSize = s2L0RealSize;
+    intriParams.dstStride = runInfo.actualSingleProcessSInnerSizeAlign;
+    intriParams.srcStride = CeilAlign(s1gL0RealSize, BLOCK_CUBE);
+    // set mode according to dtype
+    intriParams.quantPre = QuantMode_t::NoQuant;
+    intriParams.nz2ndEn = true;
+    intriParams.unitFlag = 0b11; // 3 unitflag
+    intriParams.reluPre = 1;
+    AscendC::SetFixpipeNz2ndFlag(1, 1, 1);
+    AscendC::DataCopy(mm1ResGm_[(runInfo.loop % 2) * constInfo_.mBaseSizeAlign * constInfo_.s2BaseSize +
+                                s1gGmOffset * intriParams.dstStride + s2GmOffset],
+                      cL0_[(l0BufIdx_ % L0_BUF_NUM) * L0C_BUFFER_OFFSET], intriParams);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::AllocEventID()
+{
+    SetMMLayoutTransform(true);
+    SetFlag<HardEvent::MTE1_MTE2>(KEY_MTE1_MTE2_EVENT + 0);
+    SetFlag<HardEvent::MTE1_MTE2>(KEY_MTE1_MTE2_EVENT + 1);
+    SetFlag<HardEvent::MTE1_MTE2>(KEY_MTE1_MTE2_EVENT + 2);
+
+    SetFlag<HardEvent::MTE1_MTE2>(QUERY_MTE1_MTE2_EVENT + 0);
+    SetFlag<HardEvent::MTE1_MTE2>(QUERY_MTE1_MTE2_EVENT + 1);
+
+    SetFlag<HardEvent::M_MTE1>(M_MTE1_EVENT + 0);
+    SetFlag<HardEvent::M_MTE1>(M_MTE1_EVENT + 1);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::FreeEventID()
+{
+    SetMMLayoutTransform(false);
+    WaitFlag<HardEvent::MTE1_MTE2>(KEY_MTE1_MTE2_EVENT + 0);
+    WaitFlag<HardEvent::MTE1_MTE2>(KEY_MTE1_MTE2_EVENT + 1);
+    WaitFlag<HardEvent::MTE1_MTE2>(KEY_MTE1_MTE2_EVENT + 2);
+
+    WaitFlag<HardEvent::MTE1_MTE2>(QUERY_MTE1_MTE2_EVENT + 0);
+    WaitFlag<HardEvent::MTE1_MTE2>(QUERY_MTE1_MTE2_EVENT + 1);
+
+    WaitFlag<HardEvent::M_MTE1>(M_MTE1_EVENT + 0);
+    WaitFlag<HardEvent::M_MTE1>(M_MTE1_EVENT + 1);
+}
+} // namespace LIKernel
+}  // namespace sglang::npu_kernel::liv2
+#endif

--- a/csrc/lightning_indexer_v2/op_kernel/arch22/lightning_indexer_service_vector.h
+++ b/csrc/lightning_indexer_v2/op_kernel/arch22/lightning_indexer_service_vector.h
@@ -1,0 +1,709 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+/*!
+ * \file lightning_indexer_service_vector.h
+ * \brief
+ */
+#ifndef SGL_LI_V2_LIGHTNING_INDEXER_SERVICE_VECTOR_H
+#define SGL_LI_V2_LIGHTNING_INDEXER_SERVICE_VECTOR_H
+
+#include "kernel_operator.h"
+#include "kernel_operator_list_tensor_intf.h"
+#include "kernel_tiling/kernel_tiling.h"
+#include "lib/matmul_intf.h"
+#include "lib/matrix/matmul/tiling.h"
+#include "../lightning_indexer_v2_common.h"
+#include "lightning_indexer_vector.h"
+
+namespace sglang::npu_kernel::liv2 {
+
+namespace LIKernel {
+using namespace LICommon;
+using namespace LIServiceVec;
+constexpr uint32_t BASE_TOPK = 2048;
+constexpr uint32_t SPARSE_COUNT_4K = 4096;
+constexpr uint32_t LD_PARAM_NUM = 16;
+constexpr uint32_t EVENTID_V_TO_MTE2_PING = 0;
+constexpr uint32_t EVENTID_V_TO_MTE2_PONG = 1;
+constexpr uint32_t EVENTID_V_TO_MTE2_TMPUB = 2;
+
+// 主模板：Q_T必选，W_T可选（默认void），无论W_T传什么，默认weightsType=Q_T
+template<typename Q_T, typename W_T = void>
+struct LightningIndexerTypeTraits {
+    using weightsType = Q_T;   // 默认：weightsType绑定Q_T
+};
+
+// 偏特化1：固定第二个参数W_T=float，Q_T保留泛型
+template<typename Q_T>
+struct LightningIndexerTypeTraits<Q_T, float> {
+    using weightsType = float;  // W_T=float时，强制weightsType为float
+};
+
+template <typename LIT>
+class LightningIndexerServiceVector {
+public:
+    // =================================类型定义区=================================
+    // 中间计算数据类型为float，高精度模式
+    static constexpr bool DT_W_FLAG = LIT::weightsTypeFlag;
+    using Q_T = typename LIT::queryType;
+    using K_T = typename LIT::keyType;
+    static constexpr LI_LAYOUT LAYOUT_T = LIT::layout;
+    using W_T = typename LightningIndexerTypeTraits<Q_T,
+                                         typename std::conditional<DT_W_FLAG, float, void>::type>::weightsType;
+
+    // MM输出数据类型, 当前只支持float
+    using MM1_OUT_T = float;
+
+    __aicore__ inline LightningIndexerServiceVector(){};
+    __aicore__ inline void ProcessVec(const LICommon::RunInfo &info);
+    __aicore__ inline void ProcessLD();
+    __aicore__ inline void InitBuffers(TPipe *pipe);
+    __aicore__ inline void InitParams(const struct LICommon::ConstInfo &constInfo,
+                                      const LITilingData *__restrict tilingData);
+    __aicore__ inline void InitVec1GlobalTensor(GlobalTensor<MM1_OUT_T> mm1ResGm, GlobalTensor<float> vec1ResGm,
+                                                GlobalTensor<int64_t> vec1ParamGm, GlobalTensor<W_T> weightsGm,
+                                                GlobalTensor<int32_t> indiceOutGm, GlobalTensor<K_T> valueOutGm);
+    __aicore__ inline void CleanInvalidOutput(int64_t invalidS1offset);
+    __aicore__ inline void AllocEventID();
+    __aicore__ inline void FreeEventID();
+    __aicore__ inline void InitLDBuffers(TPipe *pipe);
+
+protected:
+    GlobalTensor<MM1_OUT_T> mm1ResGm;
+    GlobalTensor<float> vec1ResGm;
+    GlobalTensor<int64_t> vec1ParamGm;
+    GlobalTensor<W_T> weightsGm;
+    GlobalTensor<int32_t> indiceOutGm;
+    GlobalTensor<K_T> valueOutGm;
+    // =================================常量区=================================
+
+private:
+    // ================================Local Buffer区====================================
+    // queue
+    TQue<QuePosition::VECOUT, 1> outQueue_;
+
+    // tmp buff for vector
+    TBuf<TPosition::VECCALC> sortOutBuf_;
+    TBuf<TPosition::VECCALC> tmpBuf_;
+    TBuf<TPosition::VECCALC> indexBuf_;
+    TBuf<TPosition::VECCALC> reduceOutBuf_;
+    TBuf<TPosition::VECCALC> brcBuf_;
+    TBuf<TPosition::VECCALC> paramBuf_;
+
+    // tmp buff for LD
+    TBuf<> ldToBeMrgBuf_;
+    TBuf<> ldTmpBuf_;
+    TBuf<> ldOutValueBuf_;
+    TBuf<> ldOutIdxBuf_;
+
+    LocalTensor<float> tmpUb_;
+    LocalTensor<int32_t> globalTopkIndice_;
+    LocalTensor<float> globalTopkUb_;
+    LocalTensor<float> SortedBasicBlock_;
+
+    int32_t blockId_ = -1;
+    // para for vector
+    int32_t groupInner_ = 0;
+    int32_t globalTopkNum_ = 0;
+    int64_t blockS2StartIdx_ = 0;
+    int32_t gSize_ = 0;
+    int32_t kHeadNum_ = 0;
+    int32_t s1BaseSize_ = 0;
+    int32_t s2BaseSize_ = 0;
+
+    // para for LD
+    uint32_t mrgListNum_ = 4;
+    uint32_t paramNum_ = 16;
+    int32_t virTopK = 0;
+
+    constexpr static uint32_t REDUCE_BANK_CONFLICT_OFFSETS = 256;
+    constexpr static uint32_t REDUCE_BANK_CONFLICT_NUM = REDUCE_BANK_CONFLICT_OFFSETS / sizeof(float);
+
+    struct LICommon::ConstInfo constInfo_;
+};
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceVector<LIT>::InitBuffers(TPipe *pipe)
+{
+    uint32_t outNeedBufSize = (BASE_TOPK * 2) * 2 * sizeof(float);
+    uint32_t reduceCacheSize = REDUCE_BANK_CONFLICT_OFFSETS + groupInner_ * s2BaseSize_ * sizeof(float);
+    outNeedBufSize = reduceCacheSize > outNeedBufSize ? reduceCacheSize : outNeedBufSize;
+    virTopK = constInfo_.isSparseCountOver2K ? constInfo_.sparseCount : BASE_TOPK;
+
+    pipe->InitBuffer(outQueue_, 1, outNeedBufSize);                                            // 32KB  extract
+    // 68KB 在搬运cube核计算得到的结果和weight时，分成两块34KB，用于db；在mrgsort时，用作临时UB
+    pipe->InitBuffer(tmpBuf_, (groupInner_ * s2BaseSize_ + s2BaseSize_) * 2 * sizeof(float));
+    pipe->InitBuffer(sortOutBuf_, CeilDiv(s1BaseSize_, 2) * virTopK * 2 * sizeof(float));    // 64KB
+    pipe->InitBuffer(indexBuf_, s2BaseSize_ * sizeof(int32_t));                                // 2KB
+    pipe->InitBuffer(reduceOutBuf_, s2BaseSize_ * 2 * sizeof(float));                          // 4KB
+    pipe->InitBuffer(brcBuf_, groupInner_ * 8 * sizeof(float));
+    pipe->InitBuffer(paramBuf_, LD_PARAM_NUM * sizeof(int64_t));
+
+    tmpUb_ = tmpBuf_.Get<float>();
+    globalTopkIndice_ = indexBuf_.Get<int32_t>();
+    globalTopkUb_ = sortOutBuf_.Get<float>();
+    SortedBasicBlock_ = globalTopkUb_[virTopK * 2 * 2];
+    globalTopkNum_ = 0;
+
+    // 基本块执行前初始化UB和GM
+    // step1. 初始化一个有序索引 0 - s2BaseSize_
+    ArithProgression<int32_t>(globalTopkIndice_, 0, 1, s2BaseSize_);
+    // step2. globalTopkUb_ [CeilDiv(s1BaseSize_, 2), BASE_TOPK, 2]   -inf,-1
+    InitSortOutBuf(globalTopkUb_, CeilDiv(s1BaseSize_, 2) * virTopK * 2);
+
+    // step3. 初始化vec1ParamGm，是否进行LD的标志位设为-1(needFd=-1)
+    // vec1ResIn32Gm = [aic, 2, s1BaseSize_, 16] int32
+    // ws清零 [needFd, s2AcSeq, s2Start, s2End, isS2End, bn2idx, s1Idx, ......]
+    LocalTensor<float> tmpBuff = outQueue_.AllocTensor<float>();
+    Duplicate(tmpBuff.template ReinterpretCast<int32_t>(), -1, 2 * (s1BaseSize_ / 2) * paramNum_ * 2);
+    outQueue_.EnQue<float>(tmpBuff);
+    tmpBuff = outQueue_.DeQue<float>();
+    int64_t wsInfoOffset = (blockId_ / 2) * s1BaseSize_ * 2 * paramNum_ +      // 2个AIV共同地址偏移
+                           (blockId_ % 2) * (s1BaseSize_ / 2) * 2 * paramNum_; // 每个AIV的地址偏移，S1方向
+    DataCopyPad(vec1ParamGm[wsInfoOffset], tmpBuff.template ReinterpretCast<int64_t>(),
+                {1, static_cast<uint16_t>((s1BaseSize_ / 2) * 2 * paramNum_ * sizeof(int64_t)), 0, 0});
+    outQueue_.FreeTensor(tmpBuff);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceVector<LIT>::InitLDBuffers(TPipe *pipe)
+{
+    pipe->Reset();
+    pipe->InitBuffer(ldToBeMrgBuf_, 2 * BASE_TOPK * mrgListNum_ * sizeof(float)); // 2：value + index
+    pipe->InitBuffer(ldTmpBuf_, 2 * BASE_TOPK * mrgListNum_ * sizeof(float));     // 2：value + index
+    pipe->InitBuffer(ldOutValueBuf_, BASE_TOPK * sizeof(float));
+    pipe->InitBuffer(ldOutIdxBuf_, BASE_TOPK * sizeof(int32_t));
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceVector<LIT>::InitParams(const struct LICommon::ConstInfo &constInfo,
+                                                 const LITilingData *__restrict tilingData)
+{
+    this->constInfo_ = constInfo;
+    blockS2StartIdx_ = 0;
+    gSize_ = constInfo.gSize;
+    // define N2 para
+    kHeadNum_ = constInfo.kHeadNum;
+    // define MMBase para
+    s1BaseSize_ = constInfo.s1BaseSize;
+    s2BaseSize_ = constInfo.s2BaseSize;
+
+    // group ub 切分因子当前按照UB空间强制为16
+    groupInner_ = 16;
+
+    blockId_ = GetBlockIdx();
+}
+
+template <typename LIT>
+__aicore__ inline void
+LightningIndexerServiceVector<LIT>::InitVec1GlobalTensor(GlobalTensor<MM1_OUT_T> mm1ResGm,
+                                    GlobalTensor<float> vec1ResGm,
+                                    GlobalTensor<int64_t> vec1ParamGm, GlobalTensor<W_T> weightsGm,
+                                    GlobalTensor<int32_t> indiceOutGm, GlobalTensor<K_T> valueOutGm)
+{
+    this->mm1ResGm = mm1ResGm;
+    this->vec1ResGm = vec1ResGm;
+    this->vec1ParamGm = vec1ParamGm;
+    this->weightsGm = weightsGm;
+    this->indiceOutGm = indiceOutGm;
+    this->valueOutGm = valueOutGm;
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceVector<LIT>::AllocEventID()
+{
+    SetFlag<HardEvent::V_MTE2>(EVENTID_V_TO_MTE2_PING);
+    SetFlag<HardEvent::V_MTE2>(EVENTID_V_TO_MTE2_PONG);
+    SetFlag<HardEvent::V_MTE2>(EVENTID_V_TO_MTE2_TMPUB);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceVector<LIT>::FreeEventID()
+{
+    WaitFlag<HardEvent::V_MTE2>(EVENTID_V_TO_MTE2_PING);
+    WaitFlag<HardEvent::V_MTE2>(EVENTID_V_TO_MTE2_PONG);
+    WaitFlag<HardEvent::V_MTE2>(EVENTID_V_TO_MTE2_TMPUB);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceVector<LIT>::CleanInvalidOutput(int64_t invalidS1offset)
+{
+    // init -1 and copy to output
+    LocalTensor<float> valueULocal = outQueue_.AllocTensor<float>();
+    LocalTensor<int32_t> idxULocal1 = valueULocal.template ReinterpretCast<int32_t>();
+    Duplicate(idxULocal1, constInfo_.INVALID_IDX, constInfo_.sparseCount);
+    outQueue_.EnQue<float>(valueULocal);
+    valueULocal = outQueue_.DeQue<float>();
+    LIServiceVec::CopyOut(indiceOutGm[invalidS1offset], idxULocal1, constInfo_.sparseCount);
+    outQueue_.FreeTensor(valueULocal);
+
+    if (constInfo_.returnValue) {
+        uint16_t negInf = 0;
+        if constexpr(std::is_same<K_T, float16_t>::value) {
+            negInf = 0xFC00;
+        } else {
+            negInf = 0xFF80;
+        }
+        LocalTensor<uint16_t> valueULocal = outQueue_.AllocTensor<uint16_t>();
+        Duplicate(valueULocal, negInf, constInfo_.sparseCount);
+        outQueue_.EnQue<uint16_t>(valueULocal);
+        valueULocal = outQueue_.DeQue<uint16_t>();
+        GlobalTensor<uint16_t> valueOutGmTmp;
+        valueOutGmTmp.SetGlobalBuffer((__gm__ uint16_t *)valueOutGm.GetPhyAddr());
+        LIServiceVec::CopyOut(valueOutGmTmp[invalidS1offset], valueULocal, constInfo_.sparseCount);
+        outQueue_.FreeTensor(valueULocal);
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceVector<LIT>::ProcessVec(const LICommon::RunInfo &info)
+{
+    int32_t cuBaseS1Idx = info.gS1Idx * s1BaseSize_;
+    int32_t cuBaseS2Idx = info.s2Idx * s2BaseSize_;
+
+    // 计算基本块基地址偏移 偶数循环 -> 0 + aic_offset  奇数循环 -> 512*512 + aic_offset
+    int64_t mmGmOffset = (info.loop % 2) * (constInfo_.mBaseSizeAlign * s2BaseSize_);
+    // (B,S1,N1,1);(T,N1,1) -> (B,S1,N2,G,1) 当前只切分到S1轴
+    int64_t weightGmOffset = info.tensorWeightsOffset + cuBaseS1Idx * kHeadNum_ * gSize_;
+
+    PipeBarrier<PIPE_V>();
+    // cuS1BeginIdxPerAiv: 每个AIV的S1起始偏移
+    int32_t cuS1BeginIdxPerAiv = cuBaseS1Idx;
+    int32_t cuS1ProcNum =
+        cuS1BeginIdxPerAiv + s1BaseSize_ > info.actS1Size ? info.actS1Size % s1BaseSize_ : s1BaseSize_;
+    // cuS1ProcNumPerAiv: 每个AIv的S1计算量
+    int32_t cuS1ProcNumPerAiv = blockId_ % 2 == 0 ? CeilDiv(cuS1ProcNum, 2) : (cuS1ProcNum / 2);
+    cuS1BeginIdxPerAiv += (blockId_ % 2) * CeilDiv(cuS1ProcNum, 2);
+
+    // 基本块基地址偏移奇数核加一个S1地址偏移
+    weightGmOffset += (blockId_ % 2) * CeilDiv(cuS1ProcNum, 2) * kHeadNum_ * gSize_;
+    mmGmOffset += (blockId_ % 2) * CeilDiv(cuS1ProcNum, 2) * gSize_ * info.actualSingleProcessSInnerSizeAlign;
+
+    // cut G
+    int32_t outerG = CeilDiv(gSize_, groupInner_);
+
+    // 非首个基本块, M(S1)轴发生切换需要初始化
+    if (info.loop != 0 && info.s2Idx == 0) {
+        // globalTopkUb_ value,index=-inf,-1
+        InitSortOutBuf(globalTopkUb_, CeilDiv(s1BaseSize_, 2) * virTopK * 2);
+        blockS2StartIdx_ = 0;
+    } else if (info.loop == 0) {
+        blockS2StartIdx_ = info.s2Idx;
+    }
+    // cuRealAcSeq: 当前基本块S1对应的AcSeq
+    int32_t cuRealAcSeq = info.actS2Size;
+    if (constInfo_.attenMaskFlag) {
+        // attenMask true场景
+        cuRealAcSeq = info.actS2Size - (info.actS1Size - cuS1BeginIdxPerAiv);
+    }
+    LocalTensor<float> reduceOutBuff = reduceOutBuf_.Get<float>();
+    LocalTensor<float> brcBuf = brcBuf_.Get<float>();
+    // LD输出S1方向偏移，保证2个Vector输出的内容连续
+    uint32_t ldS1Offset = (blockId_ % 2 == 0) ? s1BaseSize_ / 2 - cuS1ProcNumPerAiv : 0;
+    for (int innerS1Idx = 0; innerS1Idx < cuS1ProcNumPerAiv; innerS1Idx++) {
+        if (constInfo_.attenMaskFlag) {
+            cuRealAcSeq += 1;
+        }
+        int32_t cuS2Len = cuBaseS2Idx + s2BaseSize_ >= cuRealAcSeq ? cuRealAcSeq - cuBaseS2Idx : s2BaseSize_;
+        int32_t cuS1Idx = cuS1BeginIdxPerAiv + innerS1Idx;
+        if (cuRealAcSeq > 0 && cuS2Len > 0) {
+            int32_t cuS2LenVecAlign = CeilDiv(cuS2Len, s2BaseSize_) * s2BaseSize_;
+            int32_t mmUbStride = (cuS2LenVecAlign - info.actualSingleProcessSInnerSizeAlign) / B32_BLOCK_ALIGN_NUM;
+            LocalTensor<float> reduceOutInner = reduceOutBuff[s2BaseSize_];
+            PipeBarrier<PIPE_V>();
+            LocalTensor<float> reduceCacheBuf = outQueue_.AllocTensor<float>();
+            if (constInfo_.isSparseCountOver2K) {
+                WaitFlag<HardEvent::V_MTE2>(EVENTID_V_TO_MTE2_TMPUB);
+            }
+            for (int outerGidx = 0; outerGidx < outerG; outerGidx++) {
+                int32_t procGnum = outerGidx != outerG - 1 ? groupInner_ : gSize_ - outerGidx * groupInner_;
+
+                int32_t pingpong = outerGidx % 2;
+                LocalTensor<float> dbTmpUb = tmpUb_[pingpong * (groupInner_ * s2BaseSize_ + s2BaseSize_)];
+                LocalTensor<float> weightsInUb = dbTmpUb[procGnum * s2BaseSize_];
+                WaitFlag<HardEvent::V_MTE2>(pingpong);
+                LocalTensor<W_T> weightsInTUb = weightsInUb.template ReinterpretCast<W_T>();
+                if constexpr (!IsSameType<W_T, float>::value) {
+                    weightsInTUb = weightsInTUb[groupInner_];
+                }
+                int64_t mmGmAllOffet = mmGmOffset + innerS1Idx * gSize_ * info.actualSingleProcessSInnerSizeAlign +
+                                       outerGidx * groupInner_ * info.actualSingleProcessSInnerSizeAlign;
+                int64_t weightGmAllOffset = weightGmOffset + innerS1Idx * gSize_ + outerGidx * groupInner_;
+
+                LIServiceVec::CopyIn(dbTmpUb, weightsInTUb, mm1ResGm, weightsGm, mmGmAllOffet, weightGmAllOffset,
+                                     procGnum, info.actualSingleProcessSInnerSizeAlign, mmUbStride);
+
+                SetFlag<HardEvent::MTE2_V>(pingpong);
+                WaitFlag<HardEvent::MTE2_V>(pingpong);
+                LIServiceVec::DoScale(reduceCacheBuf[REDUCE_BANK_CONFLICT_NUM], dbTmpUb, weightsInUb, weightsInTUb,
+                                      brcBuf, procGnum, s2BaseSize_, outerGidx);
+                // confused reduceOp in DoScale
+                // neednot use LIServiceVec::doReduce(mmInUb, reduceOutInner, procGnum, (s2BaseSize_+8));
+                SetFlag<HardEvent::V_MTE2>(pingpong);
+            }
+
+            int32_t gRedCnt = groupInner_ > gSize_ ? gSize_ : groupInner_;
+            bool isS2End = cuBaseS2Idx + s2BaseSize_ >= cuRealAcSeq;
+            LIServiceVec::DoReduce(reduceCacheBuf[REDUCE_BANK_CONFLICT_NUM], reduceOutInner, gRedCnt, s2BaseSize_);
+            outQueue_.FreeTensor(reduceCacheBuf);
+
+            LocalTensor<float> sortScoreUb = reduceOutBuff;
+            LocalTensor<float> sortIndiceUb = reduceOutBuff[cuS2LenVecAlign];
+            Duplicate(sortScoreUb.template ReinterpretCast<int32_t>(), LIServiceVec::NEG_INF, cuS2LenVecAlign);
+            PipeBarrier<PIPE_V>();
+            Adds(sortScoreUb, reduceOutInner, 0.0f, cuS2Len);
+            PipeBarrier<PIPE_V>();
+            LocalTensor<int32_t> sortIndiceUbInt = sortIndiceUb.template ReinterpretCast<int32_t>();
+            // 无效数据索引填充为-1
+            if (cuS2LenVecAlign != cuS2Len) {
+                Duplicate(sortIndiceUbInt, -1, cuS2LenVecAlign);
+            }
+            PipeBarrier<PIPE_V>();
+            Adds(sortIndiceUbInt, globalTopkIndice_, static_cast<int32_t>(cuBaseS2Idx), cuS2Len);
+            PipeBarrier<PIPE_V>();
+
+            LocalTensor<float> tmpSortBuf = outQueue_.AllocTensor<float>();
+            if (info.actS1Size > 4 || constInfo_.isSparseCountOver2K) {
+                // info.actS1Size > 4 则单个vector核内处理的 s1>2，缓存方案无法处理
+                LIServiceVec::SortAll(reduceOutBuff, tmpSortBuf,
+                                      cuS2LenVecAlign); //  cuS2LenVecAlign <= s2BaseSize_, fill -inf
+                PipeBarrier<PIPE_V>();
+                LocalTensor<float> UbTmpSort = constInfo_.isSparseCountOver2K ? tmpUb_ : tmpSortBuf;
+                LIServiceVec::MergeSort(globalTopkUb_[innerS1Idx * virTopK * 2], virTopK, reduceOutBuff,
+                                        cuS2LenVecAlign, UbTmpSort);
+            } else {
+                int64_t globalTopkUbCacheIdx = (info.s2Idx - blockS2StartIdx_) % 4;
+                Sort<float, true>(
+                    SortedBasicBlock_[innerS1Idx * BASE_TOPK * 2 + globalTopkUbCacheIdx * s2BaseSize_ * 2],
+                    reduceOutBuff, sortIndiceUbInt.template ReinterpretCast<uint32_t>(), tmpSortBuf,
+                    cuS2LenVecAlign / 32);
+                AscendC::PipeBarrier<PIPE_V>();
+                // 缓存4块512或者S2结束, 需要进行精排
+                if (globalTopkUbCacheIdx == 3 || isS2End || info.isAllLoopEnd) {
+                    LocalTensor<float> tt = SortedBasicBlock_[innerS1Idx * BASE_TOPK * 2];
+                    // 前4块直接精排覆盖到globalTopkUb_
+                    if (info.s2Idx - blockS2StartIdx_ < 4) {
+                        MrgBasicBlock(globalTopkUb_[innerS1Idx * BASE_TOPK * 2], tt,
+                                      static_cast<int64_t>(globalTopkUbCacheIdx + 1), s2BaseSize_);
+                    } else { // 后面缓存在 SortedBasicBlock_, 先精排, 再merge到globalTopkUb_
+                        if (globalTopkUbCacheIdx > 0) {
+                            MrgBasicBlock(tmpSortBuf, tt, static_cast<int64_t>(globalTopkUbCacheIdx + 1), s2BaseSize_);
+                            PipeBarrier<PIPE_V>();
+                            DataCopy(SortedBasicBlock_[innerS1Idx * BASE_TOPK * 2], tmpSortBuf,
+                                     (globalTopkUbCacheIdx + 1) * s2BaseSize_ * 2);
+                        }
+                        PipeBarrier<PIPE_V>();
+                        SparseTopK(globalTopkUb_[innerS1Idx * BASE_TOPK * 2],
+                                   SortedBasicBlock_[innerS1Idx * BASE_TOPK * 2], tmpSortBuf, BASE_TOPK,
+                                   s2BaseSize_ * (globalTopkUbCacheIdx + 1));
+                    }
+                }
+            }
+            if (constInfo_.isSparseCountOver2K) {
+                SetFlag<HardEvent::V_MTE2>(EVENTID_V_TO_MTE2_TMPUB);
+            }
+
+            PipeBarrier<PIPE_V>();
+            outQueue_.FreeTensor(tmpSortBuf);
+
+            bool needCopyOutGm = blockS2StartIdx_ == 0 && isS2End;
+
+            // 中间结果保存
+            bool needCopyWsGm = info.isAllLoopEnd || isS2End;
+
+            if (needCopyOutGm) {
+                int64_t offset = (constInfo_.sparseCount <= SPARSE_COUNT_4K) ? virTopK : constInfo_.sparseCount / 2;
+                int64_t copyLen = (constInfo_.sparseCount <= SPARSE_COUNT_4K)
+                                ? constInfo_.sparseCount
+                                : constInfo_.sparseCount / 2;
+                int64_t copyNum = (constInfo_.sparseCount <= SPARSE_COUNT_4K) ? 1 : 2;
+                for (int64_t i = 0; i < copyNum; i++) {
+                    LocalTensor<float> outValueUb = outQueue_.AllocTensor<float>();
+                    LocalTensor<uint32_t> outIdxUb = outValueUb[offset].template ReinterpretCast<uint32_t>();
+                    Extract(outValueUb, outIdxUb,
+                     globalTopkUb_[innerS1Idx * virTopK * 2 + 2 * i * offset], (offset /32));
+
+                    LocalTensor<K_T> valueULocal1 = outValueUb.template ReinterpretCast<K_T>();
+                    if (constInfo_.returnValue) {
+                        PipeBarrier<PIPE_V>();
+                        Cast(valueULocal1, outValueUb, RoundMode::CAST_ROUND, copyLen);
+                    }
+
+                    LocalTensor<int32_t> idxULocal1 = outValueUb[offset].template ReinterpretCast<int32_t>();
+                    outQueue_.EnQue<float>(outValueUb);
+                    outValueUb = outQueue_.DeQue<float>();
+
+                    LIServiceVec::CopyOut(indiceOutGm[info.indiceOutOffset + cuS1Idx *
+                                                         constInfo_.sparseCount + i * offset],
+                                        idxULocal1, copyLen);
+                    if (constInfo_.returnValue) {
+                        LIServiceVec::CopyOut(valueOutGm[info.indiceOutOffset + cuS1Idx *
+                                                             constInfo_.sparseCount + i * offset],
+                                        valueULocal1, copyLen);
+                    }
+                    outQueue_.FreeTensor(outValueUb);
+                }
+            } else if (needCopyWsGm) {
+                // vec1Res Gm = [aic, s1BaseSize_, 2, 2, topkOut_] float32
+                // vec1Param Gm = [aic, s1BaseSize_, 2, 16] int64
+                //     16 = [needFd, s2AcSeq, s2Start, s2End, isS2End, bn2idx, s1Idx, S1ProcNum, ......]
+
+                int64_t wsOffset = (blockId_ / 2) * s1BaseSize_ * 2 * 2 * BASE_TOPK +       // 2个AIV共同地址偏移
+                                   (blockId_ % 2) * (s1BaseSize_ / 2) * 2 * 2 * BASE_TOPK + // 每个AIV的地址偏移，S1方向
+                                   (ldS1Offset + innerS1Idx) * 2 * 2 * BASE_TOPK;
+                int64_t wsInfoOffset = (blockId_ / 2) * s1BaseSize_ * 2 * paramNum_ +       // 2个AIV共同地址偏移
+                                       (blockId_ % 2) * (s1BaseSize_ / 2) * 2 * paramNum_ + // 每个AIV的地址偏移，S1方向
+                                       (ldS1Offset + innerS1Idx) * 2 * paramNum_;
+
+                LocalTensor<int64_t> tmpiBuff = paramBuf_.Get<int64_t>();
+                SetWaitFlag<HardEvent::MTE3_S>(HardEvent::MTE3_S);
+                tmpiBuff.SetValue(0, static_cast<int64_t>(1));
+                tmpiBuff.SetValue(1, static_cast<int64_t>(cuRealAcSeq));
+                tmpiBuff.SetValue(2, static_cast<int64_t>(blockS2StartIdx_));
+                tmpiBuff.SetValue(3, static_cast<int64_t>(cuBaseS2Idx + cuS2Len));
+                tmpiBuff.SetValue(4, static_cast<int64_t>(isS2End));
+                tmpiBuff.SetValue(5, static_cast<int64_t>(info.bN2Idx));
+                tmpiBuff.SetValue(6, static_cast<int64_t>(cuS1Idx));
+                tmpiBuff.SetValue(7, static_cast<int64_t>(cuS1ProcNum));
+                tmpiBuff.SetValue(8, static_cast<int64_t>(info.indiceOutOffset + cuS1Idx * constInfo_.sparseCount));
+                // 写入头尾判断
+                // [head, tail]
+                // head: 与前面规约，与前后规约
+                // tail: 与后面规约
+                bool isTailReduce = blockS2StartIdx_ == 0; // 一定是isLastTile
+                // WS偏移规则 blockS2StartIdx_ != 0
+                // 跟前面块做规约 写到0偏移 不用做计算 blockS2StartIdx_ == 0 and !isS2End
+                // 跟后面块做规约 写到1偏移  需要 + s1BaseSize_, BASE_TOPK*2
+                if (isTailReduce) { // S2不是最后结束的数据就需要往后做规约，放入第二块ws
+                    wsInfoOffset += paramNum_;
+                    wsOffset += 2 * BASE_TOPK;
+                }
+                SetWaitFlag<HardEvent::S_MTE3>(HardEvent::S_MTE3);
+                LIServiceVec::CopyOut(vec1ParamGm[wsInfoOffset], tmpiBuff, 16);
+                SetWaitFlag<HardEvent::V_MTE3>(HardEvent::V_MTE3);
+                LIServiceVec::CopyOut(vec1ResGm[wsOffset], globalTopkUb_[innerS1Idx * BASE_TOPK * 2], 2 * BASE_TOPK);
+                SetWaitFlag<HardEvent::MTE3_V>(HardEvent::MTE3_V);
+            }
+        } else if (cuRealAcSeq <= 0) {
+            CleanInvalidOutput(info.indiceOutOffset + cuS1Idx * constInfo_.sparseCount);
+        }
+    }
+
+    // BNSD场景无效S1 输出-1
+    if (LAYOUT_T == LI_LAYOUT::BSND) {
+        // 最后一个S1的基本块, 需要 >= info.actS1Size
+        bool isS1LoopEnd = (cuBaseS1Idx + s1BaseSize_) >= info.actS1Size;
+        int32_t invalidS1Num = constInfo_.qSeqSize - info.actS1Size;
+        // blockS2StartIdx_ == 0 控制S2从开始的核去做冗余清理
+        if (invalidS1Num > 0 && isS1LoopEnd && blockS2StartIdx_ == 0) {
+            int32_t s1NumPerAiv = blockId_ % 2 == 0 ? CeilDiv(invalidS1Num, 2) : (invalidS1Num / 2);
+            int32_t s1OffsetPerAiv = info.actS1Size + (blockId_ % 2) * CeilDiv(invalidS1Num, 2);
+            for (int innerS1Idx = 0; innerS1Idx < s1NumPerAiv; innerS1Idx++) {
+                CleanInvalidOutput(info.indiceOutOffset + (s1OffsetPerAiv + innerS1Idx) * constInfo_.sparseCount);
+            }
+        }
+
+        int32_t invalidS1Num2 = info.actS1Size - info.actS2Size;
+        if (invalidS1Num2 > 0 && isS1LoopEnd && blockS2StartIdx_ == 0 && constInfo_.attenMaskFlag) {
+            int32_t s1NumPerAiv = blockId_ % 2 == 0 ? CeilDiv(invalidS1Num2, 2) : (invalidS1Num2 / 2);
+            int32_t s1OffsetPerAiv = (blockId_ % 2) * CeilDiv(invalidS1Num2, 2);
+            for (int innerS1Idx = 0; innerS1Idx < s1NumPerAiv; innerS1Idx++) {
+                CleanInvalidOutput((info.bN2Idx * constInfo_.qSeqSize + s1OffsetPerAiv + innerS1Idx) *
+                                   constInfo_.sparseCount);
+            }
+        }
+    }
+
+    if (info.isLastS2InnerLoop) {
+        // S2最后一个Loop后, 下一个基本块初始从0开始
+        blockS2StartIdx_ = 0;
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceVector<LIT>::ProcessLD()
+{
+    int32_t curCubeId = blockId_ / 2;
+    int32_t tmpCubeId = curCubeId;
+
+    int64_t s2ActSeq;
+    int64_t s2Start;
+    int64_t s2End;
+    int64_t isS2End;
+    int64_t bn2Idx;
+    int64_t s1Idx;
+    uint32_t acc_list_num = 0;
+    int64_t bIdx = 0;
+    int64_t needFd;
+    int64_t wsOffset;
+    int64_t wsInfoOffset = 0;
+    int64_t nextneedFd;
+    int64_t valueOffset = 0;
+    int64_t outOffset = 0;
+
+    LocalTensor<float> curValueIdxUb = ldToBeMrgBuf_.Get<float>();
+    LocalTensor<float> tmpUb = ldTmpBuf_.Get<float>();
+
+    // S2开头信息
+    // 开始必然没有头规约，因此从尾规约开始处理，while循环读取下一个核的头规约
+    // 存满4个list或者遇到S2结尾，则做merge，直到做完S2
+    // 每个核都忽略自己的头规约，因为必然由前面的核做完
+    uint32_t s1LdStartIdx = 0;
+    uint32_t s1ProcNum = 0;
+    uint64_t paramGmCoreOffset = tmpCubeId * s1BaseSize_ * 2 * paramNum_;
+    for (uint32_t innerS1Idx = 0; innerS1Idx < s1BaseSize_; innerS1Idx++) {
+        needFd = vec1ParamGm.GetValue(paramGmCoreOffset + innerS1Idx * 2 * paramNum_ + paramNum_);
+        if (needFd == 1) {
+            s1LdStartIdx = (s1ProcNum == 0) ? innerS1Idx : s1LdStartIdx;
+            s1ProcNum++;
+        }
+    }
+
+    if (s1ProcNum == 0) {
+        return;
+    }
+
+    // S1逐行计算
+    uint32_t s1VecNum = CeilDiv(s1ProcNum, 2);
+    if (blockId_ % 2 == 1) {
+        s1LdStartIdx = s1LdStartIdx + s1VecNum;
+        s1VecNum = s1ProcNum - s1VecNum;
+    }
+    for (uint32_t innerS1Idx = s1LdStartIdx; innerS1Idx < s1LdStartIdx + s1VecNum; innerS1Idx++) {
+        // 重置偏移
+        tmpCubeId = curCubeId;
+        acc_list_num = 0;
+        valueOffset = 0;
+
+        // 搬入数据
+        wsOffset = tmpCubeId * s1BaseSize_ * 2 * 2 * BASE_TOPK + // 2个AIV共同地址偏移
+                   innerS1Idx * 2 * 2 * BASE_TOPK + 2 * BASE_TOPK;
+        SetWaitFlag<HardEvent::V_MTE2>(HardEvent::V_MTE2);
+        SetWaitFlag<HardEvent::S_MTE2>(HardEvent::S_MTE2);
+        DataCopyPad(curValueIdxUb, vec1ResGm[wsOffset],
+                    {1, static_cast<uint16_t>(2 * BASE_TOPK * sizeof(int32_t)), 0, 0}, {true, 0, 0, 0});
+        acc_list_num++;
+        valueOffset += 2 * BASE_TOPK;
+
+        // 获取下一个核规约信息
+        tmpCubeId++;
+        wsInfoOffset = tmpCubeId * s1BaseSize_ * 2 * paramNum_ + innerS1Idx * 2 * paramNum_;
+        needFd = vec1ParamGm.GetValue(wsInfoOffset);
+        isS2End = vec1ParamGm.GetValue(wsInfoOffset + 4);
+        s1Idx = vec1ParamGm.GetValue(wsInfoOffset + 6);
+        outOffset = vec1ParamGm.GetValue(wsInfoOffset + 8);
+
+        while (needFd == 1) {
+            // 搬入头规约数据
+            wsOffset = tmpCubeId * s1BaseSize_ * 2 * 2 * BASE_TOPK + // 2个AIV共同地址偏移
+                       innerS1Idx * 2 * 2 * BASE_TOPK;
+            SetWaitFlag<HardEvent::V_MTE2>(HardEvent::V_MTE2);
+            SetWaitFlag<HardEvent::S_MTE2>(HardEvent::S_MTE2);
+            DataCopyPad(curValueIdxUb[valueOffset], vec1ResGm[wsOffset],
+                        {1, static_cast<uint16_t>(2 * BASE_TOPK * sizeof(int32_t)), 0, 0}, {true, 0, 0, 0});
+            valueOffset += 2 * BASE_TOPK;
+            acc_list_num++;
+
+            // 每满4个list，聚合  前2K为mrg结果
+            if (acc_list_num == mrgListNum_) {
+                // MrgSort 四条2048的队列，Mrg成一条
+                AscendC::MrgSort4Info params;
+                params.elementLengths[0] = BASE_TOPK;
+                params.elementLengths[1] = BASE_TOPK;
+                params.elementLengths[2] = BASE_TOPK;
+                params.elementLengths[3] = BASE_TOPK;
+                params.ifExhaustedSuspension = true;
+                params.validBit = 0b1111;
+                params.repeatTimes = 1;
+
+                AscendC::MrgSortSrcList<float> srcList;
+                srcList.src1 = curValueIdxUb[0];
+                srcList.src2 = curValueIdxUb[2 * BASE_TOPK];
+                srcList.src3 = curValueIdxUb[4 * BASE_TOPK];
+                srcList.src4 = curValueIdxUb[6 * BASE_TOPK];
+                SetWaitFlag<HardEvent::MTE2_V>(HardEvent::MTE2_V);
+                MrgSort(tmpUb, srcList, params);
+                PipeBarrier<PIPE_V>();
+                DataCopy(curValueIdxUb, tmpUb, 2 * BASE_TOPK);
+                PipeBarrier<PIPE_V>();
+                acc_list_num = 1;
+                valueOffset = 2 * BASE_TOPK;
+            }
+
+            // reduce到S2末尾，则跳出
+            if (isS2End == 1) {
+                break;
+            }
+
+            tmpCubeId++;
+            wsInfoOffset = tmpCubeId * s1BaseSize_ * 2 * paramNum_ + innerS1Idx * 2 * paramNum_;
+            needFd = vec1ParamGm.GetValue(wsInfoOffset);
+            isS2End = vec1ParamGm.GetValue(wsInfoOffset + 4);
+        }
+
+        // mrg不足4个list的数据
+        if (acc_list_num != 1) {
+            AscendC::MrgSort4Info params;
+            params.elementLengths[0] = BASE_TOPK;
+            params.elementLengths[1] = BASE_TOPK;
+            params.elementLengths[2] = BASE_TOPK;
+            params.elementLengths[3] = BASE_TOPK;
+            params.ifExhaustedSuspension = true;
+            if (acc_list_num == 2) {
+                params.validBit = 0b0011;
+            } else if (acc_list_num == 3) {
+                params.validBit = 0b0111;
+            }
+            params.repeatTimes = 1;
+
+            AscendC::MrgSortSrcList<float> srcList;
+            srcList.src1 = curValueIdxUb[0];
+            srcList.src2 = curValueIdxUb[2 * BASE_TOPK];
+            srcList.src3 = curValueIdxUb[4 * BASE_TOPK];
+            srcList.src4 = curValueIdxUb[6 * BASE_TOPK];
+            SetWaitFlag<HardEvent::MTE2_V>(HardEvent::MTE2_V);
+            MrgSort(tmpUb, srcList, params);
+            PipeBarrier<PIPE_V>();
+            DataCopy(curValueIdxUb, tmpUb, 2 * BASE_TOPK);
+            PipeBarrier<PIPE_V>();
+        }
+
+        // 搬出
+        LocalTensor<float> outValueUb = ldOutValueBuf_.Get<float>();
+        LocalTensor<uint32_t> outIdxUb = ldOutIdxBuf_.Get<uint32_t>();
+        if (!constInfo_.returnValue) {
+            Extract(outValueUb, outIdxUb, curValueIdxUb, (BASE_TOPK / 32));
+            LocalTensor<int32_t> idxULocal1 = outIdxUb.template ReinterpretCast<int32_t>();
+            SetWaitFlag<HardEvent::V_MTE3>(HardEvent::V_MTE3);
+            SetWaitFlag<HardEvent::S_MTE3>(HardEvent::S_MTE3);
+            DataCopyPad(indiceOutGm[outOffset], idxULocal1,
+                        {1, static_cast<uint16_t>(constInfo_.sparseCount * sizeof(int32_t)), 0, 0});
+            SetWaitFlag<HardEvent::MTE3_V>(HardEvent::MTE3_V);
+        } else {
+            Extract(outValueUb, outIdxUb, curValueIdxUb, (BASE_TOPK / 32));
+            PipeBarrier<PIPE_V>();
+            LocalTensor<int32_t> idxULocal1 = outIdxUb.template ReinterpretCast<int32_t>();
+            LocalTensor<K_T> valueULocal1 = outValueUb.template ReinterpretCast<K_T>();
+            Cast(valueULocal1, outValueUb, RoundMode::CAST_ROUND, constInfo_.sparseCount);
+            PipeBarrier<PIPE_V>();
+            SetWaitFlag<HardEvent::V_MTE3>(HardEvent::V_MTE3);
+            SetWaitFlag<HardEvent::S_MTE3>(HardEvent::S_MTE3);
+            DataCopyPad(indiceOutGm[outOffset], idxULocal1,
+                        {1, static_cast<uint16_t>(constInfo_.sparseCount * sizeof(int32_t)), 0, 0});
+            DataCopyPad(valueOutGm[outOffset], valueULocal1,
+                        {1, static_cast<uint16_t>(constInfo_.sparseCount * sizeof(K_T)), 0, 0});
+            SetWaitFlag<HardEvent::MTE3_V>(HardEvent::MTE3_V);
+        }
+    }
+}
+} // namespace LIKernel
+}  // namespace sglang::npu_kernel::liv2
+#endif

--- a/csrc/lightning_indexer_v2/op_kernel/arch22/lightning_indexer_vector.h
+++ b/csrc/lightning_indexer_v2/op_kernel/arch22/lightning_indexer_vector.h
@@ -1,0 +1,426 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+/*!
+ * \file lightning_indexer_vector.h
+ * \brief
+ */
+#ifndef SGL_LI_V2_LIGHTNING_INDEXER_VECTOR_H
+#define SGL_LI_V2_LIGHTNING_INDEXER_VECTOR_H
+
+#include "kernel_operator.h"
+
+namespace sglang::npu_kernel::liv2 {
+
+namespace LIServiceVec {
+using namespace AscendC;
+
+constexpr int32_t NEG_INF = 0xFF800000;
+constexpr int32_t INVALID_INDEX = -1;
+constexpr uint8_t VEC_REPEAT_MAX = 255;
+constexpr uint8_t B32_VEC_ELM_NUM = 64;
+constexpr uint8_t B32_BLOCK_ALIGN_NUM = 8;
+constexpr uint8_t B32_VEC_REPEAT_STRIDE = 8;
+constexpr uint64_t VEC_REPEAT_BYTES = 256;
+constexpr int32_t CONST_TWO = 2;
+constexpr int64_t VALUE_AND_INDEX_NUM = 2;
+constexpr int64_t BLOCK_BYTES = 32;
+constexpr int64_t MRG_QUE_0 = 0;
+constexpr int64_t MRG_QUE_1 = 1;
+constexpr int64_t MRG_QUE_2 = 2;
+constexpr int64_t MRG_QUE_3 = 3;
+constexpr int64_t MRG_BLOCK_2 = 2;
+constexpr int64_t MRG_BLOCK_3 = 3;
+constexpr int64_t MRG_BLOCK_4 = 4;
+
+template <typename T>
+__aicore__ inline void CopyIn(LocalTensor<float> &mmOutUb, LocalTensor<T> &weightsUb, GlobalTensor<float> &mMoutGm,
+                              GlobalTensor<T> &weightScaleGm, int64_t MMout_gmoffset, int64_t weights_gmoffset,
+                              int64_t groupInner, int64_t s2Inner, int64_t mmUbStride)
+{
+    // 将MMout_gmoffset copy到UB上
+    AscendC::DataCopyPadExtParams<float> padParams{false, 0, 0, 0};
+    AscendC::DataCopyExtParams dataCopymMoutParams;
+    dataCopymMoutParams.blockCount = groupInner;
+    dataCopymMoutParams.blockLen = s2Inner * sizeof(float);
+    dataCopymMoutParams.srcStride = 0;
+    dataCopymMoutParams.dstStride = mmUbStride;
+    dataCopymMoutParams.rsv = 0;
+    AscendC::DataCopyPad(mmOutUb, mMoutGm[MMout_gmoffset], dataCopymMoutParams, padParams);
+
+    // 将weights_gmoffset copy到UB
+    AscendC::DataCopyPadExtParams<T> padTParams{false, 0, 0, 0};
+    AscendC::DataCopyExtParams dataCopyweightParams;
+    dataCopyweightParams.blockCount = 1;
+    dataCopyweightParams.blockLen = groupInner * sizeof(T);
+    dataCopyweightParams.srcStride = 0;
+    dataCopyweightParams.dstStride = 0;
+    dataCopyweightParams.rsv = 0;
+    AscendC::DataCopyPad(weightsUb, weightScaleGm[weights_gmoffset], dataCopyweightParams, padTParams);
+}
+
+
+template <typename T>
+__aicore__ inline void CopyOut(const GlobalTensor<T> &dstGm, const LocalTensor<T> &srcUb, int64_t copyCount)
+{
+    AscendC::DataCopyParams dataCopyOutyParams;
+    dataCopyOutyParams.blockCount = 1;
+    dataCopyOutyParams.blockLen = copyCount * sizeof(T);
+    dataCopyOutyParams.srcStride = 0;
+    dataCopyOutyParams.dstStride = 0;
+    AscendC::DataCopyPad(dstGm, srcUb, dataCopyOutyParams);
+}
+
+
+template <typename T>
+__aicore__ inline void DoScale(const LocalTensor<float> &reduceCacheBuf, LocalTensor<float> &mmOutUb,
+                               LocalTensor<float> &weightsUb, LocalTensor<T> &weightsTUb, LocalTensor<float> &tmpBuff,
+                               int64_t groupInner, int64_t s2Inner, int32_t outerGidx)
+{
+    // cast bfloat16_t to float
+    if constexpr (!IsSameType<T, float>::value) {
+        AscendC::Cast(weightsUb, weightsTUb, RoundMode::CAST_NONE, groupInner);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    // weight broadcast: [groupInner, 1] -> [groupInner, 8]
+    AscendC::Brcb(tmpBuff, weightsUb, LICommon::CeilDiv(groupInner, static_cast<int64_t>(B32_BLOCK_ALIGN_NUM)),
+                  {1, B32_VEC_REPEAT_STRIDE});
+    AscendC::PipeBarrier<PIPE_V>();
+
+    // do scale: [groupInner, 8] * [groupInner, s2Inner]
+    uint64_t countPerRepeat = VEC_REPEAT_BYTES / sizeof(float);
+    uint64_t repeatTimes = s2Inner / countPerRepeat;
+    for (int32_t i = 0; i < groupInner; i++) {
+        if (outerGidx == 0) {
+            AscendC::Mul(reduceCacheBuf[i * s2Inner], mmOutUb[i * s2Inner], tmpBuff[i * B32_BLOCK_ALIGN_NUM],
+                         countPerRepeat, repeatTimes, {1, 1, 0, B32_VEC_REPEAT_STRIDE, B32_VEC_REPEAT_STRIDE, 0});
+        } else {
+            AscendC::Mul(mmOutUb[i * s2Inner], mmOutUb[i * s2Inner], tmpBuff[i * B32_BLOCK_ALIGN_NUM], countPerRepeat,
+                         repeatTimes, {1, 1, 0, B32_VEC_REPEAT_STRIDE, B32_VEC_REPEAT_STRIDE, 0});
+        }
+    }
+
+    if (outerGidx != 0) {
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Add(reduceCacheBuf, mmOutUb, reduceCacheBuf, groupInner * s2Inner);
+    }
+    AscendC::PipeBarrier<PIPE_V>();
+}
+
+
+__aicore__ inline uint64_t FindNearestPower2(uint64_t value)
+{
+    if (value <= CONST_TWO) {
+        return value;
+    } else {
+        const uint64_t pow = 63 - AscendC::ScalarCountLeadingZero(value); // 返回前导0的个数，对于64位整数，最大有效位位置 = 63 - 前导0个数
+        return (1 << pow);
+    }
+}
+
+
+// dstTensor 需要初始化0
+__aicore__ inline void DoReduce(const LocalTensor<float> &srcTensor, LocalTensor<float> &dstTensor, int32_t rNum,
+                                int32_t aNum)
+{
+    if (rNum == 1) {
+        AscendC::Adds<float>(dstTensor, srcTensor, 0, aNum);
+        AscendC::PipeBarrier<PIPE_V>();
+        return;
+    }
+
+    uint32_t dichotomizeAddPow = FindNearestPower2(rNum);
+    uint32_t dichotomizeAddDiffSize = rNum - dichotomizeAddPow;
+    if (dichotomizeAddDiffSize != 0) {
+        AscendC::Add(srcTensor, srcTensor, srcTensor[dichotomizeAddPow * aNum], dichotomizeAddDiffSize * aNum);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+    int32_t nowRows = dichotomizeAddPow;
+    while (nowRows > CONST_TWO) {
+        nowRows = nowRows / CONST_TWO;
+        AscendC::Add(srcTensor, srcTensor, srcTensor[nowRows * aNum], nowRows * aNum);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+    AscendC::Add(dstTensor, srcTensor, srcTensor[aNum], aNum);
+    AscendC::PipeBarrier<PIPE_V>();
+}
+
+
+/**
+  src: 传入的初始化空间
+  eleNum: 需要初始化的元素个数需为64整数倍，元素将被初始化为交错排布的-inf，-1
+ */
+__aicore__ inline void InitSortOutBuf(const LocalTensor<float> &src, int64_t eleNum)
+{
+    uint64_t mask1[2] = {0x5555555555555555, 0};
+    uint64_t mask0[2] = {0xaaaaaaaaaaaaaaaa, 0};
+    int64_t repeatNum = eleNum / B32_VEC_ELM_NUM;
+    int64_t forLoop = repeatNum / VEC_REPEAT_MAX;
+    int64_t forRemain = repeatNum % VEC_REPEAT_MAX;
+    for (int i = 0; i < forLoop; i++) {
+        AscendC::Duplicate(src.template ReinterpretCast<int32_t>(), NEG_INF, mask1, VEC_REPEAT_MAX, 1,
+                           B32_VEC_REPEAT_STRIDE);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Duplicate(src.template ReinterpretCast<int32_t>(), INVALID_INDEX, mask0, VEC_REPEAT_MAX, 1,
+                           B32_VEC_REPEAT_STRIDE);
+    }
+    if (forRemain > 0) {
+        AscendC::Duplicate(src.template ReinterpretCast<int32_t>()[forLoop * VEC_REPEAT_MAX * B32_VEC_ELM_NUM], NEG_INF,
+                           mask1, forRemain, 1, B32_VEC_REPEAT_STRIDE);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Duplicate(src.template ReinterpretCast<int32_t>()[forLoop * VEC_REPEAT_MAX * B32_VEC_ELM_NUM],
+                           INVALID_INDEX, mask0, forRemain, 1, B32_VEC_REPEAT_STRIDE);
+    }
+    AscendC::PipeBarrier<PIPE_V>();
+}
+
+
+/**
+  src: logits和索引，前logitsNum为logits，后logitsNum为索引
+  tmp: 计算使用到的临时空间，大小与src一致
+  logitsNum: 排序的元素个数, 暂只支持[128,256,384,512,1024,2048]
+ */
+__aicore__ inline void SortAll(LocalTensor<float> &src, LocalTensor<float> &tmp, int64_t logitsNum)
+{
+    int64_t sort32Repeats = logitsNum / BLOCK_BYTES;
+    AscendC::Sort32(tmp, src, src[logitsNum].ReinterpretCast<uint32_t>(), sort32Repeats);
+    AscendC::PipeBarrier<PIPE_V>();
+
+    int64_t mrgGroups = sort32Repeats;
+    int64_t mrgElements = BLOCK_BYTES;
+    int64_t i = 0;
+    AscendC::LocalTensor<float> srcTensor;
+    AscendC::LocalTensor<float> dstTensor;
+    while (true) {
+        if (i % CONST_TWO == 0) {
+            srcTensor = tmp;
+            dstTensor = src;
+        } else {
+            srcTensor = src;
+            dstTensor = tmp;
+        }
+        AscendC::MrgSort4Info params;
+        params.elementLengths[0] = mrgElements;
+        params.elementLengths[MRG_QUE_1] = mrgElements;
+        params.elementLengths[MRG_QUE_2] = mrgElements;
+        params.elementLengths[MRG_QUE_3] = mrgElements;
+        params.ifExhaustedSuspension = false;
+        params.validBit = 0b1111;
+
+        AscendC::MrgSortSrcList<float> srcList;
+        srcList.src1 = srcTensor[0];
+        srcList.src2 = srcTensor[MRG_QUE_1 * VALUE_AND_INDEX_NUM * mrgElements];
+        srcList.src3 = srcTensor[MRG_QUE_2 * VALUE_AND_INDEX_NUM * mrgElements];
+        srcList.src4 = srcTensor[MRG_QUE_3 * VALUE_AND_INDEX_NUM * mrgElements];
+        if (mrgGroups <= MRG_BLOCK_4) {
+            params.repeatTimes = 1;
+            if (mrgGroups == 1) {
+                break;
+            } else if (mrgGroups == MRG_BLOCK_2) {
+                params.validBit = 0b0011;
+            } else if (mrgGroups == MRG_BLOCK_3) {
+                params.validBit = 0b0111;
+            } else if (mrgGroups == MRG_BLOCK_4) {
+                params.validBit = 0b1111;
+            }
+            AscendC::MrgSort<float>(dstTensor, srcList, params);
+            i += 1;
+            AscendC::PipeBarrier<PIPE_V>();
+            break;
+        } else {
+            params.repeatTimes = mrgGroups / MRG_BLOCK_4;
+            AscendC::MrgSort<float>(dstTensor, srcList, params);
+            i += 1;
+            mrgElements = mrgElements * MRG_BLOCK_4;
+            mrgGroups = mrgGroups / MRG_BLOCK_4;
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+    if (i % CONST_TWO == 0) {
+        AscendC::DataCopy(src, tmp, logitsNum * VALUE_AND_INDEX_NUM);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+}
+
+
+/**
+  dst: 输出全排序的结果，排布方式为value，index
+  srcValue：输入的待排序浮点数
+  srcIndex：浮点数的索引
+  tmp: 计算使用到的临时空间，大小为srcValue+srcIndex
+  logitsNum: 排序的元素个数
+ */
+__aicore__ inline void SortAll(LocalTensor<float> &dst, LocalTensor<float> &srcValue, LocalTensor<uint32_t> &srcIndex,
+                               LocalTensor<float> &tmpTensor, int64_t logitsNum)
+{
+    int64_t sort32Repeats = logitsNum / BLOCK_BYTES;
+    AscendC::Sort<float, true>(dst, srcValue, srcIndex, tmpTensor, sort32Repeats);
+    AscendC::PipeBarrier<PIPE_V>();
+}
+
+
+/**
+  mrgDst: 合并进的Tensor
+  mrgSrc: 待合并的Tensor
+  tmpTensor：空间为mrgDst+mrgSrc
+ */
+__aicore__ inline void MergeSort(const LocalTensor<float> &mrgDst, int32_t mrgDstNum, LocalTensor<float> &mrgSrc,
+                                 int32_t mrgSrcNum, LocalTensor<float> &tmpTensor)
+{
+    if (mrgDstNum <= 3072) { // 3072: threshold of data size for different processing strategy
+        AscendC::MrgSort4Info params;
+        params.elementLengths[MRG_QUE_0] = mrgSrcNum;
+        params.elementLengths[MRG_QUE_1] = mrgDstNum;
+        params.ifExhaustedSuspension = false;
+        params.validBit = 0b0011;
+        params.repeatTimes = 1;
+
+        AscendC::MrgSortSrcList<float> srcList;
+        srcList.src1 = mrgSrc;
+        srcList.src2 = mrgDst;
+
+        AscendC::MrgSort<float>(tmpTensor, srcList, params);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::DataCopy(mrgDst, tmpTensor, mrgDstNum * VALUE_AND_INDEX_NUM);
+        AscendC::PipeBarrier<PIPE_V>();
+    } else {
+        int64_t unitElements = 1024;
+        int64_t segNum = mrgDstNum / unitElements;
+        int64_t mrgQuelen_1 = (segNum + 2) / 3;
+        int64_t mrgQuelen_2 = ((segNum - mrgQuelen_1) + 1) / 2;
+        int64_t mrgQuelen_3 = segNum - mrgQuelen_1 - mrgQuelen_2;
+
+        AscendC::MrgSort4Info params;
+        params.elementLengths[MRG_QUE_0] = mrgQuelen_1 * unitElements;
+        params.elementLengths[MRG_QUE_1] = mrgQuelen_2 * unitElements;
+        params.elementLengths[MRG_QUE_2] = mrgQuelen_3 * unitElements;
+        params.elementLengths[MRG_QUE_3] = mrgSrcNum;
+
+        params.ifExhaustedSuspension = false;
+        params.validBit = 0b1111;
+        params.repeatTimes = 1;
+
+        AscendC::MrgSortSrcList<float> srcList;
+        srcList.src1 = mrgDst[0];
+        srcList.src2 = mrgDst[mrgQuelen_1 * VALUE_AND_INDEX_NUM * unitElements];
+        srcList.src3 = mrgDst[(mrgQuelen_1 + mrgQuelen_2) * VALUE_AND_INDEX_NUM * unitElements];
+        srcList.src4 = mrgSrc;
+
+        AscendC::MrgSort<float>(tmpTensor, srcList, params);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::DataCopy(mrgDst, tmpTensor, mrgDstNum * VALUE_AND_INDEX_NUM);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+}
+
+
+/**
+ * @brief 合并基础块函数
+ * @param dst 归并后的输出, 大小为blockNum * basicBlockSize * 2 * sizeof(float)
+ * @param src 基本块输入
+ * @param blockNum 基本块的数量
+ * @param basicBlockSize 基础块的大小
+ * @return 无
+ */
+__aicore__ inline void MrgBasicBlock(const LocalTensor<float> &dst, const LocalTensor<float> &src, int64_t blockNum,
+                                     int64_t basicBlockSize)
+{
+    // 初始化合并排序参数
+    AscendC::MrgSort4Info params;
+    params.elementLengths[MRG_QUE_0] = basicBlockSize;
+    params.elementLengths[MRG_QUE_1] = basicBlockSize;
+    params.elementLengths[MRG_QUE_2] = basicBlockSize;
+    params.elementLengths[MRG_QUE_3] = basicBlockSize;
+    params.ifExhaustedSuspension = false;
+    // 根据块的数量设置有效位
+    if (blockNum == MRG_BLOCK_2) {
+        params.validBit = 0b0011;
+    } else if (blockNum == MRG_BLOCK_3) {
+        params.validBit = 0b0111;
+    } else if (blockNum == MRG_BLOCK_4) {
+        params.validBit = 0b1111;
+    } else {
+        AscendC::DataCopy(dst, src, basicBlockSize * VALUE_AND_INDEX_NUM);
+        return;
+    }
+    // 初始化源列表
+    AscendC::MrgSortSrcList<float> srcList;
+    srcList.src1 = src[0];
+    srcList.src2 = src[basicBlockSize * VALUE_AND_INDEX_NUM * MRG_QUE_1];
+    srcList.src3 = src[basicBlockSize * VALUE_AND_INDEX_NUM * MRG_QUE_2];
+    srcList.src4 = src[basicBlockSize * VALUE_AND_INDEX_NUM * MRG_QUE_3];
+    // 执行合并排序
+    AscendC::MrgSort<float>(dst, srcList, params);
+}
+
+
+/**
+ * @brief 从两个队列中选择topk
+ * @param dst 已经归并好的topk数据
+ * @param needsMerging 需要合并的有序数据
+ * @param tmp 临时空间
+ * @param topk topk的元素个数
+ * @param mergSize 待合并的元素个数
+ * @return 无
+ */
+template <bool needMrg = true>
+__aicore__ inline void SparseTopK(const LocalTensor<float> &dst, const LocalTensor<float> &needsMerging,
+                                  const LocalTensor<float> &tmp, int64_t topk, int64_t mergSize)
+{
+    // 如果不需要合并，则直接复制数据
+    if (!needMrg) {
+        AscendC::DataCopy(dst, needsMerging, mergSize * VALUE_AND_INDEX_NUM);
+        return;
+    }
+    // 初始化合并排序参数
+    AscendC::MrgSort4Info params;
+    params.elementLengths[0] = topk;
+    params.elementLengths[1] = mergSize;
+    params.ifExhaustedSuspension = (topk == mergSize);
+    params.validBit = 0b0011;
+    // 初始化源列表
+    AscendC::MrgSortSrcList<float> srcList;
+    srcList.src1 = dst;
+    srcList.src2 = needsMerging;
+    // 执行合并排序
+    AscendC::MrgSort<float>(tmp, srcList, params);
+    AscendC::PipeBarrier<PIPE_V>();
+    // 将结果复制到目标张量
+    AscendC::DataCopy(dst, tmp, topk * VALUE_AND_INDEX_NUM);
+}
+
+
+__aicore__ inline void ExtractIndex(const LocalTensor<uint32_t> &idxULocal, const LocalTensor<uint32_t> &sortLocal,
+                                    int64_t extractNum)
+{
+    AscendC::GatherMaskParams gatherMaskParams;
+    gatherMaskParams.repeatTimes = Ceil(extractNum * sizeof(float) * VALUE_AND_INDEX_NUM, VEC_REPEAT_BYTES);
+    gatherMaskParams.src0BlockStride = 1;
+    gatherMaskParams.src0RepeatStride = B32_VEC_REPEAT_STRIDE;
+    gatherMaskParams.src1RepeatStride = 0;
+    uint64_t rsvdCnt = 0;    // 用于保存筛选后保留下来的元素个数
+    uint8_t src1Pattern = 2; // 固定模式2,表示筛选出奇数索引的数
+    AscendC::GatherMask(idxULocal, sortLocal, src1Pattern, false, static_cast<uint32_t>(0), gatherMaskParams, rsvdCnt);
+    AscendC::PipeBarrier<PIPE_V>();
+}
+
+
+template <HardEvent event>
+__aicore__ inline void SetWaitFlag(HardEvent evt)
+{
+    event_t eventId = static_cast<event_t>(GetTPipePtr()->FetchEventID(evt));
+    AscendC::SetFlag<event>(eventId);
+    AscendC::WaitFlag<event>(eventId);
+}
+
+} // namespace LIServiceVec
+}  // namespace sglang::npu_kernel::liv2
+#endif // SGL_LI_V2_LIGHTNING_INDEXER_VECTOR_H

--- a/csrc/lightning_indexer_v2/op_kernel/arch35/lightning_indexer_kernel.h
+++ b/csrc/lightning_indexer_v2/op_kernel/arch35/lightning_indexer_kernel.h
@@ -1,0 +1,679 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+/*!
+ * \file lightning_indexer_kernel.h
+ * \brief
+ */
+
+#ifndef SGL_LI_V2_LIGHTNING_INDEXER_KERNEL_H
+#define SGL_LI_V2_LIGHTNING_INDEXER_KERNEL_H
+
+#include "kernel_operator.h"
+#include "kernel_operator_list_tensor_intf.h"
+#include "kernel_tiling/kernel_tiling.h"
+#include "lib/matmul_intf.h"
+#include "lib/matrix/matmul/tiling.h"
+#include "../lightning_indexer_v2_common.h"
+#include "lightning_indexer_service_vector.h"
+#include "lightning_indexer_service_cube.h"
+
+namespace sglang::npu_kernel::liv2 {
+
+namespace LIKernel {
+using namespace LICommon;
+using namespace matmul;
+using AscendC::CacheMode;
+using AscendC::CrossCoreSetFlag;
+using AscendC::CrossCoreWaitFlag;
+
+// 由于S2循环前，RunInfo还没有赋值，使用TempLoopInfo临时存放B、N、S1轴相关的信息；同时减少重复计算
+struct TempLoopInfo {
+    uint32_t bN2Idx = 0;
+    uint32_t bIdx = 0U;
+    uint32_t n2Idx = 0U;
+    uint32_t gS1Idx = 0U;
+    uint32_t gS1LoopEnd = 0U;   // gS1方向循环的结束Idx
+    uint32_t s2LoopEnd = 0U;    // S2方向循环的结束Idx
+    uint32_t actS1Size = 1U;  // 当前Batch循环处理的S1轴的实际大小
+    uint32_t actS2Size = 0U;
+    uint32_t actS2SizeOrig = 0U; // 压缩前s2
+    bool curActSeqLenIsZero = false;
+    bool needDealActS1LessThanS1 = false;  // S1的实际长度小于shape的S1长度时，是否需要清理输出
+    uint32_t actMBaseSize = 0U;            // m轴(gS1)方向实际大小
+    uint32_t mBasicSizeTail = 0U;          // gS1方向循环的尾基本块大小
+    uint32_t s2BasicSizeTail = 0U;        // S2方向循环的尾基本块大小
+};
+
+template <typename LIT>
+class LightningIndexerKernel {
+public:
+    __aicore__ inline LightningIndexerKernel(){};
+    __aicore__ inline void Init(__gm__ uint8_t *query, __gm__ uint8_t *key, __gm__ uint8_t *weights,
+                                __gm__ uint8_t *actualSeqLengthsQ, __gm__ uint8_t *actualSeqLengthsK,
+                                __gm__ uint8_t *blockTable, __gm__ uint8_t *sparseIndices, __gm__ uint8_t *sparseValues,
+                                __gm__ uint8_t *workspace, const LITilingData *__restrict tiling, TPipe *tPipe);
+    __aicore__ inline void Process();
+
+    // =================================类型定义区=================================
+    static constexpr bool DT_W_FLAG = LIT::weightsTypeFlag;
+    using Q_T = typename LIT::queryType;
+    using K_T = typename LIT::keyType;
+    using OUT_T = typename LIT::outputType;
+    static constexpr bool PAGE_ATTENTION = LIT::pageAttention;
+    static constexpr LI_LAYOUT LAYOUT_T = LIT::layout;
+    static constexpr LI_LAYOUT K_LAYOUT_T = LIT::keyLayout;
+    using W_T =
+            typename LightningIndexerTypeTraits<Q_T, typename std::conditional<DT_W_FLAG,
+                                                                            float, void>::type>::weightsType;
+
+    LightningIndexerServiceCube<LIT> matmulService;
+    LightningIndexerServiceVector<LIT> vectorService;
+
+    // =================================常量区=================================
+    static constexpr uint32_t SYNC_C1_V1_FLAG = 4;
+    static constexpr uint32_t SYNC_V1_C1_FLAG = 5;
+
+    static constexpr uint32_t M_BASE_SIZE = 256;
+    static constexpr uint32_t S1_BASE_SIZE = 4;
+    static constexpr uint32_t S1_BASE_SIZE_SMALL = 2;
+    static constexpr uint32_t S2_BASE_SIZE = 128;
+    static constexpr uint32_t HEAD_DIM = 128;
+    static constexpr uint32_t K_HEAD_NUM = 1;
+    static constexpr uint32_t GM_ALIGN_BYTES = 512;
+
+    static constexpr int64_t LD_PREFETCH_LEN = 2;
+
+protected:
+    TPipe *pipe = nullptr;
+
+    // offset
+    uint64_t queryCoreOffset = 0ULL;
+    uint64_t keyCoreOffset = 0ULL;
+    uint64_t weightsCoreOffset = 0ULL;
+    uint64_t indiceOutCoreOffset = 0ULL;
+    uint64_t valueOutCoreOffset = 0ULL;
+    // ================================Global Buffer区=================================
+    GlobalTensor<Q_T> queryGm;
+    GlobalTensor<K_T> keyGm;
+    GlobalTensor<W_T> weightsGm;
+
+    GlobalTensor<int32_t> indiceOutGm;
+    GlobalTensor<K_T> valueOutGm;
+    GlobalTensor<int32_t> blockTableGm;
+
+    GlobalTensor<uint32_t> actualSeqLengthsGmQ;
+    GlobalTensor<uint32_t> actualSeqLengthsGmKv;
+
+    // ================================类成员变量====================================
+    // aic、aiv核信息
+    uint32_t tmpBlockIdx = 0U;
+    uint32_t aiCoreIdx = 0U;
+    uint32_t usedCoreNum = 0U;
+
+    LICommon::ConstInfo constInfo{};
+    TempLoopInfo tempLoopInfo{};
+    LICommon::SplitCoreInfo splitCoreInfo{};
+
+    // ================================Init functions==================================
+    __aicore__ inline void InitTilingData(const LITilingData *__restrict tilingData);
+    __aicore__ inline void InitBuffers();
+    __aicore__ inline void InitActualSeqLen(__gm__ uint8_t *actualSeqLengthsQ, __gm__ uint8_t *actualSeqLengthsK);
+    // ================================Split Core================================
+    __aicore__ inline void SplitCore(uint32_t curCoreIdx, uint32_t &coreNum, LICommon::SplitCoreInfo &info);
+    __aicore__ inline uint32_t GetTotalBaseBlockNum();
+    __aicore__ inline uint32_t GetS2BaseBlockNumOnMask(uint32_t s1gIdx, uint32_t actS1Size, uint32_t actS2SizeOrig);
+    // ================================Process functions================================
+    __aicore__ inline void ProcessMain();
+    __aicore__ inline void ProcessBaseBlock(uint32_t loop, uint64_t s2LoopIdx,
+                                            LICommon::RunInfo runInfo);
+    __aicore__ inline void ProcessInvalid();
+    // ================================Params Calc=====================================
+    __aicore__ inline void CalcGS1LoopParams(uint32_t bN2Idx);
+    __aicore__ inline void GetBN2Idx(uint32_t bN2Idx);
+    __aicore__ inline uint32_t GetActualSeqLen(uint32_t bIdx, uint32_t actualLenDims, bool isAccumSeq,
+                                               GlobalTensor<uint32_t> &actualSeqLengthsGmKv, uint32_t defaultSeqLen);
+    __aicore__ inline void GetS1S2ActualSeqLen(uint32_t bIdx, uint32_t &actS1Size,
+                                               uint32_t &actS2Size, uint32_t &actS2SizeOrig);
+    __aicore__ inline void CalcS2LoopParams(uint32_t bN2LoopIdx, uint32_t gS1LoopIdx);
+    __aicore__ inline void CalcRunInfo(uint32_t loop, uint32_t s2LoopIdx, LICommon::RunInfo &runInfo);
+    __aicore__ inline void DealActSeqLenIsZero(uint32_t bIdx, uint32_t n2Idx, uint32_t s1Start);
+};
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::InitTilingData(const LITilingData *__restrict tilingData)
+{
+    usedCoreNum = tilingData->usedCoreNum;
+    constInfo.batchSize = tilingData->bSize;
+    constInfo.qHeadNum = constInfo.gSize = tilingData->gSize;
+    constInfo.kSeqSize = tilingData->s2Size;
+    constInfo.qSeqSize = tilingData->s1Size;
+    constInfo.attenMaskFlag = (tilingData->sparseMode == 3);
+    constInfo.kCacheBlockSize = tilingData->blockSize;
+    constInfo.maxBlockNumPerBatch = tilingData->maxBlockNumPerBatch;
+    constInfo.sparseCount = tilingData->sparseCount;
+    constInfo.outputLayout = LAYOUT_T;  // 输出和输入形状一致
+    if constexpr (std::is_same_v<K_T, float16_t>) {
+        constInfo.INVALID_VAL = 0xFC00;
+    }else {
+        constInfo.INVALID_VAL = 0xFF80;
+    }
+    if constexpr (LAYOUT_T == LI_LAYOUT::TND) {
+        constInfo.isAccumSeqS1 = true;
+    }
+    if constexpr (K_LAYOUT_T == LI_LAYOUT::TND) {
+        constInfo.isAccumSeqS2 = true;
+    }
+
+    constInfo.kHeadNum = K_HEAD_NUM;
+    constInfo.headDim = HEAD_DIM;
+
+    if (constInfo.sparseCount > 2048) {
+        constInfo.mBaseSize = S1_BASE_SIZE_SMALL * constInfo.gSize;
+        constInfo.s1BaseSize = S1_BASE_SIZE_SMALL;
+    } else {
+        constInfo.mBaseSize = S1_BASE_SIZE * constInfo.gSize;
+        constInfo.s1BaseSize = S1_BASE_SIZE;
+    }
+    constInfo.s2BaseSize = S2_BASE_SIZE;
+    constInfo.returnValueFlag = tilingData->returnValue;
+    constInfo.splitMFlag = (constInfo.gSize == 64 && constInfo.sparseCount <= 2048);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::InitBuffers()
+{
+    if ASCEND_IS_AIV {
+        vectorService.InitBuffers(pipe);
+    } else {
+        matmulService.InitBuffers(pipe);
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::InitActualSeqLen(__gm__ uint8_t *actualSeqLengthsQ,
+                                                          __gm__ uint8_t *actualSeqLengthsK)
+{
+    if (actualSeqLengthsQ == nullptr) {
+        constInfo.actualLenQDims = 0;
+    } else {
+        constInfo.actualLenQDims = constInfo.batchSize;
+        actualSeqLengthsGmQ.SetGlobalBuffer((__gm__ uint32_t *)actualSeqLengthsQ, constInfo.actualLenQDims);
+    }
+    if (actualSeqLengthsK == nullptr) {
+        constInfo.actualLenDims = 0;
+    } else {
+        constInfo.actualLenDims = constInfo.batchSize;
+        actualSeqLengthsGmKv.SetGlobalBuffer((__gm__ uint32_t *)actualSeqLengthsK, constInfo.actualLenDims);
+    }
+}
+
+template <typename LIT>
+__aicore__ inline uint32_t LightningIndexerKernel<LIT>::GetActualSeqLen(uint32_t bIdx,
+                                                             uint32_t actualLenDims, bool isAccumSeq,
+                                                             GlobalTensor<uint32_t> &actualSeqLengthsGmKv,
+                                                             uint32_t defaultSeqLen)
+{
+    if (actualLenDims == 0) {
+        return defaultSeqLen;
+    } else if (isAccumSeq && bIdx > 0) {
+        return actualSeqLengthsGmKv.GetValue(bIdx) - actualSeqLengthsGmKv.GetValue(bIdx - 1);
+    } else {
+        return actualSeqLengthsGmKv.GetValue(bIdx);
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::GetS1S2ActualSeqLen(uint32_t bIdx, uint32_t &actS1Size,
+                                                           uint32_t &actS2Size, uint32_t &actS2SizeOrig)
+{
+    actS1Size = GetActualSeqLen(bIdx, constInfo.actualLenQDims, constInfo.isAccumSeqS1, actualSeqLengthsGmQ,
+                                constInfo.qSeqSize);
+    actS2SizeOrig =
+        GetActualSeqLen(bIdx, constInfo.actualLenDims,
+                         constInfo.isAccumSeqS2, actualSeqLengthsGmKv, constInfo.kSeqSize);
+    actS2Size = actS2SizeOrig;
+}
+
+template <typename LIT>
+__aicore__ inline uint32_t LightningIndexerKernel<LIT>::GetS2BaseBlockNumOnMask(uint32_t s1gIdx, uint32_t actS1Size,
+                                                                     uint32_t actS2SizeOrig)
+{
+    if (actS2SizeOrig == 0) {
+        return 0;
+    }
+    uint32_t s1Offset = constInfo.s1BaseSize * s1gIdx;
+    int32_t validS2LenBase = static_cast<int32_t>(actS2SizeOrig) - static_cast<int32_t>(actS1Size);
+    int32_t validS2Len = (static_cast<int32_t>(s1Offset) + validS2LenBase + static_cast<int32_t>(constInfo.s1BaseSize));
+    validS2Len = Min(validS2Len, static_cast<int32_t>(actS2SizeOrig));
+    validS2Len = Max(validS2Len, 1);
+    return (validS2Len + constInfo.s2BaseSize - 1) / constInfo.s2BaseSize;
+}
+
+template <typename LIT>
+__aicore__ inline uint32_t LightningIndexerKernel<LIT>::GetTotalBaseBlockNum()
+{
+    uint32_t totalBlockNum = 0;
+    uint32_t actS1Size, actS2Size, actS2SizeOrig;
+    uint32_t s1GBaseNum, s2BaseNum;
+    for (uint32_t bIdx = 0; bIdx < constInfo.batchSize; bIdx++) {
+        GetS1S2ActualSeqLen(bIdx, actS1Size, actS2Size, actS2SizeOrig);
+        s1GBaseNum = CeilDiv(actS1Size, constInfo.s1BaseSize);
+        if (!constInfo.attenMaskFlag) {
+            s2BaseNum = constInfo.isLDOpen ? CeilDiv(actS2Size, constInfo.s2BaseSize) : (actS2Size > 0 ? 1 : 0);
+            totalBlockNum += s1GBaseNum * s2BaseNum * constInfo.kHeadNum;
+            continue;
+        }
+        for (uint32_t s1gIdx = 0; s1gIdx < s1GBaseNum; s1gIdx++) {
+            s2BaseNum = constInfo.isLDOpen
+                      ? GetS2BaseBlockNumOnMask(s1gIdx, actS1Size, actS2SizeOrig)
+                      : (actS2Size > 0 ? 1 : 0);
+            totalBlockNum += s2BaseNum * constInfo.kHeadNum;
+        }
+    }
+    return totalBlockNum;
+}
+
+
+// 多核版本，双闭区间。基本原则：计算每个核最少处理的块数, 剩余的部分前面的核每个核多处理一块
+template <typename LIT>
+__aicore__ void inline LightningIndexerKernel<LIT>::SplitCore(uint32_t curCoreIdx, uint32_t &coreNum,
+                                                LICommon::SplitCoreInfo &info)
+{
+    uint32_t totalBlockNum = GetTotalBaseBlockNum();
+    uint32_t minBlockPerCore = totalBlockNum / coreNum;
+    uint32_t deal1MoreBlockCoreNum = totalBlockNum % coreNum;
+    uint32_t coreIdx = 0;
+    uint32_t lastGS1RemainBlockCnt = 0;
+    uint32_t coreDealBlockCnt = coreIdx < deal1MoreBlockCoreNum ? minBlockPerCore + 1 : minBlockPerCore;
+    coreNum = minBlockPerCore == 0 ? deal1MoreBlockCoreNum : coreNum;
+    if (curCoreIdx < coreNum) {
+        splitCoreInfo.isCoreEnable = true;
+    } else {
+        splitCoreInfo.isCoreEnable = false;
+        return;
+    }
+
+    bool findLastCoreEnd = true;
+    uint32_t actS1Size, actS2Size, actS2SizeOrig;
+    uint32_t s1GBaseNum, s2BaseNum, s2Loop;
+    for (uint32_t bN2Idx = 0; bN2Idx < constInfo.batchSize * constInfo.kHeadNum; bN2Idx++) {
+        uint32_t bIdx = bN2Idx / constInfo.kHeadNum;
+        if (bN2Idx % constInfo.kHeadNum == 0) {
+            GetS1S2ActualSeqLen(bIdx, actS1Size, actS2Size, actS2SizeOrig);
+            s1GBaseNum = CeilDiv(actS1Size, constInfo.s1BaseSize);
+            s2BaseNum = CeilDiv(actS2Size, constInfo.s2BaseSize);
+        }
+        if constexpr (LAYOUT_T == LI_LAYOUT::BSND) {
+            if (findLastCoreEnd && (s1GBaseNum == 0U || s2BaseNum == 0U)) {
+                info.bN2Start = bN2Idx;
+                info.gS1Start = 0;
+                info.s2Start = 0;
+                findLastCoreEnd = false;
+            }
+        }
+        for (uint32_t gS1Idx = 0; gS1Idx < s1GBaseNum; gS1Idx++) {
+            if (constInfo.attenMaskFlag) {
+                s2BaseNum = GetS2BaseBlockNumOnMask(gS1Idx, actS1Size, actS2SizeOrig);
+            }
+            if (findLastCoreEnd && s2BaseNum == 0U) {
+                info.bN2Start = bN2Idx;
+                info.gS1Start = gS1Idx;
+                info.s2Start = 0;
+                findLastCoreEnd = false;
+            }
+            s2Loop = constInfo.isLDOpen ? s2BaseNum : (actS2Size > 0 ? 1 : 0);
+            for (uint32_t s2Idx = 0; s2Idx < s2Loop;) {
+                if (findLastCoreEnd) {
+                    info.bN2Start = bN2Idx;
+                    info.gS1Start = gS1Idx;
+                    info.s2Start = s2Idx;
+                    findLastCoreEnd = false;
+                }
+                uint32_t s2RemainBaseNum = s2Loop - s2Idx;
+                if (lastGS1RemainBlockCnt + s2RemainBaseNum >= coreDealBlockCnt) {
+                    info.bN2End = bN2Idx;
+                    info.gS1End = gS1Idx;
+                    info.s2End = constInfo.isLDOpen
+                               ? s2Idx + coreDealBlockCnt - lastGS1RemainBlockCnt - 1
+                               : s2BaseNum - 1;
+
+                    if (coreIdx == curCoreIdx) {
+                        // S2被切N核，那么只有第一个核需要处理LD，其他核不用
+                        if (s2Idx == 0 && info.s2End + 1 < s2BaseNum) {
+                            info.isLD = true;
+                        }
+                        // 最后一个核处理的不是最后一个Batch，表明后面的Batch为空块(S2=0), 调整终点坐标以便清理输出
+                        if (coreIdx == coreNum - 1 && info.bN2End != constInfo.batchSize - 1) {
+                            info.bN2End = constInfo.batchSize - 1;
+                            info.gS1End = 0;
+                            info.s2End = 0;
+                        }
+                        return;
+                    }
+                    coreIdx++;
+                    findLastCoreEnd = true;
+                    s2Idx = info.s2End + 1;
+                    lastGS1RemainBlockCnt = 0;
+                    coreDealBlockCnt = coreIdx < deal1MoreBlockCoreNum ? minBlockPerCore + 1 : minBlockPerCore;
+                } else {
+                    lastGS1RemainBlockCnt += s2RemainBaseNum;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::DealActSeqLenIsZero(uint32_t bIdx, uint32_t n2Idx, uint32_t s1Start)
+{
+    if ASCEND_IS_AIV {
+        if (constInfo.outputLayout == LI_LAYOUT::TND) {
+            uint32_t tSize = actualSeqLengthsGmQ.GetValue(constInfo.batchSize - 1);
+            uint32_t tBase = bIdx == 0 ? 0 : actualSeqLengthsGmQ.GetValue(bIdx - 1);
+            uint32_t s1Count = tempLoopInfo.actS1Size;
+
+            for (uint32_t s1Idx = s1Start; s1Idx < s1Count; s1Idx++) {
+                uint64_t indiceOutOffset =
+                    (tBase + s1Idx) * constInfo.kHeadNum * constInfo.sparseCount +  // T轴、s1轴偏移
+                    n2Idx * constInfo.sparseCount;                                // N2轴偏移
+                vectorService.CleanInvalidOutput(indiceOutOffset);
+            }
+        } else if (constInfo.outputLayout == LI_LAYOUT::BSND) {
+            for (uint32_t s1Idx = s1Start; s1Idx < constInfo.qSeqSize; s1Idx++) {
+                // B,S1,N2,K
+                uint64_t indiceOutOffset = bIdx * constInfo.qSeqSize * constInfo.kHeadNum * constInfo.sparseCount +
+                                           s1Idx * constInfo.kHeadNum * constInfo.sparseCount +  // B轴、S1轴偏移
+                                           n2Idx * constInfo.sparseCount;                        // N2轴偏移
+                vectorService.CleanInvalidOutput(indiceOutOffset);
+            }
+        }
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::Init(__gm__ uint8_t *query,
+                                              __gm__ uint8_t *key, __gm__ uint8_t *weights,
+                                              __gm__ uint8_t *actualSeqLengthsQ, __gm__ uint8_t *actualSeqLengthsK,
+                                              __gm__ uint8_t *blockTable, __gm__ uint8_t *sparseIndices,
+                                              __gm__ uint8_t *sparseValues,
+                                              __gm__ uint8_t *workspace,  const LITilingData *__restrict tiling,
+                                              TPipe *tPipe)
+{
+    if ASCEND_IS_AIV {
+        tmpBlockIdx = GetBlockIdx();  // vec:0-47
+        aiCoreIdx = tmpBlockIdx / 2;
+    } else {
+        tmpBlockIdx = GetBlockIdx();  // cube:0-23
+        aiCoreIdx = tmpBlockIdx;
+    }
+
+    InitTilingData(tiling);
+    InitActualSeqLen(actualSeqLengthsQ, actualSeqLengthsK);
+
+    // 获取分核信息
+    SplitCore(aiCoreIdx, usedCoreNum, splitCoreInfo);
+
+    pipe = tPipe;
+
+    uint64_t offset = 0;
+    // vec 把整个s2的score存储在GM，大小为s1BaseSize * 16K * 4
+    GlobalTensor<uint16_t> scoreGm; // 存放vec核写出的score
+    uint64_t singleCoreScoreSize = constInfo.s1BaseSize *
+                                            LICommon::Align(
+                                                (uint64_t)constInfo.kSeqSize,
+                                                (uint64_t)constInfo.s2BaseSize)  *
+                                            sizeof(uint16_t);
+    scoreGm.SetGlobalBuffer((__gm__ uint16_t *)(workspace + aiCoreIdx * singleCoreScoreSize));
+    offset += GetBlockNum() * singleCoreScoreSize;
+
+    if ASCEND_IS_AIV {
+        vectorService.InitParams(constInfo, tiling);
+        indiceOutGm.SetGlobalBuffer((__gm__ int32_t *)sparseIndices);
+        valueOutGm.SetGlobalBuffer((__gm__ K_T *)sparseValues);
+        weightsGm.SetGlobalBuffer((__gm__ W_T *)weights);
+        blockTableGm.SetGlobalBuffer((__gm__ int32_t *)blockTable);
+        vectorService.InitVecInputTensor(weightsGm, indiceOutGm, valueOutGm, blockTableGm);
+        vectorService.InitVecWorkspaceTensor(scoreGm);
+    } else {
+        matmulService.InitParams(constInfo);
+        queryGm.SetGlobalBuffer((__gm__ Q_T *)query);
+        if constexpr (PAGE_ATTENTION) {
+            blockTableGm.SetGlobalBuffer((__gm__ int32_t *)blockTable);
+        }
+        keyGm.SetGlobalBuffer((__gm__ K_T *)key);
+        matmulService.InitMm1GlobalTensor(blockTableGm, keyGm, queryGm);
+    }
+    InitBuffers();
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::GetBN2Idx(uint32_t bN2Idx)
+{
+    tempLoopInfo.bN2Idx = bN2Idx;
+    tempLoopInfo.bIdx = bN2Idx / constInfo.kHeadNum;
+    tempLoopInfo.n2Idx = bN2Idx % constInfo.kHeadNum;
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::CalcS2LoopParams(uint32_t bN2LoopIdx, uint32_t gS1LoopIdx)
+{
+    tempLoopInfo.gS1Idx = gS1LoopIdx;
+    tempLoopInfo.actMBaseSize = constInfo.mBaseSize;
+    uint32_t remainedGS1Size = tempLoopInfo.actS1Size * constInfo.gSize - tempLoopInfo.gS1Idx * constInfo.mBaseSize;
+    if (remainedGS1Size <= constInfo.mBaseSize && remainedGS1Size > 0) {
+        tempLoopInfo.actMBaseSize = tempLoopInfo.mBasicSizeTail;
+    }
+
+    bool isEnd = (bN2LoopIdx == splitCoreInfo.bN2End) && (gS1LoopIdx == splitCoreInfo.gS1End);
+    uint32_t s2BlockNum;
+    if (constInfo.attenMaskFlag) {
+        s2BlockNum = GetS2BaseBlockNumOnMask(gS1LoopIdx, tempLoopInfo.actS1Size, tempLoopInfo.actS2SizeOrig);
+    } else {
+        s2BlockNum = (tempLoopInfo.actS2Size + constInfo.s2BaseSize - 1) / constInfo.s2BaseSize;
+    }
+    tempLoopInfo.s2LoopEnd = isEnd ? splitCoreInfo.s2End : s2BlockNum - 1;
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::CalcGS1LoopParams(uint32_t bN2LoopIdx)
+{
+    GetBN2Idx(bN2LoopIdx);
+    GetS1S2ActualSeqLen(tempLoopInfo.bIdx, tempLoopInfo.actS1Size, tempLoopInfo.actS2Size, tempLoopInfo.actS2SizeOrig);
+    if ((tempLoopInfo.actS2Size == 0) || (tempLoopInfo.actS1Size == 0)) {
+        tempLoopInfo.curActSeqLenIsZero = true;
+        return;
+    }
+    tempLoopInfo.curActSeqLenIsZero = false;
+    tempLoopInfo.s2BasicSizeTail = tempLoopInfo.actS2Size % constInfo.s2BaseSize;
+    tempLoopInfo.s2BasicSizeTail =
+        (tempLoopInfo.s2BasicSizeTail == 0) ? constInfo.s2BaseSize : tempLoopInfo.s2BasicSizeTail;
+    tempLoopInfo.mBasicSizeTail = (tempLoopInfo.actS1Size * constInfo.gSize) % constInfo.mBaseSize;
+    tempLoopInfo.mBasicSizeTail =
+        (tempLoopInfo.mBasicSizeTail == 0) ? constInfo.mBaseSize : tempLoopInfo.mBasicSizeTail;
+
+    uint32_t gS1SplitNum = (tempLoopInfo.actS1Size * constInfo.gSize + constInfo.mBaseSize - 1) / constInfo.mBaseSize;
+    tempLoopInfo.gS1LoopEnd = (bN2LoopIdx == splitCoreInfo.bN2End) ? splitCoreInfo.gS1End : gS1SplitNum - 1;
+    if constexpr (LAYOUT_T == LI_LAYOUT::BSND) {
+        if (tempLoopInfo.gS1LoopEnd == gS1SplitNum - 1 && constInfo.qSeqSize > tempLoopInfo.actS1Size) {
+            tempLoopInfo.needDealActS1LessThanS1 = true;
+        }
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::CalcRunInfo(uint32_t loop,
+                                                                 uint32_t s2LoopIdx, LICommon::RunInfo &runInfo)
+{
+    runInfo.loop = loop;
+    runInfo.bIdx = tempLoopInfo.bIdx;
+    runInfo.gS1Idx = tempLoopInfo.gS1Idx;
+    runInfo.s2Idx = s2LoopIdx;
+    runInfo.bN2Idx = tempLoopInfo.bN2Idx;
+    runInfo.isValid = s2LoopIdx <= tempLoopInfo.s2LoopEnd;
+
+    if (!runInfo.isValid) {
+        return;
+    }
+
+    runInfo.actS1Size = tempLoopInfo.actS1Size;
+    runInfo.actS2Size = tempLoopInfo.actS2Size;
+    runInfo.actS2SizeOrig = tempLoopInfo.actS2SizeOrig;
+    // 计算实际基本块size
+    runInfo.actMBaseSize = tempLoopInfo.actMBaseSize;
+    runInfo.actualSingleProcessSInnerSize = constInfo.s2BaseSize;
+    uint32_t s2SplitNum = (tempLoopInfo.actS2Size + constInfo.s2BaseSize - 1) / constInfo.s2BaseSize;
+    if (runInfo.s2Idx == s2SplitNum - 1) {
+        runInfo.actualSingleProcessSInnerSize = tempLoopInfo.s2BasicSizeTail;
+    }
+    runInfo.actualSingleProcessSInnerSizeAlign =
+        LICommon::Align((uint32_t)runInfo.actualSingleProcessSInnerSize, LICommon::ConstInfo::BUFFER_SIZE_BYTE_32B);
+
+    runInfo.isFirstS2InnerLoop = s2LoopIdx == splitCoreInfo.s2Start;
+    runInfo.isLastS2InnerLoop = s2LoopIdx == tempLoopInfo.s2LoopEnd;
+    runInfo.isAllLoopEnd = (runInfo.bN2Idx == splitCoreInfo.bN2End) && (runInfo.gS1Idx == splitCoreInfo.gS1End) &&
+                           (runInfo.s2Idx == splitCoreInfo.s2End);
+
+    if (runInfo.isFirstS2InnerLoop) {
+        uint64_t actualSeqQPrefixSum;
+        if constexpr (LAYOUT_T == LI_LAYOUT::TND) {
+            actualSeqQPrefixSum = (runInfo.bIdx <= 0) ? 0 : actualSeqLengthsGmQ.GetValue(runInfo.bIdx - 1);
+        } else {  // BSND
+            actualSeqQPrefixSum = (runInfo.bIdx <= 0) ? 0 : runInfo.bIdx * constInfo.qSeqSize;
+        }
+        uint64_t tndBIdxOffset = actualSeqQPrefixSum * constInfo.qHeadNum * constInfo.headDim;
+        // B,S1,N1(N2,G),D
+        queryCoreOffset = tndBIdxOffset + runInfo.gS1Idx * constInfo.mBaseSize * constInfo.headDim;
+        // B,S1,N1(N2,G)/T,N1(N2,G)
+        weightsCoreOffset = actualSeqQPrefixSum * constInfo.qHeadNum + runInfo.n2Idx * constInfo.gSize;
+        // B,S1,N2,k/T,N2,k
+        indiceOutCoreOffset =
+            actualSeqQPrefixSum * constInfo.kHeadNum * constInfo.sparseCount + runInfo.n2Idx * constInfo.sparseCount;
+        // B,S1,N2,k/T,N2,k
+        valueOutCoreOffset =
+            actualSeqQPrefixSum * constInfo.kHeadNum * constInfo.sparseCount + runInfo.n2Idx * constInfo.sparseCount;
+    }
+    uint64_t actualSeqKPrefixSum;
+    if constexpr (K_LAYOUT_T == LI_LAYOUT::TND) { // T N2 D
+        actualSeqKPrefixSum = (runInfo.bIdx <= 0) ? 0 : actualSeqLengthsGmKv.GetValue(runInfo.bIdx - 1);
+    } else {
+        actualSeqKPrefixSum = (runInfo.bIdx <= 0) ? 0 : runInfo.bIdx * constInfo.kSeqSize;
+    }
+    uint64_t tndBIdxOffsetForK = actualSeqKPrefixSum * constInfo.kHeadNum * constInfo.headDim;
+    keyCoreOffset = tndBIdxOffsetForK + runInfo.s2Idx * constInfo.s2BaseSize * constInfo.kHeadNum * constInfo.headDim;
+    runInfo.tensorQueryOffset = queryCoreOffset;
+    runInfo.tensorKeyOffset = keyCoreOffset;
+    runInfo.tensorWeightsOffset = weightsCoreOffset;
+    runInfo.indiceOutOffset = indiceOutCoreOffset;
+    runInfo.valueOutOffset = valueOutCoreOffset;
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::Process()
+{
+    if (usedCoreNum == 0) {
+        // 没有计算任务，直接清理输出
+        ProcessInvalid();
+        return;
+    }
+
+    ProcessMain();
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::ProcessInvalid()
+{
+    if ASCEND_IS_AIV {
+        uint32_t aivCoreNum = GetBlockNum() * 2;  // 2 means c:v = 1:2
+        uint64_t totalOutputSize =
+            constInfo.batchSize * constInfo.qSeqSize * constInfo.kHeadNum * constInfo.sparseCount;
+        uint64_t singleCoreSize =
+            LICommon::Align((totalOutputSize + aivCoreNum - 1) / aivCoreNum, GM_ALIGN_BYTES / sizeof(OUT_T));
+        uint64_t baseSize = tmpBlockIdx * singleCoreSize;
+        if (baseSize < totalOutputSize) {
+            uint64_t dealSize =
+                    (baseSize + singleCoreSize <= totalOutputSize) ? singleCoreSize : totalOutputSize - baseSize;
+            GlobalTensor<OUT_T> output = indiceOutGm[baseSize];
+            AscendC::InitGlobalMemory(output, dealSize, constInfo.INVALID_IDX);
+            if (constInfo.returnValueFlag) {
+                GlobalTensor<uint16_t> valueOutGmTmp;
+                valueOutGmTmp.SetGlobalBuffer((__gm__ uint16_t *)valueOutGm.GetPhyAddr());
+                GlobalTensor<uint16_t> valueOut = valueOutGmTmp[baseSize];
+                AscendC::InitGlobalMemory(valueOut, dealSize, constInfo.INVALID_VAL);
+            }
+        }
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::ProcessMain()
+{
+    if (!splitCoreInfo.isCoreEnable) {
+        return;
+    }
+
+    if ASCEND_IS_AIV {
+        vectorService.AllocEventID();
+        CrossCoreSetFlag<LICommon::ConstInfo::QLI_SYNC_MODE4, PIPE_V>(LICommon::ConstInfo::CROSS_VC_EVENT + 0);
+        CrossCoreSetFlag<LICommon::ConstInfo::QLI_SYNC_MODE4, PIPE_V>(LICommon::ConstInfo::CROSS_VC_EVENT + 1);
+    } else {
+        matmulService.AllocEventID();
+    }
+
+    LICommon::RunInfo runInfo;
+    uint32_t gloop = 0;
+    for (uint32_t bN2LoopIdx = splitCoreInfo.bN2Start; bN2LoopIdx <= splitCoreInfo.bN2End; bN2LoopIdx++) {
+        CalcGS1LoopParams(bN2LoopIdx);
+        if (tempLoopInfo.curActSeqLenIsZero) {
+            DealActSeqLenIsZero(tempLoopInfo.bIdx, tempLoopInfo.n2Idx, 0U);
+            continue;
+        }
+        for (uint32_t gS1LoopIdx = splitCoreInfo.gS1Start; gS1LoopIdx <= tempLoopInfo.gS1LoopEnd; gS1LoopIdx++) {
+            CalcS2LoopParams(bN2LoopIdx, gS1LoopIdx);
+            for (int s2LoopIdx = splitCoreInfo.s2Start; s2LoopIdx <= tempLoopInfo.s2LoopEnd; s2LoopIdx++) {
+                ProcessBaseBlock(gloop, s2LoopIdx, runInfo);
+                ++gloop;
+            }
+            splitCoreInfo.s2Start = 0;
+        }
+        if (tempLoopInfo.needDealActS1LessThanS1) {
+            DealActSeqLenIsZero(tempLoopInfo.bIdx, tempLoopInfo.n2Idx, tempLoopInfo.actS1Size);
+        }
+        splitCoreInfo.gS1Start = 0;
+    }
+
+    if ASCEND_IS_AIV {
+        vectorService.FreeEventID();
+    } else {
+        matmulService.FreeEventID();
+        CrossCoreWaitFlag<LICommon::ConstInfo::QLI_SYNC_MODE4, PIPE_FIX>(LICommon::ConstInfo::CROSS_VC_EVENT + 0);
+        CrossCoreWaitFlag<LICommon::ConstInfo::QLI_SYNC_MODE4, PIPE_FIX>(LICommon::ConstInfo::CROSS_VC_EVENT + 1);
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerKernel<LIT>::ProcessBaseBlock(uint32_t loop,
+                                                                     uint64_t s2LoopIdx, LICommon::RunInfo runInfo)
+{
+    CalcRunInfo(loop, s2LoopIdx, runInfo);
+    if ASCEND_IS_AIC {
+        matmulService.ComputeMm1(runInfo);
+    } else {
+        vectorService.ProcessVec1(runInfo);
+        if (runInfo.isLastS2InnerLoop) {   // 本核s2last
+            vectorService.ProcessTopK(runInfo);
+        }
+    }
+}
+
+}  // namespace LIKernel
+}  // namespace sglang::npu_kernel::liv2
+#endif  // SGL_LI_V2_LIGHTNING_INDEXER_KERNEL_H

--- a/csrc/lightning_indexer_v2/op_kernel/arch35/lightning_indexer_service_cube.h
+++ b/csrc/lightning_indexer_v2/op_kernel/arch35/lightning_indexer_service_cube.h
@@ -1,0 +1,473 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+/*!
+ * \file lightning_indexer_service_cube.h
+ * \brief use 5 buffer for matmul l1, better pipeline
+ */
+#ifndef SGL_LI_V2_LIGHTNING_INDEXER_SERVICE_CUBE_H
+#define SGL_LI_V2_LIGHTNING_INDEXER_SERVICE_CUBE_H
+
+#include "kernel_operator.h"
+#include "kernel_operator_list_tensor_intf.h"
+#include "kernel_tiling/kernel_tiling.h"
+#include "lib/matmul_intf.h"
+#include "lib/matrix/matmul/tiling.h"
+#include "../lightning_indexer_v2_common.h"
+
+namespace sglang::npu_kernel::liv2 {
+
+namespace LIKernel {
+using namespace LICommon;
+template <typename LIT>
+class LightningIndexerServiceCube {
+public:
+    using Q_T = typename LIT::queryType;
+    using K_T = typename LIT::keyType;
+
+    __aicore__ inline LightningIndexerServiceCube(){};
+    __aicore__ inline void InitBuffers(TPipe *pipe);
+    __aicore__ inline void InitMm1GlobalTensor(const GlobalTensor<int32_t> &blkTableGm, const GlobalTensor<K_T> &keyGm,
+                                               const GlobalTensor<Q_T> &queryGm);
+    __aicore__ inline void InitParams(const ConstInfo &constInfo);
+    __aicore__ inline void AllocEventID();
+    __aicore__ inline void FreeEventID();
+    __aicore__ inline void ComputeMm1(const LICommon::RunInfo &runInfo);
+
+    static constexpr uint64_t KEY_BUF_NUM = 3;
+    static constexpr uint64_t QUERY_BUF_NUM = 2;
+    static constexpr uint64_t L0_BUF_NUM = 2;
+
+    static constexpr uint32_t KEY_MTE1_MTE2_EVENT = EVENT_ID2;
+    static constexpr uint32_t QUERY_MTE1_MTE2_EVENT = EVENT_ID5;         // KEY_MTE1_MTE2_EVENT + KEY_BUF_NUM;
+    static constexpr uint32_t M_MTE1_EVENT = EVENT_ID3;
+
+    static constexpr uint32_t MTE2_MTE1_EVENT = EVENT_ID2;
+    static constexpr uint32_t MTE1_M_EVENT = EVENT_ID2;
+    static constexpr uint32_t FIX_M_EVENT = EVENT_ID2;
+    static constexpr uint32_t M_FIX_EVENT = EVENT_ID3;
+
+    static constexpr uint64_t M_BASIC_BLOCK = 256;
+    static constexpr uint64_t D_BASIC_BLOCK = 128;
+    static constexpr uint64_t S2_BASIC_BLOCK = 128;
+
+    static constexpr uint64_t M_BASIC_BLOCK_L0 = 128;
+    static constexpr uint64_t D_BASIC_BLOCK_L0 = 128;
+    static constexpr uint64_t S2_BASIC_BLOCK_L0 = 128;
+
+    static constexpr uint64_t FP16_BLOCK_CUBE = 16;
+    static constexpr FixpipeConfig QLI_CFG_ROW_MAJOR_UB = {CO2Layout::ROW_MAJOR, true};
+
+    static constexpr uint64_t QUERY_BUFFER_OFFSET = M_BASIC_BLOCK * D_BASIC_BLOCK;
+    static constexpr uint64_t KEY_BUFFER_OFFSET = S2_BASIC_BLOCK * D_BASIC_BLOCK;
+    static constexpr uint64_t L0AB_BUFFER_OFFSET = M_BASIC_BLOCK_L0 * D_BASIC_BLOCK_L0;
+    static constexpr uint64_t L0C_BUFFER_OFFSET = M_BASIC_BLOCK_L0 * S2_BASIC_BLOCK_L0;
+
+protected:
+    __aicore__ inline void Fixp(uint64_t s1gGmOffset, uint64_t s2GmOffset, uint64_t s1gL0RealSize,
+                                uint64_t s2L0RealSize, const LICommon::RunInfo &runInfo);
+    __aicore__ inline void ComputeL0c(uint64_t s1gL0RealSize, uint64_t s2L0RealSize, const LICommon::RunInfo &runInfo);
+    __aicore__ inline void LoadKeyToL0b(uint64_t s2L0Offset, uint64_t s2L1RealSize, uint64_t s2L0RealSize,
+                                        const LICommon::RunInfo &runInfo);
+    __aicore__ inline void LoadQueryToL0a(uint64_t s1gL1Offset, uint64_t s1gL0Offset, uint64_t s1gL1RealSize,
+                                          uint64_t s1gL0RealSize, const LICommon::RunInfo &runInfo);
+    __aicore__ inline void QueryNd2Nz(uint64_t s1gL1RealSize, uint64_t s1gL1Offset, const LICommon::RunInfo &runInfo);
+    __aicore__ inline void KeyNd2Nz(uint64_t s2L1RealSize, uint64_t s2GmOffset, const LICommon::RunInfo &runInfo);
+    __aicore__ inline void KeyNd2NzForPA(uint64_t s2L1RealSize, uint64_t s2GmOffset, const LICommon::RunInfo &runInfo);
+    GlobalTensor<int32_t> blkTableGm_;
+    GlobalTensor<K_T> keyGm_;
+    GlobalTensor<Q_T> queryGm_;
+
+    TBuf<TPosition::A1> bufQL1_;
+    LocalTensor<Q_T> queryL1_;
+    TBuf<TPosition::B1> bufKeyL1_;
+    LocalTensor<K_T> keyL1_;
+
+    TBuf<TPosition::A2> bufQL0_;
+    LocalTensor<Q_T> queryL0_;
+    TBuf<TPosition::B2> bufKeyL0_;
+    LocalTensor<K_T> keyL0_;
+
+    TBuf<TPosition::CO1> bufL0C_;
+    LocalTensor<float> cL0_;
+
+    TBuf<TPosition::VECCALC> bufUB_;
+    LocalTensor<float> mm1ResUB_;
+
+    uint64_t keyL1BufIdx_ = 0;
+    uint64_t queryL1Mte2BufIdx_ = 0;
+    uint64_t queryL1Mte1BufIdx_ = 0;
+    uint64_t l0BufIdx_ = 0;
+    uint64_t kl0BufIdx_ = 0;
+
+    ConstInfo constInfo_;
+
+private:
+    static constexpr bool PAGE_ATTENTION = LIT::pageAttention;
+};
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::InitParams(const ConstInfo &constInfo)
+{
+    constInfo_ = constInfo;
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::InitBuffers(TPipe *pipe)
+{
+    pipe->InitBuffer(bufUB_, 2 *CeilDiv(constInfo_.mBaseSize, 2) *
+                                constInfo_.s2BaseSize *
+                                sizeof(float));  // 大小：2(开dB) * 2 * 64 * 128 * 4 = 128KB
+    mm1ResUB_ = bufUB_.Get<float>();
+    pipe->InitBuffer(bufQL1_, QUERY_BUF_NUM * M_BASIC_BLOCK * D_BASIC_BLOCK * sizeof(Q_T));
+    queryL1_ = bufQL1_.Get<Q_T>();
+    pipe->InitBuffer(bufKeyL1_, KEY_BUF_NUM * S2_BASIC_BLOCK * D_BASIC_BLOCK * sizeof(K_T));
+    keyL1_ = bufKeyL1_.Get<K_T>();
+
+    pipe->InitBuffer(bufQL0_, L0_BUF_NUM * M_BASIC_BLOCK_L0 * D_BASIC_BLOCK_L0 * sizeof(Q_T));
+    queryL0_ = bufQL0_.Get<Q_T>();
+    pipe->InitBuffer(bufKeyL0_, L0_BUF_NUM * D_BASIC_BLOCK_L0 * S2_BASIC_BLOCK_L0 * sizeof(K_T));
+    keyL0_ = bufKeyL0_.Get<K_T>();
+
+    pipe->InitBuffer(bufL0C_, L0_BUF_NUM * M_BASIC_BLOCK_L0 * S2_BASIC_BLOCK_L0 * sizeof(float));
+    cL0_ = bufL0C_.Get<float>();
+}
+
+template <typename LIT>
+__aicore__ inline void
+LightningIndexerServiceCube<LIT>::InitMm1GlobalTensor(const GlobalTensor<int32_t> &blkTableGm,
+                                                      const GlobalTensor<K_T> &keyGm, const GlobalTensor<Q_T> &queryGm)
+{
+    blkTableGm_ = blkTableGm;
+    keyGm_ = keyGm;
+    queryGm_ = queryGm;
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::ComputeMm1(const LICommon::RunInfo &runInfo)
+{
+    CrossCoreWaitFlag<LICommon::ConstInfo::QLI_SYNC_MODE4, PIPE_FIX>(
+                                                    LICommon::ConstInfo::CROSS_VC_EVENT + runInfo.loop % 2);
+    CrossCoreWaitFlag<LICommon::ConstInfo::QLI_SYNC_MODE4, PIPE_FIX>(
+                                                    LICommon::ConstInfo::CROSS_VC_EVENT +
+                                                    runInfo.loop % 2 +
+                                                    LICommon::ConstInfo::AIV0_AIV1_OFFSET);
+    uint64_t s2GmBaseOffset = runInfo.s2Idx * constInfo_.s2BaseSize;
+    uint64_t s1gProcessSize = runInfo.actMBaseSize;
+    uint64_t s2ProcessSize = runInfo.actualSingleProcessSInnerSize;
+    for (uint64_t s2GmOffset = 0; s2GmOffset < s2ProcessSize; s2GmOffset += S2_BASIC_BLOCK) {
+        WaitFlag<HardEvent::MTE1_MTE2>(KEY_MTE1_MTE2_EVENT + keyL1BufIdx_ % KEY_BUF_NUM);
+        uint64_t s2L1RealSize =
+            s2GmOffset + S2_BASIC_BLOCK > s2ProcessSize ? s2ProcessSize - s2GmOffset : S2_BASIC_BLOCK;
+        if (PAGE_ATTENTION) {
+            KeyNd2NzForPA(s2L1RealSize, s2GmBaseOffset + s2GmOffset, runInfo);
+        }else {
+            KeyNd2Nz(s2L1RealSize, s2GmOffset, runInfo);
+        }
+
+        SetFlag<HardEvent::MTE2_MTE1>(MTE2_MTE1_EVENT);
+        WaitFlag<HardEvent::MTE2_MTE1>(MTE2_MTE1_EVENT);
+        // s1gProcessSize当前必定不会超过2倍的s1g basic block
+        for (uint64_t s1gGmOffset = 0; s1gGmOffset < s1gProcessSize; s1gGmOffset += constInfo_.mBaseSize) {
+            uint64_t s1gL1RealSize =
+                s1gGmOffset + constInfo_.mBaseSize > s1gProcessSize
+                                                   ? s1gProcessSize - s1gGmOffset
+                                                   : constInfo_.mBaseSize;
+            uint64_t s1gL1SizeAlign2G = CeilAlign(s1gL1RealSize, 2 * constInfo_.gSize);
+            if (runInfo.isFirstS2InnerLoop && s2GmOffset == 0) {
+                queryL1Mte2BufIdx_++;
+                queryL1Mte1BufIdx_ = queryL1Mte2BufIdx_;
+                WaitFlag<HardEvent::MTE1_MTE2>(QUERY_MTE1_MTE2_EVENT + queryL1Mte2BufIdx_ % QUERY_BUF_NUM);
+                QueryNd2Nz(s1gL1RealSize, s1gGmOffset, runInfo);
+                SetFlag<HardEvent::MTE2_MTE1>(MTE2_MTE1_EVENT);
+                WaitFlag<HardEvent::MTE2_MTE1>(MTE2_MTE1_EVENT);
+            } else {
+                queryL1Mte1BufIdx_ =
+                    queryL1Mte2BufIdx_ - (CeilDiv(s1gProcessSize, constInfo_.mBaseSize) - 1 - (s1gGmOffset > 0));
+            }
+            for (uint64_t s2L1Offset = 0; s2L1Offset < s2L1RealSize; s2L1Offset += S2_BASIC_BLOCK_L0) {
+                uint64_t s2L0RealSize =
+                    s2L1Offset + S2_BASIC_BLOCK_L0 > s2L1RealSize ? s2L1RealSize - s2L1Offset : S2_BASIC_BLOCK_L0;
+
+                uint64_t l0Stride = constInfo_.mBaseSize;
+                if (constInfo_.splitMFlag) {
+                    l0Stride /= 2;
+                }
+
+                for (uint64_t s1gL1Offset = 0; s1gL1Offset < s1gL1SizeAlign2G; s1gL1Offset += l0Stride) {
+                    WaitFlag<HardEvent::M_MTE1>(M_MTE1_EVENT + l0BufIdx_ % L0_BUF_NUM);
+                    uint64_t s1gL0RealSize =
+                        s1gL1Offset + constInfo_.mBaseSize > s1gL1SizeAlign2G
+                                                           ? s1gL1SizeAlign2G - s1gL1Offset
+                                                           : constInfo_.mBaseSize;
+                    if (constInfo_.splitMFlag) {
+                        s1gL0RealSize = 128; // g=64, topK=2k时固定m=128
+                    }
+                    LoadQueryToL0a(s1gGmOffset, s1gL1Offset, s1gL1SizeAlign2G, s1gL0RealSize, runInfo);
+                    if (s1gL1Offset == 0) {
+                        LoadKeyToL0b(s2L1Offset, s2L1RealSize, s2L0RealSize, runInfo);
+                    }
+
+                    SetFlag<HardEvent::MTE1_M>(MTE1_M_EVENT);
+                    WaitFlag<HardEvent::MTE1_M>(MTE1_M_EVENT);
+
+                    WaitFlag<HardEvent::FIX_M>(FIX_M_EVENT + l0BufIdx_ % L0_BUF_NUM);
+                    ComputeL0c(s1gL0RealSize, s2L0RealSize, runInfo);
+
+                    SetFlag<HardEvent::M_MTE1>(M_MTE1_EVENT + l0BufIdx_ % L0_BUF_NUM);
+
+                    bool lastIter = s1gL1Offset + l0Stride >= s1gL1SizeAlign2G;
+                    if (lastIter) {
+                        kl0BufIdx_++;
+                    }
+
+                    Fixp(s1gGmOffset + s1gL1Offset, s2GmOffset + s2L1Offset, s1gL0RealSize, s2L0RealSize, runInfo);
+                    SetFlag<HardEvent::FIX_M>(FIX_M_EVENT + l0BufIdx_ % L0_BUF_NUM);
+                    l0BufIdx_++;
+                }
+            }
+            if (s2GmOffset + S2_BASIC_BLOCK >= s2ProcessSize && runInfo.isLastS2InnerLoop) {
+                SetFlag<HardEvent::MTE1_MTE2>(QUERY_MTE1_MTE2_EVENT + queryL1Mte1BufIdx_ % QUERY_BUF_NUM);
+            }
+        }
+        SetFlag<HardEvent::MTE1_MTE2>(KEY_MTE1_MTE2_EVENT + keyL1BufIdx_ % KEY_BUF_NUM);
+        keyL1BufIdx_++;
+    }
+    CrossCoreSetFlag<LICommon::ConstInfo::QLI_SYNC_MODE4, PIPE_FIX>(
+                                                LICommon::ConstInfo::CROSS_CV_EVENT +
+                                                runInfo.loop % 2);
+    CrossCoreSetFlag<LICommon::ConstInfo::QLI_SYNC_MODE4, PIPE_FIX>(
+                                                LICommon::ConstInfo::CROSS_CV_EVENT +
+                                                runInfo.loop % 2 +
+                                                LICommon::ConstInfo::AIV0_AIV1_OFFSET);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::KeyNd2Nz(uint64_t s2L1RealSize, uint64_t s2GmOffset,
+                                                    const LICommon::RunInfo &runInfo)
+{
+    Nd2NzParams nd2nzPara;
+    nd2nzPara.ndNum = 1;
+    nd2nzPara.nValue = s2L1RealSize; // 行数
+    nd2nzPara.dValue = constInfo_.headDim;
+    nd2nzPara.srcDValue = constInfo_.headDim;
+    nd2nzPara.dstNzC0Stride = CeilAlign(s2L1RealSize, (uint64_t)BLOCK_CUBE); // 对齐到16 单位block
+    nd2nzPara.dstNzNStride = 1;
+    nd2nzPara.srcNdMatrixStride = 0;
+    nd2nzPara.dstNzMatrixStride = 0;
+    // 默认一块buf最多放两份
+    DataCopy(keyL1_[(keyL1BufIdx_ % KEY_BUF_NUM) * KEY_BUFFER_OFFSET],
+             keyGm_[runInfo.tensorKeyOffset + s2GmOffset * constInfo_.headDim], nd2nzPara);
+}
+
+// blkNum, blkSize, N2, D
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::KeyNd2NzForPA(uint64_t s2L1RealSize, uint64_t s2GmOffset,
+                                                    const LICommon::RunInfo &runInfo)
+{
+    uint64_t s2L1Offset = 0;
+    while (s2L1Offset < s2L1RealSize) {
+        uint64_t s2BlkId = (s2L1Offset + s2GmOffset) / constInfo_.kCacheBlockSize;
+        uint64_t s2BlkOffset = (s2L1Offset + s2GmOffset) % constInfo_.kCacheBlockSize;
+        uint64_t keyGmOffset = blkTableGm_.GetValue(runInfo.bIdx * constInfo_.maxBlockNumPerBatch + s2BlkId) *
+                                constInfo_.kCacheBlockSize * constInfo_.kHeadNum * constInfo_.headDim +
+                             s2BlkOffset * constInfo_.headDim;
+
+        uint64_t s2Mte2Size = s2L1RealSize - s2L1Offset;
+        s2Mte2Size = s2BlkOffset + s2Mte2Size >= constInfo_.kCacheBlockSize
+                                                ? constInfo_.kCacheBlockSize - s2BlkOffset
+                                                : s2Mte2Size;
+        Nd2NzParams nd2nzPara;
+        nd2nzPara.ndNum = 1;
+        nd2nzPara.nValue = s2Mte2Size; // 行数
+        nd2nzPara.dValue = constInfo_.headDim;
+        nd2nzPara.srcDValue = constInfo_.headDim;
+        nd2nzPara.dstNzC0Stride = CeilAlign(s2L1RealSize, (uint64_t)BLOCK_CUBE); // 对齐到16 单位block
+        nd2nzPara.dstNzNStride = 1;
+        nd2nzPara.srcNdMatrixStride = 0;
+        nd2nzPara.dstNzMatrixStride = 0;
+        DataCopy(keyL1_[(keyL1BufIdx_ % KEY_BUF_NUM) * KEY_BUFFER_OFFSET + s2L1Offset * FP16_BLOCK_CUBE],
+                 keyGm_[keyGmOffset], nd2nzPara);
+
+        s2L1Offset += s2Mte2Size;
+    }
+}
+
+// batch, s1, n2, g, d
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::QueryNd2Nz(uint64_t s1gL1RealSize, uint64_t s1gGmOffset,
+                                                 const LICommon::RunInfo &runInfo)
+{
+    uint64_t dstNzC0Stride = CeilAlign(s1gL1RealSize, 2 * constInfo_.gSize);
+    Nd2NzParams nd2nzPara;
+    nd2nzPara.ndNum = 1;
+    nd2nzPara.nValue = s1gL1RealSize; // 行数
+    nd2nzPara.dValue = constInfo_.headDim;
+    nd2nzPara.srcDValue = constInfo_.headDim;
+    nd2nzPara.dstNzC0Stride = CeilAlign(dstNzC0Stride, (uint64_t)BLOCK_CUBE); // 对齐到16 单位block
+    nd2nzPara.dstNzNStride = 1;
+    nd2nzPara.srcNdMatrixStride = 0;
+    nd2nzPara.dstNzMatrixStride = 0;
+    // 默认一块buf最多放两份
+    DataCopy(queryL1_[(queryL1Mte2BufIdx_ % QUERY_BUF_NUM) * QUERY_BUFFER_OFFSET],
+    queryGm_[runInfo.tensorQueryOffset + s1gGmOffset * constInfo_.headDim], nd2nzPara);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::LoadQueryToL0a(uint64_t s1gGmOffset,
+                                                     uint64_t s1gL1Offset, uint64_t s1gL1RealSize,
+                                                     uint64_t s1gL0RealSize, const LICommon::RunInfo &runInfo)
+{
+    LoadData2DParamsV2 loadData2DParamsV2;
+    if (constInfo_.splitMFlag && runInfo.actMBaseSize > 128) { // 非尾块，切M
+        uint64_t dstOffset = 0;
+        loadData2DParamsV2.kStartPosition = 0;
+        loadData2DParamsV2.mStep = CeilDiv(64, BLOCK_CUBE);
+        loadData2DParamsV2.kStep = CeilDiv(constInfo_.headDim, FP16_BLOCK_CUBE);
+        loadData2DParamsV2.srcStride = CeilDiv(s1gL1RealSize, BLOCK_CUBE);
+        loadData2DParamsV2.dstStride = CeilDiv(s1gL0RealSize, BLOCK_CUBE);
+        loadData2DParamsV2.ifTranspose = false;
+        for (int i = 0; i < 2; i++) {
+            loadData2DParamsV2.mStartPosition = CeilDiv((s1gL1Offset / 2) + i * 128, BLOCK_CUBE);
+            dstOffset = i * 64 * 16;
+
+            LoadData(queryL0_[(l0BufIdx_ % L0_BUF_NUM) * L0AB_BUFFER_OFFSET + dstOffset],
+                queryL1_[(queryL1Mte1BufIdx_ % QUERY_BUF_NUM) * QUERY_BUFFER_OFFSET], loadData2DParamsV2);
+        }
+    } else {
+        loadData2DParamsV2.mStartPosition = CeilDiv(s1gL1Offset, BLOCK_CUBE);
+        loadData2DParamsV2.kStartPosition = 0;
+        loadData2DParamsV2.mStep = CeilDiv(s1gL0RealSize, BLOCK_CUBE);
+        loadData2DParamsV2.kStep = CeilDiv(constInfo_.headDim, FP16_BLOCK_CUBE);
+        loadData2DParamsV2.srcStride = CeilDiv(s1gL1RealSize, BLOCK_CUBE);
+        loadData2DParamsV2.dstStride = CeilDiv(s1gL0RealSize, BLOCK_CUBE);
+        loadData2DParamsV2.ifTranspose = false;
+
+        LoadData(queryL0_[(l0BufIdx_ % L0_BUF_NUM) * L0AB_BUFFER_OFFSET],
+            queryL1_[(queryL1Mte1BufIdx_ % QUERY_BUF_NUM) * QUERY_BUFFER_OFFSET], loadData2DParamsV2);
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::LoadKeyToL0b(uint64_t s2L1Offset,
+                                                     uint64_t s2L1RealSize, uint64_t s2L0RealSize,
+                                                     const LICommon::RunInfo &runInfo)
+{
+    LoadData2DParamsV2 loadData2DParamsV2;
+    loadData2DParamsV2.mStartPosition = CeilDiv(s2L1Offset, BLOCK_CUBE);
+    loadData2DParamsV2.kStartPosition = 0;
+    loadData2DParamsV2.mStep = CeilDiv(s2L0RealSize, BLOCK_CUBE);
+    loadData2DParamsV2.kStep = CeilDiv(constInfo_.headDim, FP16_BLOCK_CUBE);
+    loadData2DParamsV2.srcStride = CeilDiv(s2L1RealSize, BLOCK_CUBE);
+    loadData2DParamsV2.dstStride = CeilDiv(s2L0RealSize, BLOCK_CUBE);
+    loadData2DParamsV2.ifTranspose = false;
+
+    LoadData(keyL0_[(kl0BufIdx_ % L0_BUF_NUM) * L0AB_BUFFER_OFFSET],
+             keyL1_[(keyL1BufIdx_ % KEY_BUF_NUM) * KEY_BUFFER_OFFSET], loadData2DParamsV2);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::ComputeL0c(uint64_t s1gL0RealSize, uint64_t s2L0RealSize,
+                                                const LICommon::RunInfo &runInfo)
+{
+    MmadParams mmadParams;
+    mmadParams.m = CeilAlign(s1gL0RealSize, BLOCK_CUBE);
+    mmadParams.n = s2L0RealSize;
+    mmadParams.k = constInfo_.headDim;
+    mmadParams.cmatrixInitVal = true;
+    mmadParams.cmatrixSource = false;
+    Mmad(cL0_[(l0BufIdx_ % L0_BUF_NUM) * L0C_BUFFER_OFFSET], queryL0_[(l0BufIdx_ % L0_BUF_NUM) * L0AB_BUFFER_OFFSET],
+         keyL0_[(kl0BufIdx_ % L0_BUF_NUM) * L0AB_BUFFER_OFFSET], mmadParams);
+    if ((mmadParams.m / 16) * (mmadParams.n / 16) < 10) {
+        PipeBarrier<PIPE_M>();
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::Fixp(uint64_t s1gGmOffset,
+                                            uint64_t s2GmOffset, uint64_t s1gL0RealSize,
+                                            uint64_t s2L0RealSize, const LICommon::RunInfo &runInfo)
+{
+    SetFlag<HardEvent::M_FIX>(M_FIX_EVENT + l0BufIdx_ % L0_BUF_NUM);
+    WaitFlag<HardEvent::M_FIX>(M_FIX_EVENT + l0BufIdx_ % L0_BUF_NUM);
+
+    static_assert(S2_BASIC_BLOCK == S2_BASIC_BLOCK_L0 && S2_BASIC_BLOCK_L0 == 128);
+    // s1gL0RealSize：2*gSize(128)对齐, 最大256
+    // s2L0RealSize <= S2_BASIC_BLOCK_L0, 未约束
+    uint32_t nSize = (s2L0RealSize + 7) >> 3 << 3; // 32B对齐
+    uint32_t mSize = (s1gL0RealSize + 1) >> 1 << 1;
+    FixpipeParamsC310<CO2Layout::ROW_MAJOR> fixpipeParams;
+    // 固定参数
+    fixpipeParams.mSize = mSize;
+    fixpipeParams.srcStride = mSize; // 已16对齐
+    fixpipeParams.dstStride = UB_BANK_DEPTH_STRIDE / sizeof(float); // 落到同一个bank
+    fixpipeParams.dualDstCtl = 1; // 双目标模式，按M维度拆分， M / 2 * N写入每个UB，M必须为2的倍数
+
+    uint64_t dstOffset = 0;
+    if (constInfo_.splitMFlag && runInfo.actMBaseSize > 128) { // 非尾块，切M
+        dstOffset = s1gGmOffset * 64;
+    }
+
+    // nSize已保证N方向32B对齐
+    if (nSize <= (256 / sizeof(float))) {
+        // N方向小于一个bank(256B), 只需搬一个ND块, 且不用补齐
+        fixpipeParams.nSize = nSize;
+        fixpipeParams.params.ndNum = 1;
+        fixpipeParams.params.srcNdStride = 0;
+        fixpipeParams.params.dstNdStride = 0;
+    } else {
+        // N方向在(256B, 512B]范围， 直接按512B搬, 注意此时不能开unitflag
+        fixpipeParams.nSize = S2_BASIC_BLOCK_L0 / 2; // 分2个ND搬, S2_BASIC_BLOCK_L0不为128会有问题
+        fixpipeParams.params.ndNum = 2;
+        fixpipeParams.params.srcNdStride = ((fixpipeParams.mSize + 15) / 16) * fixpipeParams.nSize;
+        fixpipeParams.params.dstNdStride = constInfo_.s2BaseSize * constInfo_.mBaseSize / 2;
+    }
+    Fixpipe<float, float, QLI_CFG_ROW_MAJOR_UB>(mm1ResUB_[(runInfo.loop % 2) * constInfo_.s2BaseSize / 2 + dstOffset],
+                                                cL0_[(l0BufIdx_ % L0_BUF_NUM) * L0C_BUFFER_OFFSET], fixpipeParams);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::AllocEventID()
+{
+    SetMMLayoutTransform(true);
+    SetFlag<HardEvent::MTE1_MTE2>(KEY_MTE1_MTE2_EVENT + 0);
+    SetFlag<HardEvent::MTE1_MTE2>(KEY_MTE1_MTE2_EVENT + 1);
+    SetFlag<HardEvent::MTE1_MTE2>(KEY_MTE1_MTE2_EVENT + 2);
+
+    SetFlag<HardEvent::MTE1_MTE2>(QUERY_MTE1_MTE2_EVENT + 0);
+    SetFlag<HardEvent::MTE1_MTE2>(QUERY_MTE1_MTE2_EVENT + 1);
+
+    SetFlag<HardEvent::M_MTE1>(M_MTE1_EVENT + 0);
+    SetFlag<HardEvent::M_MTE1>(M_MTE1_EVENT + 1);
+
+    SetFlag<HardEvent::FIX_M>(FIX_M_EVENT + 0);
+    SetFlag<HardEvent::FIX_M>(FIX_M_EVENT + 1);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceCube<LIT>::FreeEventID()
+{
+    SetMMLayoutTransform(false);
+    WaitFlag<HardEvent::MTE1_MTE2>(KEY_MTE1_MTE2_EVENT + 0);
+    WaitFlag<HardEvent::MTE1_MTE2>(KEY_MTE1_MTE2_EVENT + 1);
+    WaitFlag<HardEvent::MTE1_MTE2>(KEY_MTE1_MTE2_EVENT + 2);
+
+    WaitFlag<HardEvent::MTE1_MTE2>(QUERY_MTE1_MTE2_EVENT + 0);
+    WaitFlag<HardEvent::MTE1_MTE2>(QUERY_MTE1_MTE2_EVENT + 1);
+
+    WaitFlag<HardEvent::M_MTE1>(M_MTE1_EVENT + 0);
+    WaitFlag<HardEvent::M_MTE1>(M_MTE1_EVENT + 1);
+
+    WaitFlag<HardEvent::FIX_M>(FIX_M_EVENT + 0);
+    WaitFlag<HardEvent::FIX_M>(FIX_M_EVENT + 1);
+}
+} // namespace LIKernel
+}  // namespace sglang::npu_kernel::liv2
+#endif

--- a/csrc/lightning_indexer_v2/op_kernel/arch35/lightning_indexer_service_vector.h
+++ b/csrc/lightning_indexer_v2/op_kernel/arch35/lightning_indexer_service_vector.h
@@ -1,0 +1,578 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file lightning_indexer_service_vector.h
+ * \brief
+ */
+#ifndef SGL_LI_V2_LIGHTNING_INDEXER_SERVICE_VECTOR_H
+#define SGL_LI_V2_LIGHTNING_INDEXER_SERVICE_VECTOR_H
+
+#include "kernel_operator.h"
+#include "kernel_operator_list_tensor_intf.h"
+#include "kernel_tiling/kernel_tiling.h"
+#include "lib/matmul_intf.h"
+#include "lib/matrix/matmul/tiling.h"
+#include "../lightning_indexer_v2_common.h"
+#include "../arch35/vf/lightning_indexer_vector1.h"
+#include "../arch35/vf/lightning_indexer_topk.h"
+
+namespace sglang::npu_kernel::liv2 {
+
+namespace LIKernel {
+using namespace LICommon;
+constexpr uint32_t TRUNK_LEN_16K = 16384;
+constexpr uint32_t TRUNK_LEN_8K = 8192;
+constexpr uint32_t TOPK_LEN_4K = 4096;
+
+template<typename Q_T, typename W_T = void>
+struct LightningIndexerTypeTraits {
+    using weightsType = Q_T;   // 默认：weightsType绑定Q_T
+};
+
+template<typename Q_T>
+struct LightningIndexerTypeTraits<Q_T, float> {
+    using weightsType = float;  // W_T=float时，强制weightsType为float
+};
+template <typename LIT>
+class LightningIndexerServiceVector {
+public:
+    // =================================类型定义区=================================
+    static constexpr LI_LAYOUT LAYOUT_T = LIT::layout;
+    static constexpr LI_LAYOUT K_LAYOUT_T = LIT::keyLayout;
+    static constexpr bool PAGE_ATTENTION = LIT::pageAttention;
+    static constexpr bool DT_W_FLAG = LIT::weightsTypeFlag;
+    using Q_T = typename LIT::queryType;
+    using K_T = typename LIT::keyType;
+    using W_T = typename LightningIndexerTypeTraits<Q_T,
+                                                typename std::conditional<DT_W_FLAG, float, void>::type>::weightsType;
+
+    __aicore__ inline LightningIndexerServiceVector(){};
+    __aicore__ inline void ProcessVec1(const LICommon::RunInfo &info);
+    __aicore__ inline void ProcessTopK(const LICommon::RunInfo &info);
+    __aicore__ inline void InitBuffers(TPipe *pipe);
+    __aicore__ inline void InitParams(const struct LICommon::ConstInfo &constInfo,
+                                      const LITilingData *__restrict tilingData);
+    __aicore__ inline void InitVecWorkspaceTensor(GlobalTensor<uint16_t> scoreGm);
+    __aicore__ inline void InitVecInputTensor(GlobalTensor<W_T> weightsGm, GlobalTensor<int32_t> indiceOutGm,
+                                              GlobalTensor<K_T> valueOutGm, GlobalTensor<int32_t> blockTableGm);
+    __aicore__ inline void CleanInvalidOutput(int64_t invalidS1offset);
+    __aicore__ inline void AllocEventID();
+    __aicore__ inline void FreeEventID();
+
+protected:
+    GlobalTensor<uint16_t> scoreGm;
+    GlobalTensor<W_T> weightsGm;
+    GlobalTensor<int32_t> indiceOutGm;
+    GlobalTensor<K_T> valueOutGm;
+    GlobalTensor<int32_t> blockTableGm;
+    // =================================常量区=================================
+    static constexpr uint32_t VEC1_V_MTE2_EVENT = EVENT_ID0;
+    static constexpr uint32_t VEC1_MTE2_V_EVENT = EVENT_ID1;
+    static constexpr uint32_t VEC1_V_MTE3_EVENT = EVENT_ID2;
+    static constexpr uint32_t VEC1_MTE3_V_EVENT = EVENT_ID3;
+
+    static constexpr uint32_t TOPK_V_MTE2_EVENT = EVENT_ID4;
+    static constexpr uint32_t TOPK_MTE2_V_EVENT = EVENT_ID5;
+    static constexpr uint32_t TOPK_V_MTE3_EVENT = EVENT_ID6;
+    static constexpr uint32_t TOPK_MTE3_V_EVENT = EVENT_ID7;
+
+    static constexpr uint32_t MTE3_MTE2_EVENT = EVENT_ID0;
+    static constexpr uint32_t V_MTE2_EVENT = EVENT_ID7;
+    static constexpr uint32_t V_MTE2_EVENT1 = EVENT_ID2;
+    static constexpr uint32_t V_MTE2_EVENT2 = EVENT_ID3;
+    static constexpr uint32_t V_MTE2_EVENT3 = EVENT_ID5;
+
+private:
+    // ================================Local Buffer区====================================
+
+    // tmp buff for vector
+    TBuf<TPosition::VECCALC> resMm1Buf_;
+    LocalTensor<float> resMm1UB_;
+    // tmp buff for weight
+    TBuf<TPosition::VECCALC> weightBuf_;
+    LocalTensor<W_T> weightUB_;
+    // tmp buff for weight cast float
+    TBuf<TPosition::VECCALC> weightFloatBuf_;
+    LocalTensor<float> weightFloatUB_;
+
+    // tmp buff for out
+    TBuf<TPosition::VECCALC> outBuf_;
+    LocalTensor<uint16_t> vec1OutUB_;
+
+    // tmp buff for returnValue K_T
+    TBuf<TPosition::VECCALC> valueOutBuf_;
+    LocalTensor<K_T> valueOutLocal_;
+
+    // tmp buff for topk
+    TBuf<TPosition::VECCALC> mrgValueBuf_;
+    LocalTensor<uint16_t> mrgValueLocal_;
+
+    TBuf<TPosition::VECCALC> indicesOutBuf_;
+    LocalTensor<uint32_t> indicesOutLocal_;
+
+    TBuf<TPosition::VECCALC> scoreOutBuf_;
+    LocalTensor<uint16_t> scoreOutLocal_;
+
+    TBuf<TPosition::VECCALC> topkSharedTmpBuf_;
+    LocalTensor<uint32_t> topkSharedTmpLocal_;
+
+    int32_t blockId_ = -1;
+    // para for vector
+    int32_t groupInner_ = 0;
+    int32_t globalTopkNum_ = 0;
+    int64_t blockS2StartIdx_ = 0;
+    int32_t gSize_ = 0;
+    int32_t kSeqSize_ = 0;
+    int32_t kHeadNum_ = 0;
+    int32_t qHeadNum_ = 0;
+    int32_t s1BaseSize_ = 0;
+    int32_t s2BaseSize_ = 0;
+    int32_t kCacheBlockSize_ = 0;
+    int32_t maxBlockNumPerBatch_ = 0;
+    uint32_t topkCount_ = 0;
+    uint32_t topkCountAlign256_ = 0; // topkCount对齐到256(直方图需要)，支持topk泛化
+    uint32_t trunkLen_ = 0;
+    bool returnValueFlag = false;
+
+    struct LICommon::ConstInfo constInfo_;
+    topk::LITopk<uint16_t> topkOp_;
+};
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceVector<LIT>::InitBuffers(TPipe *pipe)
+{
+    pipe->InitBuffer(resMm1Buf_, 2 * CeilDiv(constInfo_.mBaseSize, 2) * s2BaseSize_ * sizeof(float));
+    resMm1UB_ = resMm1Buf_.Get<float>();
+
+    pipe->InitBuffer(weightBuf_, 2 * CeilDiv(s1BaseSize_, 2) * UB_BANK_DEPTH_STRIDE);
+    weightUB_ = weightBuf_.Get<W_T>();
+    pipe->InitBuffer(weightFloatBuf_, 2 * CeilDiv(s1BaseSize_, 2) * UB_BANK_DEPTH_STRIDE);
+    weightFloatUB_ = weightFloatBuf_.Get<float>();
+    pipe->InitBuffer(outBuf_,
+                    2 * CeilDiv(s1BaseSize_, 2) * s2BaseSize_ * sizeof(uint16_t));      // 大小：2(开dB) * 2 * 128 * 4 = 2KB
+    vec1OutUB_ = outBuf_.Get<uint16_t>(); // out
+
+    // Topk
+    pipe->InitBuffer(mrgValueBuf_,
+                    (topkCountAlign256_ + trunkLen_) * sizeof(uint16_t));
+    mrgValueLocal_ = mrgValueBuf_.Get<uint16_t>();
+    // returnvalue
+    if (topkCount_ <= 2048) {
+        pipe->InitBuffer(valueOutBuf_, topkCountAlign256_ * sizeof(K_T));
+        valueOutLocal_ = valueOutBuf_.Get<K_T>();
+    } else { // sparseCount > 2k时，复用return value相关UB
+        valueOutLocal_ = mrgValueBuf_.Get<K_T>(); // returnValue float
+    }
+
+    // 大小：(topkCountAlign256_ + 64) * 4  64:duplicate刷-1需要额外空间
+    pipe->InitBuffer(indicesOutBuf_,
+                    (topkCountAlign256_ + 64) * sizeof(uint32_t));
+    indicesOutLocal_ = indicesOutBuf_.Get<uint32_t>();
+
+    pipe->InitBuffer(scoreOutBuf_, topkCountAlign256_ * sizeof(uint16_t));
+    scoreOutLocal_ = scoreOutBuf_.Get<uint16_t>();
+
+    uint64_t topkSharedTmpSize = topkOp_.GetSharedTmpBufferSize();
+    pipe->InitBuffer(topkSharedTmpBuf_, topkSharedTmpSize);
+    topkSharedTmpLocal_ = topkSharedTmpBuf_.Get<uint32_t>();
+    topkOp_.InitBuffers(topkSharedTmpLocal_);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceVector<LIT>::InitParams(const struct LICommon::ConstInfo &constInfo,
+                                                   const LITilingData *__restrict tilingData)
+{
+    this->constInfo_ = constInfo;
+    blockS2StartIdx_ = 0;
+    gSize_ = constInfo.gSize;
+    kSeqSize_ = constInfo.kSeqSize;
+    // define N2 para
+    kHeadNum_ = constInfo.kHeadNum;
+    qHeadNum_ = constInfo.qHeadNum;
+    // define MMBase para
+    s1BaseSize_ = constInfo.s1BaseSize;  // 4
+    s2BaseSize_ = constInfo.s2BaseSize;  // 128
+    kCacheBlockSize_ = constInfo.kCacheBlockSize;
+    maxBlockNumPerBatch_ = constInfo.maxBlockNumPerBatch;
+    returnValueFlag = constInfo.returnValueFlag;
+    blockId_ = GetBlockIdx();
+    trunkLen_ = constInfo.sparseCount >= TOPK_LEN_4K ? TRUNK_LEN_8K : TRUNK_LEN_16K;
+    topkCount_ = constInfo.sparseCount;
+    topkOp_.Init(topkCount_, trunkLen_);
+    topkCountAlign256_ = LICommon::Align(constInfo.sparseCount, (uint64_t)256); // topkCount对齐到256
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceVector<LIT>::InitVecInputTensor(GlobalTensor<W_T> weightsGm,
+                                                                                GlobalTensor<int32_t> indiceOutGm,
+                                                                                GlobalTensor<K_T> valueOutGm,
+                                                                                GlobalTensor<int32_t> blockTableGm)
+{
+    this->weightsGm = weightsGm;
+    this->indiceOutGm = indiceOutGm;
+    this->valueOutGm = valueOutGm;
+    this->blockTableGm = blockTableGm;
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceVector<LIT>::InitVecWorkspaceTensor(GlobalTensor<uint16_t> scoreGm)
+{
+    this->scoreGm = scoreGm; // resucesum*k
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceVector<LIT>::AllocEventID()
+{
+    SetFlag<HardEvent::V_MTE2>(VEC1_V_MTE2_EVENT + 0);
+    SetFlag<HardEvent::V_MTE2>(VEC1_V_MTE2_EVENT + 1);
+    SetFlag<HardEvent::MTE3_V>(VEC1_MTE3_V_EVENT + 0);
+    SetFlag<HardEvent::MTE3_V>(VEC1_MTE3_V_EVENT + 1);
+
+    SetFlag<HardEvent::V_MTE2>(TOPK_V_MTE2_EVENT);
+    SetFlag<HardEvent::MTE3_V>(TOPK_MTE3_V_EVENT);
+    SetFlag<HardEvent::V_MTE2>(V_MTE2_EVENT1);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceVector<LIT>::FreeEventID()
+{
+    WaitFlag<HardEvent::V_MTE2>(VEC1_V_MTE2_EVENT + 0);
+    WaitFlag<HardEvent::V_MTE2>(VEC1_V_MTE2_EVENT + 1);
+    WaitFlag<HardEvent::MTE3_V>(VEC1_MTE3_V_EVENT + 0);
+    WaitFlag<HardEvent::MTE3_V>(VEC1_MTE3_V_EVENT + 1);
+
+    WaitFlag<HardEvent::V_MTE2>(TOPK_V_MTE2_EVENT);
+    WaitFlag<HardEvent::MTE3_V>(TOPK_MTE3_V_EVENT);
+    WaitFlag<HardEvent::V_MTE2>(V_MTE2_EVENT1);
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceVector<LIT>::CleanInvalidOutput(int64_t invalidS1Offset)
+{
+    // init -1 and copy to output
+    uint64_t dealSize = constInfo_.sparseCount;
+    GlobalTensor<int32_t> indexOutput = indiceOutGm[invalidS1Offset];
+    AscendC::InitGlobalMemory(indexOutput, dealSize, constInfo_.INVALID_IDX);
+    if (returnValueFlag) {
+        SetFlag<HardEvent::MTE3_V>(TOPK_MTE3_V_EVENT);
+        WaitFlag<HardEvent::MTE3_V>(TOPK_MTE3_V_EVENT);
+        Duplicate(valueOutLocal_.template ReinterpretCast<uint16_t>(), constInfo_.INVALID_VAL, constInfo_.sparseCount);
+
+        SetFlag<HardEvent::V_MTE3>(TOPK_V_MTE3_EVENT);
+        WaitFlag<HardEvent::V_MTE3>(TOPK_V_MTE3_EVENT);
+
+        AscendC::DataCopyParams copyOutValueParams;
+        copyOutValueParams.blockCount = 1;
+        copyOutValueParams.blockLen = constInfo_.sparseCount * sizeof(K_T);
+        copyOutValueParams.srcStride = 0;
+        copyOutValueParams.dstStride = 0;
+        AscendC::DataCopyPad(valueOutGm[invalidS1Offset], valueOutLocal_, copyOutValueParams);
+    }
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceVector<LIT>::ProcessVec1(const LICommon::RunInfo &info)
+{
+    auto pingpong = (info.loop % 2);
+    auto s1BaseSizePerAIV = CeilDiv(s1BaseSize_, 2);
+    int64_t curS1Idx = info.gS1Idx * s1BaseSize_;
+    int64_t curS2Idx = info.s2Idx * s2BaseSize_;
+    int64_t curS1ProcNum = curS1Idx + s1BaseSize_ > info.actS1Size ? info.actS1Size % s1BaseSize_ : s1BaseSize_;
+    int64_t curAivS1Idx = curS1Idx + (blockId_ % 2) * CeilDiv(curS1ProcNum, 2);
+    int64_t curAivS1ProcNum = (blockId_ % 2 == 0) ? CeilDiv(curS1ProcNum, 2) : curS1ProcNum / 2;
+    if (curAivS1ProcNum == 0) {
+        CrossCoreWaitFlag<LICommon::ConstInfo::QLI_SYNC_MODE4, PIPE_V>(
+            LICommon::ConstInfo::CROSS_CV_EVENT + pingpong
+        );  // V核等C核计算完mm1，mm1Res已搬运到UB
+        CrossCoreSetFlag<LICommon::ConstInfo::QLI_SYNC_MODE4, PIPE_V>(
+            LICommon::ConstInfo::CROSS_VC_EVENT + pingpong
+        );   // V核处理完，通知C核可以把mm1Res搬运到UB
+        return;
+    }
+    WaitFlag<HardEvent::V_MTE2>(VEC1_V_MTE2_EVENT + pingpong);
+    // weightsGm --> weightUB_
+    int64_t weightGmOffset = info.tensorWeightsOffset + curAivS1Idx * kHeadNum_ * gSize_;
+    DataCopyPadExtParams<W_T> padWeightsParams{false, 0, 0, 0};
+    DataCopyExtParams wDataCopyExtParams;
+    wDataCopyExtParams.blockCount = curAivS1ProcNum;
+    wDataCopyExtParams.blockLen = gSize_ * sizeof(W_T);
+    wDataCopyExtParams.srcStride = 0;
+    wDataCopyExtParams.dstStride = (UB_BANK_DEPTH_STRIDE - wDataCopyExtParams.blockLen) / 32;
+    DataCopyPad(weightUB_[pingpong * (UB_BANK_STRIDE / sizeof(W_T))],
+                weightsGm[weightGmOffset], wDataCopyExtParams, padWeightsParams);
+
+    SetFlag<HardEvent::MTE2_V>(VEC1_MTE2_V_EVENT + pingpong);
+    WaitFlag<HardEvent::MTE2_V>(VEC1_MTE2_V_EVENT + pingpong);
+    WaitFlag<HardEvent::MTE3_V>(VEC1_MTE3_V_EVENT + pingpong);
+
+    // CV同步
+    CrossCoreWaitFlag<LICommon::ConstInfo::QLI_SYNC_MODE4, PIPE_V>(
+        LICommon::ConstInfo::CROSS_CV_EVENT + info.loop % 2
+    );   // V核等C核计算完mm1，mm1Res已搬运到UB
+
+    auto outBase = vec1OutUB_[pingpong * (UB_BANK_STRIDE / sizeof(uint16_t))];
+    auto weightBase = weightUB_[pingpong * (UB_BANK_STRIDE / sizeof(W_T))];
+    auto weightFloatBase = weightFloatUB_[pingpong * (UB_BANK_STRIDE / sizeof(float))];
+    auto qkBase = resMm1UB_[pingpong * (UB_BANK_STRIDE / sizeof(float))];
+    auto qkVLstride = (UB_BANK_DEPTH_STRIDE / sizeof(float)) / 2 * constInfo_.mBaseSize;
+
+    vector1::BatchMulWeightAndReduceSum(outBase, UB_BANK_DEPTH_STRIDE / sizeof(uint16_t),
+                                        qkBase, qkVLstride, (uint32_t)(gSize_ * UB_BANK_DEPTH_STRIDE / sizeof(float)),
+                                        weightBase, UB_BANK_DEPTH_STRIDE / sizeof(W_T), weightFloatBase,
+                                        gSize_, curAivS1ProcNum);
+    SetFlag<HardEvent::V_MTE2>(VEC1_V_MTE2_EVENT + pingpong);
+    SetFlag<HardEvent::V_MTE3>(VEC1_V_MTE3_EVENT + pingpong);
+    WaitFlag<HardEvent::V_MTE3>(VEC1_V_MTE3_EVENT + pingpong);
+    // outUB_ --->  scoreGm
+    int64_t vec1OutGmOffset = blockId_ % 2 == 0
+                                            ? curS2Idx
+                                            : s1BaseSizePerAIV * LICommon::Align(
+                                                (uint64_t)constInfo_.kSeqSize, (uint64_t)s2BaseSize_
+                                                ) + curS2Idx;
+    DataCopyExtParams copyOutParams;
+    copyOutParams.blockCount = curAivS1ProcNum;
+    copyOutParams.blockLen = s2BaseSize_ * sizeof(uint16_t);
+    copyOutParams.srcStride = (UB_BANK_DEPTH_STRIDE - UB_BANK_STRIDE) / 32;
+    copyOutParams.dstStride = (LICommon::Align(
+                                        (uint64_t)constInfo_.kSeqSize, (uint64_t)s2BaseSize_
+                                        ) - s2BaseSize_) * sizeof(uint16_t);
+    DataCopyPad(scoreGm[vec1OutGmOffset], outBase, copyOutParams);
+    SetFlag<HardEvent::MTE3_V>(VEC1_MTE3_V_EVENT + pingpong);
+    CrossCoreSetFlag<LICommon::ConstInfo::QLI_SYNC_MODE4, PIPE_V>(
+        LICommon::ConstInfo::CROSS_VC_EVENT + pingpong
+    );   // V核处理完，通知C核可以把mm1Res搬运到UB
+}
+
+template <typename LIT>
+__aicore__ inline void LightningIndexerServiceVector<LIT>::ProcessTopK(const LICommon::RunInfo &info)
+{
+    SetFlag<HardEvent::MTE3_MTE2>(MTE3_MTE2_EVENT);
+    WaitFlag<HardEvent::MTE3_MTE2>(MTE3_MTE2_EVENT);
+
+    int64_t curS1Idx = info.gS1Idx * s1BaseSize_;
+    int64_t curS2Idx = info.s2Idx * s2BaseSize_;
+    int64_t curS1ProcNum = curS1Idx + s1BaseSize_ > info.actS1Size ? info.actS1Size % s1BaseSize_ : s1BaseSize_;
+    int64_t curAivS1Idx = curS1Idx + (blockId_ % 2) * CeilDiv(curS1ProcNum, 2);
+    int64_t curAivS1ProcNum = (blockId_ % 2 == 0) ? CeilDiv(curS1ProcNum, 2) : curS1ProcNum / 2;
+
+    AscendC::DataCopyExtParams copyInParams;
+    copyInParams.blockCount = 1;
+    copyInParams.srcStride = 0;
+    copyInParams.dstStride = 0;
+    copyInParams.rsv = 0;
+
+    AscendC::DataCopyParams copyOutParams;
+    copyOutParams.blockCount = 1;
+    copyOutParams.blockLen = topkCount_ * sizeof(uint32_t); // bytes
+    copyOutParams.srcStride = 0;
+    copyOutParams.dstStride = 0;
+
+    int32_t cuRealAcSeq = info.actS2Size;
+    if (constInfo_.attenMaskFlag) {
+        cuRealAcSeq = info.actS2SizeOrig - info.actS1Size + curAivS1Idx + 1;
+    }
+
+    int32_t validS2Len = cuRealAcSeq;
+    for (uint32_t i = 0; i < curAivS1ProcNum; i++) {
+        uint32_t rowIdx = blockId_ % 2 * CeilDiv(curS1ProcNum, 2) + i;
+        uint32_t vecOffset = blockId_ % 2 * CeilDiv(s1BaseSize_, 2) + i;
+
+        uint16_t zero = 0;
+        int32_t neg = -1;
+        if (constInfo_.attenMaskFlag) {
+            validS2Len = (int32_t)i + cuRealAcSeq;
+        }
+        if (validS2Len <= 0) {
+            WaitFlag<HardEvent::MTE3_V>(TOPK_MTE3_V_EVENT);
+            Duplicate(indicesOutLocal_.ReinterpretCast<int32_t>(), neg, topkCount_);
+            SetFlag<HardEvent::V_MTE3>(TOPK_V_MTE3_EVENT);
+            WaitFlag<HardEvent::V_MTE3>(TOPK_V_MTE3_EVENT);
+            AscendC::DataCopyPad(indiceOutGm[info.indiceOutOffset + (curS1Idx + rowIdx) * topkCount_],
+                                                          indicesOutLocal_.ReinterpretCast<int32_t>(),
+                                                          copyOutParams);
+            SetFlag<HardEvent::MTE3_V>(TOPK_MTE3_V_EVENT);
+            if (returnValueFlag) {
+                WaitFlag<HardEvent::MTE3_V>(TOPK_MTE3_V_EVENT);
+                Duplicate(valueOutLocal_.template ReinterpretCast<uint16_t>(), constInfo_.INVALID_VAL, topkCount_);
+
+                SetFlag<HardEvent::V_MTE3>(TOPK_V_MTE3_EVENT);
+                WaitFlag<HardEvent::V_MTE3>(TOPK_V_MTE3_EVENT);
+
+                AscendC::DataCopyParams copyOutValueParams;
+                copyOutValueParams.blockCount = 1;
+                copyOutValueParams.blockLen = topkCount_ * sizeof(K_T);
+                copyOutValueParams.srcStride = 0;
+                copyOutValueParams.dstStride = 0;
+                AscendC::DataCopyPad(
+                    valueOutGm[info.valueOutOffset + (curS1Idx + rowIdx) * topkCount_],
+                    valueOutLocal_,
+                    copyOutValueParams);
+                SetFlag<HardEvent::MTE3_V>(TOPK_MTE3_V_EVENT);
+            }
+            continue;
+        }
+
+        WaitFlag<HardEvent::V_MTE2>(TOPK_V_MTE2_EVENT);
+        WaitFlag<HardEvent::MTE3_V>(TOPK_MTE3_V_EVENT);
+
+        AscendC::DataCopyPadExtParams<uint16_t> padParams{true, 0, 0, 0};
+        if (validS2Len >= topkCount_) {
+            uint32_t s2LoopNum = (validS2Len + trunkLen_ - 1) / trunkLen_;
+            if (s2LoopNum == 1) {
+                uint32_t validS2LenAlign = LICommon::Align(validS2Len, (int32_t)256);
+                Duplicate(mrgValueLocal_[validS2Len / 256 * 256], zero, validS2LenAlign - validS2Len / 256 * 256);
+                SetFlag<HardEvent::V_MTE2>(V_MTE2_EVENT);
+                WaitFlag<HardEvent::V_MTE2>(V_MTE2_EVENT);
+                copyInParams.blockLen = validS2Len * sizeof(uint16_t); // byte
+                AscendC::DataCopyPadExtParams<uint16_t> padParams{true, 0, 0, 0};
+                AscendC::DataCopyPad(
+                    mrgValueLocal_,
+                    scoreGm[vecOffset * LICommon::Align((uint64_t)constInfo_.kSeqSize, (uint64_t)s2BaseSize_)],
+                    copyInParams, padParams);
+                SetFlag<HardEvent::MTE2_V>(TOPK_MTE2_V_EVENT);
+                WaitFlag<HardEvent::MTE2_V>(TOPK_MTE2_V_EVENT);
+                topkOp_(mrgValueLocal_, indicesOutLocal_, scoreOutLocal_, validS2LenAlign, 0, 1, returnValueFlag);
+            } else {
+                for (uint32_t loopIdx = 0; loopIdx < s2LoopNum; loopIdx++) {
+                    if (loopIdx == 0) {
+                        copyInParams.blockLen = trunkLen_ * sizeof(uint16_t); // byte
+                        AscendC::DataCopyPad(
+                            mrgValueLocal_,
+                            scoreGm[vecOffset * LICommon::Align((uint64_t)constInfo_.kSeqSize, (uint64_t)s2BaseSize_)],
+                            copyInParams, padParams);
+                        SetFlag<HardEvent::MTE2_V>(TOPK_MTE2_V_EVENT);
+                        WaitFlag<HardEvent::MTE2_V>(TOPK_MTE2_V_EVENT);
+                        topkOp_(mrgValueLocal_, indicesOutLocal_,
+                            scoreOutLocal_, trunkLen_, loopIdx,
+                            s2LoopNum, returnValueFlag);
+                        continue;
+                    }
+                    SetFlag<HardEvent::V_MTE2>(V_MTE2_EVENT2);
+                    WaitFlag<HardEvent::V_MTE2>(V_MTE2_EVENT2);
+                    uint32_t validTrunkLen = (loopIdx * trunkLen_ + trunkLen_) > validS2Len
+                                                                               ? validS2Len % trunkLen_
+                                                                               :trunkLen_;
+                    uint32_t offset = vecOffset *
+                                 LICommon::Align((uint64_t)constInfo_.kSeqSize, (uint64_t)s2BaseSize_) +
+                                 loopIdx * trunkLen_;
+                    AscendC::DataCopy(mrgValueLocal_, scoreOutLocal_, topkCountAlign256_);
+                    // topk如果没有对齐到256，则把topkCountAlign256_ - topkCount_部分刷0
+                    if (topkCountAlign256_ != topkCount_) {
+                        uint64_t mask[1];
+                        mask[0] = ~0;
+                        mask[0] = mask[0] << (topkCount_ % 64);
+                        PipeBarrier<PIPE_V>();
+                        // 把topkCount_对齐到64刷0，此处由于duplicate的限制mask[0]刷64个数
+                        Duplicate(mrgValueLocal_[topkCount_ / 64 * 64], zero, mask, 1, 1, 0);
+                        PipeBarrier<PIPE_V>();
+                        // 把topk剩余对齐到256的部分刷0
+                        Duplicate(mrgValueLocal_[topkCount_ / 64 * 64 + 64], zero,
+                                             topkCountAlign256_ - (topkCount_ / 64 * 64 + 64));
+                        SetFlag<HardEvent::V_MTE2>(V_MTE2_EVENT3);
+                        WaitFlag<HardEvent::V_MTE2>(V_MTE2_EVENT3);
+                    }
+                    copyInParams.blockLen = validTrunkLen * sizeof(uint16_t); // byte
+                    // TOPK 直方图一次必须计算256，输入处理数据需要和256对齐
+                    if ((topkCountAlign256_ + validTrunkLen) % 256 != 0) {
+                        Duplicate(mrgValueLocal_[topkCountAlign256_ + validTrunkLen / 256 * 256],
+                                        zero, LICommon::Align(validTrunkLen,
+                                        (uint32_t)256) - validTrunkLen / 256 * 256);
+                        SetFlag<HardEvent::V_MTE2>(V_MTE2_EVENT);
+                        WaitFlag<HardEvent::V_MTE2>(V_MTE2_EVENT);
+                    }
+                    WaitFlag<HardEvent::V_MTE2>(V_MTE2_EVENT1);
+                    AscendC::DataCopyPad(mrgValueLocal_[topkCountAlign256_], scoreGm[offset], copyInParams, padParams);
+                    SetFlag<HardEvent::MTE2_V>(TOPK_MTE2_V_EVENT);
+                    WaitFlag<HardEvent::MTE2_V>(TOPK_MTE2_V_EVENT);
+                    topkOp_(mrgValueLocal_, indicesOutLocal_,
+                                scoreOutLocal_,
+                                LICommon::Align(topkCountAlign256_ + validTrunkLen, (uint32_t)256),
+                                loopIdx, s2LoopNum, returnValueFlag);
+                    SetFlag<HardEvent::V_MTE2>(V_MTE2_EVENT1);
+                }
+            }
+        } else {
+            AscendC::CreateVecIndex(indicesOutLocal_.ReinterpretCast<int32_t>(), (int32_t)zero, validS2Len);
+            if (returnValueFlag) {
+                copyInParams.blockLen = LICommon::Align(validS2Len, (int32_t)32) * sizeof(uint16_t);
+                AscendC::DataCopyPad(scoreOutLocal_,
+                            scoreGm[vecOffset * LICommon::Align((uint64_t)constInfo_.kSeqSize, (uint64_t)s2BaseSize_)],
+                            copyInParams, padParams);
+                SetFlag<HardEvent::MTE2_V>(TOPK_MTE2_V_EVENT);
+                WaitFlag<HardEvent::MTE2_V>(TOPK_MTE2_V_EVENT);
+            }
+        }
+
+        if (validS2Len < topkCount_) {
+            uint64_t mask[1];
+            mask[0] = ~0;
+            mask[0] = mask[0] << (validS2Len % 8);
+            PipeBarrier<PIPE_V>();
+            Duplicate(indicesOutLocal_.ReinterpretCast<int32_t>()[validS2Len / 8 * 8], neg, mask, 1, 1, 0);
+        }
+
+        if (validS2Len / 8 * 8 + 64 < topkCount_) {
+            PipeBarrier<PIPE_V>();
+            Duplicate(indicesOutLocal_.ReinterpretCast<int32_t>()[validS2Len / 8 * 8 + 64],
+                                        neg, topkCount_ - (validS2Len / 8 * 8 + 64));
+        }
+
+        SetFlag<HardEvent::V_MTE2>(TOPK_V_MTE2_EVENT);
+        SetFlag<HardEvent::V_MTE3>(TOPK_V_MTE3_EVENT);
+        WaitFlag<HardEvent::V_MTE3>(TOPK_V_MTE3_EVENT);
+        AscendC::DataCopyPad(indiceOutGm[info.indiceOutOffset + (curS1Idx + rowIdx) * topkCount_],
+                             indicesOutLocal_.ReinterpretCast<int32_t>(), copyOutParams);
+
+
+        // 是否返回Value值
+        if (returnValueFlag) {
+            WaitFlag<HardEvent::V_MTE2>(TOPK_V_MTE2_EVENT);
+            // uint16_t -> bfloat16
+            if (std::is_same_v<K_T, bfloat16_t>) {
+                vector1::UIntToFloatReturnValue(valueOutLocal_.template ReinterpretCast<bfloat16_t>(),
+                    scoreOutLocal_, topkCountAlign256_);
+            } else {
+                vector1::UIntToFloatReturnValue(valueOutLocal_.template ReinterpretCast<half>(),
+                    scoreOutLocal_, topkCountAlign256_);
+            }
+
+            if (validS2Len < topkCount_) {
+                uint64_t mask[1];
+                mask[0] = ~0;
+                mask[0] = mask[0] << (validS2Len % 16);
+                PipeBarrier<PIPE_V>();
+                Duplicate(valueOutLocal_.template ReinterpretCast<uint16_t>()[validS2Len / 16 * 16],
+                            constInfo_.INVALID_VAL, mask, 1, 1, 0);
+            }
+            if (validS2Len / 16 * 16 + 64 < topkCount_) {
+                PipeBarrier<PIPE_V>();
+                Duplicate(valueOutLocal_.template ReinterpretCast<uint16_t>()[validS2Len / 16 * 16 + 64],
+                            constInfo_.INVALID_VAL, topkCount_ - (validS2Len / 16 * 16 + 64));
+            }
+            SetFlag<HardEvent::V_MTE2>(TOPK_V_MTE2_EVENT);
+            SetFlag<HardEvent::V_MTE3>(TOPK_V_MTE3_EVENT);
+            WaitFlag<HardEvent::V_MTE3>(TOPK_V_MTE3_EVENT);
+            AscendC::DataCopyParams copyOutValueParams;
+            copyOutValueParams.blockCount = 1;
+            copyOutValueParams.blockLen = topkCount_ * sizeof(K_T); // bytes
+            copyOutValueParams.srcStride = 0;
+            copyOutValueParams.dstStride = 0;
+            // 搬运到GM
+            AscendC::DataCopyPad(
+                valueOutGm[info.valueOutOffset + (curS1Idx + rowIdx) * topkCount_],
+                valueOutLocal_, copyOutValueParams);
+        }
+        SetFlag<HardEvent::MTE3_V>(TOPK_MTE3_V_EVENT);
+    }
+}
+}  // namespace LIKernel
+}  // namespace sglang::npu_kernel::liv2
+#endif

--- a/csrc/lightning_indexer_v2/op_kernel/arch35/vf/lightning_indexer_topk.h
+++ b/csrc/lightning_indexer_v2/op_kernel/arch35/vf/lightning_indexer_topk.h
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+/*!
+ * \file lightning_indexer_topk.h
+ * \brief
+ */
+#ifndef SGL_LI_V2_LIGHTNING_INDEXER_TOPK_H
+#define SGL_LI_V2_LIGHTNING_INDEXER_TOPK_H
+
+#include "kernel_operator.h"
+#include "vf_topk.h"
+#include "vf_topk_16_gather.h"
+
+namespace sglang::npu_kernel::liv2 {
+
+namespace topk {
+template<typename T>
+class LITopk {
+public:
+    __aicore__ inline void operator()(LocalTensor<uint32_t>& outputIdxLocal,
+                                      LocalTensor<T>& inputLocal,
+                                      uint32_t s2SeqLen)
+    {
+    }
+};
+
+template<>
+class LITopk<uint32_t> {
+public:
+    static __aicore__ inline uint32_t GetSharedTmpBufferSize(uint32_t topK)
+    {
+        return 2 * topK * sizeof(uint32_t) + 5 * 256 * sizeof(uint32_t) + 64 * sizeof(uint32_t) +
+               (topK + 64) * sizeof(uint32_t); // for output value tensor
+    }
+
+    static __aicore__ inline uint32_t GetIndexBufferSize(uint32_t topK)
+    {
+        return (topK + 64) * sizeof(uint32_t);
+    }
+
+    __aicore__ inline void Init(uint32_t topK)
+    {
+        this->topK = topK;
+    }
+
+    __aicore__ inline void InitBuffers(LocalTensor<uint32_t>& sharedTmpBuffer)
+    {
+        tmpIdxLocal = sharedTmpBuffer[0];
+        tmpValueLocal = tmpIdxLocal[topK];
+        histogramsLocal = tmpValueLocal[topK];
+        idx0Local = histogramsLocal[256];
+        idx1Local = idx0Local[256];
+        idx2Local = idx1Local[256];
+        idx3Local = idx2Local[256];
+        nkValueLocal = idx3Local[256];
+        outputValueLocal = nkValueLocal[64];
+    }
+
+    __aicore__ inline void operator()(LocalTensor<uint32_t>& outputIdxLocal,
+                                      LocalTensor<uint32_t>& inputLocal,
+                                      uint32_t s2SeqLen)
+    {
+        topkb32::LiTopKVF(outputIdxLocal, // filter阶段使用输出value Buf topK * 4B
+                          outputValueLocal, // filter阶段使用输出 Idx Buf topK * 4B
+                          inputLocal, // 输入 s2SeqLen * 4B
+                          tmpIdxLocal, // filter阶段使用暂存index Buf topK * 4B
+                          tmpValueLocal, // filter阶段使用暂存value Buf topK * 4B
+                          histogramsLocal, // 直方图的临时Buf 256 * 4B
+                          idx0Local, // 输入数据第1个8位Buf 256 * 4B
+                          idx1Local, // 输入数据第2个8位Buf 256 * 4B
+                          idx2Local, // 输入数据第3个8位Buf 256 * 4B
+                          idx3Local, // 输入数据第4个8位Buf 256 * 4B
+                          nkValueLocal, // next_k 暂存Buf 64 * 4B
+                          topK,       // topk数量
+                          s2SeqLen); // 输入元素总数
+    }
+private:
+    LocalTensor<uint32_t> tmpIdxLocal;     // filter阶段使用暂存index Buf topK * 4B
+    LocalTensor<uint32_t> tmpValueLocal;   // filter阶段使用暂存value Buf topK * 4B
+    LocalTensor<uint32_t> histogramsLocal; // 直方图的临时Buf 256 * 4B
+    LocalTensor<uint32_t> idx0Local;       // 输入数据第1个8位Buf 256 * 4B
+    LocalTensor<uint32_t> idx1Local;       // 输入数据第2个8位Buf 256 * 4B
+    LocalTensor<uint32_t> idx2Local;       // 输入数据第3个8位Buf 256 * 4B
+    LocalTensor<uint32_t> idx3Local;       // 输入数据第4个8位Buf 256 * 4B
+    LocalTensor<uint32_t> nkValueLocal; // next_k 暂存Buf 64 * 4B
+    LocalTensor<uint32_t> outputValueLocal; // 输出value tensor
+    uint32_t topK;
+};
+
+template<>
+class LITopk<uint16_t> {
+public:
+    __aicore__ inline uint32_t GetSharedTmpBufferSize()
+    {
+        // 2 * LICommon::Align(topK, (uint32_t)256):两块hisIndexLocal；
+        // 3 * 256：histogramsLocal idxHighLocal idxLowLocal；64：nkValueLocal
+        uint64_t bufferSize1 = (2 * LICommon::Align(topK, (uint32_t)256) + 3 * 256 + 64)  * sizeof(uint32_t);
+        // LICommon::Align(topK, (uint32_t)256) + trunkLen：tmpIndexLocal
+        uint64_t bufferSize2 = (LICommon::Align(topK, (uint32_t)256) + trunkLen)  * sizeof(uint16_t);
+        return bufferSize1 + bufferSize2;
+    }
+
+    __aicore__ inline void Init(uint32_t topK, uint32_t trunkLen)
+    {
+        this->topK = topK;
+        this->trunkLen =  trunkLen;
+    }
+
+    __aicore__ inline void InitBuffers(LocalTensor<uint32_t>& sharedTmpBuffer)
+    {
+        LocalTensor<uint32_t> hisIndexLocal1 = sharedTmpBuffer[0];
+        LocalTensor<uint32_t> hisIndexLocal2 = hisIndexLocal1[LICommon::Align(topK, (uint32_t)256)];
+        hisIndexLocal[0] = hisIndexLocal1;
+        hisIndexLocal[1] = hisIndexLocal2;
+        histogramsLocal = hisIndexLocal2[LICommon::Align(topK, (uint32_t)256)];
+        idxHighLocal = histogramsLocal[256];
+        idxLowLocal = idxHighLocal[256];
+        nkValueLocal = idxLowLocal[256];
+        LocalTensor<uint32_t> tmpIndexLocalTmp = nkValueLocal[64];
+        tmpIndexLocal = tmpIndexLocalTmp.template ReinterpretCast<uint16_t>();
+    }
+
+    __aicore__ inline void operator()(LocalTensor<uint16_t>& mrgValueLocal, LocalTensor<uint32_t>& indicesOutLocal,
+                                      LocalTensor<uint16_t>& hisValueLocal, uint32_t s2SeqLen, uint32_t loopIdx,
+                                      uint32_t s2LoopNum, bool returnValueFlag)
+    {
+        if (s2LoopNum == 1) {
+            if (returnValueFlag) {
+                topkb16gather::LiTopKVF<true>(tmpIndexLocal, hisValueLocal,
+                                              mrgValueLocal, histogramsLocal, idxHighLocal,
+                                              idxLowLocal, nkValueLocal, topK, s2SeqLen);
+            } else {
+                topkb16gather::LiTopKVF<false>(tmpIndexLocal, hisValueLocal,
+                                               mrgValueLocal, histogramsLocal, idxHighLocal,
+                                               idxLowLocal, nkValueLocal, topK, s2SeqLen);
+            }
+            PipeBarrier<PIPE_V>();
+            Cast(indicesOutLocal, tmpIndexLocal, RoundMode::CAST_NONE, topK);
+            return;
+        }
+
+        if (loopIdx == 0) {
+            topkb16gather::LiTopKVF<true>(tmpIndexLocal, hisValueLocal,
+                                          mrgValueLocal, histogramsLocal, idxHighLocal,
+                                          idxLowLocal, nkValueLocal, topK, s2SeqLen);
+            PipeBarrier<PIPE_V>();
+            Cast(hisIndexLocal[(loopIdx + 1) % 2], tmpIndexLocal, RoundMode::CAST_NONE, topK);
+        } else {
+            topkb16gather::LiTopKVF<true>(tmpIndexLocal, hisValueLocal,
+                                          mrgValueLocal, histogramsLocal, idxHighLocal,
+                                          idxLowLocal, nkValueLocal, topK, s2SeqLen);
+            PipeBarrier<PIPE_V>();
+            topkb16gather::LiTopKGatherVF(hisIndexLocal[(loopIdx + 1) % 2], hisValueLocal, mrgValueLocal, tmpIndexLocal,
+                                          hisIndexLocal[loopIdx % 2], topK,
+                                          loopIdx * trunkLen - LICommon::Align(topK, (uint32_t)256), s2SeqLen);
+            if (loopIdx == s2LoopNum - 1) {
+                PipeBarrier<PIPE_V>();
+                AscendC::DataCopy(indicesOutLocal,
+                                  hisIndexLocal[(loopIdx + 1) % 2],
+                                  LICommon::Align(topK, (uint32_t)256));
+            }
+        }
+    }
+private:
+    LocalTensor<uint32_t> hisIndexLocal[2];      // 每trunkLen长度的s2选出的topK个索引
+    LocalTensor<uint32_t> histogramsLocal;       // 直方图的临时Buf 256 * 4B
+    LocalTensor<uint32_t> idxHighLocal;          // 输入数据高8位Buf 256 * 4B
+    LocalTensor<uint32_t> idxLowLocal;           // 输入数据低8位Buf 256 * 4B
+    LocalTensor<uint32_t> nkValueLocal;          // next_k 暂存Buf 64 * 4B
+    LocalTensor<uint16_t> tmpIndexLocal;         // 每trunkLen + topK的临时index
+    uint32_t topK = 512;
+    uint32_t trunkLen = 16384;
+};
+}
+}  // namespace sglang::npu_kernel::liv2
+#endif

--- a/csrc/lightning_indexer_v2/op_kernel/arch35/vf/lightning_indexer_vector1.h
+++ b/csrc/lightning_indexer_v2/op_kernel/arch35/vf/lightning_indexer_vector1.h
@@ -1,0 +1,833 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file lightning_indexer_vector1.h
+ * \brief
+ */
+#ifndef SGL_LI_V2_LIGHTNING_INDEXER_VECTOR1_H
+#define SGL_LI_V2_LIGHTNING_INDEXER_VECTOR1_H
+
+#include "kernel_operator.h"
+
+namespace sglang::npu_kernel::liv2 {
+
+namespace vector1 {
+
+template <typename T>
+struct FloatSortTraits;
+
+template <typename T>
+struct UIntSortTraits;
+
+// fp32
+template <>
+struct FloatSortTraits<float> {
+    using UInt = uint32_t;
+    static constexpr UInt ZERO      = 0x00000000;
+    static constexpr UInt SIGN_MASK = 0x80000000;
+    static constexpr UInt NAN_MASK  = 0x7FC00000;
+    static constexpr UInt ALL_ONE   = 0xFFFFFFFF;
+};
+
+// bf16
+template <>
+struct FloatSortTraits<bfloat16_t> {
+    using UInt = uint16_t;
+    static constexpr UInt ZERO      = 0x0000;
+    static constexpr UInt SIGN_MASK = 0x8000;
+    static constexpr UInt NAN_MASK  = 0x7FC0;
+    static constexpr UInt ALL_ONE   = 0xFFFF;
+};
+
+
+template <typename FloatT>
+struct FloatSortConstCtx {
+    using Traits = FloatSortTraits<FloatT>;
+    using UInt   = typename Traits::UInt;
+    AscendC::MicroAPI::RegTensor<UInt> zeros;
+    AscendC::MicroAPI::RegTensor<UInt> all_one;
+    AscendC::MicroAPI::RegTensor<UInt> signMask;
+    AscendC::MicroAPI::RegTensor<UInt> nan;
+};
+
+
+template <typename FloatT>
+__simd_callee__ inline void InitFloatSortConstCtx(FloatSortConstCtx<FloatT>& ctx, AscendC::MicroAPI::MaskReg& maskAll)
+{
+    using Traits = FloatSortTraits<FloatT>;
+    AscendC::MicroAPI::Duplicate(ctx.zeros,    Traits::ZERO,      maskAll);
+    AscendC::MicroAPI::Duplicate(ctx.all_one,   Traits::ALL_ONE,   maskAll);
+    AscendC::MicroAPI::Duplicate(ctx.signMask, Traits::SIGN_MASK, maskAll);
+    AscendC::MicroAPI::Duplicate(ctx.nan,      Traits::NAN_MASK,  maskAll);
+}
+
+
+template <typename FloatT>
+__simd_callee__ inline void FloatToSortableKey(
+                                               AscendC::MicroAPI::RegTensor<typename FloatSortTraits<FloatT>::UInt>&
+                                                outKey,
+                                               AscendC::MicroAPI::RegTensor<FloatT>& inVal,
+                                               FloatSortConstCtx<FloatT>& ctx,
+                                               AscendC::MicroAPI::MaskReg& maskAll)
+{
+    using Traits = FloatSortTraits<FloatT>;
+    using UInt   = typename Traits::UInt;
+
+    AscendC::MicroAPI::RegTensor<UInt> regTemp;
+    AscendC::MicroAPI::RegTensor<UInt> regMask;
+    AscendC::MicroAPI::MaskReg regSelectNan;
+    AscendC::MicroAPI::MaskReg regSelectSign;
+
+    auto& inBits = (AscendC::MicroAPI::RegTensor<UInt>&)inVal;
+
+    // 1. NaN check
+    AscendC::MicroAPI::Compare<UInt, CMPMODE::EQ>(regSelectNan, inBits, ctx.nan, maskAll);
+
+    // 2. NaN -> ALL_ONE
+    AscendC::MicroAPI::Select(outKey, ctx.all_one, inBits, regSelectNan);
+
+    // 3. sign bit
+    AscendC::MicroAPI::And(regTemp, outKey, ctx.signMask, maskAll);
+
+    AscendC::MicroAPI::Compare<UInt, CMPMODE::GT>(regSelectSign, regTemp, ctx.zeros, maskAll);
+
+    // 4. xor mask
+    AscendC::MicroAPI::Select(regMask, ctx.all_one, ctx.signMask, regSelectSign);
+    AscendC::MicroAPI::Xor(outKey, outKey, regMask, maskAll);
+}
+
+// uint16-bf16
+template <>
+struct UIntSortTraits<bfloat16_t> {
+    using UInt = uint16_t;
+    static constexpr UInt ZERO      = 0x0000;
+    static constexpr UInt SIGN_MASK = 0x8000;
+    static constexpr UInt NAN_MASK  = 0xFFC0;
+    static constexpr UInt ALL_ONE   = 0xFFFF;
+};
+
+template <typename FloatT>
+struct UIntSortConstCtx {
+    using Traits = UIntSortTraits<FloatT>;
+    using UInt   = typename Traits::UInt;
+    AscendC::MicroAPI::RegTensor<UInt> zeros;
+    AscendC::MicroAPI::RegTensor<UInt> all_one;
+    AscendC::MicroAPI::RegTensor<UInt> signMask;
+    AscendC::MicroAPI::RegTensor<UInt> nan;
+};
+
+template <typename FloatT>
+__simd_callee__ inline void InitUIntSortConstCtx(UIntSortConstCtx<FloatT>& ctx, AscendC::MicroAPI::MaskReg& maskAll)
+{
+    using Traits = UIntSortTraits<FloatT>;
+    AscendC::MicroAPI::Duplicate(ctx.zeros,    Traits::ZERO,      maskAll);
+    AscendC::MicroAPI::Duplicate(ctx.all_one,   Traits::ALL_ONE,   maskAll);
+    AscendC::MicroAPI::Duplicate(ctx.signMask, Traits::SIGN_MASK, maskAll);
+    AscendC::MicroAPI::Duplicate(ctx.nan,      Traits::NAN_MASK,  maskAll);
+}
+
+template <typename FloatT>
+__simd_callee__ inline void UIntToSortableKey(AscendC::MicroAPI::RegTensor<FloatT>& outKey,
+                                              AscendC::MicroAPI::RegTensor<typename UIntSortConstCtx<FloatT>::UInt>&
+                                                inVal,
+                                              UIntSortConstCtx<FloatT>& ctx,
+                                              AscendC::MicroAPI::MaskReg& maskAll)
+{
+    using Traits = UIntSortTraits<FloatT>;
+    using UInt   = typename Traits::UInt;
+
+    AscendC::MicroAPI::RegTensor<UInt> regTemp;
+    AscendC::MicroAPI::RegTensor<UInt> regMask;
+    AscendC::MicroAPI::MaskReg regSelectZero;
+    AscendC::MicroAPI::MaskReg regSelectSign;
+
+    auto& inBits = inVal;
+
+    // 1. 0 check
+    AscendC::MicroAPI::Compare<UInt, CMPMODE::EQ>(regSelectZero, inBits, ctx.zeros, maskAll);
+
+    // 2. 0 -> -NAN
+    AscendC::MicroAPI::Select((AscendC::MicroAPI::RegTensor<UInt>&)outKey, ctx.nan, inBits, regSelectZero);
+
+    // 3. sign bit
+    AscendC::MicroAPI::And(regTemp, (AscendC::MicroAPI::RegTensor<UInt>&)outKey, ctx.signMask, maskAll);
+
+    AscendC::MicroAPI::Compare<UInt, CMPMODE::GT>(regSelectSign, regTemp, ctx.zeros, maskAll);
+
+    // 4. xor mask
+    AscendC::MicroAPI::Select(regMask, ctx.signMask, ctx.all_one, regSelectSign);
+    AscendC::MicroAPI::Xor((AscendC::MicroAPI::RegTensor<UInt>&)outKey,
+                           (AscendC::MicroAPI::RegTensor<UInt>&)outKey, regMask, maskAll);
+}
+
+__aicore__ inline void UIntToFloatReturnValue(const LocalTensor<bfloat16_t> &out_,
+                                              const LocalTensor<uint16_t> &in,
+                                              const uint32_t topK)
+{
+    auto outBuf = (__local_mem__ bfloat16_t*)out_.GetPhyAddr();
+    auto inBuf = (__local_mem__ uint16_t*)in.GetPhyAddr();
+
+    const uint16_t repeatSize16 = 128;
+    uint16_t topkLoopNum = (topK + repeatSize16 - 1) / repeatSize16;
+
+    __VEC_SCOPE__
+    {
+        AscendC::MicroAPI::RegTensor<uint16_t> regIn;
+        AscendC::MicroAPI::RegTensor<bfloat16_t> regOut;
+        AscendC::MicroAPI::MaskReg maskAllB16 =
+                                    AscendC::MicroAPI::CreateMask<bfloat16_t, AscendC::MicroAPI::MaskPattern::ALL>();
+
+        for (uint16_t i = 0; i < topkLoopNum; ++i) {
+            AscendC::MicroAPI::LoadAlign<uint16_t>(regIn, inBuf + i * 128);
+
+            UIntSortConstCtx<bfloat16_t> uint16Ctx;
+            InitUIntSortConstCtx(uint16Ctx, maskAllB16);
+
+            UIntToSortableKey<bfloat16_t>(regOut, regIn, uint16Ctx, maskAllB16);
+
+            AscendC::MicroAPI::StoreAlign<bfloat16_t, AscendC::MicroAPI::StoreDist::DIST_NORM>(
+                outBuf + i * 128,
+                regOut,
+                maskAllB16);
+        }
+    }
+}
+
+__aicore__ inline void UIntToFloatReturnValue(const LocalTensor<half> &out_,
+                                              const LocalTensor<uint16_t> &in,
+                                              const uint32_t topK)
+{
+    auto outBuf = (__local_mem__ half*)out_.GetPhyAddr();
+    auto inBuf = (__local_mem__ uint16_t*)in.GetPhyAddr();
+
+    const uint16_t repeatSize16 = 128;
+    uint16_t topkLoopNum = (topK + repeatSize16 - 1) / repeatSize16;
+
+    __VEC_SCOPE__
+    {
+        AscendC::MicroAPI::RegTensor<uint16_t> regIn;
+        AscendC::MicroAPI::RegTensor<bfloat16_t> regOut;
+        AscendC::MicroAPI::RegTensor<half> regOutHalf;
+        AscendC::MicroAPI::MaskReg maskAllB16 =
+                                    AscendC::MicroAPI::CreateMask<bfloat16_t, AscendC::MicroAPI::MaskPattern::ALL>();
+        AscendC::MicroAPI::MaskReg maskAllHalf =
+                                    AscendC::MicroAPI::CreateMask<half, AscendC::MicroAPI::MaskPattern::ALL>();
+        constexpr static MicroAPI::CastTrait castTraitBF16ToHalf =
+                                    {MicroAPI::RegLayout::ZERO, MicroAPI::SatMode::NO_SAT,
+                                     MicroAPI::MaskMergeMode::ZEROING,
+                                     RoundMode::CAST_RINT};
+
+        for (uint16_t i = 0; i < topkLoopNum; ++i) {
+            AscendC::MicroAPI::LoadAlign<uint16_t>(regIn, inBuf + i * repeatSize16);
+
+            UIntSortConstCtx<bfloat16_t> uint16Ctx;
+            InitUIntSortConstCtx(uint16Ctx, maskAllB16);
+
+            UIntToSortableKey<bfloat16_t>(regOut, regIn, uint16Ctx, maskAllB16);
+
+            AscendC::MicroAPI::Cast<half, bfloat16_t, castTraitBF16ToHalf>(regOutHalf, regOut, maskAllB16);
+
+            AscendC::MicroAPI::StoreAlign<half, AscendC::MicroAPI::StoreDist::DIST_NORM>(
+                outBuf + i * repeatSize16,
+                regOutHalf,
+                maskAllHalf);
+        }
+    }
+}
+
+template <typename FloatT>
+__simd_callee__ inline void FloatX2ToSortableKey(AscendC::MicroAPI::RegTensor<typename FloatSortTraits<FloatT>::UInt>&
+                                                     outKey0,
+                                                 AscendC::MicroAPI::RegTensor<typename FloatSortTraits<FloatT>::UInt>&
+                                                     outKey1,
+                                                 AscendC::MicroAPI::RegTensor<FloatT>& inVal0,
+                                                 AscendC::MicroAPI::RegTensor<FloatT>& inVal1,
+                                                 FloatSortConstCtx<FloatT>& ctx,
+                                                 AscendC::MicroAPI::MaskReg& maskAll)
+{
+    using Traits = FloatSortTraits<FloatT>;
+    using UInt   = typename Traits::UInt;
+
+    AscendC::MicroAPI::RegTensor<UInt> regTemp[2];
+    AscendC::MicroAPI::RegTensor<UInt> regMask[2];
+    AscendC::MicroAPI::MaskReg regSelectNan[2];
+    AscendC::MicroAPI::MaskReg regSelectSign[2];
+
+    auto& inBits0 = (AscendC::MicroAPI::RegTensor<UInt>&)inVal0;
+    auto& inBits1 = (AscendC::MicroAPI::RegTensor<UInt>&)inVal1;
+
+    // 1. NaN check
+    AscendC::MicroAPI::Compare<UInt, CMPMODE::EQ>(regSelectNan[0], inBits0, ctx.nan, maskAll);
+    AscendC::MicroAPI::Compare<UInt, CMPMODE::EQ>(regSelectNan[1], inBits1, ctx.nan, maskAll);
+
+    // 2. NaN -> ALL_ONE
+    AscendC::MicroAPI::Select(outKey0, ctx.all_one, inBits0, regSelectNan[0]);
+    AscendC::MicroAPI::Select(outKey1, ctx.all_one, inBits1, regSelectNan[1]);
+
+    // 3. sign bit
+    AscendC::MicroAPI::And(regTemp[0], outKey0, ctx.signMask, maskAll);
+    AscendC::MicroAPI::And(regTemp[1], outKey1, ctx.signMask, maskAll);
+
+    AscendC::MicroAPI::Compare<UInt, CMPMODE::GT>(regSelectSign[0], regTemp[0], ctx.zeros, maskAll);
+    AscendC::MicroAPI::Compare<UInt, CMPMODE::GT>(regSelectSign[1], regTemp[1], ctx.zeros, maskAll);
+
+    // 4. xor mask
+    AscendC::MicroAPI::Select(regMask[0], ctx.all_one, ctx.signMask, regSelectSign[0]);
+    AscendC::MicroAPI::Select(regMask[1], ctx.all_one, ctx.signMask, regSelectSign[1]);
+    AscendC::MicroAPI::Xor(outKey0, outKey0, regMask[0], maskAll);
+    AscendC::MicroAPI::Xor(outKey1, outKey1, regMask[1], maskAll);
+}
+
+
+template <typename T, size_t N>
+__simd_callee__ inline void DuplicateZero(AscendC::MicroAPI::RegTensor<T> (&regArray)[N],
+                                          AscendC::MicroAPI::MaskReg& mask)
+{
+    static_assert(N <= 4, "N must be <= 4");
+    // 不能用循环, 会导致fatal error: error in backend: Unsupported Inst must be hoisted.
+    if constexpr (N >= 1) {
+        AscendC::MicroAPI::Duplicate(regArray[0], static_cast<T>(0), mask);
+    }
+    if constexpr (N >= 2) {
+        AscendC::MicroAPI::Duplicate(regArray[1], static_cast<T>(0), mask);
+    }
+    if constexpr (N >= 3) {
+        AscendC::MicroAPI::Duplicate(regArray[2], static_cast<T>(0), mask);
+    }
+    if constexpr (N >= 4) {
+        AscendC::MicroAPI::Duplicate(regArray[3], static_cast<T>(0), mask);
+    }
+}
+
+
+template <typename T, size_t N, bool ApplyRelu = true>
+__simd_callee__ inline void WeightedAccum(AscendC::MicroAPI::RegTensor<T> (&accum)[N],
+                                          AscendC::MicroAPI::RegTensor<T> (&input)[N],
+                                          AscendC::MicroAPI::RegTensor<T>& weight,
+                                          AscendC::MicroAPI::MaskReg& mask)
+{
+    static_assert(N <= 2, "N must be <= 2");
+    // ---- Relu block ----
+    if constexpr (ApplyRelu) {
+        if constexpr (N >= 1) {
+            AscendC::MicroAPI::Relu(input[0], input[0], mask);
+        }
+        if constexpr (N >= 2) {
+            AscendC::MicroAPI::Relu(input[1], input[1], mask);
+        }
+    }
+    // ---- MulAdd block ----
+    if constexpr (N >= 1) {
+        AscendC::MicroAPI::MulAddDst(accum[0], input[0], weight, mask);
+    }
+    if constexpr (N >= 2) {
+        AscendC::MicroAPI::MulAddDst(accum[1], input[1], weight, mask);
+    }
+}
+
+
+__simd_callee__ inline void BroadcastLane(AscendC::MicroAPI::RegTensor<float>& dst,
+                                          AscendC::MicroAPI::RegTensor<float>& src,
+                                          uint16_t laneIdx)
+{
+    AscendC::MicroAPI::RegTensor<uint32_t> brcGatherIndex;
+    AscendC::MicroAPI::Duplicate(brcGatherIndex, laneIdx);
+    AscendC::MicroAPI::Gather(dst, src, brcGatherIndex);
+}
+
+__simd_callee__ inline void BroadcastLane(AscendC::MicroAPI::RegTensor<float>& dst,
+                                          __local_mem__ float* src,
+                                          uint16_t laneIdx)
+{
+    AscendC::MicroAPI::LoadAlign<float, AscendC::MicroAPI::LoadDist::DIST_BRC_B32>(dst, src + laneIdx);
+}
+
+// float in uint16 out
+__simd_vf__ inline void MulWeightAndReduceSum(__ubuf__ uint16_t* out_,
+                                              __ubuf__ float* qk_,
+                                              const uint32_t qkVLStride,
+                                              __ubuf__ float* weight_,
+                                              const int gSize)
+{
+    AscendC::MicroAPI::RegTensor<float> regwBrc;
+    AscendC::MicroAPI::RegTensor<float> regQK[2];
+    AscendC::MicroAPI::RegTensor<float> regW;
+
+    AscendC::MicroAPI::RegTensor<float> regSum0[2];
+    AscendC::MicroAPI::RegTensor<float> regSum1[2];
+    AscendC::MicroAPI::MaskReg maskAllB32 =
+                     AscendC::MicroAPI::CreateMask<float, AscendC::MicroAPI::MaskPattern::ALL>();
+    AscendC::MicroAPI::MaskReg maskAllB16 =
+                     AscendC::MicroAPI::CreateMask<bfloat16_t, AscendC::MicroAPI::MaskPattern::ALL>();
+
+    FloatSortConstCtx<bfloat16_t> bf16Ctx;
+    InitFloatSortConstCtx(bf16Ctx, maskAllB16);
+
+    constexpr static MicroAPI::CastTrait castTraitF32ToF16_EVEN =
+                                    {MicroAPI::RegLayout::ZERO, MicroAPI::SatMode::NO_SAT,
+                                     MicroAPI::MaskMergeMode::MERGING,
+                                     RoundMode::CAST_ROUND};
+    constexpr static MicroAPI::CastTrait castTraitF32ToF16_ODD =
+                                    {MicroAPI::RegLayout::ONE, MicroAPI::SatMode::NO_SAT,
+                                     MicroAPI::MaskMergeMode::ZEROING,
+                                     RoundMode::CAST_ROUND};
+
+    AscendC::MicroAPI::LoadAlign<float>(regW, weight_);
+    DuplicateZero(regSum0, maskAllB32);
+    DuplicateZero(regSum1, maskAllB32);
+
+    // unroll2
+    for (uint16_t i = (uint16_t)(0); i < (uint16_t)(gSize); i += 2) {
+        MicroAPI::LoadAlign<float>(regQK[0], qk_ + 128 * i); // RowStride是128, 行都落在一个bank上
+        MicroAPI::LoadAlign<float>(regQK[1], qk_ + 128 * i + qkVLStride);
+        BroadcastLane(regwBrc, regW, i);
+        WeightedAccum(regSum0, regQK, regwBrc, maskAllB32);
+
+        MicroAPI::LoadAlign<float>(regQK[0], qk_ + 128 * i + 128);
+        MicroAPI::LoadAlign<float>(regQK[1], qk_ + 128 * i + 128 + qkVLStride);
+        BroadcastLane(regwBrc, regW, i + 1);
+        WeightedAccum(regSum1, regQK, regwBrc, maskAllB32);
+    }
+
+    AscendC::MicroAPI::Add(regSum0[0], regSum0[0], regSum1[0], maskAllB32);
+    AscendC::MicroAPI::Add(regSum0[1], regSum0[1], regSum1[1], maskAllB32);
+
+    AscendC::MicroAPI::RegTensor<bfloat16_t> regSumBF16;
+    // interleave cast ==> regSum[1] high regSum[0] low
+    AscendC::MicroAPI::DeInterleave(regSum0[0], regSum0[1], regSum0[0], regSum0[1]);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_ODD>(regSumBF16, regSum0[1], maskAllB32);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_EVEN>(regSumBF16, regSum0[0], maskAllB32);
+
+    AscendC::MicroAPI::RegTensor<uint16_t> regOut;
+    FloatToSortableKey<bfloat16_t>(regOut, regSumBF16, bf16Ctx, maskAllB16);
+    // normal store
+    AscendC::MicroAPI::StoreAlign<uint16_t, AscendC::MicroAPI::StoreDist::DIST_NORM>(out_, regOut, maskAllB16);
+}
+
+// float in uint16 out
+__simd_vf__ inline void MulWeightAndReduceSum(__ubuf__ uint16_t* out_,
+                                              __ubuf__ float* qk_,
+                                              const uint32_t qkVLStride,
+                                              __ubuf__ bfloat16_t* weight_,
+                                              const int gSize)
+{
+    AscendC::MicroAPI::RegTensor<float> regwBrc;
+    AscendC::MicroAPI::RegTensor<float> regQK[2];
+    AscendC::MicroAPI::RegTensor<bfloat16_t> regWBF16;
+    AscendC::MicroAPI::RegTensor<float> regW;
+
+    AscendC::MicroAPI::RegTensor<float> regSum0[2];
+    AscendC::MicroAPI::RegTensor<float> regSum1[2];
+    AscendC::MicroAPI::MaskReg maskAllB32 =
+                     AscendC::MicroAPI::CreateMask<float, AscendC::MicroAPI::MaskPattern::ALL>();
+    AscendC::MicroAPI::MaskReg maskAllB16 =
+                     AscendC::MicroAPI::CreateMask<bfloat16_t, AscendC::MicroAPI::MaskPattern::ALL>();
+
+    FloatSortConstCtx<bfloat16_t> bf16Ctx;
+    InitFloatSortConstCtx(bf16Ctx, maskAllB16);
+
+    constexpr static MicroAPI::CastTrait castTraitF32ToF16_EVEN = {MicroAPI::RegLayout::ZERO, MicroAPI::SatMode::NO_SAT,
+                                                                    MicroAPI::MaskMergeMode::MERGING,
+                                                                    RoundMode::CAST_ROUND};
+    constexpr static MicroAPI::CastTrait castTraitF32ToF16_ODD = {MicroAPI::RegLayout::ONE, MicroAPI::SatMode::NO_SAT,
+                                                                    MicroAPI::MaskMergeMode::ZEROING,
+                                                                    RoundMode::CAST_ROUND};
+    constexpr static MicroAPI::CastTrait castTraitBF16ToFP32 = {MicroAPI::RegLayout::ZERO, MicroAPI::SatMode::UNKNOWN,
+                                                                MicroAPI::MaskMergeMode::ZEROING,
+                                                                RoundMode::UNKNOWN};
+
+    AscendC::MicroAPI::LoadAlign<bfloat16_t, AscendC::MicroAPI::LoadDist::DIST_UNPACK_B16>(regWBF16, weight_);
+    AscendC::MicroAPI::Cast<float, bfloat16_t, castTraitBF16ToFP32>(regW, regWBF16, maskAllB16);
+
+    DuplicateZero(regSum0, maskAllB32);
+    DuplicateZero(regSum1, maskAllB32);
+
+    // unroll2
+    for (uint16_t i = (uint16_t)(0); i < (uint16_t)(gSize); i += 2) {
+        MicroAPI::LoadAlign<float>(regQK[0], qk_ + 128 * i); // RowStride是128, 行都落在一个bank上
+        MicroAPI::LoadAlign<float>(regQK[1], qk_ + 128 * i + qkVLStride);
+        BroadcastLane(regwBrc, regW, i);
+        WeightedAccum(regSum0, regQK, regwBrc, maskAllB32);
+
+        MicroAPI::LoadAlign<float>(regQK[0], qk_ + 128 * i + 128);
+        MicroAPI::LoadAlign<float>(regQK[1], qk_ + 128 * i + 128 + qkVLStride);
+        BroadcastLane(regwBrc, regW, i + 1);
+        WeightedAccum(regSum1, regQK, regwBrc, maskAllB32);
+    }
+
+    AscendC::MicroAPI::Add(regSum0[0], regSum0[0], regSum1[0], maskAllB32);
+    AscendC::MicroAPI::Add(regSum0[1], regSum0[1], regSum1[1], maskAllB32);
+
+    AscendC::MicroAPI::RegTensor<bfloat16_t> regSumBF16;
+    // interleave cast ==> regSum[1] high regSum[0] low
+    AscendC::MicroAPI::DeInterleave(regSum0[0], regSum0[1], regSum0[0], regSum0[1]);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_ODD>(regSumBF16, regSum0[1], maskAllB32);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_EVEN>(regSumBF16, regSum0[0], maskAllB32);
+
+    AscendC::MicroAPI::RegTensor<uint16_t> regOut;
+    FloatToSortableKey<bfloat16_t>(regOut, regSumBF16, bf16Ctx, maskAllB16);
+    // normal store
+    AscendC::MicroAPI::StoreAlign<uint16_t, AscendC::MicroAPI::StoreDist::DIST_NORM>(out_, regOut, maskAllB16);
+}
+
+// float in uint16 out
+__simd_vf__ inline void MulWeightAndReduceSum(__ubuf__ uint16_t* out_,
+                                              __ubuf__ float* qk_,
+                                              const uint32_t qkVLStride,
+                                              __ubuf__ half* weight_,
+                                              const int gSize)
+{
+    AscendC::MicroAPI::RegTensor<float> regwBrc;
+    AscendC::MicroAPI::RegTensor<float> regQK[2];
+    AscendC::MicroAPI::RegTensor<float> regW;
+    AscendC::MicroAPI::RegTensor<half> regWFP16;
+    AscendC::MicroAPI::RegTensor<float> regSum0[2];
+    AscendC::MicroAPI::RegTensor<float> regSum1[2];
+    AscendC::MicroAPI::MaskReg maskAllB32 =
+                     AscendC::MicroAPI::CreateMask<float, AscendC::MicroAPI::MaskPattern::ALL>();
+    AscendC::MicroAPI::MaskReg maskAllB16 =
+                     AscendC::MicroAPI::CreateMask<bfloat16_t, AscendC::MicroAPI::MaskPattern::ALL>();
+
+    FloatSortConstCtx<bfloat16_t> bf16Ctx;
+    InitFloatSortConstCtx(bf16Ctx, maskAllB16);
+
+    constexpr static MicroAPI::CastTrait castTraitF32ToF16_EVEN = {MicroAPI::RegLayout::ZERO, MicroAPI::SatMode::NO_SAT,
+                                                                    MicroAPI::MaskMergeMode::MERGING,
+                                                                    RoundMode::CAST_ROUND};
+    constexpr static MicroAPI::CastTrait castTraitF32ToF16_ODD = {MicroAPI::RegLayout::ONE, MicroAPI::SatMode::NO_SAT,
+                                                                    MicroAPI::MaskMergeMode::ZEROING,
+                                                                    RoundMode::CAST_ROUND};
+    constexpr static MicroAPI::CastTrait castTraitFP16ToFP32 = {MicroAPI::RegLayout::ZERO, MicroAPI::SatMode::UNKNOWN,
+                                                                MicroAPI::MaskMergeMode::ZEROING,
+                                                                RoundMode::UNKNOWN};
+
+    AscendC::MicroAPI::LoadAlign<half, AscendC::MicroAPI::LoadDist::DIST_UNPACK_B16>(regWFP16, weight_);
+    AscendC::MicroAPI::Cast<float, half, castTraitFP16ToFP32>(regW, regWFP16, maskAllB16);
+
+    DuplicateZero(regSum0, maskAllB32);
+    DuplicateZero(regSum1, maskAllB32);
+
+    // unroll2
+    for (uint16_t i = (uint16_t)(0); i < (uint16_t)(gSize); i += 2) {
+        MicroAPI::LoadAlign<float>(regQK[0], qk_ + 128 * i); // RowStride是128, 行都落在一个bank上
+        MicroAPI::LoadAlign<float>(regQK[1], qk_ + 128 * i + qkVLStride);
+        BroadcastLane(regwBrc, regW, i);
+        WeightedAccum(regSum0, regQK, regwBrc, maskAllB32);
+
+        MicroAPI::LoadAlign<float>(regQK[0], qk_ + 128 * i + 128);
+        MicroAPI::LoadAlign<float>(regQK[1], qk_ + 128 * i + 128 + qkVLStride);
+        BroadcastLane(regwBrc, regW, i + 1);
+        WeightedAccum(regSum1, regQK, regwBrc, maskAllB32);
+    }
+
+    AscendC::MicroAPI::Add(regSum0[0], regSum0[0], regSum1[0], maskAllB32);
+    AscendC::MicroAPI::Add(regSum0[1], regSum0[1], regSum1[1], maskAllB32);
+
+    AscendC::MicroAPI::RegTensor<bfloat16_t> regSumBF16;
+    // interleave cast ==> regSum[1] high regSum[0] low
+    AscendC::MicroAPI::DeInterleave(regSum0[0], regSum0[1], regSum0[0], regSum0[1]);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_ODD>(regSumBF16, regSum0[1], maskAllB32);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_EVEN>(regSumBF16, regSum0[0], maskAllB32);
+
+    AscendC::MicroAPI::RegTensor<uint16_t> regOut;
+    FloatToSortableKey<bfloat16_t>(regOut, regSumBF16, bf16Ctx, maskAllB16);
+    // normal store
+    AscendC::MicroAPI::StoreAlign<uint16_t, AscendC::MicroAPI::StoreDist::DIST_NORM>(out_, regOut, maskAllB16);
+}
+
+// 计算S1=2
+// float in uint16 out
+__simd_vf__ inline void MulWeightAndReduceSum2(__ubuf__ uint16_t* out0_,
+                                               __ubuf__ uint16_t* out1_,
+                                               uint32_t outStride,
+                                               __ubuf__ float* qk0_,
+                                               __ubuf__ float* qk1_,
+                                               uint32_t qkVLStride,
+                                               uint32_t qkStride,
+                                               __ubuf__ float* weight0_,
+                                               __ubuf__ float* weight1_,
+                                               uint32_t weightStride,
+                                               __ubuf__ float* weightFloat_,
+                                               const int gSize)
+{
+    AscendC::MicroAPI::RegTensor<float> regwBrc[2];
+    AscendC::MicroAPI::RegTensor<float> regQK0[2];
+    AscendC::MicroAPI::RegTensor<float> regQK1[2];
+    AscendC::MicroAPI::RegTensor<float> regW[2];
+
+    AscendC::MicroAPI::RegTensor<float> regSum0[2];
+    AscendC::MicroAPI::RegTensor<float> regSum1[2];
+    AscendC::MicroAPI::MaskReg maskAllB32 =
+                        AscendC::MicroAPI::CreateMask<float, AscendC::MicroAPI::MaskPattern::ALL>();
+    AscendC::MicroAPI::MaskReg maskAllB16 =
+                        AscendC::MicroAPI::CreateMask<bfloat16_t, AscendC::MicroAPI::MaskPattern::ALL>();
+
+    FloatSortConstCtx<bfloat16_t> bf16Ctx;
+    InitFloatSortConstCtx(bf16Ctx, maskAllB16);
+
+    constexpr static MicroAPI::CastTrait castTraitF32ToF16_EVEN = {MicroAPI::RegLayout::ZERO, MicroAPI::SatMode::NO_SAT,
+                                                                    MicroAPI::MaskMergeMode::MERGING,
+                                                                    RoundMode::CAST_ROUND};
+    constexpr static MicroAPI::CastTrait castTraitF32ToF16_ODD = {MicroAPI::RegLayout::ONE, MicroAPI::SatMode::NO_SAT,
+                                                                    MicroAPI::MaskMergeMode::ZEROING,
+                                                                    RoundMode::CAST_ROUND};
+
+    AscendC::MicroAPI::LoadAlign<float>(regW[0], weight0_);
+    AscendC::MicroAPI::LoadAlign<float>(regW[1], weight1_);
+    // regW[0]与weight1混合使用
+    AscendC::MicroAPI::StoreAlign<float, AscendC::MicroAPI::StoreDist::DIST_NORM>(weight1_, regW[1], maskAllB32);
+    AscendC::MicroAPI::LocalMemBar<AscendC::MicroAPI::MemType::VEC_STORE, AscendC::MicroAPI::MemType::VEC_LOAD>();
+    DuplicateZero(regSum0, maskAllB32);
+    DuplicateZero(regSum1, maskAllB32);
+
+    for (uint16_t i = (uint16_t)(0); i < (uint16_t)(gSize); i++) {
+        MicroAPI::LoadAlign<float>(regQK0[0], qk0_ + 128 * i);
+        MicroAPI::LoadAlign<float>(regQK0[1], qk0_ + 128 * i + qkVLStride);
+        MicroAPI::LoadAlign<float>(regQK1[0], qk1_ + 128 * i);
+        MicroAPI::LoadAlign<float>(regQK1[1], qk1_ + 128 * i + qkVLStride);
+        // 混合使用对整体性能更好
+        BroadcastLane(regwBrc[0], regW[0], i);
+        // Weight无bank冲突，用LoadAlign来提取weight标量
+        BroadcastLane(regwBrc[1], weight1_, i);
+        AscendC::MicroAPI::Relu(regQK0[0], regQK0[0], maskAllB32);
+        AscendC::MicroAPI::Relu(regQK0[1], regQK0[1], maskAllB32);
+        AscendC::MicroAPI::Relu(regQK1[0], regQK1[0], maskAllB32);
+        AscendC::MicroAPI::Relu(regQK1[1], regQK1[1], maskAllB32);
+        AscendC::MicroAPI::MulAddDst(regSum0[0], regQK0[0], regwBrc[0], maskAllB32);
+        AscendC::MicroAPI::MulAddDst(regSum0[1], regQK0[1], regwBrc[0], maskAllB32);
+        AscendC::MicroAPI::MulAddDst(regSum1[0], regQK1[0], regwBrc[1], maskAllB32);
+        AscendC::MicroAPI::MulAddDst(regSum1[1], regQK1[1], regwBrc[1], maskAllB32);
+    }
+
+    // Convert to bfloat16 and store output channel
+    AscendC::MicroAPI::RegTensor<bfloat16_t> regSumBF16[2];
+    AscendC::MicroAPI::RegTensor<uint16_t> regOut[2];
+    AscendC::MicroAPI::DeInterleave(regSum0[0], regSum0[1], regSum0[0], regSum0[1]);
+    AscendC::MicroAPI::DeInterleave(regSum1[0], regSum1[1], regSum1[0], regSum1[1]);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_ODD>(regSumBF16[0], regSum0[1], maskAllB32);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_ODD>(regSumBF16[1], regSum1[1], maskAllB32);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_EVEN>(regSumBF16[0], regSum0[0], maskAllB32);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_EVEN>(regSumBF16[1], regSum1[0], maskAllB32);
+
+    FloatX2ToSortableKey<bfloat16_t>(regOut[0], regOut[1], regSumBF16[0], regSumBF16[1], bf16Ctx, maskAllB16);
+    AscendC::MicroAPI::StoreAlign<uint16_t, AscendC::MicroAPI::StoreDist::DIST_NORM>(out0_, regOut[0], maskAllB16);
+    AscendC::MicroAPI::StoreAlign<uint16_t, AscendC::MicroAPI::StoreDist::DIST_NORM>(out1_, regOut[1], maskAllB16);
+}
+
+// 计算S1=2
+// float in uint16 out
+__simd_vf__ inline void MulWeightAndReduceSum2(__ubuf__ uint16_t* out0_,
+                                               __ubuf__ uint16_t* out1_,
+                                               uint32_t outStride,
+                                               __ubuf__ float* qk0_,
+                                               __ubuf__ float* qk1_,
+                                               uint32_t qkVLStride,
+                                               uint32_t qkStride,
+                                               __ubuf__ bfloat16_t* weight0_,
+                                               __ubuf__ bfloat16_t* weight1_,
+                                               uint32_t weightStride,
+                                               __ubuf__ float* weightFloat_,
+                                               const int gSize)
+{
+    AscendC::MicroAPI::RegTensor<float> regwBrc[2];
+    AscendC::MicroAPI::RegTensor<float> regQK0[2];
+    AscendC::MicroAPI::RegTensor<float> regQK1[2];
+    AscendC::MicroAPI::RegTensor<float> regW[2];
+    AscendC::MicroAPI::RegTensor<bfloat16_t> regWBF16[2];
+
+    AscendC::MicroAPI::RegTensor<float> regSum0[2];
+    AscendC::MicroAPI::RegTensor<float> regSum1[2];
+    AscendC::MicroAPI::MaskReg maskAllB32 =
+                     AscendC::MicroAPI::CreateMask<float, AscendC::MicroAPI::MaskPattern::ALL>();
+    AscendC::MicroAPI::MaskReg maskAllB16 =
+                     AscendC::MicroAPI::CreateMask<bfloat16_t, AscendC::MicroAPI::MaskPattern::ALL>();
+
+    FloatSortConstCtx<bfloat16_t> bf16Ctx;
+    InitFloatSortConstCtx(bf16Ctx, maskAllB16);
+
+    constexpr static MicroAPI::CastTrait castTraitF32ToF16_EVEN = {MicroAPI::RegLayout::ZERO, MicroAPI::SatMode::NO_SAT,
+                                                                    MicroAPI::MaskMergeMode::MERGING,
+                                                                    RoundMode::CAST_ROUND};
+    constexpr static MicroAPI::CastTrait castTraitF32ToF16_ODD = {MicroAPI::RegLayout::ONE, MicroAPI::SatMode::NO_SAT,
+                                                                    MicroAPI::MaskMergeMode::ZEROING,
+                                                                    RoundMode::CAST_ROUND};
+    constexpr static MicroAPI::CastTrait castTraitBF16ToFP32 = {MicroAPI::RegLayout::ZERO, MicroAPI::SatMode::UNKNOWN,
+                                                                MicroAPI::MaskMergeMode::ZEROING,
+                                                                RoundMode::UNKNOWN};
+
+    AscendC::MicroAPI::LoadAlign<bfloat16_t, AscendC::MicroAPI::LoadDist::DIST_UNPACK_B16>(regWBF16[0], weight0_);
+    AscendC::MicroAPI::LoadAlign<bfloat16_t, AscendC::MicroAPI::LoadDist::DIST_UNPACK_B16>(regWBF16[1], weight1_);
+    AscendC::MicroAPI::Cast<float, bfloat16_t, castTraitBF16ToFP32>(regW[0], regWBF16[0], maskAllB16);
+    AscendC::MicroAPI::Cast<float, bfloat16_t, castTraitBF16ToFP32>(regW[1], regWBF16[1], maskAllB16);
+
+    // regW[0]与weight1混合使用
+    AscendC::MicroAPI::StoreAlign<float, AscendC::MicroAPI::StoreDist::DIST_NORM>(weightFloat_, regW[1], maskAllB32);
+    AscendC::MicroAPI::LocalMemBar<AscendC::MicroAPI::MemType::VEC_STORE, AscendC::MicroAPI::MemType::VEC_LOAD>();
+    DuplicateZero(regSum0, maskAllB32);
+    DuplicateZero(regSum1, maskAllB32);
+
+    for (uint16_t i = (uint16_t)(0); i < (uint16_t)(gSize); i++) {
+        MicroAPI::LoadAlign<float>(regQK0[0], qk0_ + 128 * i);
+        MicroAPI::LoadAlign<float>(regQK0[1], qk0_ + 128 * i + qkVLStride);
+        MicroAPI::LoadAlign<float>(regQK1[0], qk1_ + 128 * i);
+        MicroAPI::LoadAlign<float>(regQK1[1], qk1_ + 128 * i + qkVLStride);
+        // 混合使用对整体性能更好
+        BroadcastLane(regwBrc[0], regW[0], i);
+        // Weight无bank冲突，用LoadAlign来提取weight标量
+        BroadcastLane(regwBrc[1], weightFloat_, i);
+        AscendC::MicroAPI::Relu(regQK0[0], regQK0[0], maskAllB32);
+        AscendC::MicroAPI::Relu(regQK0[1], regQK0[1], maskAllB32);
+        AscendC::MicroAPI::Relu(regQK1[0], regQK1[0], maskAllB32);
+        AscendC::MicroAPI::Relu(regQK1[1], regQK1[1], maskAllB32);
+        AscendC::MicroAPI::MulAddDst(regSum0[0], regQK0[0], regwBrc[0], maskAllB32);
+        AscendC::MicroAPI::MulAddDst(regSum0[1], regQK0[1], regwBrc[0], maskAllB32);
+        AscendC::MicroAPI::MulAddDst(regSum1[0], regQK1[0], regwBrc[1], maskAllB32);
+        AscendC::MicroAPI::MulAddDst(regSum1[1], regQK1[1], regwBrc[1], maskAllB32);
+    }
+
+    // Convert to bfloat16 and store output channel
+    AscendC::MicroAPI::RegTensor<bfloat16_t> regSumBF16[2];
+    AscendC::MicroAPI::RegTensor<uint16_t> regOut[2];
+    AscendC::MicroAPI::DeInterleave(regSum0[0], regSum0[1], regSum0[0], regSum0[1]);
+    AscendC::MicroAPI::DeInterleave(regSum1[0], regSum1[1], regSum1[0], regSum1[1]);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_ODD>(regSumBF16[0], regSum0[1], maskAllB32);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_ODD>(regSumBF16[1], regSum1[1], maskAllB32);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_EVEN>(regSumBF16[0], regSum0[0], maskAllB32);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_EVEN>(regSumBF16[1], regSum1[0], maskAllB32);
+
+    FloatX2ToSortableKey<bfloat16_t>(regOut[0], regOut[1], regSumBF16[0], regSumBF16[1], bf16Ctx, maskAllB16);
+    AscendC::MicroAPI::StoreAlign<uint16_t, AscendC::MicroAPI::StoreDist::DIST_NORM>(out0_, regOut[0], maskAllB16);
+    AscendC::MicroAPI::StoreAlign<uint16_t, AscendC::MicroAPI::StoreDist::DIST_NORM>(out1_, regOut[1], maskAllB16);
+}
+
+// 计算S1=2
+// float in uint16 out
+__simd_vf__ inline void MulWeightAndReduceSum2(__ubuf__ uint16_t* out0_,
+                                               __ubuf__ uint16_t* out1_,
+                                               uint32_t outStride,
+                                               __ubuf__ float* qk0_,
+                                               __ubuf__ float* qk1_,
+                                               uint32_t qkVLStride,
+                                               uint32_t qkStride,
+                                               __ubuf__ half* weight0_,
+                                               __ubuf__ half* weight1_,
+                                               uint32_t weightStride,
+                                               __ubuf__ float* weightFloat_,
+                                               const int gSize)
+{
+    AscendC::MicroAPI::RegTensor<float> regwBrc[2];
+    AscendC::MicroAPI::RegTensor<float> regQK0[2];
+    AscendC::MicroAPI::RegTensor<float> regQK1[2];
+    AscendC::MicroAPI::RegTensor<float> regW[2];
+    AscendC::MicroAPI::RegTensor<half> regWFP16[2];
+
+    AscendC::MicroAPI::RegTensor<float> regSum0[2];
+    AscendC::MicroAPI::RegTensor<float> regSum1[2];
+    AscendC::MicroAPI::MaskReg maskAllB32 =
+                     AscendC::MicroAPI::CreateMask<float, AscendC::MicroAPI::MaskPattern::ALL>();
+    AscendC::MicroAPI::MaskReg maskAllB16 =
+                     AscendC::MicroAPI::CreateMask<bfloat16_t, AscendC::MicroAPI::MaskPattern::ALL>();
+
+    FloatSortConstCtx<bfloat16_t> bf16Ctx;
+    InitFloatSortConstCtx(bf16Ctx, maskAllB16);
+
+    constexpr static MicroAPI::CastTrait castTraitF32ToF16_EVEN = {MicroAPI::RegLayout::ZERO, MicroAPI::SatMode::NO_SAT,
+                                                                    MicroAPI::MaskMergeMode::MERGING,
+                                                                    RoundMode::CAST_ROUND};
+    constexpr static MicroAPI::CastTrait castTraitF32ToF16_ODD = {MicroAPI::RegLayout::ONE, MicroAPI::SatMode::NO_SAT,
+                                                                    MicroAPI::MaskMergeMode::ZEROING,
+                                                                    RoundMode::CAST_ROUND};
+    constexpr static MicroAPI::CastTrait castTraitFP16ToFP32 = {MicroAPI::RegLayout::ZERO, MicroAPI::SatMode::UNKNOWN,
+                                                                MicroAPI::MaskMergeMode::ZEROING,
+                                                                RoundMode::UNKNOWN};
+
+    AscendC::MicroAPI::LoadAlign<half, AscendC::MicroAPI::LoadDist::DIST_UNPACK_B16>(regWFP16[0], weight0_);
+    AscendC::MicroAPI::LoadAlign<half, AscendC::MicroAPI::LoadDist::DIST_UNPACK_B16>(regWFP16[1], weight1_);
+    AscendC::MicroAPI::Cast<float, half, castTraitFP16ToFP32>(regW[0], regWFP16[0], maskAllB16);
+    AscendC::MicroAPI::Cast<float, half, castTraitFP16ToFP32>(regW[1], regWFP16[1], maskAllB16);
+
+    // regW[0]与weight1混合使用
+    AscendC::MicroAPI::StoreAlign<float, AscendC::MicroAPI::StoreDist::DIST_NORM>(weightFloat_, regW[1], maskAllB32);
+    AscendC::MicroAPI::LocalMemBar<AscendC::MicroAPI::MemType::VEC_STORE, AscendC::MicroAPI::MemType::VEC_LOAD>();
+    DuplicateZero(regSum0, maskAllB32);
+    DuplicateZero(regSum1, maskAllB32);
+
+    for (uint16_t i = (uint16_t)(0); i < (uint16_t)(gSize); i++) {
+        MicroAPI::LoadAlign<float>(regQK0[0], qk0_ + 128 * i);
+        MicroAPI::LoadAlign<float>(regQK0[1], qk0_ + 128 * i + qkVLStride);
+        MicroAPI::LoadAlign<float>(regQK1[0], qk1_ + 128 * i);
+        MicroAPI::LoadAlign<float>(regQK1[1], qk1_ + 128 * i + qkVLStride);
+        // 混合使用对整体性能更好
+        BroadcastLane(regwBrc[0], regW[0], i);
+        // Weight无bank冲突，用LoadAlign来提取weight标量
+        BroadcastLane(regwBrc[1], weightFloat_, i);
+        AscendC::MicroAPI::Relu(regQK0[0], regQK0[0], maskAllB32);
+        AscendC::MicroAPI::Relu(regQK0[1], regQK0[1], maskAllB32);
+        AscendC::MicroAPI::Relu(regQK1[0], regQK1[0], maskAllB32);
+        AscendC::MicroAPI::Relu(regQK1[1], regQK1[1], maskAllB32);
+        AscendC::MicroAPI::MulAddDst(regSum0[0], regQK0[0], regwBrc[0], maskAllB32);
+        AscendC::MicroAPI::MulAddDst(regSum0[1], regQK0[1], regwBrc[0], maskAllB32);
+        AscendC::MicroAPI::MulAddDst(regSum1[0], regQK1[0], regwBrc[1], maskAllB32);
+        AscendC::MicroAPI::MulAddDst(regSum1[1], regQK1[1], regwBrc[1], maskAllB32);
+    }
+
+    // Convert to bfloat16 and store output channel
+    AscendC::MicroAPI::RegTensor<bfloat16_t> regSumBF16[2];
+    AscendC::MicroAPI::RegTensor<uint16_t> regOut[2];
+    AscendC::MicroAPI::DeInterleave(regSum0[0], regSum0[1], regSum0[0], regSum0[1]);
+    AscendC::MicroAPI::DeInterleave(regSum1[0], regSum1[1], regSum1[0], regSum1[1]);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_ODD>(regSumBF16[0], regSum0[1], maskAllB32);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_ODD>(regSumBF16[1], regSum1[1], maskAllB32);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_EVEN>(regSumBF16[0], regSum0[0], maskAllB32);
+    AscendC::MicroAPI::Cast<bfloat16_t, float, castTraitF32ToF16_EVEN>(regSumBF16[1], regSum1[0], maskAllB32);
+
+    FloatX2ToSortableKey<bfloat16_t>(regOut[0], regOut[1], regSumBF16[0], regSumBF16[1], bf16Ctx, maskAllB16);
+    AscendC::MicroAPI::StoreAlign<uint16_t, AscendC::MicroAPI::StoreDist::DIST_NORM>(out0_, regOut[0], maskAllB16);
+    AscendC::MicroAPI::StoreAlign<uint16_t, AscendC::MicroAPI::StoreDist::DIST_NORM>(out1_, regOut[1], maskAllB16);
+}
+
+template<typename QK_T, typename W_T, typename SCORE_T>
+__aicore__ inline void BatchMulWeightAndReduceSum(const LocalTensor<SCORE_T> &out_,   // out    [S2Base]     [128   ]
+                                                  uint32_t outStride,
+                                                  const LocalTensor<QK_T> &qk_,       // q*k^t  [G, S2Base]  [64 128]
+                                                  uint32_t qkVLStride,
+                                                  uint32_t qkStride,
+                                                  const LocalTensor<W_T> &weight_,   // w      [G]          [64    ]
+                                                  uint32_t weightStride,
+                                                  const LocalTensor<float> &weightFloat_,
+                                                  const int gSize,                     // G 64
+                                                  const int batch)
+{
+    // 暂只支持这两种情况, 后续改成循环
+    if (batch != 2 && batch != 1) {
+        return;
+    }
+    auto weight = (__ubuf__ W_T *)weight_.GetPhyAddr();
+    auto weightFloat = (__ubuf__ float *)weightFloat_.GetPhyAddr();
+    auto qk = (__ubuf__ float *)qk_.GetPhyAddr();
+    auto out = (__ubuf__ uint16_t *)out_.GetPhyAddr();
+    if (batch == 2) {
+        auto weight1 = weight + weightStride;
+        auto qk1 = qk + qkStride;
+        auto out1 = out + outStride;
+        MulWeightAndReduceSum2(out, out1, outStride,
+                               qk, qk1, qkVLStride, qkStride,
+                               weight, weight1, weightStride, weightFloat,
+                               gSize);
+    } else {
+        MulWeightAndReduceSum(out, qk, qkVLStride, weight, gSize);
+    }
+}
+
+}
+
+}  // namespace sglang::npu_kernel::liv2
+#endif

--- a/csrc/lightning_indexer_v2/op_kernel/arch35/vf/vf_topk.h
+++ b/csrc/lightning_indexer_v2/op_kernel/arch35/vf/vf_topk.h
@@ -1,0 +1,739 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+/*!
+* \file vf_top_k.h
+* \brief
+*/
+
+#ifndef SGL_LI_V2_VF_TOP_K_H
+#define SGL_LI_V2_VF_TOP_K_H
+
+namespace sglang::npu_kernel::liv2 {
+
+namespace topkb32 {
+template<typename T>
+__simd_vf__ void HistogramsFirstVFImpl(__ubuf__ uint32_t* histogramsBuf,
+                                       __ubuf__ uint32_t* inputBuf,
+                                       uint16_t vfLoop, bool init)
+{
+    MicroAPI::MaskReg pregB32 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+    MicroAPI::MaskReg pregB16 = MicroAPI::CreateMask<uint16_t, MicroAPI::MaskPattern::ALL>();
+    MicroAPI::MaskReg pregB8 = MicroAPI::CreateMask<uint8_t, MicroAPI::MaskPattern::ALL>();
+
+    // 计算直方图cout0 0-127 cout1 128-255
+    MicroAPI::RegTensor<uint16_t> cout0;
+    MicroAPI::RegTensor<uint16_t> cout1;
+    MicroAPI::Duplicate(cout0, 0);
+    MicroAPI::Duplicate(cout1, 0);
+
+    MicroAPI::RegTensor<uint32_t> cout0U32Even;
+    MicroAPI::RegTensor<uint32_t> cout0U32Odd;
+    MicroAPI::RegTensor<uint32_t> cout1U32Even;
+    MicroAPI::RegTensor<uint32_t> cout1U32Odd;
+
+    // 32bit 高16bit
+    MicroAPI::RegTensor<uint32_t> vreg0U16;
+    // 32bit 低16bit
+    MicroAPI::RegTensor<uint32_t> vreg1U16;
+    MicroAPI::RegTensor<uint32_t> vreg2U16;
+    MicroAPI::RegTensor<uint32_t> vreg3U16;
+
+    MicroAPI::RegTensor<uint8_t> vreg0;
+    MicroAPI::RegTensor<uint8_t> vreg1;
+    MicroAPI::RegTensor<uint8_t> vreg2;
+    MicroAPI::RegTensor<uint8_t> vreg3;
+
+    static constexpr MicroAPI::CastTrait CAST_TRAIT_UINT16_TOUINT32_EVEN = {MicroAPI::RegLayout::ZERO,
+                MicroAPI::SatMode::UNKNOWN, MicroAPI::MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
+
+    static constexpr MicroAPI::CastTrait CAST_TRAIT_UINT16_TOUINT32_ODD = {MicroAPI::RegLayout::ONE,
+                MicroAPI::SatMode::UNKNOWN, MicroAPI::MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
+
+    for (uint16_t i = 0; i < vfLoop; ++i) {
+        MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_DINTLV_B16>(vreg1U16, vreg0U16, inputBuf + i * 256);
+        MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_DINTLV_B16>(
+                                                        vreg3U16, vreg2U16, inputBuf + (i * 256) + 128);
+
+        MicroAPI::DeInterleave(vreg1, vreg0,
+                                (MicroAPI::RegTensor<uint8_t>&)vreg0U16,
+                                (MicroAPI::RegTensor<uint8_t>&)vreg2U16);
+
+        MicroAPI::Histograms<uint8_t, uint16_t, MicroAPI::HistogramsBinType::BIN0,
+                             MicroAPI::HistogramsType::ACCUMULATE>(cout0, vreg0, pregB8);
+        MicroAPI::Histograms<uint8_t, uint16_t, MicroAPI::HistogramsBinType::BIN1,
+                             MicroAPI::HistogramsType::ACCUMULATE>(cout1, vreg0, pregB8);
+    }
+
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_EVEN>(cout0U32Even, cout0, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_ODD>(cout0U32Odd, cout0, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_EVEN>(cout1U32Even, cout1, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_ODD>(cout1U32Odd, cout1, pregB16);
+
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_INTLV_B32>(
+                                                            histogramsBuf, cout0U32Even, cout0U32Odd, pregB32);
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_INTLV_B32>(
+                                                            histogramsBuf + 128, cout1U32Even, cout1U32Odd, pregB32);
+}
+
+__simd_vf__ void FindFirstTargetBinVFImpl(__ubuf__ uint32_t* idx0Buf,
+                                          __ubuf__ uint32_t* nkValueBuf, __ubuf__ uint32_t*
+                                          histogramsBuf, uint32_t bottomK)
+{
+    MicroAPI::MaskReg pregB32 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+    MicroAPI::ClearSpr<AscendC::SpecialPurposeReg::AR>();
+
+    MicroAPI::UnalignRegForStore alignIdx0;
+
+    MicroAPI::RegTensor<uint32_t> btmK;
+    MicroAPI::Duplicate(btmK, bottomK);
+
+    for (uint16_t i = 0; i < (uint16_t)(4); ++i) {
+        MicroAPI::RegTensor<int32_t> idxC;
+        MicroAPI::RegTensor<uint32_t> cout;
+        MicroAPI::RegTensor<uint32_t> sqzIdx0;
+
+        MicroAPI::MaskReg pregGE = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+        MicroAPI::Arange(idxC, i * 64);
+        MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(cout, histogramsBuf + i * 64);
+        MicroAPI::Compare<uint32_t, CMPMODE::GE>(pregGE, cout, btmK, pregB32);
+        MicroAPI::Squeeze<uint32_t, MicroAPI::GatherMaskMode::STORE_REG>(
+                                                sqzIdx0, (MicroAPI::RegTensor<uint32_t>&)idxC, pregGE);
+        MicroAPI::StoreUnAlign<uint32_t, MicroAPI::PostLiteral::POST_MODE_UPDATE>(idx0Buf, sqzIdx0, alignIdx0);
+    }
+    MicroAPI::StoreUnAlignPost(idx0Buf, alignIdx0);
+
+    MicroAPI::LocalMemBar<AscendC::MicroAPI::MemType::VEC_STORE, AscendC::MicroAPI::MemType::VEC_LOAD>();
+
+    MicroAPI::RegTensor<uint32_t> idx0;
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B8>(idx0, idx0Buf);
+
+    MicroAPI::RegTensor<uint8_t> idxAll1;
+    MicroAPI::RegTensor<uint32_t> idxPrev0;
+    MicroAPI::RegTensor<uint32_t> prevBinValue;
+    MicroAPI::Duplicate(idxAll1, 1);
+
+    MicroAPI::RegTensor<uint32_t> zeroAll;
+    MicroAPI::Duplicate(zeroAll, 0);
+
+    MicroAPI::MaskReg preg0 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+    MicroAPI::Compare<uint32_t, CMPMODE::EQ>(preg0, idx0, zeroAll, pregB32);
+    MicroAPI::Sub(idxPrev0, idx0, (MicroAPI::RegTensor<uint32_t>&)idxAll1, pregB32);
+    MicroAPI::ShiftRights(idxPrev0, idxPrev0, (int16_t)24, pregB32);
+
+    MicroAPI::Gather(prevBinValue, histogramsBuf, idxPrev0, pregB32);
+    MicroAPI::Select(prevBinValue, zeroAll, prevBinValue, preg0);
+
+    MicroAPI::RegTensor<uint32_t> nextK;
+    MicroAPI::Sub(nextK, btmK, prevBinValue, pregB32);
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_NORM>(nkValueBuf, nextK, pregB32);
+}
+
+template<typename T>
+__simd_vf__ void HistogramsSecondVFImpl(__ubuf__ uint32_t* histogramsBuf,
+                                        __ubuf__ uint32_t* inputBuf, __ubuf__ uint32_t* idx0Buf,
+                                        uint16_t vfLoop, bool init)
+{
+    MicroAPI::MaskReg pregB32 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+    MicroAPI::MaskReg pregB16 = MicroAPI::CreateMask<uint16_t, MicroAPI::MaskPattern::ALL>();
+    MicroAPI::MaskReg pregB8 = MicroAPI::CreateMask<uint8_t, MicroAPI::MaskPattern::ALL>();
+
+    // 计算直方图0-127 128-255
+    MicroAPI::RegTensor<uint16_t> cout0;
+    MicroAPI::RegTensor<uint16_t> cout1;
+    MicroAPI::Duplicate(cout0, 0);
+    MicroAPI::Duplicate(cout1, 0);
+
+    MicroAPI::RegTensor<uint32_t> cout0U32Even;
+    MicroAPI::RegTensor<uint32_t> cout0U32Odd;
+    MicroAPI::RegTensor<uint32_t> cout1U32Even;
+    MicroAPI::RegTensor<uint32_t> cout1U32Odd;
+
+    MicroAPI::RegTensor<uint32_t> idx0;
+    // 0x000000fc -> 0xfcfcfcfc
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B8>(idx0, idx0Buf);
+
+    MicroAPI::RegTensor<uint32_t> vreg0U16;
+    MicroAPI::RegTensor<uint32_t> vreg1U16;
+    MicroAPI::RegTensor<uint32_t> vreg2U16;
+    MicroAPI::RegTensor<uint32_t> vreg3U16;
+
+    MicroAPI::RegTensor<uint8_t> vreg0;
+    MicroAPI::RegTensor<uint8_t> vreg1;
+    MicroAPI::RegTensor<uint8_t> vreg2;
+    MicroAPI::RegTensor<uint8_t> vreg3;
+
+    static constexpr MicroAPI::CastTrait CAST_TRAIT_UINT16_TOUINT32_EVEN = {MicroAPI::RegLayout::ZERO,
+                MicroAPI::SatMode::UNKNOWN, MicroAPI::MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
+
+    static constexpr MicroAPI::CastTrait CAST_TRAIT_UINT16_TOUINT32_ODD = {MicroAPI::RegLayout::ONE,
+                MicroAPI::SatMode::UNKNOWN, MicroAPI::MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
+
+    for (uint16_t i = 0; i < vfLoop; ++i) {
+        MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_DINTLV_B16>(vreg1U16,
+                                                                            vreg0U16, inputBuf + i * 256);
+        MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_DINTLV_B16>(vreg3U16,
+                                                                            vreg2U16, inputBuf + (i * 256) + 128);
+
+        MicroAPI::DeInterleave(vreg1, vreg0,
+                                (MicroAPI::RegTensor<uint8_t>&)vreg0U16,
+                                (MicroAPI::RegTensor<uint8_t>&)vreg2U16);
+
+        MicroAPI::MaskReg pregEQ = MicroAPI::CreateMask<uint8_t, MicroAPI::MaskPattern::ALL>();
+        MicroAPI::Compare<uint8_t, CMPMODE::EQ>(pregEQ, vreg0, (MicroAPI::RegTensor<uint8_t>&)idx0, pregB8);
+
+        MicroAPI::Histograms<uint8_t, uint16_t, MicroAPI::HistogramsBinType::BIN0,
+                             MicroAPI::HistogramsType::ACCUMULATE>(cout0, vreg1, pregEQ);
+        MicroAPI::Histograms<uint8_t, uint16_t, MicroAPI::HistogramsBinType::BIN1,
+                             MicroAPI::HistogramsType::ACCUMULATE>(cout1, vreg1, pregEQ);
+    }
+
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_EVEN>(cout0U32Even, cout0, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_ODD>(cout0U32Odd, cout0, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_EVEN>(cout1U32Even, cout1, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_ODD>(cout1U32Odd, cout1, pregB16);
+
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_INTLV_B32>(histogramsBuf,
+                                                                        cout0U32Even, cout0U32Odd, pregB32);
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_INTLV_B32>(histogramsBuf + 128,
+                                                                        cout1U32Even, cout1U32Odd, pregB32);
+}
+
+// kValue新的bottomK
+__simd_vf__ void FindSecondTargetBinVFImpl(__ubuf__ uint32_t* idx1Buf,
+                                            __ubuf__ uint32_t* nkValueBuf,  __ubuf__ uint32_t* kValue,
+                                            __ubuf__ uint32_t* histogramsBuf)
+{
+    MicroAPI::MaskReg pregB32 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+    MicroAPI::ClearSpr<AscendC::SpecialPurposeReg::AR>();
+
+    MicroAPI::UnalignRegForStore alignIdx1;
+
+    MicroAPI::RegTensor<uint32_t> btmK1;
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(btmK1, kValue);
+
+    for (uint16_t i = 0; i < (uint16_t)(4); ++i) {
+        MicroAPI::RegTensor<int32_t> idxC;
+        MicroAPI::RegTensor<uint32_t> cout;
+        MicroAPI::RegTensor<uint32_t> sqzIdx1;
+
+        MicroAPI::MaskReg pregGE = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+        MicroAPI::Arange(idxC, i * 64);
+        MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(cout, histogramsBuf + i * 64);
+        MicroAPI::Compare<uint32_t, CMPMODE::GE>(pregGE, cout, btmK1, pregB32);
+        MicroAPI::Squeeze<uint32_t, MicroAPI::GatherMaskMode::STORE_REG>(sqzIdx1,
+                                                                         (MicroAPI::RegTensor<uint32_t>&)idxC, pregGE);
+        MicroAPI::StoreUnAlign<uint32_t, MicroAPI::PostLiteral::POST_MODE_UPDATE>(idx1Buf, sqzIdx1, alignIdx1);
+    }
+    MicroAPI::StoreUnAlignPost(idx1Buf, alignIdx1);
+
+    MicroAPI::LocalMemBar<AscendC::MicroAPI::MemType::VEC_STORE, AscendC::MicroAPI::MemType::VEC_LOAD>();
+
+    MicroAPI::RegTensor<uint32_t> idx1;
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B8>(idx1, idx1Buf);
+
+    MicroAPI::RegTensor<uint8_t> idxAll1;
+    MicroAPI::RegTensor<uint32_t> idxPrev1;
+    MicroAPI::RegTensor<uint32_t> prevBinValue;
+    MicroAPI::Duplicate(idxAll1, 1);
+
+    MicroAPI::RegTensor<uint32_t> zeroAll;
+    MicroAPI::Duplicate(zeroAll, 0);
+
+    MicroAPI::MaskReg preg1 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+    MicroAPI::Compare<uint32_t, CMPMODE::EQ>(preg1, idx1, zeroAll, pregB32);
+    MicroAPI::Sub(idxPrev1, idx1, (MicroAPI::RegTensor<uint32_t>&)idxAll1, pregB32);
+    MicroAPI::ShiftRights(idxPrev1, idxPrev1, (int16_t)24, pregB32);
+
+    MicroAPI::Gather(prevBinValue, histogramsBuf, idxPrev1, pregB32);
+    MicroAPI::Select(prevBinValue, zeroAll, prevBinValue, preg1);
+
+    MicroAPI::RegTensor<uint32_t> nextK;
+    MicroAPI::Sub(nextK, btmK1, prevBinValue, pregB32);
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_NORM>(nkValueBuf, nextK, pregB32);
+}
+
+template<typename T>
+__simd_vf__ void HistogramsThirdVFImpl(__ubuf__ uint32_t* histogramsBuf,
+                                         __ubuf__ uint32_t* inputBuf, __ubuf__ uint32_t* idx0Buf,
+                                         __ubuf__ uint32_t* idx1Buf, uint16_t vfLoop, bool init)
+{
+    MicroAPI::MaskReg pregB32 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+    MicroAPI::MaskReg pregB16 = MicroAPI::CreateMask<uint16_t, MicroAPI::MaskPattern::ALL>();
+    MicroAPI::MaskReg pregB8 = MicroAPI::CreateMask<uint8_t, MicroAPI::MaskPattern::ALL>();
+
+    // 计算直方图0-127 128-255
+    MicroAPI::RegTensor<uint16_t> cout0;
+    MicroAPI::RegTensor<uint16_t> cout1;
+    MicroAPI::Duplicate(cout0, 0);
+    MicroAPI::Duplicate(cout1, 0);
+
+    MicroAPI::RegTensor<uint32_t> cout0U32Even;
+    MicroAPI::RegTensor<uint32_t> cout0U32Odd;
+    MicroAPI::RegTensor<uint32_t> cout1U32Even;
+    MicroAPI::RegTensor<uint32_t> cout1U32Odd;
+
+    MicroAPI::RegTensor<uint32_t> idx0;
+    MicroAPI::RegTensor<uint32_t> idx1;
+    // 0x000000fc -> 0xfcfcfcfc
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B8>(idx0, idx0Buf);
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B8>(idx1, idx1Buf);
+
+    MicroAPI::RegTensor<uint32_t> vreg0U16;
+    MicroAPI::RegTensor<uint32_t> vreg1U16;
+    MicroAPI::RegTensor<uint32_t> vreg2U16;
+    MicroAPI::RegTensor<uint32_t> vreg3U16;
+
+    MicroAPI::RegTensor<uint8_t> vreg0;
+    MicroAPI::RegTensor<uint8_t> vreg1;
+    MicroAPI::RegTensor<uint8_t> vreg2;
+    MicroAPI::RegTensor<uint8_t> vreg3;
+
+    static constexpr MicroAPI::CastTrait CAST_TRAIT_UINT16_TOUINT32_EVEN = {MicroAPI::RegLayout::ZERO,
+                MicroAPI::SatMode::UNKNOWN, MicroAPI::MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
+
+    static constexpr MicroAPI::CastTrait CAST_TRAIT_UINT16_TOUINT32_ODD = {MicroAPI::RegLayout::ONE,
+                MicroAPI::SatMode::UNKNOWN, MicroAPI::MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
+
+    for (uint16_t i = 0; i < vfLoop; ++i) {
+        MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_DINTLV_B16>(vreg1U16,
+                                                                             vreg0U16, inputBuf + i * 256);
+        MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_DINTLV_B16>(vreg3U16,
+                                                                             vreg2U16, inputBuf + (i * 256) + 128);
+
+        MicroAPI::DeInterleave(vreg1, vreg0, (MicroAPI::RegTensor<uint8_t>&)vreg0U16,
+                                             (MicroAPI::RegTensor<uint8_t>&)vreg2U16);
+        MicroAPI::DeInterleave(vreg3, vreg2, (MicroAPI::RegTensor<uint8_t>&)vreg1U16,
+                                             (MicroAPI::RegTensor<uint8_t>&)vreg3U16);
+
+        MicroAPI::MaskReg pregEQ0 = MicroAPI::CreateMask<uint8_t, MicroAPI::MaskPattern::ALL>();
+        MicroAPI::MaskReg pregEQ1 = MicroAPI::CreateMask<uint8_t, MicroAPI::MaskPattern::ALL>();
+        MicroAPI::Compare<uint8_t, CMPMODE::EQ>(pregEQ0, vreg0, (MicroAPI::RegTensor<uint8_t>&)idx0, pregB8);
+        MicroAPI::Compare<uint8_t, CMPMODE::EQ>(pregEQ1, vreg1, (MicroAPI::RegTensor<uint8_t>&)idx1, pregB8);
+
+        MicroAPI::MaskReg pregEQ = MicroAPI::CreateMask<uint8_t, MicroAPI::MaskPattern::ALL>();
+        MicroAPI::And(pregEQ, pregEQ0, pregEQ1, pregB8);
+
+        MicroAPI::Histograms<uint8_t, uint16_t, MicroAPI::HistogramsBinType::BIN0,
+                             MicroAPI::HistogramsType::ACCUMULATE>(cout0, vreg2, pregEQ);
+        MicroAPI::Histograms<uint8_t, uint16_t, MicroAPI::HistogramsBinType::BIN1,
+                             MicroAPI::HistogramsType::ACCUMULATE>(cout1, vreg2, pregEQ);
+    }
+
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_EVEN>(cout0U32Even, cout0, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_ODD>(cout0U32Odd, cout0, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_EVEN>(cout1U32Even, cout1, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_ODD>(cout1U32Odd, cout1, pregB16);
+
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_INTLV_B32>(histogramsBuf,
+                                                                         cout0U32Even, cout0U32Odd, pregB32);
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_INTLV_B32>(histogramsBuf + 128,
+                                                                         cout1U32Even, cout1U32Odd, pregB32);
+}
+
+__simd_vf__ void FindThirdTargetBinVFImpl(__ubuf__ uint32_t* idx2Buf,
+                                          __ubuf__ uint32_t* nkValueBuf, __ubuf__ uint32_t* kValue,
+                                          __ubuf__ uint32_t* histogramsBuf)
+{
+    MicroAPI::MaskReg pregB32 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+    MicroAPI::ClearSpr<AscendC::SpecialPurposeReg::AR>();
+
+    MicroAPI::UnalignRegForStore alignIdx2;
+
+    MicroAPI::RegTensor<uint32_t> btmK2;
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(btmK2, kValue);
+
+    for (uint16_t i = 0; i < (uint16_t)(4); ++i) {
+        MicroAPI::RegTensor<int32_t> idxC;
+        MicroAPI::RegTensor<uint32_t> cout;
+        MicroAPI::RegTensor<uint32_t> sqzIdx2;
+
+        MicroAPI::MaskReg pregGE = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+        MicroAPI::Arange(idxC, i * 64);
+        MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(cout, histogramsBuf + i * 64);
+        MicroAPI::Compare<uint32_t, CMPMODE::GE>(pregGE, cout, btmK2, pregB32);
+        MicroAPI::Squeeze<uint32_t, MicroAPI::GatherMaskMode::STORE_REG>(
+            sqzIdx2,
+            (MicroAPI::RegTensor<uint32_t>&)idxC,
+            pregGE);
+        MicroAPI::StoreUnAlign<uint32_t, MicroAPI::PostLiteral::POST_MODE_UPDATE>(idx2Buf, sqzIdx2, alignIdx2);
+    }
+    MicroAPI::StoreUnAlignPost(idx2Buf, alignIdx2);
+
+    MicroAPI::LocalMemBar<AscendC::MicroAPI::MemType::VEC_STORE, AscendC::MicroAPI::MemType::VEC_LOAD>();
+
+    MicroAPI::RegTensor<uint32_t> idx2;
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B8>(idx2, idx2Buf);
+
+    MicroAPI::RegTensor<uint8_t> idxAll1;
+    MicroAPI::RegTensor<uint32_t> idxPrev2;
+    MicroAPI::RegTensor<uint32_t> prevBinValue;
+    MicroAPI::Duplicate(idxAll1, 1);
+
+    MicroAPI::RegTensor<uint32_t> zeroAll;
+    MicroAPI::Duplicate(zeroAll, 0);
+
+    MicroAPI::MaskReg preg2 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+    MicroAPI::Compare<uint32_t, CMPMODE::EQ>(preg2, idx2, zeroAll, pregB32);
+    MicroAPI::Sub(idxPrev2, idx2, (MicroAPI::RegTensor<uint32_t>&)idxAll1, pregB32);
+    MicroAPI::ShiftRights(idxPrev2, idxPrev2, (int16_t)24, pregB32);
+
+    MicroAPI::Gather(prevBinValue, histogramsBuf, idxPrev2, pregB32);
+    MicroAPI::Select(prevBinValue, zeroAll, prevBinValue, preg2);
+
+    MicroAPI::RegTensor<uint32_t> nextK;
+    MicroAPI::Sub(nextK, btmK2, prevBinValue, pregB32);
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_NORM>(nkValueBuf, nextK, pregB32);
+}
+
+template<typename T>
+__simd_vf__ void HistogramsLastVFImpl(__ubuf__ uint32_t* histogramsBuf,
+                                      __ubuf__ uint32_t* inputBuf, __ubuf__ uint32_t* idx0Buf,
+                                      __ubuf__ uint32_t* idx1Buf, __ubuf__ uint32_t* idx2Buf,
+                                      uint16_t vfLoop, bool init)
+{
+    MicroAPI::MaskReg pregB32 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+    MicroAPI::MaskReg pregB16 = MicroAPI::CreateMask<uint16_t, MicroAPI::MaskPattern::ALL>();
+    MicroAPI::MaskReg pregB8 = MicroAPI::CreateMask<uint8_t, MicroAPI::MaskPattern::ALL>();
+
+    // 计算直方图0-127 128-255
+    MicroAPI::RegTensor<uint16_t> cout0;
+    MicroAPI::RegTensor<uint16_t> cout1;
+    MicroAPI::Duplicate(cout0, 0);
+    MicroAPI::Duplicate(cout1, 0);
+
+    MicroAPI::RegTensor<uint32_t> cout0U32Even;
+    MicroAPI::RegTensor<uint32_t> cout0U32Odd;
+    MicroAPI::RegTensor<uint32_t> cout1U32Even;
+    MicroAPI::RegTensor<uint32_t> cout1U32Odd;
+
+    MicroAPI::RegTensor<uint32_t> idx0;
+    MicroAPI::RegTensor<uint32_t> idx1;
+    MicroAPI::RegTensor<uint32_t> idx2;
+    // 0x000000fc -> 0xfcfcfcfc
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B8>(idx0, idx0Buf);
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B8>(idx1, idx1Buf);
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B8>(idx2, idx2Buf);
+
+    MicroAPI::RegTensor<uint32_t> vreg0U16;
+    MicroAPI::RegTensor<uint32_t> vreg1U16;
+    MicroAPI::RegTensor<uint32_t> vreg2U16;
+    MicroAPI::RegTensor<uint32_t> vreg3U16;
+
+    MicroAPI::RegTensor<uint8_t> vreg0;
+    MicroAPI::RegTensor<uint8_t> vreg1;
+    MicroAPI::RegTensor<uint8_t> vreg2;
+    MicroAPI::RegTensor<uint8_t> vreg3;
+
+    static constexpr MicroAPI::CastTrait CAST_TRAIT_UINT16_TOUINT32_EVEN = {MicroAPI::RegLayout::ZERO,
+                MicroAPI::SatMode::UNKNOWN, MicroAPI::MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
+
+    static constexpr MicroAPI::CastTrait CAST_TRAIT_UINT16_TOUINT32_ODD = {MicroAPI::RegLayout::ONE,
+                MicroAPI::SatMode::UNKNOWN, MicroAPI::MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
+
+    for (uint16_t i = 0; i < vfLoop; ++i) {
+        MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_DINTLV_B16>(vreg1U16, vreg0U16, inputBuf + i * 256);
+        MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_DINTLV_B16>(vreg3U16,
+                                                                             vreg2U16, inputBuf + (i * 256) + 128);
+
+        MicroAPI::DeInterleave(vreg1, vreg0,
+         (MicroAPI::RegTensor<uint8_t>&)vreg0U16,
+         (MicroAPI::RegTensor<uint8_t>&)vreg2U16);
+        MicroAPI::DeInterleave(vreg3, vreg2,
+         (MicroAPI::RegTensor<uint8_t>&)vreg1U16,
+         (MicroAPI::RegTensor<uint8_t>&)vreg3U16);
+
+        MicroAPI::MaskReg pregEQ0 = MicroAPI::CreateMask<uint8_t, MicroAPI::MaskPattern::ALL>();
+        MicroAPI::MaskReg pregEQ1 = MicroAPI::CreateMask<uint8_t, MicroAPI::MaskPattern::ALL>();
+        MicroAPI::MaskReg pregEQ2 = MicroAPI::CreateMask<uint8_t, MicroAPI::MaskPattern::ALL>();
+        MicroAPI::Compare<uint8_t, CMPMODE::EQ>(pregEQ0, vreg0, (MicroAPI::RegTensor<uint8_t>&)idx0, pregB8);
+        MicroAPI::Compare<uint8_t, CMPMODE::EQ>(pregEQ1, vreg1, (MicroAPI::RegTensor<uint8_t>&)idx1, pregB8);
+        MicroAPI::Compare<uint8_t, CMPMODE::EQ>(pregEQ2, vreg2, (MicroAPI::RegTensor<uint8_t>&)idx2, pregB8);
+
+        MicroAPI::MaskReg pregEQ0And1 = MicroAPI::CreateMask<uint8_t, MicroAPI::MaskPattern::ALL>();
+        MicroAPI::MaskReg pregEQAll = MicroAPI::CreateMask<uint8_t, MicroAPI::MaskPattern::ALL>();
+        MicroAPI::And(pregEQ0And1, pregEQ0, pregEQ1, pregB8);
+        MicroAPI::And(pregEQAll, pregEQ0And1, pregEQ2, pregB8);
+
+        MicroAPI::Histograms<uint8_t, uint16_t, MicroAPI::HistogramsBinType::BIN0,
+                             MicroAPI::HistogramsType::ACCUMULATE>(cout0, vreg3, pregEQAll);
+        MicroAPI::Histograms<uint8_t, uint16_t, MicroAPI::HistogramsBinType::BIN1,
+                             MicroAPI::HistogramsType::ACCUMULATE>(cout1, vreg3, pregEQAll);
+    }
+
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_EVEN>(cout0U32Even, cout0, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_ODD>(cout0U32Odd, cout0, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_EVEN>(cout1U32Even, cout1, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_ODD>(cout1U32Odd, cout1, pregB16);
+
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_INTLV_B32>(histogramsBuf,
+                                                                         cout0U32Even, cout0U32Odd, pregB32);
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_INTLV_B32>(histogramsBuf + 128,
+                                                                         cout1U32Even, cout1U32Odd, pregB32);
+}
+
+__simd_vf__ void FindKthVFImpl(__ubuf__ uint32_t* kValue,
+                                 __ubuf__ uint32_t* histogramsBuf, __ubuf__ uint32_t* idx0Buf,
+                                 __ubuf__ uint32_t* idx1Buf, __ubuf__ uint32_t* idx2Buf,
+                                 __ubuf__ uint32_t* idx3Buf)
+{
+    MicroAPI::MaskReg pregB32 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+    MicroAPI::ClearSpr<AscendC::SpecialPurposeReg::AR>();
+
+    MicroAPI::UnalignRegForStore alignIdx3;
+
+    MicroAPI::RegTensor<uint32_t> btmK3;
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(btmK3, kValue);
+
+    for (uint16_t i = 0; i < (uint16_t)(4); ++i) {
+        MicroAPI::RegTensor<int32_t> idxC;
+        MicroAPI::RegTensor<uint32_t> cout;
+        MicroAPI::RegTensor<uint32_t> sqzIdx3;
+
+        MicroAPI::MaskReg pregGE = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+        MicroAPI::Arange(idxC, i * 64);
+        MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(cout, histogramsBuf + i * 64);
+        MicroAPI::Compare<uint32_t, CMPMODE::GE>(pregGE, cout, btmK3, pregB32);
+        MicroAPI::Squeeze<uint32_t, MicroAPI::GatherMaskMode::STORE_REG>(sqzIdx3,
+                                                                         (MicroAPI::RegTensor<uint32_t>&)idxC, pregGE);
+        MicroAPI::StoreUnAlign<uint32_t, MicroAPI::PostLiteral::POST_MODE_UPDATE>(idx3Buf, sqzIdx3, alignIdx3);
+    }
+    MicroAPI::StoreUnAlignPost(idx3Buf, alignIdx3);
+
+    MicroAPI::LocalMemBar<AscendC::MicroAPI::MemType::VEC_STORE, AscendC::MicroAPI::MemType::VEC_LOAD>();
+
+    MicroAPI::RegTensor<uint32_t> idx0;
+    MicroAPI::RegTensor<uint32_t> idx1;
+    MicroAPI::RegTensor<uint32_t> idx2;
+    MicroAPI::RegTensor<uint32_t> idx3;
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B32>(idx0, idx0Buf);
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B32>(idx1, idx1Buf);
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B32>(idx2, idx2Buf);
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B32>(idx3, idx3Buf);
+
+    MicroAPI::ShiftLefts(idx0, idx0, (int16_t)24, pregB32);
+    MicroAPI::ShiftLefts(idx1, idx1, (int16_t)16, pregB32);
+    MicroAPI::ShiftLefts(idx2, idx2, (int16_t)8, pregB32);
+
+    // ADD
+    MicroAPI::Add(idx0, idx0, idx1, pregB32);
+    MicroAPI::Add(idx0, idx0, idx2, pregB32);
+    MicroAPI::Add(idx0, idx0, idx3, pregB32);
+
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_NORM>(kValue, idx0, pregB32);
+}
+
+__simd_vf__ void FindIdxGTOutputVFImpl(__ubuf__ uint32_t* outputIdxBuf,
+                                        __ubuf__ uint32_t* inputBuf, uint32_t beginIdx,
+                                        __ubuf__ uint32_t* kValue, uint16_t vfLoop)
+{
+    MicroAPI::MaskReg pregB32 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+    MicroAPI::ClearSpr<AscendC::SpecialPurposeReg::AR>();
+
+    MicroAPI::UnalignRegForStore alignIdx;
+
+    MicroAPI::RegTensor<uint32_t> kthValue;
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(kthValue, kValue);
+
+    MicroAPI::RegTensor<uint32_t> vregInput;
+
+    for (uint16_t i = 0; i < (uint16_t)(vfLoop); ++i) {
+        MicroAPI::RegTensor<int32_t> idxC;
+        MicroAPI::Arange(idxC, beginIdx + i * 64);
+
+        MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(vregInput, inputBuf + i * 64);
+
+        MicroAPI::MaskReg poutGT = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+        MicroAPI::RegTensor<uint32_t> sqzIdxOut;
+        MicroAPI::Compare<uint32_t, CMPMODE::GT>(poutGT, vregInput, kthValue, pregB32);
+
+        MicroAPI::Squeeze<uint32_t, MicroAPI::GatherMaskMode::STORE_REG>(sqzIdxOut,
+                                                                         (MicroAPI::RegTensor<uint32_t>&)idxC, poutGT);
+        MicroAPI::StoreUnAlign<uint32_t, MicroAPI::PostLiteral::POST_MODE_UPDATE>(outputIdxBuf, sqzIdxOut, alignIdx);
+    }
+    MicroAPI::StoreUnAlignPost(outputIdxBuf, alignIdx);
+}
+
+__simd_vf__ void FindIdxEQOutputVFImpl(__ubuf__ uint32_t* outputIdxBuf,
+                                        __ubuf__ uint32_t* inputBuf, uint32_t beginIdx,
+                                        __ubuf__ uint32_t* kValue)
+{
+    MicroAPI::MaskReg pregB32 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+    MicroAPI::UnalignRegForStore alignIdx;
+
+    MicroAPI::RegTensor<uint32_t> kthValue;
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(kthValue, kValue);
+
+    MicroAPI::RegTensor<uint32_t> vregInput;
+
+    MicroAPI::RegTensor<int32_t> idxC;
+    MicroAPI::Arange(idxC, beginIdx);
+
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(vregInput, inputBuf);
+
+    MicroAPI::MaskReg poutEQ = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+    MicroAPI::RegTensor<uint32_t> sqzIdxOut;
+    MicroAPI::Compare<uint32_t, CMPMODE::EQ>(poutEQ, vregInput, kthValue, pregB32);
+
+    MicroAPI::Squeeze<uint32_t, MicroAPI::GatherMaskMode::STORE_REG>(sqzIdxOut,
+                                                                     (MicroAPI::RegTensor<uint32_t>&)idxC, poutEQ);
+    MicroAPI::StoreUnAlign<uint32_t, MicroAPI::PostLiteral::POST_MODE_UPDATE>(outputIdxBuf, sqzIdxOut, alignIdx);
+    MicroAPI::StoreUnAlignPost(outputIdxBuf, alignIdx);
+}
+
+__simd_vf__ void FindValueGTOutputVFImpl(__ubuf__ uint32_t* outputValueBuf,
+                                         __ubuf__ uint32_t* inputBuf, __ubuf__ uint32_t* kValue,
+                                         uint16_t vfLoop)
+{
+    MicroAPI::MaskReg pregB32 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+    MicroAPI::ClearSpr<AscendC::SpecialPurposeReg::AR>();
+
+    MicroAPI::UnalignRegForStore alignValue;
+
+    MicroAPI::RegTensor<uint32_t> kthValue;
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(kthValue, kValue);
+
+    MicroAPI::RegTensor<uint32_t> vregInput;
+
+    for (uint16_t i = 0; i < (uint16_t)(vfLoop); ++i) {
+        MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(vregInput, inputBuf + i * 64);
+
+        MicroAPI::MaskReg poutGT = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+        MicroAPI::RegTensor<uint32_t> sqzValueOut;
+        MicroAPI::Compare<uint32_t, CMPMODE::GT>(poutGT, vregInput, kthValue, pregB32);
+
+        MicroAPI::Squeeze<uint32_t, MicroAPI::GatherMaskMode::STORE_REG>(sqzValueOut, vregInput, poutGT);
+        MicroAPI::StoreUnAlign<uint32_t, MicroAPI::PostLiteral::POST_MODE_UPDATE>(outputValueBuf,
+                                                                                     sqzValueOut, alignValue);
+    }
+    MicroAPI::StoreUnAlignPost(outputValueBuf, alignValue);
+}
+
+__simd_vf__ void FindValueEQOutputVFImpl(__ubuf__ uint32_t* outputValueBuf,
+                                         __ubuf__ uint32_t* inputBuf, __ubuf__ uint32_t* kValue)
+{
+    MicroAPI::MaskReg pregB32 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+    MicroAPI::UnalignRegForStore alignValue;
+
+    MicroAPI::RegTensor<uint32_t> kthValue;
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(kthValue, kValue);
+
+    MicroAPI::RegTensor<uint32_t> vregInput;
+
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(vregInput, inputBuf);
+
+    MicroAPI::MaskReg poutEQ = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+    MicroAPI::RegTensor<uint32_t> sqzValueOut;
+    MicroAPI::Compare<uint32_t, CMPMODE::EQ>(poutEQ, vregInput, kthValue, pregB32);
+
+    MicroAPI::Squeeze<uint32_t, MicroAPI::GatherMaskMode::STORE_REG>(sqzValueOut, vregInput, poutEQ);
+    MicroAPI::StoreUnAlign<uint32_t, MicroAPI::PostLiteral::POST_MODE_UPDATE>(outputValueBuf, sqzValueOut, alignValue);
+    MicroAPI::StoreUnAlignPost(outputValueBuf, alignValue);
+}
+
+__aicore__ inline void LiTopKVF(const LocalTensor<uint32_t>& outputIdxLocal,
+                                const LocalTensor<uint32_t>& outputValueLocal,
+                                const LocalTensor<uint32_t>& inputLocal,
+                                const LocalTensor<uint32_t>& tmpIdxLocal,
+                                const LocalTensor<uint32_t>& tmpValueLocal,
+                                const LocalTensor<uint32_t>& histogramsLocal,
+                                const LocalTensor<uint32_t>& idx0Local,
+                                const LocalTensor<uint32_t>& idx1Local,
+                                const LocalTensor<uint32_t>& idx2Local,
+                                const LocalTensor<uint32_t>& idx3Local,
+                                const LocalTensor<uint32_t>& nkValueLocal,
+                                uint32_t topK,
+                                uint32_t s2SeqLen)
+{
+    __ubuf__ uint32_t* outputIdxBuf = (__ubuf__ uint32_t*)outputIdxLocal.GetPhyAddr();
+    __ubuf__ uint32_t* outputValueBuf = (__ubuf__ uint32_t*)outputValueLocal.GetPhyAddr();
+    __ubuf__ uint32_t* inputBuf = (__ubuf__ uint32_t*)inputLocal.GetPhyAddr();
+    __ubuf__ uint32_t* tmpIdxBuf = (__ubuf__ uint32_t*)tmpIdxLocal.GetPhyAddr();
+    __ubuf__ uint32_t* tmpValueBuf = (__ubuf__ uint32_t*)tmpValueLocal.GetPhyAddr();
+    __ubuf__ uint32_t* histogramsBuf = (__ubuf__ uint32_t*)histogramsLocal.GetPhyAddr();
+    __ubuf__ uint32_t* idx0Buf = (__ubuf__ uint32_t*)idx0Local.GetPhyAddr();
+    __ubuf__ uint32_t* idx1Buf = (__ubuf__ uint32_t*)idx1Local.GetPhyAddr();
+    __ubuf__ uint32_t* idx2Buf = (__ubuf__ uint32_t*)idx2Local.GetPhyAddr();
+    __ubuf__ uint32_t* idx3Buf = (__ubuf__ uint32_t*)idx3Local.GetPhyAddr();
+    __ubuf__ uint32_t* nkValueBuf = (__ubuf__ uint32_t*)nkValueLocal.GetPhyAddr();
+
+    uint32_t bottomK = s2SeqLen - topK + 1;
+    uint32_t beginIdx = 0;
+    bool flag = true;
+
+    const uint16_t repeatSize8 = 256;
+    const uint16_t repeatSize32 = 64;
+
+    uint16_t histogramsLoopNum = (s2SeqLen + repeatSize8 - 1) / repeatSize8;
+    uint16_t inputLoopNum = (s2SeqLen + repeatSize32 - 1) / repeatSize32;
+    uint16_t topkLoopNum = (topK + 64 - 1) / 64;
+
+    // find kth-value
+    HistogramsFirstVFImpl<uint32_t>(histogramsBuf, inputBuf, histogramsLoopNum, flag);
+    FindFirstTargetBinVFImpl(idx0Buf, nkValueBuf, histogramsBuf, bottomK);
+    HistogramsSecondVFImpl<uint32_t>(histogramsBuf, inputBuf, idx0Buf, histogramsLoopNum, flag);
+    FindSecondTargetBinVFImpl(idx1Buf, nkValueBuf, nkValueBuf, histogramsBuf);
+    HistogramsThirdVFImpl<uint32_t>(histogramsBuf, inputBuf, idx0Buf, idx1Buf, histogramsLoopNum, flag);
+    FindThirdTargetBinVFImpl(idx2Buf, nkValueBuf, nkValueBuf, histogramsBuf);
+    HistogramsLastVFImpl<uint32_t>(histogramsBuf, inputBuf, idx0Buf, idx1Buf, idx2Buf, histogramsLoopNum, flag);
+    FindKthVFImpl(nkValueBuf, histogramsBuf, idx0Buf, idx1Buf, idx2Buf, idx3Buf);
+
+    // filter
+    // 输出大于k-value的值value
+    FindValueGTOutputVFImpl(outputValueBuf, inputBuf, nkValueBuf, inputLoopNum);
+    // value-当前偏移大于k-value的值在AR特殊寄存器中的有效字节数
+    int64_t arValueNum = AscendC::GetSpr<AscendC::SpecialPurposeReg::AR>();
+    // value-剩余需要输出等于k-value的数量
+    int64_t remainValueNum = topK - (arValueNum / sizeof(uint32_t));
+    for (uint16_t i = 0; i < inputLoopNum; ++i) {
+        int64_t arValueNumPerLoop = AscendC::GetSpr<AscendC::SpecialPurposeReg::AR>();
+        if (((arValueNumPerLoop - arValueNum) / sizeof(uint32_t)) < remainValueNum) {
+            // 调用一次查找等于k-value情况的过程
+            FindValueEQOutputVFImpl(outputValueBuf, inputBuf + i * 64, nkValueBuf);
+        } else {
+            break;
+        }
+    }
+
+    // 输出大于k-value的值idx
+    FindIdxGTOutputVFImpl(outputIdxBuf, inputBuf, (uint32_t)(0), nkValueBuf, inputLoopNum);
+    // idx-当前偏移大于k-value的值在AR特殊寄存器中的有效字节数
+    int64_t arIdxNum = AscendC::GetSpr<AscendC::SpecialPurposeReg::AR>();
+    int64_t remainIdxNum = topK - (arIdxNum / sizeof(uint32_t));
+    for (uint16_t i = 0; i < inputLoopNum; ++i) {
+        int64_t arIdxNumPerLoop = AscendC::GetSpr<AscendC::SpecialPurposeReg::AR>();
+        if (((arIdxNumPerLoop - arIdxNum) / sizeof(uint32_t)) < remainIdxNum) {
+            // 调用一次查找等于k-value情况的过程
+            beginIdx = i * 64;
+            FindIdxEQOutputVFImpl(outputIdxBuf, inputBuf + i * 64, beginIdx, nkValueBuf);
+        } else {
+            break;
+        }
+    }
+}
+}
+}  // namespace sglang::npu_kernel::liv2
+#endif

--- a/csrc/lightning_indexer_v2/op_kernel/arch35/vf/vf_topk_16_gather.h
+++ b/csrc/lightning_indexer_v2/op_kernel/arch35/vf/vf_topk_16_gather.h
@@ -1,0 +1,468 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+  */
+
+/*!
+* \file vf_top_k_16_gather.h
+* \brief
+*/
+
+#ifndef SGL_LI_V2_VF_TOP_K_16_GATHER_H
+#define SGL_LI_V2_VF_TOP_K_16_GATHER_H
+
+namespace sglang::npu_kernel::liv2 {
+
+namespace topkb16gather {
+
+template<typename T>
+__simd_vf__ void HistogramsHighVFImpl(__ubuf__ uint32_t* histogramsBuf,
+                                      __ubuf__ uint16_t* inputBuf,
+                                      uint16_t vfLoop, bool init)
+{
+    MicroAPI::MaskReg pregB32 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+    MicroAPI::MaskReg pregB16 = MicroAPI::CreateMask<uint16_t, MicroAPI::MaskPattern::ALL>();
+    MicroAPI::MaskReg pregB8 = MicroAPI::CreateMask<uint8_t, MicroAPI::MaskPattern::ALL>();
+
+    // 计算直方图cout0 0-127 cout1 128-255
+    MicroAPI::RegTensor<uint16_t> cout0;
+    MicroAPI::RegTensor<uint16_t> cout1;
+    MicroAPI::Duplicate(cout0, 0);
+    MicroAPI::Duplicate(cout1, 0);
+
+    MicroAPI::RegTensor<uint32_t> cout0U32Even;
+    MicroAPI::RegTensor<uint32_t> cout0U32Odd;
+    MicroAPI::RegTensor<uint32_t> cout1U32Even;
+    MicroAPI::RegTensor<uint32_t> cout1U32Odd;
+
+    MicroAPI::RegTensor<uint16_t> vregHigh;
+    MicroAPI::RegTensor<uint16_t> vregLow;
+
+    static constexpr MicroAPI::CastTrait CAST_TRAIT_UINT16_TOUINT32_EVEN = {MicroAPI::RegLayout::ZERO,
+                MicroAPI::SatMode::UNKNOWN, MicroAPI::MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
+
+    static constexpr MicroAPI::CastTrait CAST_TRAIT_UINT16_TOUINT32_ODD = {MicroAPI::RegLayout::ONE,
+                MicroAPI::SatMode::UNKNOWN, MicroAPI::MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
+
+    for (uint16_t i = 0; i < vfLoop; ++i) {
+        MicroAPI::LoadAlign<uint16_t, MicroAPI::LoadDist::DIST_DINTLV_B8>(vregLow, vregHigh, inputBuf + i * 256);
+
+        MicroAPI::Histograms<uint8_t, uint16_t, MicroAPI::HistogramsBinType::BIN0,
+                             MicroAPI::HistogramsType::ACCUMULATE>(cout0,
+                                                                    (MicroAPI::RegTensor<uint8_t>&)vregHigh,
+                                                                    pregB8);
+        MicroAPI::Histograms<uint8_t, uint16_t, MicroAPI::HistogramsBinType::BIN1,
+                             MicroAPI::HistogramsType::ACCUMULATE>(cout1,
+                                                                    (MicroAPI::RegTensor<uint8_t>&)vregHigh,
+                                                                    pregB8);
+    }
+
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_EVEN>(cout0U32Even, cout0, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_ODD>(cout0U32Odd, cout0, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_EVEN>(cout1U32Even, cout1, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_ODD>(cout1U32Odd, cout1, pregB16);
+
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_INTLV_B32>(histogramsBuf,
+                                                            cout0U32Even, cout0U32Odd, pregB32);
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_INTLV_B32>(histogramsBuf + 128,
+                                                            cout1U32Even, cout1U32Odd, pregB32);
+}
+
+__simd_vf__ void FindHighTargetBinVFImpl(__ubuf__ uint32_t* idxHighBuf,
+                                         __ubuf__ uint32_t* nkValueBuf,
+                                         __ubuf__ uint32_t* histogramsBuf,
+                                         uint32_t bottomK)
+{
+    MicroAPI::MaskReg pregB32 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+    MicroAPI::MaskReg pregGE;
+
+    MicroAPI::ClearSpr<AscendC::SpecialPurposeReg::AR>();
+
+    MicroAPI::UnalignRegForStore alignIdxHigh;
+
+    MicroAPI::RegTensor<uint32_t> btmK;
+    MicroAPI::Duplicate(btmK, bottomK);
+
+    MicroAPI::RegTensor<int32_t> idxC;
+    MicroAPI::RegTensor<uint32_t> cout;
+    MicroAPI::RegTensor<uint32_t> sqzIdxHigh;
+
+    for (uint16_t i = 0; i < (uint16_t)(4); ++i) {
+        MicroAPI::Arange(idxC, i * 64);
+
+        MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(cout, histogramsBuf + i * 64);
+
+        MicroAPI::Compare<uint32_t, CMPMODE::GE>(pregGE, cout, btmK, pregB32);
+
+        MicroAPI::Squeeze<uint32_t, MicroAPI::GatherMaskMode::STORE_REG>(
+                                                    sqzIdxHigh, (MicroAPI::RegTensor<uint32_t>&)idxC, pregGE);
+        MicroAPI::StoreUnAlign<uint32_t, MicroAPI::PostLiteral::POST_MODE_UPDATE>(idxHighBuf, sqzIdxHigh, alignIdxHigh);
+    }
+    MicroAPI::StoreUnAlignPost(idxHighBuf, alignIdxHigh);
+
+    MicroAPI::LocalMemBar<AscendC::MicroAPI::MemType::VEC_STORE, AscendC::MicroAPI::MemType::VEC_LOAD>();
+
+    MicroAPI::RegTensor<uint32_t> idxHigh;
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B8>(idxHigh, idxHighBuf);
+
+    MicroAPI::RegTensor<uint8_t> idxAll1;
+    MicroAPI::RegTensor<uint32_t> idxPrev0;
+    MicroAPI::RegTensor<uint32_t> prevBinValue;
+    MicroAPI::Duplicate(idxAll1, 1);
+
+    MicroAPI::RegTensor<uint32_t> zeroAll;
+    MicroAPI::Duplicate(zeroAll, 0);
+
+    MicroAPI::MaskReg preg0 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+    MicroAPI::Compare<uint32_t, CMPMODE::EQ>(preg0, idxHigh, zeroAll, pregB32);
+    MicroAPI::Sub(idxPrev0, idxHigh, (MicroAPI::RegTensor<uint32_t>&)idxAll1, pregB32);
+    MicroAPI::ShiftRights(idxPrev0, idxPrev0, (int16_t)24, pregB32);
+
+    MicroAPI::Gather(prevBinValue, histogramsBuf, idxPrev0, pregB32);
+    MicroAPI::Select(prevBinValue, zeroAll, prevBinValue, preg0);
+
+    MicroAPI::RegTensor<uint32_t> nextK;
+    MicroAPI::Sub(nextK, btmK, prevBinValue, pregB32);
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_NORM>(nkValueBuf, nextK, pregB32);
+}
+
+template<typename T>
+__simd_vf__ void HistogramsLowVFImpl(__ubuf__ uint32_t* histogramsBuf,
+                                     __ubuf__ uint16_t* inputBuf, __ubuf__ uint32_t* idxHighBuf,
+                                     uint16_t vfLoop, bool init)
+{
+    MicroAPI::MaskReg pregB32 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+    MicroAPI::MaskReg pregB16 = MicroAPI::CreateMask<uint16_t, MicroAPI::MaskPattern::ALL>();
+    MicroAPI::MaskReg pregB8 = MicroAPI::CreateMask<uint8_t, MicroAPI::MaskPattern::ALL>();
+
+    MicroAPI::MaskReg pregEQ;
+
+    // 计算直方图0-127 128-255
+    MicroAPI::RegTensor<uint16_t> cout0;
+    MicroAPI::RegTensor<uint16_t> cout1;
+    MicroAPI::Duplicate(cout0, 0);
+    MicroAPI::Duplicate(cout1, 0);
+
+    MicroAPI::RegTensor<uint32_t> cout0U32Even;
+    MicroAPI::RegTensor<uint32_t> cout0U32Odd;
+    MicroAPI::RegTensor<uint32_t> cout1U32Even;
+    MicroAPI::RegTensor<uint32_t> cout1U32Odd;
+
+    MicroAPI::RegTensor<uint32_t> idxHigh;
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B8>(idxHigh, idxHighBuf);
+
+    MicroAPI::RegTensor<uint16_t> vregHigh;
+    MicroAPI::RegTensor<uint16_t> vregLow;
+
+    static constexpr MicroAPI::CastTrait CAST_TRAIT_UINT16_TOUINT32_EVEN = {MicroAPI::RegLayout::ZERO,
+                MicroAPI::SatMode::UNKNOWN, MicroAPI::MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
+
+    static constexpr MicroAPI::CastTrait CAST_TRAIT_UINT16_TOUINT32_ODD = {MicroAPI::RegLayout::ONE,
+                MicroAPI::SatMode::UNKNOWN, MicroAPI::MaskMergeMode::ZEROING, RoundMode::UNKNOWN};
+
+    for (uint16_t i = 0; i < vfLoop; ++i) {
+        MicroAPI::LoadAlign<uint16_t, MicroAPI::LoadDist::DIST_DINTLV_B8>(vregLow, vregHigh, inputBuf + i * 256);
+
+        MicroAPI::Compare<uint8_t, CMPMODE::EQ>(pregEQ,
+                                                (MicroAPI::RegTensor<uint8_t>&)vregHigh,
+                                                (MicroAPI::RegTensor<uint8_t>&)idxHigh, pregB8);
+
+        MicroAPI::Histograms<uint8_t, uint16_t, MicroAPI::HistogramsBinType::BIN0,
+                             MicroAPI::HistogramsType::ACCUMULATE>(cout0,
+                            (MicroAPI::RegTensor<uint8_t>&)vregLow, pregEQ);
+        MicroAPI::Histograms<uint8_t, uint16_t, MicroAPI::HistogramsBinType::BIN1,
+                             MicroAPI::HistogramsType::ACCUMULATE>(cout1,
+                            (MicroAPI::RegTensor<uint8_t>&)vregLow, pregEQ);
+    }
+
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_EVEN>(cout0U32Even, cout0, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_ODD>(cout0U32Odd, cout0, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_EVEN>(cout1U32Even, cout1, pregB16);
+    MicroAPI::Cast<uint32_t, uint16_t, CAST_TRAIT_UINT16_TOUINT32_ODD>(cout1U32Odd, cout1, pregB16);
+
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_INTLV_B32>(histogramsBuf,
+                                                                        cout0U32Even, cout0U32Odd, pregB32);
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_INTLV_B32>(histogramsBuf + 128,
+                                                                        cout1U32Even, cout1U32Odd, pregB32);
+}
+
+__simd_vf__ void FindKthVFImpl(__ubuf__ uint32_t* kValue,
+                               __ubuf__ uint32_t* histogramsBuf, __ubuf__ uint32_t* idxHighBuf,
+                               __ubuf__ uint32_t* idxLowBuf)
+{
+    MicroAPI::MaskReg pregB32 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+    MicroAPI::MaskReg pregB16 = MicroAPI::CreateMask<uint16_t, MicroAPI::MaskPattern::ALL>();
+
+    MicroAPI::MaskReg pregGE;
+
+    MicroAPI::ClearSpr<AscendC::SpecialPurposeReg::AR>();
+
+    MicroAPI::UnalignRegForStore alignIdxLow;
+
+    MicroAPI::RegTensor<uint32_t> btmK;
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(btmK, kValue);
+
+    MicroAPI::RegTensor<int32_t> idxC;
+    MicroAPI::RegTensor<uint32_t> cout;
+    MicroAPI::RegTensor<uint32_t> sqzIdxLow;
+
+    for (uint16_t i = 0; i < (uint16_t)(4); ++i) {
+        MicroAPI::Arange(idxC, i * 64);
+
+        MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_NORM>(cout, histogramsBuf + i * 64);
+
+        MicroAPI::Compare<uint32_t, CMPMODE::GE>(pregGE, cout, btmK, pregB32);
+
+        MicroAPI::Squeeze<uint32_t, MicroAPI::GatherMaskMode::STORE_REG>(sqzIdxLow,
+                                                                         (MicroAPI::RegTensor<uint32_t>&)idxC, pregGE);
+        MicroAPI::StoreUnAlign<uint32_t, MicroAPI::PostLiteral::POST_MODE_UPDATE>(idxLowBuf, sqzIdxLow, alignIdxLow);
+    }
+    MicroAPI::StoreUnAlignPost(idxLowBuf, alignIdxLow);
+
+    MicroAPI::LocalMemBar<AscendC::MicroAPI::MemType::VEC_STORE, AscendC::MicroAPI::MemType::VEC_LOAD>();
+
+    MicroAPI::RegTensor<uint32_t> idxHigh;
+    MicroAPI::RegTensor<uint32_t> idxLow;
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B8>(idxHigh, idxHighBuf);
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B16>(idxLow, idxLowBuf);
+
+    MicroAPI::RegTensor<uint16_t> idxTmp;
+    MicroAPI::Duplicate(idxTmp, 0xff00);
+
+    MicroAPI::And(idxHigh, idxHigh, (MicroAPI::RegTensor<uint32_t>&)idxTmp, pregB32);
+
+    MicroAPI::RegTensor<uint32_t> idxK;
+    MicroAPI::Add(idxK, idxHigh, idxLow, pregB16);
+
+    MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_NORM_B16>(kValue, idxK, pregB32);
+}
+
+/**
+    输出所有大于的kth-value的Index
+ */
+__simd_vf__ void FindIdxGTOutputVFImpl(__ubuf__ uint16_t* outputIdxBuf,
+                                         __ubuf__ uint16_t* inputValueBuf, uint16_t beginIdx,
+                                         __ubuf__ uint32_t* kValue, uint16_t vfLoop)
+{
+    MicroAPI::MaskReg pregB16 = MicroAPI::CreateMask<uint16_t, MicroAPI::MaskPattern::ALL>();
+
+    MicroAPI::MaskReg poutGT;
+
+    MicroAPI::ClearSpr<AscendC::SpecialPurposeReg::AR>();
+
+    MicroAPI::UnalignRegForStore alignIdx;
+
+    MicroAPI::RegTensor<uint32_t> kthValue;
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B16>(kthValue, kValue);
+
+    MicroAPI::RegTensor<uint16_t> vregInput;
+    MicroAPI::RegTensor<int16_t> idxC;
+    MicroAPI::RegTensor<uint16_t> sqzIdxOut;
+
+    for (uint16_t i = 0; i < (uint16_t)(vfLoop); ++i) {
+        MicroAPI::Arange(idxC, beginIdx + i * 128);
+
+        MicroAPI::LoadAlign<uint16_t, MicroAPI::LoadDist::DIST_NORM>(vregInput, inputValueBuf + i * 128);
+
+        MicroAPI::Compare<uint16_t, CMPMODE::GT>(poutGT, vregInput, (MicroAPI::RegTensor<uint16_t>&)kthValue, pregB16);
+
+        MicroAPI::Squeeze<uint16_t, MicroAPI::GatherMaskMode::STORE_REG>(sqzIdxOut,
+                                                                         (MicroAPI::RegTensor<uint16_t>&)idxC, poutGT);
+        MicroAPI::StoreUnAlign<uint16_t, MicroAPI::PostLiteral::POST_MODE_UPDATE>(outputIdxBuf, sqzIdxOut, alignIdx);
+    }
+    MicroAPI::StoreUnAlignPost(outputIdxBuf, alignIdx);
+}
+
+/**
+    输出所有等于的kth-value的Index
+ */
+__simd_vf__ void FindIdxEQOutputVFImpl(__ubuf__ uint16_t* outputIdxBuf,
+                                         __ubuf__ uint16_t* inputValueBuf, uint16_t beginIdx,
+                                         __ubuf__ uint32_t* kValue, uint16_t vfLoop)
+{
+    MicroAPI::MaskReg pregB16 = MicroAPI::CreateMask<uint16_t, MicroAPI::MaskPattern::ALL>();
+
+    MicroAPI::MaskReg poutEQ;
+
+    MicroAPI::UnalignRegForStore alignIdx;
+
+    MicroAPI::RegTensor<uint32_t> kthValue;
+    MicroAPI::LoadAlign<uint32_t, MicroAPI::LoadDist::DIST_BRC_B16>(kthValue, kValue);
+
+    MicroAPI::RegTensor<uint16_t> vregInput;
+    MicroAPI::RegTensor<int16_t> idxC;
+    MicroAPI::RegTensor<uint16_t> sqzIdxOut;
+
+    for (uint16_t i = 0; i < (uint16_t)(vfLoop); ++i) {
+        MicroAPI::Arange(idxC, beginIdx + i * 128);
+
+        MicroAPI::LoadAlign<uint16_t, MicroAPI::LoadDist::DIST_NORM>(vregInput, inputValueBuf + i * 128);
+
+        MicroAPI::Compare<uint16_t, CMPMODE::EQ>(poutEQ, vregInput, (MicroAPI::RegTensor<uint16_t>&)kthValue, pregB16);
+
+        MicroAPI::Squeeze<uint16_t, MicroAPI::GatherMaskMode::STORE_REG>(sqzIdxOut,
+                                                                         (MicroAPI::RegTensor<uint16_t>&)idxC, poutEQ);
+        MicroAPI::StoreUnAlign<uint16_t, MicroAPI::PostLiteral::POST_MODE_UPDATE>(outputIdxBuf, sqzIdxOut, alignIdx);
+    }
+    MicroAPI::StoreUnAlignPost(outputIdxBuf, alignIdx);
+}
+
+/**
+    输出最终的Value
+ */
+__simd_vf__ void FindValueOutputVFImpl(__ubuf__ uint16_t* outputValueBuf,
+                                         __ubuf__ uint16_t* inputValueBuf,
+                                         __ubuf__ uint16_t* tmpIdxBuf, uint16_t vfLoop)
+{
+    MicroAPI::MaskReg pregB16 = MicroAPI::CreateMask<uint16_t, MicroAPI::MaskPattern::ALL>();
+
+    MicroAPI::RegTensor<uint16_t> tmpIdx;
+    MicroAPI::RegTensor<uint16_t> outputValue;
+
+    for (uint16_t i = 0; i < (uint16_t)(vfLoop); ++i) {
+        MicroAPI::LoadAlign<uint16_t, MicroAPI::LoadDist::DIST_NORM>(tmpIdx, tmpIdxBuf + i * 128);
+
+        MicroAPI::Gather(outputValue, inputValueBuf, tmpIdx, pregB16);
+
+        MicroAPI::StoreAlign<uint16_t, MicroAPI::StoreDist::DIST_NORM>(outputValueBuf + i * 128, outputValue, pregB16);
+    }
+}
+
+/**
+    输出最终的Idx
+ */
+__simd_vf__ void FindRealIndexVFImpl(__ubuf__ uint32_t* outputIdxBuf,
+                                     __ubuf__ uint16_t* tmpIdxBuf, __ubuf__ uint32_t* hisIdxBuf,
+                                     uint32_t topK, uint32_t loopIndex, uint16_t vfLoop)
+{
+    MicroAPI::MaskReg pregB32 = MicroAPI::CreateMask<uint32_t, MicroAPI::MaskPattern::ALL>();
+
+    MicroAPI::MaskReg pregNow;
+    MicroAPI::MaskReg pregHis;
+
+    MicroAPI::RegTensor<uint16_t> tmpIdx;
+    MicroAPI::RegTensor<uint32_t> outputGatherIdx;
+    MicroAPI::RegTensor<uint32_t> outputAddsIdx;
+
+    for (uint16_t i = 0; i < (uint16_t)(vfLoop); ++i) {
+        MicroAPI::LoadAlign<uint16_t, MicroAPI::LoadDist::DIST_UNPACK_B16>(tmpIdx, tmpIdxBuf + i * 64);
+
+        MicroAPI::Compares<uint32_t, CMPMODE::GT>(pregNow, (MicroAPI::RegTensor<uint32_t>&)tmpIdx, topK - 1, pregB32);
+        MicroAPI::Xor(pregHis, pregNow, pregB32, pregB32);
+
+        MicroAPI::Gather(outputGatherIdx, hisIdxBuf, (MicroAPI::RegTensor<uint32_t>&)tmpIdx, pregHis);
+        MicroAPI::Adds(outputAddsIdx, (MicroAPI::RegTensor<uint32_t>&)tmpIdx, loopIndex, pregNow);
+
+        MicroAPI::Add(outputGatherIdx, outputGatherIdx, outputAddsIdx, pregB32);
+
+        MicroAPI::StoreAlign<uint32_t, MicroAPI::StoreDist::DIST_NORM>(outputIdxBuf + i * 64, outputGatherIdx, pregB32);
+    }
+}
+
+/**
+ * @brief LiTopKVF 对一个validLen的输入进行topk算法，输出idx_tmp
+ * @param tmpIdxLocal Temp阶段输出的TopKIndex;如果s2SeqLen < 16K作为最终输出 validLen * 2B
+ * @param outputValueLocal 如果s2SeqLen > 16K并且是首轮输出Value topK * 2B
+ * @param inputValueLocal 输入Value validLen * 2B
+ * @param histogramsLocal 直方图 256 * 4B
+ * @param idxHighLocal 目标桶高八位 256 * 4B
+ * @param idxLowLocal 目标桶低八位 256 * 4B
+ * @param nkValueLocal 存储next_k的值 64 * 4B
+ * @param topK topK元素
+ * @param validLen 有效元素个数:LICommon::Align(topkCountAlign256_ + validTrunkLen, (uint32_t)256)
+ */
+template<bool ISOUTVALUE> // 是否输出VALUE
+__aicore__ inline void LiTopKVF(const LocalTensor<uint16_t>& tmpIdxLocal,
+                                const LocalTensor<uint16_t>& outputValueLocal,
+                                const LocalTensor<uint16_t>& inputValueLocal,
+                                const LocalTensor<uint32_t>& histogramsLocal,
+                                const LocalTensor<uint32_t>& idxHighLocal,
+                                const LocalTensor<uint32_t>& idxLowLocal,
+                                const LocalTensor<uint32_t>& nkValueLocal,
+                                uint32_t topK,
+                                uint32_t validLen)
+{
+    __ubuf__ uint16_t* tmpIdxBuf = (__ubuf__ uint16_t*)tmpIdxLocal.GetPhyAddr();
+    __ubuf__ uint16_t* outputValueBuf = (__ubuf__ uint16_t*)outputValueLocal.GetPhyAddr();
+    __ubuf__ uint16_t* inputValueBuf = (__ubuf__ uint16_t*)inputValueLocal.GetPhyAddr();
+    __ubuf__ uint32_t* histogramsBuf = (__ubuf__ uint32_t*)histogramsLocal.GetPhyAddr();
+    __ubuf__ uint32_t* idxHighBuf = (__ubuf__ uint32_t*)idxHighLocal.GetPhyAddr();
+    __ubuf__ uint32_t* idxLowBuf = (__ubuf__ uint32_t*)idxLowLocal.GetPhyAddr();
+    __ubuf__ uint32_t* nkValueBuf = (__ubuf__ uint32_t*)nkValueLocal.GetPhyAddr();
+
+    uint32_t bottomK = validLen - topK + 1;
+    uint32_t beginIdx = 0;
+    bool flag = true;
+
+    const uint16_t repeatSize8 = 256;
+    const uint16_t repeatSize16 = 128;
+    const uint16_t repeatSize32 = 64;
+
+    uint16_t histogramsLoopNum = (validLen + repeatSize8 - 1) / repeatSize8;
+    uint16_t inputLoopNum = (validLen + repeatSize16 - 1) / repeatSize16;
+    uint16_t topkLoopNum = (topK + repeatSize32 - 1) / repeatSize32;
+    uint16_t topkLoopNum16 = (topK + repeatSize16 - 1) / repeatSize16;
+
+    // find kth-value
+    HistogramsHighVFImpl<uint16_t>(histogramsBuf, inputValueBuf, histogramsLoopNum, flag);
+    FindHighTargetBinVFImpl(idxHighBuf, nkValueBuf, histogramsBuf, bottomK);
+
+    HistogramsLowVFImpl<uint16_t>(histogramsBuf, inputValueBuf, idxHighBuf, histogramsLoopNum, flag);
+    FindKthVFImpl(nkValueBuf, histogramsBuf, idxHighBuf, idxLowBuf);
+
+    // filter
+    int32_t count = LICommon::Align(topK, (uint32_t)128) - topK / 128 * 128;
+    AscendC::Duplicate(tmpIdxLocal[topK / 128 * 128], (uint16_t)(0), count);
+    // 输出大于k-value的值idx
+    FindIdxGTOutputVFImpl(tmpIdxBuf, inputValueBuf, (uint32_t)(0), nkValueBuf, inputLoopNum);
+    // 输出等于k-value的值idx
+    FindIdxEQOutputVFImpl(tmpIdxBuf, inputValueBuf, (uint32_t)(0), nkValueBuf, inputLoopNum);
+
+    // 是否输出Value
+    if constexpr (ISOUTVALUE) {
+        FindValueOutputVFImpl(outputValueBuf, inputValueBuf, tmpIdxBuf, topkLoopNum16);
+    }
+}
+
+/**
+ * @brief 通过idx_tmp gather出实际的TopKIndex，s2SeqLen > 16K才会执行
+ * @param outputIdxLocal 输出Idx 有效:topK * 2B
+ * @param outputValueLocal 输出Value topK * 2B(以后需要输出实际value使用)
+ * @param inputValueLocal 输入Value validLen * 2B
+ * @param tmpIdxLocal 本轮tmpIdx输入 validLen * 2B (0 ~ validLen - 1)
+ * @param hisIdxLocal 上一轮实际Idx输入 有效:topK * 4B
+ * @param topK topK元素个数
+ * @param loopBasicIdx 当前循环需要加上得基准Index
+ * @param validLen 有效元素个数
+ */
+__aicore__ inline void LiTopKGatherVF(const LocalTensor<uint32_t>& outputIdxLocal,
+                                      const LocalTensor<uint16_t>& outputValueLocal,
+                                      const LocalTensor<uint16_t>& inputValueLocal,
+                                      const LocalTensor<uint16_t>& tmpIdxLocal,
+                                      const LocalTensor<uint32_t>& hisIdxLocal,
+                                      uint32_t topK,
+                                      uint32_t loopBasicIdx,
+                                      uint32_t validLen)
+{
+    __ubuf__ uint32_t* outputIdxBuf = (__ubuf__ uint32_t*)outputIdxLocal.GetPhyAddr();
+    __ubuf__ uint16_t* outputValueBuf = (__ubuf__ uint16_t*)outputValueLocal.GetPhyAddr();
+    __ubuf__ uint16_t* inputValueBuf = (__ubuf__ uint16_t*)inputValueLocal.GetPhyAddr();
+    __ubuf__ uint16_t* tmpIdxBuf = (__ubuf__ uint16_t*)tmpIdxLocal.GetPhyAddr();
+    __ubuf__ uint32_t* hisIdxBuf = (__ubuf__ uint32_t*)hisIdxLocal.GetPhyAddr();
+
+    const uint16_t repeatSize32 = 64;
+    const uint16_t repeatSize16 = 128;
+    uint16_t topkLoopNum16 = (topK + repeatSize16 - 1) / repeatSize16;
+    uint16_t topkLoopNum32 = (topK + repeatSize32 - 1) / repeatSize32;
+
+    FindRealIndexVFImpl(outputIdxBuf, tmpIdxBuf, hisIdxBuf, topK, loopBasicIdx, topkLoopNum32);
+}
+}
+}  // namespace sglang::npu_kernel::liv2
+#endif

--- a/csrc/lightning_indexer_v2/op_kernel/lightning_indexer_v2_common.h
+++ b/csrc/lightning_indexer_v2/op_kernel/lightning_indexer_v2_common.h
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file lightning_indexer_common.h
+ * \brief
+ */
+#ifndef SGL_LI_V2_LIGHTNING_INDEXER_COMMON_H
+#define SGL_LI_V2_LIGHTNING_INDEXER_COMMON_H
+
+#include "../op_host/tiling/lightning_indexer_v2_tiling_data.h"
+
+// AscendC 的 kernel-direct-launch 构建会把 kernel 源码再编译一遍给 host 侧生成
+// aclrtlaunch_* stub（bisheng --cce-host-only）。那一遍没有 __DAV_*/__CCE_AICORE__
+// 目标宏，编译器内置的 EVENT_ID4..EVENT_ID7 也就不存在，而 arch22/arch35 的
+// service 层用到了它们。stub 只需要签名，kernel body 不会在 host 上执行，因此
+// 这里给出占位值；device 侧仍使用编译器内置定义。
+#if !defined(__CCE_AICORE__)
+#ifndef EVENT_ID4
+#define EVENT_ID4 EVENT_ID0
+#endif
+#ifndef EVENT_ID5
+#define EVENT_ID5 EVENT_ID1
+#endif
+#ifndef EVENT_ID6
+#define EVENT_ID6 EVENT_ID2
+#endif
+#ifndef EVENT_ID7
+#define EVENT_ID7 EVENT_ID3
+#endif
+#endif
+
+namespace sglang::npu_kernel::liv2 {
+// 上游由 CANN 的 BEGIN_TILING_DATA_DEF 生成，这里改为 host/device 共用的 POD。
+using LITilingData = ::sglang::LIV2Host::LITilingData;
+
+using namespace AscendC;
+namespace LICommon {
+
+// 与tiling的layout保持一致
+enum class LI_LAYOUT {
+    BSND = 0,
+    TND = 1,
+    PA_BSND = 2
+};
+
+template <typename Q_T, typename K_T, typename OUT_T, const bool PAGE_ATTENTION = false,
+          LI_LAYOUT LAYOUT_T = LI_LAYOUT::BSND, LI_LAYOUT K_LAYOUT_T = LI_LAYOUT::PA_BSND,
+          bool DT_W_FLAG = false, typename... Args>
+struct LIType {
+    static constexpr bool weightsTypeFlag = DT_W_FLAG;   // weight的dtype是否为FP32
+    using queryType = Q_T;
+    using keyType = K_T;
+    using outputType = OUT_T;
+    static constexpr bool pageAttention = PAGE_ATTENTION;
+    static constexpr LI_LAYOUT layout = LAYOUT_T;
+    static constexpr LI_LAYOUT keyLayout = K_LAYOUT_T;
+};
+
+struct RunInfo {
+    uint32_t loop;
+    uint32_t bN2Idx;
+    uint32_t bIdx;
+    uint32_t n2Idx = 0;
+    uint32_t gS1Idx;
+    uint32_t s2Idx;
+
+    uint32_t actS1Size = 1;
+    uint32_t actS2Size = 1;
+    uint32_t actS2SizeOrig = 1;
+    uint32_t actMBaseSize;
+    uint32_t actualSingleProcessSInnerSize;
+    uint32_t actualSingleProcessSInnerSizeAlign;
+
+    uint64_t tensorQueryOffset;
+    uint64_t tensorKeyOffset;
+    uint64_t tensorWeightsOffset;
+    uint64_t indiceOutOffset;
+    uint64_t valueOutOffset;
+
+    bool isFirstS2InnerLoop;
+    bool isLastS2InnerLoop;
+    bool isAllLoopEnd = false;
+    bool isValid = false;
+};
+
+struct ConstInfo {
+    // CUBE与VEC核间同步的模式
+    static constexpr uint32_t FIA_SYNC_MODE2 = 2;
+    static constexpr uint32_t QLI_SYNC_MODE4 = 4;
+    static constexpr uint32_t AIV0_AIV1_OFFSET = 16;
+    static constexpr uint32_t CROSS_VC_EVENT = 0;
+    static constexpr uint32_t CROSS_CV_EVENT = 2;
+    // BUFFER的字节数
+    static constexpr uint32_t BUFFER_SIZE_BYTE_32B = 32;
+    static constexpr uint32_t BUFFER_SIZE_BYTE_64B = 64;
+    static constexpr uint32_t BUFFER_SIZE_BYTE_256B = 256;
+    static constexpr uint32_t BUFFER_SIZE_BYTE_512B = 512;
+    static constexpr uint32_t BUFFER_SIZE_BYTE_1K = 1024;
+    static constexpr uint32_t BUFFER_SIZE_BYTE_2K = 2048;
+    static constexpr uint32_t BUFFER_SIZE_BYTE_4K = 4096;
+    static constexpr uint32_t BUFFER_SIZE_BYTE_8K = 8192;
+    static constexpr uint32_t BUFFER_SIZE_BYTE_16K = 16384;
+    static constexpr uint32_t BUFFER_SIZE_BYTE_32K = 32768;
+    // 无效索引
+    static constexpr int INVALID_IDX = -1;
+    uint16_t INVALID_VAL = 0;
+    // CUBE和VEC的核间同步EventID
+    uint32_t syncC1V1 = 0U;
+    uint32_t syncC1V0 = 2U;
+    uint32_t syncV1C1 = 0U;
+    uint32_t syncV0C1 = 1U;
+
+    // 基本块大小
+    uint32_t mBaseSize = 1ULL;
+    uint32_t mBaseSizeAlign = 1ULL;
+    uint32_t s1BaseSize = 1ULL;
+    uint32_t s2BaseSize = 1ULL;
+
+    uint64_t batchSize = 0ULL;
+    uint64_t gSize = 0ULL;
+    uint64_t qHeadNum = 0ULL;
+    uint64_t kHeadNum;
+    uint64_t headDim;
+    uint64_t sparseCount;             // topK选取大小
+    uint64_t kSeqSize = 0ULL;         // kv最大S长度
+    uint64_t qSeqSize = 1ULL;         // q最大S长度
+    uint32_t kCacheBlockSize = 0;     // PA场景的block size
+    uint32_t maxBlockNumPerBatch = 0; // PA场景的最大单batch block number
+    LI_LAYOUT outputLayout;           // 输出的格式
+    bool attenMaskFlag = false;
+    int64_t preTokens = INT64_MAX;
+    int64_t nextTokens = INT64_MAX;
+    bool returnValue = false;
+
+    uint32_t actualLenQDims = 0U; // query的actualSeqLength 的维度
+    uint32_t actualLenDims = 0U;  // KV 的actualSeqLength 的维度
+    bool isAccumSeqS1 = false;    // 是否累加模式
+    bool isAccumSeqS2 = false;    // 是否累加模式
+    bool isSparseCountOver2K = false; //sparseCount小于等于2048为false
+    bool isLDOpen = false;
+    bool returnValueFlag = false;
+    bool splitMFlag = false;
+};
+
+struct SplitCoreInfo {
+    uint32_t s2Start = 0U; // S2的起始位置
+    uint32_t s2End = 0U;   // S2循环index上限
+    uint32_t bN2Start = 0U;
+    uint32_t bN2End = 0U;
+    uint32_t gS1Start = 0U;
+    uint32_t gS1End = 0U;
+    bool isLD = false;     // 当前核是否需要进行Decode归约任务
+    bool isCoreEnable = false;
+};
+
+template <typename T>
+__aicore__ inline T Align(T num, T rnd)
+{
+    return (((rnd) == 0) ? 0 : (((num) + (rnd)-1) / (rnd) * (rnd)));
+}
+
+template <typename T1, typename T2>
+__aicore__ inline T1 Min(T1 a, T2 b)
+{
+    return (a > b) ? (b) : (a);
+}
+
+template <typename T1, typename T2>
+__aicore__ inline T1 Max(T1 a, T2 b)
+{
+    return (a > b) ? (a) : (b);
+}
+
+// 与上游的差异：上游为单模板参数 template <typename T>，依赖其构建环境里另一个
+// CeilDiv 重载来吃掉 CeilDiv(uint64_t, int32_t) 这类混合类型调用；CANN 9.1.0 的
+// 内核头里没有该重载，会报 "deduced conflicting types"。这里放宽为两个模板参数
+// （与上面的 Max 一致），返回类型仍为第一个实参的类型，语义等价于在调用点把第二
+// 个实参显式转成 T1。
+template <typename T1, typename T2>
+__aicore__ inline T1 CeilDiv(T1 num, T2 rnd)
+{
+    return (((rnd) == 0) ? 0 : (((num) + (rnd)-1) / (rnd)));
+}
+} // namespace LICommon
+
+// bank冲突优化
+// david 256KB bank layout
+// shape  (             bank_depth  (            banks  bank_groups  block))  (512  (  2   8  32))
+// stride (banks*bank_groups*block  (bank_groups*block        block      1))  (512  (256  32   1))
+#define UB_BLOCK              32   // 32B
+#define UB_BANK_GROUPS        8
+#define UB_BANKS              2
+#define UB_BANK_DEPTH         512
+
+#define UB_BANK_GROUP_STRIDE  UB_BLOCK                                   // 32B
+#define UB_BANK_STRIDE        (UB_BANK_GROUPS * UB_BLOCK)               // 256B
+#define UB_BANK_DEPTH_STRIDE  (UB_BANKS * UB_BANK_GROUPS * UB_BLOCK)    // 512B
+
+}  // namespace sglang::npu_kernel::liv2
+#endif // SGL_LI_V2_LIGHTNING_INDEXER_COMMON_H

--- a/csrc/lightning_indexer_v2/op_kernel/lightning_indexer_v2_kernel.cpp
+++ b/csrc/lightning_indexer_v2/op_kernel/lightning_indexer_v2_kernel.cpp
@@ -1,0 +1,115 @@
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. See LICENSE in the root of
+ * the software repository for the full text of the License.
+ */
+
+/*!
+ * \file lightning_indexer_v2_kernel.cpp
+ * \brief
+ *
+ * 上游 (vllm-ascend csrc/attention/lightning_indexer) 使用 CANN 的
+ * ASCENDC_TPL_ARGS_DECL/ASCENDC_TPL_SEL 由框架为每个模板组合生成一个二进制，
+ * 内核入口只需接收模板形参。sgl-kernel-npu 走 kernel-direct-launch，只有一个
+ * __global__ 符号，因此这里把上游 ASCENDC_TPL_SEL 中列举的合法组合手工展开成
+ * 一个 tilingKey 分发表。tilingKey 的编码与 host 侧 DoTiling 保持一致。
+ */
+
+#include "kernel_operator.h"
+#include "kernel_operator_list_tensor_intf.h"
+#include "kernel_tiling/kernel_tiling.h"
+#include "lib/matmul_intf.h"
+#include "lib/matrix/matmul/tiling.h"
+
+#include "lightning_indexer_v2_common.h"
+#include "lightning_indexer_v2_tiling_key.h"
+
+#if (__CCE_AICORE__ == 310)
+#include "arch35/lightning_indexer_kernel.h"
+#else
+#include "arch22/lightning_indexer_kernel.h"
+#endif
+
+namespace sglang::npu_kernel::liv2 {
+
+// tilingData 由 host 以 GM buffer 传入。上游用 GET_TILING_DATA_WITH_STRUCT 把
+// GM 拷到本地再传给 kernel，这里做同样的事，从而 arch22/arch35 的 Init 签名
+// (const LITilingData *) 可以原样复用。
+__aicore__ inline void LoadTilingData(LITilingData &dst, __gm__ uint8_t *src)
+{
+    auto *__restrict s = reinterpret_cast<__gm__ LITilingData *>(src);
+    dst.preTokens = s->preTokens;
+    dst.nextTokens = s->nextTokens;
+    dst.bSize = s->bSize;
+    dst.n2Size = s->n2Size;
+    dst.gSize = s->gSize;
+    dst.s1Size = s->s1Size;
+    dst.s2Size = s->s2Size;
+    dst.sparseCount = s->sparseCount;
+    dst.usedCoreNum = s->usedCoreNum;
+    dst.blockSize = s->blockSize;
+    dst.maxBlockNumPerBatch = s->maxBlockNumPerBatch;
+    dst.sparseMode = s->sparseMode;
+    dst.returnValue = s->returnValue;
+    dst.tilingKey = s->tilingKey;
+}
+
+}  // namespace sglang::npu_kernel::liv2
+
+#define INVOKE_LI_V2_OP_IMPL(...)                                                                                  \
+    do {                                                                                                           \
+        LIKernel::LightningIndexerKernel<LICommon::LIType<__VA_ARGS__>> op;                                        \
+        op.Init(query, key, weights, actualSeqLengthsQ, actualSeqLengths, blocktable, sparseIndices, sparseValues, \
+                userWorkspace, &tilingData, &tPipe);                                                               \
+        op.Process();                                                                                              \
+    } while (0)
+
+// 一条 dispatch 分支。Q_T/K_T 由 dtype 决定，其余为 LIType 的非类型模板实参。
+#define LI_V2_CASE(KEY_Q, KEY_K, Q_T, K_T, PA, Q_LAYOUT, K_LAYOUT, W_FP32)                                        \
+    case SGL_LI_V2_TILING_KEY(KEY_Q, KEY_K, SGL_LI_V2_DT_INT32, W_FP32, PA, SGL_LI_V2_LAYOUT_##Q_LAYOUT,          \
+                              SGL_LI_V2_LAYOUT_##K_LAYOUT):                                                       \
+        INVOKE_LI_V2_OP_IMPL(Q_T, K_T, int32_t, PA, LICommon::LI_LAYOUT::Q_LAYOUT, LICommon::LI_LAYOUT::K_LAYOUT,  \
+                             W_FP32);                                                                             \
+        break;
+
+// 上游 ASCENDC_TPL_SEL 允许的 (PAGE_ATTENTION, LAYOUT_T, K_LAYOUT_T) 组合：
+// 非 PA 场景要求 layout_query == layout_key，故上游共 4 种布局组合（PA 2 种 +
+// 非 PA 2 种）x 2 dtype x 2 weights 档 = 16 份实例，全部编进同一个 kernel 二进制。
+#define LI_V2_NON_PA_COMBOS(KEY_D, T, W_FP32)             \
+    LI_V2_CASE(KEY_D, KEY_D, T, T, 0, BSND, BSND, W_FP32) \
+    LI_V2_CASE(KEY_D, KEY_D, T, T, 0, TND, TND, W_FP32)
+
+#define LI_V2_LAYOUT_COMBOS(KEY_D, T, W_FP32)                \
+    LI_V2_CASE(KEY_D, KEY_D, T, T, 1, BSND, PA_BSND, W_FP32) \
+    LI_V2_CASE(KEY_D, KEY_D, T, T, 1, TND, PA_BSND, W_FP32)  \
+    LI_V2_NON_PA_COMBOS(KEY_D, T, W_FP32)
+
+#define LI_V2_DTYPE_COMBOS(KEY_D, T)  \
+    LI_V2_LAYOUT_COMBOS(KEY_D, T, 0)  \
+    LI_V2_LAYOUT_COMBOS(KEY_D, T, 1)
+
+extern "C" __global__ __aicore__ void lightning_indexer_v2(
+    GM_ADDR query, GM_ADDR key, GM_ADDR weights, GM_ADDR actualSeqLengthsQ, GM_ADDR actualSeqLengths,
+    GM_ADDR blocktable, GM_ADDR sparseIndices, GM_ADDR sparseValues, GM_ADDR workspace, GM_ADDR tiling)
+{
+    using namespace sglang::npu_kernel::liv2;
+
+    AscendC::TPipe tPipe;
+    __gm__ uint8_t *userWorkspace = workspace;
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
+
+    LITilingData tilingData;
+    LoadTilingData(tilingData, tiling);
+
+    switch (tilingData.tilingKey) {
+        LI_V2_DTYPE_COMBOS(SGL_LI_V2_DT_FP16, half)
+        LI_V2_DTYPE_COMBOS(SGL_LI_V2_DT_BF16, bfloat16_t)
+        default:
+            break;
+    }
+}

--- a/csrc/lightning_indexer_v2/op_kernel/lightning_indexer_v2_tiling_key.h
+++ b/csrc/lightning_indexer_v2/op_kernel/lightning_indexer_v2_tiling_key.h
@@ -1,0 +1,50 @@
+/**
+ * This program is free software, you can redistribute it and/or modify it.
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This file is a part of the CANN Open Software.
+ * Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. See LICENSE in the root of
+ * the software repository for the full text of the License.
+ */
+
+/*!
+ * \file lightning_indexer_v2_tiling_key.h
+ * \brief tilingKey 编码，host 侧 DoTiling 与 device 侧 dispatch 共用。
+ *
+ * 替代上游的 ASCENDC_TPL_ARGS_DECL / GET_TPL_TILING_KEY：sgl-kernel-npu 只有一个
+ * kernel 二进制，tilingKey 纯粹用于 device 侧 switch 分发，因此沿用本仓库
+ * lightning_indexer 已有的 nibble 编码，并新增 weights-fp32 位。
+ *
+ *   bits 24-27 : query dtype
+ *   bits 20-23 : weights 为 fp32 时置 1 (对应上游 DT_W_FLAG)
+ *   bits 16-19 : key dtype
+ *   bits 12-15 : output dtype
+ *   bits  8-11 : page attention flag
+ *   bits  4-7  : query layout
+ *   bits  0-3  : key layout
+ *
+ * dtype 取值必须与 ge_helper.h 的 GE_DATATYPE_TO_KEY() 一致（host 侧有
+ * static_assert 守护）。
+ */
+#ifndef SGL_LI_V2_TILING_KEY_H
+#define SGL_LI_V2_TILING_KEY_H
+
+// 与 GE_DATATYPE_TO_KEY() 对齐
+#define SGL_LI_V2_DT_FP16 1
+#define SGL_LI_V2_DT_INT32 3
+#define SGL_LI_V2_DT_BF16 12
+
+// 与 LICommon::LI_LAYOUT 对齐
+#define SGL_LI_V2_LAYOUT_BSND 0
+#define SGL_LI_V2_LAYOUT_TND 1
+#define SGL_LI_V2_LAYOUT_PA_BSND 2
+
+#define SGL_LI_V2_TILING_KEY(DT_Q, DT_K, DT_OUT, W_FP32, PAGE_ATTENTION, LAYOUT_Q, LAYOUT_K)                    \
+    ((static_cast<unsigned int>(DT_Q) << 24) | (static_cast<unsigned int>(W_FP32) << 20) |                      \
+     (static_cast<unsigned int>(DT_K) << 16) | (static_cast<unsigned int>(DT_OUT) << 12) |                      \
+     (static_cast<unsigned int>(PAGE_ATTENTION) << 8) | (static_cast<unsigned int>(LAYOUT_Q) << 4) |            \
+     (static_cast<unsigned int>(LAYOUT_K)))
+
+#endif  // SGL_LI_V2_TILING_KEY_H

--- a/csrc/pytorch_extensions.cpp
+++ b/csrc/pytorch_extensions.cpp
@@ -101,9 +101,25 @@ TORCH_LIBRARY_FRAGMENT(npu, m)
     m.def("apply_token_bitmask(Tensor logits, Tensor bitmask, Tensor? indices=None) -> Tensor");
 
     m.def(
+        "compressor(Tensor x, Tensor wkv, Tensor wgate, Tensor! state_cache, "
+        "Tensor ape, Tensor norm_weight, Tensor rope_sin, Tensor rope_cos, "
+        "Tensor? state_block_table=None, Tensor? cu_seqlens=None, Tensor? seqused=None, "
+        "Tensor? start_pos=None, int rope_head_dim=64, int cmp_ratio=4, int coff=1, "
+        "float norm_eps=1e-6, int rotary_mode=1, int cache_mode=1, "
+        "int state_cache_stride_dim0=0) -> Tensor");
+
+
+    m.def(
         "causal_conv1d_update(Tensor x, Tensor weight, Tensor(a!) conv_state, "
         "Tensor conv_state_indices, Tensor? bias=None, Tensor? num_accepted_tokens=None, "
         "Tensor? query_start_loc=None, bool activation_mode=False, int pad_slot_id=-1) -> Tensor");
+
+    m.def(
+        "lightning_indexer_v2(Tensor query, Tensor key, Tensor weights, Tensor? actual_seq_lengths_query=None, "
+        "Tensor? actual_seq_lengths_key=None, Tensor? block_table=None, "
+        "str? layout_query=None, str? layout_key=None, "
+        "int? sparse_count=None, int? sparse_mode=None, "
+        "int? pre_tokens=None, int? next_tokens=None, bool? return_values=None) -> (Tensor, Tensor)");
 
 #ifdef SGL_KERNEL_ENABLE_A3_ONLY_OPS
     m.def(
@@ -165,14 +181,6 @@ TORCH_LIBRARY_FRAGMENT(npu, m)
         "int ori_mask_mode=4, int cmp_mask_mode=3, int ori_win_left=128, int ori_win_right=0, "
         "str layout_q='BSND', str layout_kv='PA_ND', "
         "bool return_softmax_lse=False) -> (Tensor, Tensor)");
-
-    m.def(
-        "compressor(Tensor x, Tensor wkv, Tensor wgate, Tensor! state_cache, "
-        "Tensor ape, Tensor norm_weight, Tensor rope_sin, Tensor rope_cos, "
-        "Tensor? state_block_table=None, Tensor? cu_seqlens=None, Tensor? seqused=None, "
-        "Tensor? start_pos=None, int rope_head_dim=64, int cmp_ratio=4, int coff=1, "
-        "float norm_eps=1e-6, int rotary_mode=1, int cache_mode=1, "
-        "int state_cache_stride_dim0=0) -> Tensor");
 
     m.def("triangular_inverse(Tensor x) -> Tensor");
 
@@ -274,6 +282,8 @@ TORCH_LIBRARY_IMPL(npu, PrivateUse1, m)
                                                                     bias_or_empty, num_accepted_or_empty,
                                                                     query_loc_or_empty, activation_mode, pad_slot_id);
            });
+
+    m.impl("lightning_indexer_v2", TORCH_FN(sglang::npu_kernel::lightning_indexer_v2));
 
 #ifdef SGL_KERNEL_ENABLE_A3_ONLY_OPS
     m.impl("mla_preprocess", TORCH_FN(sglang::npu_kernel::mla_preprocess));

--- a/csrc/utils/ge_helper.h
+++ b/csrc/utils/ge_helper.h
@@ -281,6 +281,15 @@ public:
         return *this;
     }
 
+    AttrDef &Int64(int64_t value)
+    {
+        TORCH_CHECK(valueInitialized_ == false,
+                    "[GE_Helper] Cannot set default value for an attribute that has already been initialized.");
+        anyValue_ = value;
+        valueInitialized_ = true;
+        return *this;
+    }
+
     AttrDef &Float(float value)
     {
         TORCH_CHECK(valueInitialized_ == false,
@@ -413,6 +422,14 @@ public:
         auto dataType = (*descPtr)[index]->GetDataType();
         auto geTensor = std::make_shared<gert::Tensor>(shapePtr->back(), storageFormat, dataType);
         tensorPtr->push_back(geTensor);
+    }
+
+    // Must be called after SetToContext() and before RegisterTensor() for that index:
+    // RegisterTensor() snapshots the dtype from the desc into the gert::Tensor.
+    void OverrideInputDataType(uint32_t index, ge::DataType dataType)
+    {
+        TORCH_CHECK(index < inputDesc_.size(), "[GE_Helper] OverrideInputDataType index out of range");
+        inputDesc_[index]->SetDataType(dataType);
     }
 
     const gert::CompileTimeTensorDesc *GetInputDesc(uint32_t index) const

--- a/include/sgl_kenel_npu_ops.h
+++ b/include/sgl_kenel_npu_ops.h
@@ -101,6 +101,35 @@ void sgemmc_shrink(at::Tensor &x, at::Tensor &weight, at::Tensor &lora_indices,
 at::Tensor apply_token_bitmask(at::Tensor logits, at::Tensor bitmask,
                                c10::optional<at::Tensor> indices);
 
+// Not A3-only: compressor's host and kernel sources are both built
+// unconditionally and m.impl("compressor", ...) is registered unconditionally,
+// so the declaration must be visible in the A5/Ascend950 build too.
+at::Tensor compressor(const at::Tensor &x, const at::Tensor &wkv,
+                      const at::Tensor &wgate, at::Tensor &state_cache,
+                      const at::Tensor &ape, const at::Tensor &norm_weight,
+                      const at::Tensor &rope_sin, const at::Tensor &rope_cos,
+                      const c10::optional<at::Tensor> &state_block_table,
+                      const c10::optional<at::Tensor> &cu_seqlens,
+                      const c10::optional<at::Tensor> &seqused,
+                      const c10::optional<at::Tensor> &start_pos,
+                      int64_t rope_head_dim, int64_t cmp_ratio, int64_t coff,
+                      double norm_eps, int64_t rotary_mode, int64_t cache_mode,
+                      int64_t state_cache_stride_dim0);
+
+// Ported from vllm-ascend csrc/attention/lightning_indexer. Unlike the older
+// `lightning_indexer` above this one carries both the arch22 (A2/A3) and the
+// arch35 (A5/Ascend950) kernel, so it is not gated on SGL_KERNEL_ENABLE_A3_ONLY_OPS.
+std::tuple<at::Tensor, at::Tensor> lightning_indexer_v2(
+    const at::Tensor &query, const at::Tensor &key, const at::Tensor &weights,
+    const c10::optional<at::Tensor> &actual_seq_lengths_query,
+    const c10::optional<at::Tensor> &actual_seq_lengths_key,
+    const c10::optional<at::Tensor> &block_table,
+    c10::optional<c10::string_view> layout_query,
+    c10::optional<c10::string_view> layout_key,
+    c10::optional<int64_t> sparse_count, c10::optional<int64_t> sparse_mode,
+    c10::optional<int64_t> pre_tokens, c10::optional<int64_t> next_tokens,
+    c10::optional<bool> return_values);
+
 #ifdef SGL_KERNEL_ENABLE_A3_ONLY_OPS
 std::tuple<at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &>
 mla_preprocess(const at::Tensor &hiddenState, const at::Tensor &gamma0,
@@ -159,18 +188,6 @@ at::Tensor lightning_indexer(
     c10::optional<int64_t> sparse_count, c10::optional<int64_t> sparse_mode);
 
 #endif
-
-at::Tensor compressor(const at::Tensor &x, const at::Tensor &wkv,
-                      const at::Tensor &wgate, at::Tensor &state_cache,
-                      const at::Tensor &ape, const at::Tensor &norm_weight,
-                      const at::Tensor &rope_sin, const at::Tensor &rope_cos,
-                      const c10::optional<at::Tensor> &state_block_table,
-                      const c10::optional<at::Tensor> &cu_seqlens,
-                      const c10::optional<at::Tensor> &seqused,
-                      const c10::optional<at::Tensor> &start_pos,
-                      int64_t rope_head_dim, int64_t cmp_ratio, int64_t coff,
-                      double norm_eps, int64_t rotary_mode, int64_t cache_mode,
-                      int64_t state_cache_stride_dim0);
 
 std::tuple<at::Tensor, at::Tensor> sparse_attn_sharedkv(
     const at::Tensor &q, const c10::optional<at::Tensor> &ori_kv,

--- a/tests/python/sgl_kernel_npu/test_lightning_indexer_v2.py
+++ b/tests/python/sgl_kernel_npu/test_lightning_indexer_v2.py
@@ -1,0 +1,291 @@
+# This program is free software, you can redistribute it and/or modify it.
+# Copyright (c) 2025 Huawei Technologies Co., Ltd.
+# This file is a part of the CANN Open Software.
+# Licensed under CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import unittest
+
+import numpy as np
+import sgl_kernel_npu
+import torch
+import torch_npu
+from utils import require_npu_op
+
+pytestmark = require_npu_op("lightning_indexer_v2")
+
+DEVICE_ID = 0
+torch_npu.npu.set_device(int(DEVICE_ID))
+
+
+def _get_data_from_pa_cache(key, block_table, act_s2):
+    block_num, block_size, n2, d = key.shape
+    if n2 != 1:
+        raise ValueError("n2 only support 1")
+    need_block_num = (act_s2 + block_size - 1) // block_size
+    act_s2_align = need_block_num * block_size
+    out = torch.zeros((act_s2_align, d), dtype=key.dtype, device=key.device)
+    for i in range(need_block_num):
+        out[i * block_size : (i + 1) * block_size, :] = key[
+            block_table[i], ...
+        ].reshape(block_size, d)
+
+    return out[:act_s2, :]
+
+
+def _lightning_indexer_ref(
+    query,
+    key,
+    weights,
+    actual_seq_lengths_query,
+    actual_seq_lengths_key,
+    block_table,
+    layout_query="BSND",
+    sparse_count=2048,
+    sparse_mode=3,
+):
+    """CPU reference. Returns (indices, values), values aligned with indices."""
+    batch_size = query.shape[0]
+    if layout_query == "TND":
+        batch_size = actual_seq_lengths_query.shape[0]
+    out_shape = list(query.shape)
+    n2 = key.shape[2]
+    d = query.shape[-1]
+    n1 = query.shape[-2]
+    out_shape[-1] = sparse_count
+    out_shape[-2] = n2
+
+    idx_out = (
+        torch.zeros(out_shape, dtype=torch.int32, device=query.device).reshape(
+            -1, n2, sparse_count
+        )
+        - 1
+    )
+    val_out = torch.full(
+        (idx_out.shape[0], n2, sparse_count),
+        float("-inf"),
+        dtype=torch.float32,
+        device=query.device,
+    )
+
+    process_q_len = 0
+    for batch_id in range(batch_size):
+        if actual_seq_lengths_query is None:
+            act_s1 = query.shape[1]
+        elif layout_query == "TND":  # prefix sums
+            act_s1 = actual_seq_lengths_query[batch_id] - process_q_len
+        else:
+            act_s1 = actual_seq_lengths_query[batch_id]
+        act_s2 = actual_seq_lengths_key[batch_id]
+
+        now_q = (
+            query.reshape(-1, n1, d)[process_q_len : process_q_len + act_s1, :, :]
+            .transpose(0, 1)
+            .to(torch.float32)
+        )
+        now_weights = (
+            weights.reshape(-1, n1, 1)[process_q_len : process_q_len + act_s1, :, :]
+            .transpose(0, 1)
+            .to(torch.float32)
+        )
+        process_q_len += act_s1
+        now_block_table = block_table[batch_id, :]
+        now_k = (
+            _get_data_from_pa_cache(key, now_block_table, act_s2)
+            .transpose(0, 1)
+            .to(torch.float32)
+        )
+        # n1,s1,d @ d,s2 -> n1,s1,s2
+        relu_out = torch.maximum(torch.matmul(now_q, now_k), torch.tensor(0))
+        weight_out = relu_out * now_weights
+        # n1,s1,s2 -> s1,s2
+        reduce_out = torch.sum(weight_out, dim=0)
+
+        tmp_s1 = reduce_out.shape[0]
+        tmp_s2 = reduce_out.shape[1]
+        if sparse_mode == 3:
+            for i in range(tmp_s1):
+                reduce_out[-1 - i, tmp_s2 - i :] = float("-inf")
+        sorted_value, sorted_indices = torch.sort(reduce_out, dim=1, descending=True)
+        return_s2 = min(sparse_count, tmp_s2)
+        lo, hi = process_q_len - act_s1, process_q_len
+        idx_out[lo:hi, 0, :return_s2] = sorted_indices.to(torch.int32)[:, :return_s2]
+        val_out[lo:hi, 0, :return_s2] = sorted_value[:, :return_s2]
+
+    return idx_out.reshape(out_shape), val_out.reshape(out_shape)
+
+
+def _make_tnd_inputs(dtype, b=3, t=5, s2=8192, n1=64, n2=1, d=128, block_size=256):
+    np.random.seed(3)
+    query = torch.tensor(np.random.uniform(-10, 10, (t, n1, d))).to(dtype)
+    key = torch.tensor(
+        np.random.uniform(-10, 10, (b * (s2 // block_size), block_size, n2, d))
+    ).to(dtype)
+    weights = torch.tensor(np.random.uniform(-1, 1, (t, n1))).to(dtype)
+    # TND: actual_seq_lengths_query is a prefix sum
+    actual_seq_lengths_query = torch.tensor([1, 3, 5]).to(torch.int32)
+    actual_seq_lengths_key = torch.tensor(np.random.uniform(s2, s2, (b))).to(
+        torch.int32
+    )
+    block_table = torch.tensor([range(b * s2 // block_size)], dtype=torch.int32).reshape(
+        b, -1
+    )
+    return query, key, weights, actual_seq_lengths_query, actual_seq_lengths_key, block_table
+
+
+def _to_npu(*tensors):
+    return [x.to("npu:%s" % DEVICE_ID) for x in tensors]
+
+
+def _assert_index_sets_equal(testcase, npu_out, cpu_out, sparse_count):
+    """The kernel does not guarantee ordering among equal scores, so compare as sets."""
+    npu_out = npu_out.reshape(-1, sparse_count).cpu()
+    cpu_out = cpu_out.reshape(-1, sparse_count).cpu()
+    for i in range(npu_out.shape[0]):
+        testcase.assertEqual(sorted(npu_out[i].tolist()), sorted(cpu_out[i].tolist()))
+
+
+class TestLightningIndexerV2(unittest.TestCase):
+    def test_tnd_pa_eager(self):
+        sparse_count, sparse_mode = 2048, 3
+        for dtype in [torch.bfloat16, torch.float16]:
+            (
+                query,
+                key,
+                weights,
+                asl_q,
+                asl_k,
+                block_table,
+            ) = _make_tnd_inputs(dtype)
+
+            cpu_idx, _ = _lightning_indexer_ref(
+                query,
+                key,
+                weights,
+                asl_q,
+                asl_k,
+                block_table,
+                layout_query="TND",
+                sparse_count=sparse_count,
+                sparse_mode=sparse_mode,
+            )
+
+            q, k, w, aq, ak, bt = _to_npu(
+                query, key, weights, asl_q, asl_k, block_table
+            )
+            npu_idx, npu_val = torch.ops.npu.lightning_indexer_v2(
+                q,
+                k,
+                w,
+                actual_seq_lengths_query=aq,
+                actual_seq_lengths_key=ak,
+                block_table=bt,
+                layout_query="TND",
+                layout_key="PA_BSND",
+                sparse_count=sparse_count,
+                sparse_mode=sparse_mode,
+            )
+
+            _assert_index_sets_equal(self, npu_idx, cpu_idx, sparse_count)
+            # return_values defaults to False -> empty second output
+            self.assertEqual(npu_val.numel(), 0)
+
+    def test_tnd_pa_return_values(self):
+        sparse_count, sparse_mode = 2048, 3
+        dtype = torch.bfloat16
+        (
+            query,
+            key,
+            weights,
+            asl_q,
+            asl_k,
+            block_table,
+        ) = _make_tnd_inputs(dtype)
+
+        cpu_idx, cpu_val = _lightning_indexer_ref(
+            query,
+            key,
+            weights,
+            asl_q,
+            asl_k,
+            block_table,
+            layout_query="TND",
+            sparse_count=sparse_count,
+            sparse_mode=sparse_mode,
+        )
+
+        q, k, w, aq, ak, bt = _to_npu(query, key, weights, asl_q, asl_k, block_table)
+        npu_idx, npu_val = torch.ops.npu.lightning_indexer_v2(
+            q,
+            k,
+            w,
+            actual_seq_lengths_query=aq,
+            actual_seq_lengths_key=ak,
+            block_table=bt,
+            layout_query="TND",
+            layout_key="PA_BSND",
+            sparse_count=sparse_count,
+            sparse_mode=sparse_mode,
+            return_values=True,
+        )
+
+        _assert_index_sets_equal(self, npu_idx, cpu_idx, sparse_count)
+        self.assertEqual(tuple(npu_val.shape), tuple(npu_idx.shape))
+        self.assertEqual(npu_val.dtype, dtype)
+        # Scores are sorted descending, so comparing the sorted vectors is
+        # order-independent w.r.t. ties.
+        npu_val_f = npu_val.float().reshape(-1, sparse_count).cpu()
+        cpu_val_f = cpu_val.float().reshape(-1, sparse_count).cpu()
+        finite = torch.isfinite(cpu_val_f)
+        torch.testing.assert_close(
+            npu_val_f[finite], cpu_val_f[finite], rtol=4e-2, atol=4e-2
+        )
+
+    def test_fp32_weights(self):
+        """weights may be fp32 while query/key stay fp16/bf16 (upstream DT_W_FLAG)."""
+        sparse_count, sparse_mode = 2048, 3
+        dtype = torch.bfloat16
+        (
+            query,
+            key,
+            weights,
+            asl_q,
+            asl_k,
+            block_table,
+        ) = _make_tnd_inputs(dtype)
+
+        cpu_idx, _ = _lightning_indexer_ref(
+            query,
+            key,
+            weights.float(),
+            asl_q,
+            asl_k,
+            block_table,
+            layout_query="TND",
+            sparse_count=sparse_count,
+            sparse_mode=sparse_mode,
+        )
+
+        q, k, w, aq, ak, bt = _to_npu(
+            query, key, weights.float(), asl_q, asl_k, block_table
+        )
+        npu_idx, _ = torch.ops.npu.lightning_indexer_v2(
+            q,
+            k,
+            w,
+            actual_seq_lengths_query=aq,
+            actual_seq_lengths_key=ak,
+            block_table=bt,
+            layout_query="TND",
+            layout_key="PA_BSND",
+            sparse_count=sparse_count,
+            sparse_mode=sparse_mode,
+        )
+
+        _assert_index_sets_equal(self, npu_idx, cpu_idx, sparse_count)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A new NPU op **ported from vllm-ascend/csrc/attention/lightning_indexer**, added alongside the existing lightning_indexer (which is untouched) as lightning_indexer_v2. Main difference is A5 support as well as A2/A3.

Changes:

1. `csrc/lightning_indexer_v2/`: docs, host op + tiling, and the two kernel paths. Small hand-written shims stand in for CANN's op-project codegen (tiling-key expansion, OP_CHECK_IF→TORCH_CHECK, kernel-direct-launch instead of aclnn).
2. `CMakeLists.txt`: new lightning_indexer_v2_kernel build target with the upstream compile flags, plus include/link wiring.
3. `pytorch_extensions.cpp` / `sgl_kenel_npu_ops.h`: register and declare the op; **compressor moved out of the A3-only block**.
4. `ge_helper.h`: two small helpers — Int64 attr default and OverrideInputDataType (for the fp32-weights case).
5. New `tests/python/sgl_kernel_npu/test_lightning_indexer_v2.py`.

Performance testing:
A5 (successful launch): 
<img width="400" height="120" alt="image" src="https://github.com/user-attachments/assets/4d019731-6788-49b8-9c19-9550cbd10c0e" />

Provides ~8% performance improvement compared to torch_npu operator on big shapes on A5:
<img width="1452" height="209" alt="image" src="https://github.com/user-attachments/assets/81ef4dbe-6643-4c35-94e3-ae96ab060413" />

A3 (v2 vs v1):
<img width="427" height="123" alt="image" src="https://github.com/user-attachments/assets/8802e3be-c832-443c-8c57-fa2b90fe2d61" />