### PR TITLE
[NPU] Add affine-state kernels for Kimi-K3 prefill context parallelism

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_chunk_delta_h.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_chunk_delta_h.py
@@ -313,3 +313,711 @@ def chunk_gated_delta_rule_fwd_h_npu(
         updated_state = kernel_state.transpose(-1, -2).contiguous()
         initial_state.index_copy_(0, source_indices, updated_state)
     return h, v_new
+
+
+_KDA_CP_AFFINE_STREAMS: dict[int, object] = {}
+
+
+def _get_kda_cp_affine_stream(device_index: int):
+    stream = _KDA_CP_AFFINE_STREAMS.get(device_index)
+    if stream is None:
+        stream = torch.npu.Stream(device=device_index)
+        _KDA_CP_AFFINE_STREAMS[device_index] = stream
+    return stream
+
+
+@triton.jit
+def _load_kda_cp_chunk_row_tile(
+    tensor,
+    segment_len,
+    stride,
+    chunk_id,
+    row_offset: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+):
+    ptr = tl.make_block_ptr(
+        tensor,
+        (segment_len, K),
+        (stride, 1),
+        (chunk_id * BT, row_offset),
+        (BT, 64),
+        (1, 0),
+    )
+    return tl.load(ptr, boundary_check=(0, 1))
+
+
+@triton.jit
+def _load_kda_cp_chunk_column_tile(
+    tensor,
+    segment_len,
+    stride,
+    chunk_id,
+    row_offset: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+):
+    ptr = tl.make_block_ptr(
+        tensor,
+        (K, segment_len),
+        (1, stride),
+        (row_offset, chunk_id * BT),
+        (64, BT),
+        (0, 1),
+    )
+    return tl.load(ptr, boundary_check=(0, 1))
+
+
+@triton.jit
+def _load_kda_cp_gate_tile(
+    gk,
+    gate_offset,
+    row_offset: tl.constexpr,
+    K: tl.constexpr,
+):
+    rows = row_offset + tl.arange(0, 64)
+    gate = tl.load(gk + gate_offset + rows, mask=rows < K, other=0.0)
+    return exp2(gate)[:, None]
+
+
+@triton.jit
+def _load_kda_cp_row_tile(
+    tensor,
+    col_offset,
+    row_offset: tl.constexpr,
+    K: tl.constexpr,
+    C: tl.constexpr,
+    ROW_STRIDE: tl.constexpr,
+    BC: tl.constexpr,
+):
+    ptr = tl.make_block_ptr(
+        tensor,
+        (K, C),
+        (ROW_STRIDE, 1),
+        (row_offset, col_offset),
+        (64, BC),
+        (1, 0),
+    )
+    return tl.load(ptr, boundary_check=(0, 1))
+
+
+@triton.jit
+def _store_kda_cp_row_tile(
+    tensor,
+    tile,
+    col_offset,
+    row_offset: tl.constexpr,
+    K: tl.constexpr,
+    C: tl.constexpr,
+    ROW_STRIDE: tl.constexpr,
+    BC: tl.constexpr,
+):
+    ptr = tl.make_block_ptr(
+        tensor,
+        (K, C),
+        (ROW_STRIDE, 1),
+        (row_offset, col_offset),
+        (64, BC),
+        (1, 0),
+    )
+    tl.store(ptr, tile.to(ptr.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.jit(do_not_specialize=["T"])
+def chunk_gated_delta_rule_fwd_affine_h_kernel(
+    k,
+    v,
+    w,
+    gk,
+    affine,
+    cu_seqlens,
+    T,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+):
+    """Compute the additive half of a segment's recurrent affine map.
+
+    This is the multi-segment Ascend adaptation of FLA PR 691's
+    ``pre_process_fwd_kernel_stage1``.  Unlike the ordinary state kernel it
+    keeps only the final state of every segment and therefore does not write a
+    ``[num_chunks, H, K, V]`` intermediate tensor.
+    """
+    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_h = i_nh // H, i_nh % H
+    bos = tl.load(cu_seqlens + i_n).to(tl.int32)
+    eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+    segment_len = eos - bos
+    num_chunks = tl.cdiv(segment_len, BT)
+
+    affine += ((i_n * H + i_h) * K * (V + K)).to(tl.int64)
+    v += ((bos * H + i_h) * V).to(tl.int64)
+    k += ((bos * Hg + i_h // (H // Hg)) * K).to(tl.int64)
+    w += ((bos * H + i_h) * K).to(tl.int64)
+    stride_v = H * V
+    stride_k = Hg * K
+    stride_w = H * K
+
+    h0 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 64:
+        h1 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 128:
+        h2 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 192:
+        h3 = tl.zeros([64, BV], dtype=tl.float32)
+
+    for chunk_id in range(num_chunks):
+        w0 = _load_kda_cp_chunk_row_tile(
+            w, segment_len, stride_w, chunk_id, 0, K=K, BT=BT
+        )
+        value = tl.dot(w0, h0.to(w0.dtype))
+        if K > 64:
+            w1 = _load_kda_cp_chunk_row_tile(
+                w, segment_len, stride_w, chunk_id, 64, K=K, BT=BT
+            )
+            value += tl.dot(w1, h1.to(w1.dtype))
+        if K > 128:
+            w2 = _load_kda_cp_chunk_row_tile(
+                w, segment_len, stride_w, chunk_id, 128, K=K, BT=BT
+            )
+            value += tl.dot(w2, h2.to(w2.dtype))
+        if K > 192:
+            w3 = _load_kda_cp_chunk_row_tile(
+                w, segment_len, stride_w, chunk_id, 192, K=K, BT=BT
+            )
+            value += tl.dot(w3, h3.to(w3.dtype))
+
+        value_ptr = tl.make_block_ptr(
+            v,
+            (segment_len, V),
+            (stride_v, 1),
+            (chunk_id * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        value = tl.load(value_ptr, boundary_check=(0, 1)) - value
+
+        last_token = min((chunk_id + 1) * BT, segment_len) - 1
+        gate_offset = (bos + last_token) * H * K + i_h * K
+        h0 *= _load_kda_cp_gate_tile(gk, gate_offset, 0, K=K)
+        if K > 64:
+            h1 *= _load_kda_cp_gate_tile(gk, gate_offset, 64, K=K)
+        if K > 128:
+            h2 *= _load_kda_cp_gate_tile(gk, gate_offset, 128, K=K)
+        if K > 192:
+            h3 *= _load_kda_cp_gate_tile(gk, gate_offset, 192, K=K)
+
+        value = value.to(k.dtype.element_ty)
+        key0 = _load_kda_cp_chunk_column_tile(
+            k, segment_len, stride_k, chunk_id, 0, K=K, BT=BT
+        )
+        h0 += tl.dot(key0, value)
+        if K > 64:
+            key1 = _load_kda_cp_chunk_column_tile(
+                k, segment_len, stride_k, chunk_id, 64, K=K, BT=BT
+            )
+            h1 += tl.dot(key1, value)
+        if K > 128:
+            key2 = _load_kda_cp_chunk_column_tile(
+                k, segment_len, stride_k, chunk_id, 128, K=K, BT=BT
+            )
+            h2 += tl.dot(key2, value)
+        if K > 192:
+            key3 = _load_kda_cp_chunk_column_tile(
+                k, segment_len, stride_k, chunk_id, 192, K=K, BT=BT
+            )
+            h3 += tl.dot(key3, value)
+
+    _store_kda_cp_row_tile(
+        affine, h0, i_v * BV, 0, K=K, C=V, ROW_STRIDE=V + K, BC=BV
+    )
+    if K > 64:
+        _store_kda_cp_row_tile(
+            affine, h1, i_v * BV, 64, K=K, C=V, ROW_STRIDE=V + K, BC=BV
+        )
+    if K > 128:
+        _store_kda_cp_row_tile(
+            affine, h2, i_v * BV, 128, K=K, C=V, ROW_STRIDE=V + K, BC=BV
+        )
+    if K > 192:
+        _store_kda_cp_row_tile(
+            affine, h3, i_v * BV, 192, K=K, C=V, ROW_STRIDE=V + K, BC=BV
+        )
+
+
+@triton.jit(do_not_specialize=["T"])
+def chunk_gated_delta_rule_fwd_affine_m_kernel(
+    k,
+    w,
+    gk,
+    affine,
+    cu_seqlens,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+):
+    """Compute the transition half of a segment affine map.
+
+    This is the Ascend-friendly counterpart of FLA PR 691's stage-2
+    preprocessing kernel.  PR 691 forms a full KxK chunk transition before
+    multiplying it into the running transform.  Keeping that full accumulator
+    across a dynamic loop is not currently stable in BiShengIR.  Instead, this
+    kernel advances one 64-column slab of M at a time using
+
+        M <- D @ M - K.T @ (W @ M).
+
+    The recurrence is identical, but every live dot accumulator is at most
+    64x64 -- the same shape already proven by the regular Ascend KDA state
+    kernel.  Unlike that generic kernel, this path creates the identity in
+    registers and has no state-index, value, or chunk-state branches.
+    """
+    i_c, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_h = i_nh // H, i_nh % H
+    bos = tl.load(cu_seqlens + i_n).to(tl.int32)
+    eos = tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+    segment_len = eos - bos
+    num_chunks = tl.cdiv(segment_len, BT)
+
+    affine += ((i_n * H + i_h) * K * (V + K) + V).to(tl.int64)
+    k += ((bos * H + i_h) * K).to(tl.int64)
+    w += ((bos * H + i_h) * K).to(tl.int64)
+    stride_kw = H * K
+
+    cols = i_c * BC + tl.arange(0, BC)
+    rows0 = tl.arange(0, 64)
+    m0 = (rows0[:, None] == cols[None, :]).to(tl.float32)
+    if K > 64:
+        rows1 = 64 + rows0
+        m1 = (rows1[:, None] == cols[None, :]).to(tl.float32)
+    if K > 128:
+        rows2 = 128 + rows0
+        m2 = (rows2[:, None] == cols[None, :]).to(tl.float32)
+    if K > 192:
+        rows3 = 192 + rows0
+        m3 = (rows3[:, None] == cols[None, :]).to(tl.float32)
+
+    for chunk_id in range(num_chunks):
+        w0 = _load_kda_cp_chunk_row_tile(
+            w, segment_len, stride_kw, chunk_id, 0, K=K, BT=BT
+        )
+        tmp = tl.dot(w0, m0.to(w0.dtype))
+        if K > 64:
+            w1 = _load_kda_cp_chunk_row_tile(
+                w, segment_len, stride_kw, chunk_id, 64, K=K, BT=BT
+            )
+            tmp += tl.dot(w1, m1.to(w1.dtype))
+        if K > 128:
+            w2 = _load_kda_cp_chunk_row_tile(
+                w, segment_len, stride_kw, chunk_id, 128, K=K, BT=BT
+            )
+            tmp += tl.dot(w2, m2.to(w2.dtype))
+        if K > 192:
+            w3 = _load_kda_cp_chunk_row_tile(
+                w, segment_len, stride_kw, chunk_id, 192, K=K, BT=BT
+            )
+            tmp += tl.dot(w3, m3.to(w3.dtype))
+
+        last_token = min((chunk_id + 1) * BT, segment_len) - 1
+        gate_offset = (bos + last_token) * H * K + i_h * K
+        m0 *= _load_kda_cp_gate_tile(gk, gate_offset, 0, K=K)
+        if K > 64:
+            m1 *= _load_kda_cp_gate_tile(gk, gate_offset, 64, K=K)
+        if K > 128:
+            m2 *= _load_kda_cp_gate_tile(gk, gate_offset, 128, K=K)
+        if K > 192:
+            m3 *= _load_kda_cp_gate_tile(gk, gate_offset, 192, K=K)
+
+        tmp = tmp.to(k.dtype.element_ty)
+        k0 = _load_kda_cp_chunk_column_tile(
+            k, segment_len, stride_kw, chunk_id, 0, K=K, BT=BT
+        )
+        m0 -= tl.dot(k0, tmp)
+        if K > 64:
+            k1 = _load_kda_cp_chunk_column_tile(
+                k, segment_len, stride_kw, chunk_id, 64, K=K, BT=BT
+            )
+            m1 -= tl.dot(k1, tmp)
+        if K > 128:
+            k2 = _load_kda_cp_chunk_column_tile(
+                k, segment_len, stride_kw, chunk_id, 128, K=K, BT=BT
+            )
+            m2 -= tl.dot(k2, tmp)
+        if K > 192:
+            k3 = _load_kda_cp_chunk_column_tile(
+                k, segment_len, stride_kw, chunk_id, 192, K=K, BT=BT
+            )
+            m3 -= tl.dot(k3, tmp)
+
+    _store_kda_cp_row_tile(
+        affine, m0, i_c * BC, 0, K=K, C=K, ROW_STRIDE=V + K, BC=BC
+    )
+    if K > 64:
+        _store_kda_cp_row_tile(
+            affine, m1, i_c * BC, 64, K=K, C=K, ROW_STRIDE=V + K, BC=BC
+        )
+    if K > 128:
+        _store_kda_cp_row_tile(
+            affine, m2, i_c * BC, 128, K=K, C=K, ROW_STRIDE=V + K, BC=BC
+        )
+    if K > 192:
+        _store_kda_cp_row_tile(
+            affine, m3, i_c * BC, 192, K=K, C=K, ROW_STRIDE=V + K, BC=BC
+        )
+
+
+@triton.jit
+def _apply_kda_cp_affine_block(
+    gathered,
+    h0,
+    h1,
+    owner_rank,
+    source_segment,
+    i_h,
+    i_v,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    MAX_SEGMENTS: tl.constexpr,
+    BV: tl.constexpr,
+):
+    """Apply one execution-plan affine transform to a state tile."""
+    affine = gathered + (
+        ((owner_rank * MAX_SEGMENTS + source_segment) * H + i_h) * K * (V + K)
+    ).to(tl.int64)
+
+    add0 = _load_kda_cp_row_tile(
+        affine, i_v * BV, 0, K=K, C=V, ROW_STRIDE=V + K, BC=BV
+    ).to(tl.float32)
+    m00 = _load_kda_cp_row_tile(
+        affine + V, 0, 0, K=K, C=K, ROW_STRIDE=V + K, BC=64
+    )
+    next0 = tl.dot(m00, h0.to(m00.dtype)) + add0
+
+    if K > 64:
+        m01 = _load_kda_cp_row_tile(
+            affine + V, 64, 0, K=K, C=K, ROW_STRIDE=V + K, BC=64
+        )
+        next0 += tl.dot(m01, h1.to(m01.dtype))
+
+        add1 = _load_kda_cp_row_tile(
+            affine, i_v * BV, 64, K=K, C=V, ROW_STRIDE=V + K, BC=BV
+        ).to(tl.float32)
+        m10 = _load_kda_cp_row_tile(
+            affine + V, 0, 64, K=K, C=K, ROW_STRIDE=V + K, BC=64
+        )
+        m11 = _load_kda_cp_row_tile(
+            affine + V, 64, 64, K=K, C=K, ROW_STRIDE=V + K, BC=64
+        )
+        next1 = tl.dot(m10, h0.to(m10.dtype)) + tl.dot(m11, h1.to(m11.dtype)) + add1
+    else:
+        next1 = h1
+    return next0, next1
+
+
+@triton.jit
+def _store_kda_cp_state_tile(
+    target,
+    h0,
+    h1,
+    local_index: tl.constexpr,
+    i_h,
+    i_v,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BV: tl.constexpr,
+):
+    target += ((local_index * H + i_h) * K * V).to(tl.int64)
+    _store_kda_cp_row_tile(
+        target, h0, i_v * BV, 0, K=K, C=V, ROW_STRIDE=V, BC=BV
+    )
+    if K > 64:
+        _store_kda_cp_row_tile(
+            target, h1, i_v * BV, 64, K=K, C=V, ROW_STRIDE=V, BC=BV
+        )
+
+
+@triton.jit
+def merge_kda_cp_affine_states_kernel(
+    gathered,
+    initial_state,
+    local_initial,
+    final_state,
+    tracked_state,
+    owner_ranks,
+    source_segments,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    MAX_SEGMENTS: tl.constexpr,
+    NUM_STEPS: tl.constexpr,
+    TRACK_STEP: tl.constexpr,
+    LOCAL_STEP_0: tl.constexpr,
+    LOCAL_STEP_1: tl.constexpr,
+    LOCAL_STEP_2: tl.constexpr,
+    BV: tl.constexpr,
+):
+    """Fuse plan-driven affine composition for the batch-one hot path."""
+    i_v, i_h = tl.program_id(0), tl.program_id(1)
+    initial_state += (i_h * K * V).to(tl.int64)
+
+    h0 = _load_kda_cp_row_tile(
+        initial_state, i_v * BV, 0, K=K, C=V, ROW_STRIDE=V, BC=BV
+    ).to(tl.float32)
+    if K > 64:
+        h1 = _load_kda_cp_row_tile(
+            initial_state, i_v * BV, 64, K=K, C=V, ROW_STRIDE=V, BC=BV
+        ).to(tl.float32)
+    else:
+        h1 = tl.zeros([64, BV], dtype=tl.float32)
+
+    for step_id in range(NUM_STEPS):
+        owner_rank = tl.load(owner_ranks + step_id)
+        source_segment = tl.load(source_segments + step_id)
+
+        local_index = -1
+        if step_id == LOCAL_STEP_0:
+            local_index = 0
+        if step_id == LOCAL_STEP_1:
+            local_index = 1
+        if step_id == LOCAL_STEP_2:
+            local_index = 2
+        if local_index >= 0:
+            _store_kda_cp_state_tile(
+                local_initial,
+                h0,
+                h1,
+                local_index,
+                i_h,
+                i_v,
+                H=H,
+                K=K,
+                V=V,
+                BV=BV,
+            )
+
+        h0, h1 = _apply_kda_cp_affine_block(
+            gathered,
+            h0,
+            h1,
+            owner_rank,
+            source_segment,
+            i_h,
+            i_v,
+            H=H,
+            K=K,
+            V=V,
+            MAX_SEGMENTS=MAX_SEGMENTS,
+            BV=BV,
+        )
+        if step_id == TRACK_STEP:
+            _store_kda_cp_state_tile(
+                tracked_state,
+                h0,
+                h1,
+                0,
+                i_h,
+                i_v,
+                H=H,
+                K=K,
+                V=V,
+                BV=BV,
+            )
+    _store_kda_cp_state_tile(
+        final_state,
+        h0,
+        h1,
+        0,
+        i_h,
+        i_v,
+        H=H,
+        K=K,
+        V=V,
+        BV=BV,
+    )
+
+
+def merge_kda_cp_affine_states(
+    gathered: torch.Tensor,
+    initial_state: torch.Tensor,
+    local_initial: torch.Tensor,
+    final_state: torch.Tensor,
+    *,
+    cp_rank: int,
+    owner_ranks: torch.Tensor | None = None,
+    source_segments: torch.Tensor | None = None,
+    local_indices: torch.Tensor | None = None,
+    local_steps: tuple[int, ...] | None = None,
+    tracked_state: torch.Tensor | None = None,
+    track_step: int = -1,
+) -> None:
+    """Launch the fused batch-one affine merge used by Kimi-K3 PCP.
+
+    ``gathered`` is ``[cp, max_segments, H, K, V+K]`` in rank-owned
+    segment order.  The optional device plan supports the extra segment
+    created when a radix checkpoint splits a natural zigzag block.
+    """
+    cp_size, max_segments, num_heads, key_dim, affine_dim = gathered.shape
+    value_dim = affine_dim - key_dim
+    if initial_state.shape[0] != 1 or key_dim > 128:
+        raise ValueError(
+            "fused KDA CP merge requires batch one and K <= 128; "
+            f"got batch={initial_state.shape[0]}, K={key_dim}"
+        )
+    if owner_ranks is None or source_segments is None or local_indices is None:
+        owners = []
+        sources = []
+        locals_ = []
+        local_id = 0
+        for block_id in range(2 * cp_size):
+            owner = block_id if block_id < cp_size else 2 * cp_size - block_id - 1
+            source = int(block_id >= cp_size)
+            owners.append(owner)
+            sources.append(source)
+            if owner == cp_rank:
+                locals_.append(local_id)
+                local_id += 1
+            else:
+                locals_.append(-1)
+        owner_ranks = torch.tensor(owners, dtype=torch.int32, device=gathered.device)
+        source_segments = torch.tensor(
+            sources, dtype=torch.int32, device=gathered.device
+        )
+        local_indices = torch.tensor(locals_, dtype=torch.int32, device=gathered.device)
+        local_steps = tuple(
+            step_id for step_id, local_id in enumerate(locals_) if local_id >= 0
+        )
+    num_steps = owner_ranks.numel()
+    if tracked_state is None:
+        tracked_state = final_state
+    valid_plan = (
+        num_steps == source_segments.numel() == local_indices.numel()
+        and 0 < local_initial.shape[0] <= max_segments
+        and track_step < num_steps
+        and local_steps is not None
+        and len(local_steps) == local_initial.shape[0]
+        and len(local_steps) <= 3
+    )
+    if not valid_plan:
+        raise ValueError(
+            "invalid fused KDA CP merge plan; "
+            f"steps=({num_steps},{source_segments.numel()},{local_indices.numel()}), "
+            f"local_states={local_initial.shape[0]}/{max_segments}, "
+            f"local_steps={local_steps}, track_step={track_step}"
+        )
+    padded_local_steps = (*local_steps, -1, -1, -1)[:3]
+    merge_kda_cp_affine_states_kernel[(triton.cdiv(value_dim, 64), num_heads)](
+        gathered=gathered,
+        initial_state=initial_state,
+        local_initial=local_initial,
+        final_state=final_state,
+        tracked_state=tracked_state,
+        owner_ranks=owner_ranks,
+        source_segments=source_segments,
+        H=num_heads,
+        K=key_dim,
+        V=value_dim,
+        MAX_SEGMENTS=max_segments,
+        NUM_STEPS=num_steps,
+        TRACK_STEP=track_step,
+        LOCAL_STEP_0=padded_local_steps[0],
+        LOCAL_STEP_1=padded_local_steps[1],
+        LOCAL_STEP_2=padded_local_steps[2],
+        BV=64,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+def chunk_gated_delta_rule_fwd_affine_npu(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    gk: torch.Tensor,
+    cu_seqlens: torch.LongTensor,
+) -> torch.Tensor:
+    """Return per-segment ``[H | M]`` without materializing chunk states.
+
+    The output satisfies ``state_out = M @ state_in + H`` and is laid out as
+    ``[segments, heads, K, V + K]``.  It is intentionally FP32 because the
+    cross-rank affine composition is numerically sensitive.
+    """
+    if cu_seqlens is None or gk is None:
+        raise ValueError("KDA CP affine preprocessing requires cu_seqlens and gk")
+    _, token_count, key_heads, key_dim = k.shape
+    num_heads = u.shape[-2]
+    value_dim = u.shape[-1]
+    num_segments = len(cu_seqlens) - 1
+    if key_dim > 256 or num_heads % key_heads != 0:
+        raise ValueError(
+            "KDA CP affine preprocessing requires K <= 256 and H divisible "
+            f"by Hg; got K={key_dim}, H={num_heads}, Hg={key_heads}"
+        )
+
+    affine = torch.empty(
+        num_segments,
+        num_heads,
+        key_dim,
+        value_dim + key_dim,
+        dtype=torch.float32,
+        device=k.device,
+    )
+
+    def launch_additive() -> None:
+        chunk_gated_delta_rule_fwd_affine_h_kernel[
+            (triton.cdiv(value_dim, 64), num_segments * num_heads)
+        ](
+            k=k,
+            v=u,
+            w=w,
+            gk=gk,
+            affine=affine,
+            cu_seqlens=cu_seqlens,
+            T=token_count,
+            H=num_heads,
+            Hg=key_heads,
+            K=key_dim,
+            V=value_dim,
+            BT=CHUNK_SIZE,
+            BV=64,
+            num_warps=4,
+            num_stages=2,
+        )
+
+    def launch_transition() -> None:
+        chunk_gated_delta_rule_fwd_affine_m_kernel[
+            (triton.cdiv(key_dim, 64), num_segments * num_heads)
+        ](
+            k=k,
+            w=w,
+            gk=gk,
+            affine=affine,
+            cu_seqlens=cu_seqlens,
+            T=token_count,
+            H=num_heads,
+            K=key_dim,
+            V=value_dim,
+            BT=CHUNK_SIZE,
+            BC=64,
+            num_warps=4,
+            num_stages=2,
+        )
+
+    # H and M write disjoint affine columns and have no data dependency. Run
+    # them on separate streams, then join before the caller starts the
+    # collective. Streams are cached per process/device.
+    device_index = k.device.index or 0
+    main_stream = torch.npu.current_stream(device_index)
+    affine_stream = _get_kda_cp_affine_stream(device_index)
+    affine_stream.wait_stream(main_stream)
+    with torch.npu.stream(affine_stream):
+        launch_additive()
+    launch_transition()
+    main_stream.wait_stream(affine_stream)
+    return affine

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_chunk_delta_h.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_chunk_delta_h.py
@@ -462,33 +462,17 @@ def chunk_gated_delta_rule_fwd_affine_h_kernel(
     stride_w = H * K
 
     h0 = tl.zeros([64, BV], dtype=tl.float32)
-    if K > 64:
-        h1 = tl.zeros([64, BV], dtype=tl.float32)
-    if K > 128:
-        h2 = tl.zeros([64, BV], dtype=tl.float32)
-    if K > 192:
-        h3 = tl.zeros([64, BV], dtype=tl.float32)
+    h1 = tl.zeros([64, BV], dtype=tl.float32)
 
     for chunk_id in range(num_chunks):
         w0 = _load_kda_cp_chunk_row_tile(
             w, segment_len, stride_w, chunk_id, 0, K=K, BT=BT
         )
         value = tl.dot(w0, h0.to(w0.dtype))
-        if K > 64:
-            w1 = _load_kda_cp_chunk_row_tile(
-                w, segment_len, stride_w, chunk_id, 64, K=K, BT=BT
-            )
-            value += tl.dot(w1, h1.to(w1.dtype))
-        if K > 128:
-            w2 = _load_kda_cp_chunk_row_tile(
-                w, segment_len, stride_w, chunk_id, 128, K=K, BT=BT
-            )
-            value += tl.dot(w2, h2.to(w2.dtype))
-        if K > 192:
-            w3 = _load_kda_cp_chunk_row_tile(
-                w, segment_len, stride_w, chunk_id, 192, K=K, BT=BT
-            )
-            value += tl.dot(w3, h3.to(w3.dtype))
+        w1 = _load_kda_cp_chunk_row_tile(
+            w, segment_len, stride_w, chunk_id, 64, K=K, BT=BT
+        )
+        value += tl.dot(w1, h1.to(w1.dtype))
 
         value_ptr = tl.make_block_ptr(
             v,
@@ -503,49 +487,24 @@ def chunk_gated_delta_rule_fwd_affine_h_kernel(
         last_token = min((chunk_id + 1) * BT, segment_len) - 1
         gate_offset = (bos + last_token) * H * K + i_h * K
         h0 *= _load_kda_cp_gate_tile(gk, gate_offset, 0, K=K)
-        if K > 64:
-            h1 *= _load_kda_cp_gate_tile(gk, gate_offset, 64, K=K)
-        if K > 128:
-            h2 *= _load_kda_cp_gate_tile(gk, gate_offset, 128, K=K)
-        if K > 192:
-            h3 *= _load_kda_cp_gate_tile(gk, gate_offset, 192, K=K)
+        h1 *= _load_kda_cp_gate_tile(gk, gate_offset, 64, K=K)
 
         value = value.to(k.dtype.element_ty)
         key0 = _load_kda_cp_chunk_column_tile(
             k, segment_len, stride_k, chunk_id, 0, K=K, BT=BT
         )
         h0 += tl.dot(key0, value)
-        if K > 64:
-            key1 = _load_kda_cp_chunk_column_tile(
-                k, segment_len, stride_k, chunk_id, 64, K=K, BT=BT
-            )
-            h1 += tl.dot(key1, value)
-        if K > 128:
-            key2 = _load_kda_cp_chunk_column_tile(
-                k, segment_len, stride_k, chunk_id, 128, K=K, BT=BT
-            )
-            h2 += tl.dot(key2, value)
-        if K > 192:
-            key3 = _load_kda_cp_chunk_column_tile(
-                k, segment_len, stride_k, chunk_id, 192, K=K, BT=BT
-            )
-            h3 += tl.dot(key3, value)
+        key1 = _load_kda_cp_chunk_column_tile(
+            k, segment_len, stride_k, chunk_id, 64, K=K, BT=BT
+        )
+        h1 += tl.dot(key1, value)
 
     _store_kda_cp_row_tile(
         affine, h0, i_v * BV, 0, K=K, C=V, ROW_STRIDE=V + K, BC=BV
     )
-    if K > 64:
-        _store_kda_cp_row_tile(
-            affine, h1, i_v * BV, 64, K=K, C=V, ROW_STRIDE=V + K, BC=BV
-        )
-    if K > 128:
-        _store_kda_cp_row_tile(
-            affine, h2, i_v * BV, 128, K=K, C=V, ROW_STRIDE=V + K, BC=BV
-        )
-    if K > 192:
-        _store_kda_cp_row_tile(
-            affine, h3, i_v * BV, 192, K=K, C=V, ROW_STRIDE=V + K, BC=BV
-        )
+    _store_kda_cp_row_tile(
+        affine, h1, i_v * BV, 64, K=K, C=V, ROW_STRIDE=V + K, BC=BV
+    )
 
 
 @triton.jit(do_not_specialize=["T"])
@@ -592,83 +551,40 @@ def chunk_gated_delta_rule_fwd_affine_m_kernel(
     cols = i_c * BC + tl.arange(0, BC)
     rows0 = tl.arange(0, 64)
     m0 = (rows0[:, None] == cols[None, :]).to(tl.float32)
-    if K > 64:
-        rows1 = 64 + rows0
-        m1 = (rows1[:, None] == cols[None, :]).to(tl.float32)
-    if K > 128:
-        rows2 = 128 + rows0
-        m2 = (rows2[:, None] == cols[None, :]).to(tl.float32)
-    if K > 192:
-        rows3 = 192 + rows0
-        m3 = (rows3[:, None] == cols[None, :]).to(tl.float32)
+    rows1 = 64 + rows0
+    m1 = (rows1[:, None] == cols[None, :]).to(tl.float32)
 
     for chunk_id in range(num_chunks):
         w0 = _load_kda_cp_chunk_row_tile(
             w, segment_len, stride_kw, chunk_id, 0, K=K, BT=BT
         )
         tmp = tl.dot(w0, m0.to(w0.dtype))
-        if K > 64:
-            w1 = _load_kda_cp_chunk_row_tile(
-                w, segment_len, stride_kw, chunk_id, 64, K=K, BT=BT
-            )
-            tmp += tl.dot(w1, m1.to(w1.dtype))
-        if K > 128:
-            w2 = _load_kda_cp_chunk_row_tile(
-                w, segment_len, stride_kw, chunk_id, 128, K=K, BT=BT
-            )
-            tmp += tl.dot(w2, m2.to(w2.dtype))
-        if K > 192:
-            w3 = _load_kda_cp_chunk_row_tile(
-                w, segment_len, stride_kw, chunk_id, 192, K=K, BT=BT
-            )
-            tmp += tl.dot(w3, m3.to(w3.dtype))
+        w1 = _load_kda_cp_chunk_row_tile(
+            w, segment_len, stride_kw, chunk_id, 64, K=K, BT=BT
+        )
+        tmp += tl.dot(w1, m1.to(w1.dtype))
 
         last_token = min((chunk_id + 1) * BT, segment_len) - 1
         gate_offset = (bos + last_token) * H * K + i_h * K
         m0 *= _load_kda_cp_gate_tile(gk, gate_offset, 0, K=K)
-        if K > 64:
-            m1 *= _load_kda_cp_gate_tile(gk, gate_offset, 64, K=K)
-        if K > 128:
-            m2 *= _load_kda_cp_gate_tile(gk, gate_offset, 128, K=K)
-        if K > 192:
-            m3 *= _load_kda_cp_gate_tile(gk, gate_offset, 192, K=K)
+        m1 *= _load_kda_cp_gate_tile(gk, gate_offset, 64, K=K)
 
         tmp = tmp.to(k.dtype.element_ty)
         k0 = _load_kda_cp_chunk_column_tile(
             k, segment_len, stride_kw, chunk_id, 0, K=K, BT=BT
         )
         m0 -= tl.dot(k0, tmp)
-        if K > 64:
-            k1 = _load_kda_cp_chunk_column_tile(
-                k, segment_len, stride_kw, chunk_id, 64, K=K, BT=BT
-            )
-            m1 -= tl.dot(k1, tmp)
-        if K > 128:
-            k2 = _load_kda_cp_chunk_column_tile(
-                k, segment_len, stride_kw, chunk_id, 128, K=K, BT=BT
-            )
-            m2 -= tl.dot(k2, tmp)
-        if K > 192:
-            k3 = _load_kda_cp_chunk_column_tile(
-                k, segment_len, stride_kw, chunk_id, 192, K=K, BT=BT
-            )
-            m3 -= tl.dot(k3, tmp)
+        k1 = _load_kda_cp_chunk_column_tile(
+            k, segment_len, stride_kw, chunk_id, 64, K=K, BT=BT
+        )
+        m1 -= tl.dot(k1, tmp)
 
     _store_kda_cp_row_tile(
         affine, m0, i_c * BC, 0, K=K, C=K, ROW_STRIDE=V + K, BC=BC
     )
-    if K > 64:
-        _store_kda_cp_row_tile(
-            affine, m1, i_c * BC, 64, K=K, C=K, ROW_STRIDE=V + K, BC=BC
-        )
-    if K > 128:
-        _store_kda_cp_row_tile(
-            affine, m2, i_c * BC, 128, K=K, C=K, ROW_STRIDE=V + K, BC=BC
-        )
-    if K > 192:
-        _store_kda_cp_row_tile(
-            affine, m3, i_c * BC, 192, K=K, C=K, ROW_STRIDE=V + K, BC=BC
-        )
+    _store_kda_cp_row_tile(
+        affine, m1, i_c * BC, 64, K=K, C=K, ROW_STRIDE=V + K, BC=BC
+    )
 
 
 @triton.jit
@@ -699,24 +615,21 @@ def _apply_kda_cp_affine_block(
     )
     next0 = tl.dot(m00, h0.to(m00.dtype)) + add0
 
-    if K > 64:
-        m01 = _load_kda_cp_row_tile(
-            affine + V, 64, 0, K=K, C=K, ROW_STRIDE=V + K, BC=64
-        )
-        next0 += tl.dot(m01, h1.to(m01.dtype))
+    m01 = _load_kda_cp_row_tile(
+        affine + V, 64, 0, K=K, C=K, ROW_STRIDE=V + K, BC=64
+    )
+    next0 += tl.dot(m01, h1.to(m01.dtype))
 
-        add1 = _load_kda_cp_row_tile(
-            affine, i_v * BV, 64, K=K, C=V, ROW_STRIDE=V + K, BC=BV
-        ).to(tl.float32)
-        m10 = _load_kda_cp_row_tile(
-            affine + V, 0, 64, K=K, C=K, ROW_STRIDE=V + K, BC=64
-        )
-        m11 = _load_kda_cp_row_tile(
-            affine + V, 64, 64, K=K, C=K, ROW_STRIDE=V + K, BC=64
-        )
-        next1 = tl.dot(m10, h0.to(m10.dtype)) + tl.dot(m11, h1.to(m11.dtype)) + add1
-    else:
-        next1 = h1
+    add1 = _load_kda_cp_row_tile(
+        affine, i_v * BV, 64, K=K, C=V, ROW_STRIDE=V + K, BC=BV
+    ).to(tl.float32)
+    m10 = _load_kda_cp_row_tile(
+        affine + V, 0, 64, K=K, C=K, ROW_STRIDE=V + K, BC=64
+    )
+    m11 = _load_kda_cp_row_tile(
+        affine + V, 64, 64, K=K, C=K, ROW_STRIDE=V + K, BC=64
+    )
+    next1 = tl.dot(m10, h0.to(m10.dtype)) + tl.dot(m11, h1.to(m11.dtype)) + add1
     return next0, next1
 
 
@@ -737,10 +650,9 @@ def _store_kda_cp_state_tile(
     _store_kda_cp_row_tile(
         target, h0, i_v * BV, 0, K=K, C=V, ROW_STRIDE=V, BC=BV
     )
-    if K > 64:
-        _store_kda_cp_row_tile(
-            target, h1, i_v * BV, 64, K=K, C=V, ROW_STRIDE=V, BC=BV
-        )
+    _store_kda_cp_row_tile(
+        target, h1, i_v * BV, 64, K=K, C=V, ROW_STRIDE=V, BC=BV
+    )
 
 
 @triton.jit
@@ -770,12 +682,9 @@ def merge_kda_cp_affine_states_kernel(
     h0 = _load_kda_cp_row_tile(
         initial_state, i_v * BV, 0, K=K, C=V, ROW_STRIDE=V, BC=BV
     ).to(tl.float32)
-    if K > 64:
-        h1 = _load_kda_cp_row_tile(
-            initial_state, i_v * BV, 64, K=K, C=V, ROW_STRIDE=V, BC=BV
-        ).to(tl.float32)
-    else:
-        h1 = tl.zeros([64, BV], dtype=tl.float32)
+    h1 = _load_kda_cp_row_tile(
+        initial_state, i_v * BV, 64, K=K, C=V, ROW_STRIDE=V, BC=BV
+    ).to(tl.float32)
 
     for step_id in range(NUM_STEPS):
         owner_rank = tl.load(owner_ranks + step_id)
@@ -865,9 +774,9 @@ def merge_kda_cp_affine_states(
     """
     cp_size, max_segments, num_heads, key_dim, affine_dim = gathered.shape
     value_dim = affine_dim - key_dim
-    if initial_state.shape[0] != 1 or key_dim > 128:
+    if initial_state.shape[0] != 1 or key_dim != 128:
         raise ValueError(
-            "fused KDA CP merge requires batch one and K <= 128; "
+            "fused KDA CP merge requires batch one and K = 128; "
             f"got batch={initial_state.shape[0]}, K={key_dim}"
         )
     if owner_ranks is None or source_segments is None or local_indices is None:
@@ -954,9 +863,9 @@ def chunk_gated_delta_rule_fwd_affine_npu(
     num_heads = u.shape[-2]
     value_dim = u.shape[-1]
     num_segments = len(cu_seqlens) - 1
-    if key_dim > 256 or num_heads % key_heads != 0:
+    if key_dim != 128 or num_heads % key_heads != 0:
         raise ValueError(
-            "KDA CP affine preprocessing requires K <= 256 and H divisible "
+            "KDA CP affine preprocessing requires K = 128 and H divisible "
             f"by Hg; got K={key_dim}, H={num_heads}, Hg={key_heads}"
         )
 

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_prefill.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_prefill.py
@@ -1,13 +1,32 @@
+"""Framework-ready WY recompute with wrapper-owned beta layout conversion.
+
+The public ``recompute_w_u_fwd`` retains
+the original contiguous ``beta[B,T,H]`` interface and materializes a contiguous
+head-major copy before launch. The kernel body is adapted from
+``sglang.srt.layers.attention.fla.kda.recompute_w_u_fwd_kernel``.
+
+Framework contract:
+
+* ``k``: ``[B, T, H, K]``, contiguous.
+* ``v``: ``[B, T, H, V]``, contiguous.
+* public-wrapper ``beta``: ``[B, T, H]``, contiguous.
+* kernel/direct-wrapper ``beta``: ``[B, H, T]``, contiguous.
+* ``A``: ``[B, T, H, BT]``, contiguous.
+* ``gk``: ``[B, T, H, K]``, contiguous FP32 chunk-local cumulative gate.
+* varlen input is packed with physical ``B == 1`` and sequence boundaries in
+  ``cu_seqlens``; ``beta`` covers the complete packed ``T`` axis.
+"""
+
 from typing import Optional
 
 import torch
 import triton
 import triton.language as tl
-from sgl_kernel_npu.fla.utils import exp2, prepare_chunk_indices
+from sgl_kernel_npu.fla.utils import exp, exp2, prepare_chunk_indices
 
 
 @triton.jit(do_not_specialize=["T"])
-def _recompute_w_u_fwd_kernel(
+def recompute_w_u_fwd_head_major_kernel(
     k,
     kg,
     v,
@@ -25,10 +44,12 @@ def _recompute_w_u_fwd_kernel(
     BT: tl.constexpr,
     BK: tl.constexpr,
     BV: tl.constexpr,
-    STORE_KG: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     DOT_PRECISION: tl.constexpr,
 ):
+    # T_TOTAL remains the physical packed-token extent even when the varlen
+    # branch replaces T with the current logical sequence length.
+    T_TOTAL = T
     i_t, i_bh = tl.program_id(0), tl.program_id(1)
     i_b, i_h = i_bh // H, i_bh % H
     if IS_VARLEN:
@@ -43,7 +64,19 @@ def _recompute_w_u_fwd_kernel(
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
-    p_b = tl.make_block_ptr(beta + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+
+    # beta is physical [B,H,T_TOTAL].  Fixed mode selects the physical batch
+    # through i_b.  Packed varlen requires B=1, and bos selects the logical
+    # sequence inside the shared T_TOTAL axis.
+    beta_bos = bos if IS_VARLEN else 0
+    p_b = tl.make_block_ptr(
+        beta + (i_b * H + i_h) * T_TOTAL + beta_bos,
+        (T,),
+        (1,),
+        (i_t * BT,),
+        (BT,),
+        (0,),
+    )
     b_b = tl.load(p_b, boundary_check=(0,))
 
     p_A = tl.make_block_ptr(
@@ -102,29 +135,193 @@ def _recompute_w_u_fwd_kernel(
             (1, 0),
         )
         b_gk = tl.load(p_gk, boundary_check=(0, 1))
-        b_kb *= exp2(b_gk)
-        if STORE_KG:
-            last_idx = min(i_t * BT + BT, T) - 1
+        b_kb *= exp(b_gk)
+        last_idx = min(i_t * BT + BT, T) - 1
 
-            o_k = i_k * BK + tl.arange(0, BK)
-            m_k = o_k < K
-            b_gn = tl.load(
-                gk + ((bos + last_idx) * H + i_h) * K + o_k, mask=m_k, other=0.0
-            )
-            b_kg = b_k * exp2(b_gn - b_gk)
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+        b_gn = tl.load(
+            gk + ((bos + last_idx) * H + i_h) * K + o_k, mask=m_k, other=0.0
+        )
+        b_kg = b_k * exp(b_gn - b_gk)
 
-            p_kg = tl.make_block_ptr(
-                kg + (bos * H + i_h) * K,
-                (T, K),
-                (H * K, 1),
-                (i_t * BT, i_k * BK),
-                (BT, BK),
-                (1, 0),
-            )
-            tl.store(p_kg, b_kg.to(p_kg.dtype.element_ty), boundary_check=(0, 1))
+        p_kg = tl.make_block_ptr(
+            kg + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        tl.store(p_kg, b_kg.to(p_kg.dtype.element_ty), boundary_check=(0, 1))
 
         b_w = tl.dot(b_A, b_kb.to(b_k.dtype))
         tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+
+
+def _validate_inputs(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    gk: torch.Tensor | None,
+    cu_seqlens: torch.Tensor | None,
+    chunk_indices: torch.Tensor | None,
+) -> tuple[int, int, int, int, int, int]:
+    """Validate pointer-layout invariants without synchronizing the device."""
+    if k.ndim != 4:
+        raise ValueError(f"k must be [B,T,H,K], got shape={tuple(k.shape)}")
+    B, T, H, K = k.shape
+    valid_shapes = (
+        min(B, T, H, K) > 0
+        and v.ndim == 4
+        and tuple(v.shape[:3]) == (B, T, H)
+        and v.shape[-1] > 0
+        and tuple(beta.shape) == (B, H, T)
+        and A.ndim == 4
+        and tuple(A.shape[:3]) == (B, T, H)
+        and A.shape[-1] == 64
+        and gk is not None
+        and tuple(gk.shape) == (B, T, H, K)
+    )
+    if not valid_shapes:
+        raise ValueError(
+            "invalid KDA recompute shapes; expected v/A to match k[B,T,H], "
+            "beta[B,H,T], gk==k, and A chunk size 64; "
+            f"got k={tuple(k.shape)}, v={tuple(v.shape)}, beta={tuple(beta.shape)}, "
+            f"A={tuple(A.shape)}, gk={None if gk is None else tuple(gk.shape)}"
+        )
+    V, BT = v.shape[-1], A.shape[-1]
+
+    tensors = {"k": k, "v": v, "beta": beta, "A": A, "gk": gk}
+    invalid_layouts = [
+        name
+        for name, tensor in tensors.items()
+        if not tensor.is_contiguous() or tensor.device != k.device
+    ]
+    if invalid_layouts:
+        raise ValueError(
+            "KDA recompute inputs must be contiguous and on "
+            f"{k.device}; invalid={invalid_layouts}"
+        )
+    if not (
+        k.dtype == v.dtype == A.dtype
+        and gk.dtype == torch.float32
+        and beta.dtype in (k.dtype, torch.float32)
+    ):
+        raise ValueError(
+            "invalid KDA recompute dtypes; expected k/v/A to match, gk FP32, "
+            f"and beta data dtype or FP32; got k={k.dtype}, v={v.dtype}, "
+            f"A={A.dtype}, gk={gk.dtype}, beta={beta.dtype}"
+        )
+
+    if cu_seqlens is None:
+        if chunk_indices is not None:
+            raise ValueError("chunk_indices requires cu_seqlens")
+    else:
+        valid_cu_seqlens = (
+            B == 1
+            and cu_seqlens.ndim == 1
+            and cu_seqlens.numel() >= 2
+            and cu_seqlens.dtype in (torch.int32, torch.int64)
+            and cu_seqlens.device == k.device
+            and cu_seqlens.is_contiguous()
+        )
+        if not valid_cu_seqlens:
+            raise ValueError(
+                "packed varlen requires B=1 and contiguous int32/int64 "
+                f"cu_seqlens on {k.device}; got B={B}, "
+                f"shape={tuple(cu_seqlens.shape)}, dtype={cu_seqlens.dtype}, "
+                f"device={cu_seqlens.device}, stride={cu_seqlens.stride()}"
+            )
+        valid_chunk_indices = chunk_indices is None or (
+            chunk_indices.ndim == 2
+            and chunk_indices.shape[1] == 2
+            and chunk_indices.dtype == cu_seqlens.dtype
+            and chunk_indices.device == k.device
+            and chunk_indices.is_contiguous()
+        )
+        if not valid_chunk_indices:
+            raise ValueError(
+                "chunk_indices must be contiguous [num_chunks,2] and match "
+                f"cu_seqlens; got shape={tuple(chunk_indices.shape)}, "
+                f"device={chunk_indices.device}, dtype={chunk_indices.dtype}, "
+                f"stride={chunk_indices.stride()}"
+            )
+    return B, T, H, K, V, BT
+
+
+def recompute_w_u_fwd_head_major(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    A: torch.Tensor,
+    gk: torch.Tensor | None = None,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_indices: torch.LongTensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run WY recompute using caller-owned contiguous ``beta[B,H,T]``.
+
+    No beta view, transpose, allocation, or copy occurs in this wrapper.
+    """
+    B, T, H, K, V, BT = _validate_inputs(
+        k=k,
+        v=v,
+        beta=beta,
+        A=A,
+        gk=gk,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    w = torch.empty_like(k)
+    u = torch.empty_like(v)
+    kg = torch.empty_like(k)
+    recompute_w_u_fwd_head_major_kernel[(NT, B * H)](
+        k=k,
+        kg=kg,
+        v=v,
+        beta=beta,
+        w=w,
+        u=u,
+        A=A,
+        gk=gk,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        BK=64,
+        BV=64,
+        IS_VARLEN=cu_seqlens is not None,
+        DOT_PRECISION="ieee",
+    )
+    return w, u, kg
+
+
+def prepare_recompute_beta_head_major(
+    beta: torch.Tensor,
+    *,
+    expected_shape: tuple[int, int, int] | None = None,
+) -> torch.Tensor:
+    """Materialize contiguous ``beta[B,T,H]`` as physical ``[B,H,T]``."""
+    valid_beta = (
+        beta.ndim == 3
+        and (expected_shape is None or tuple(beta.shape) == expected_shape)
+        and beta.is_contiguous()
+    )
+    if not valid_beta:
+        raise ValueError(
+            "beta must be contiguous [B,T,H] matching k; "
+            f"expected={expected_shape}, shape={tuple(beta.shape)}, "
+            f"stride={beta.stride()}"
+        )
+    return beta.permute(0, 2, 1).contiguous()
 
 
 @triton.jit(do_not_specialize=["T"])
@@ -255,39 +452,21 @@ def recompute_w_u_fwd_npu(
     cu_seqlens: Optional[torch.LongTensor] = None,
     chunk_indices: Optional[torch.LongTensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Build the KDA WY representation with Ascend's fixed 64x64 tile."""
-    B, T, H, K, V = *k.shape, v.shape[-1]
-    chunk_size = A.shape[-1]
-    if chunk_indices is None and cu_seqlens is not None:
-        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
-    num_chunks = (
-        triton.cdiv(T, chunk_size) if cu_seqlens is None else len(chunk_indices)
+    """Keep the existing public API while using the head-major kernel."""
+    if k.ndim != 4:
+        raise ValueError(f"k must be [B,T,H,K], got shape={tuple(k.shape)}")
+    beta_head_major = prepare_recompute_beta_head_major(
+        beta,
+        expected_shape=tuple(k.shape[:3]),
     )
-
-    w = torch.empty_like(k)
-    u = torch.empty_like(v)
-    kg = torch.empty_like(k)
-    _recompute_w_u_fwd_kernel[(num_chunks, B * H)](
+    w, u, kg = recompute_w_u_fwd_head_major(
         k=k,
-        kg=kg,
         v=v,
-        beta=beta,
-        w=w,
-        u=u,
+        beta=beta_head_major,
         A=A,
         gk=gk,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
-        T=T,
-        H=H,
-        K=K,
-        V=V,
-        BT=chunk_size,
-        BK=64,
-        BV=64,
-        STORE_KG=True,
-        IS_VARLEN=cu_seqlens is not None,
-        DOT_PRECISION="ieee",
     )
     return w, u, kg
 

--- a/tests/python/sgl_kernel_npu/test_kda_cp_affine.py
+++ b/tests/python/sgl_kernel_npu/test_kda_cp_affine.py
@@ -1,0 +1,109 @@
+import pytest
+import sgl_kernel_npu  # noqa: F401
+import torch
+import torch_npu  # noqa: F401
+from sgl_kernel_npu.fla.kda_chunk_delta_h import (
+    chunk_gated_delta_rule_fwd_affine_npu,
+    merge_kda_cp_affine_states,
+)
+
+requires_npu = pytest.mark.skipif(
+    not torch.npu.is_available(), reason="KDA CP affine kernels require an NPU"
+)
+
+
+@requires_npu
+@pytest.mark.parametrize("key_dim", [64, 128, 192, 256])
+def test_kda_cp_affine_preprocess_identity(key_dim):
+    device = torch.device("npu")
+    batch, tokens, heads, value_dim = 1, 128, 2, 128
+    k = torch.zeros(
+        (batch, tokens, heads, key_dim), dtype=torch.bfloat16, device=device
+    )
+    w = torch.zeros_like(k)
+    u = torch.zeros(
+        (batch, tokens, heads, value_dim), dtype=torch.bfloat16, device=device
+    )
+    g = torch.zeros((batch, tokens, heads, key_dim), dtype=torch.float32, device=device)
+    cu_seqlens = torch.tensor([0, 64, 128], dtype=torch.int32, device=device)
+
+    affine = chunk_gated_delta_rule_fwd_affine_npu(k, w, u, g, cu_seqlens)
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(
+        affine[..., :value_dim], torch.zeros_like(affine[..., :value_dim])
+    )
+    expected_transition = (
+        torch.eye(key_dim, dtype=torch.float32, device=device)
+        .view(1, 1, key_dim, key_dim)
+        .expand_as(affine[..., value_dim:])
+    )
+    torch.testing.assert_close(affine[..., value_dim:], expected_transition)
+
+
+@requires_npu
+def test_kda_cp_fused_merge_identity_plan():
+    device = torch.device("npu")
+    cp_size, max_segments = 2, 2
+    heads, key_dim, value_dim = 2, 128, 128
+    gathered = torch.zeros(
+        (
+            cp_size,
+            max_segments,
+            heads,
+            key_dim,
+            value_dim + key_dim,
+        ),
+        dtype=torch.float32,
+        device=device,
+    )
+    gathered[..., value_dim:].copy_(
+        torch.eye(key_dim, dtype=torch.float32, device=device).view(
+            1, 1, 1, key_dim, key_dim
+        )
+    )
+    initial = torch.randn(
+        (1, heads, key_dim, value_dim), dtype=torch.float32, device=device
+    )
+    local_initial = torch.empty(
+        (2, heads, key_dim, value_dim), dtype=torch.float32, device=device
+    )
+    final = torch.empty_like(initial)
+
+    merge_kda_cp_affine_states(
+        gathered,
+        initial,
+        local_initial,
+        final,
+        cp_rank=0,
+        owner_ranks=torch.tensor([0, 1, 1, 0], dtype=torch.int32, device=device),
+        source_segments=torch.tensor([0, 0, 1, 1], dtype=torch.int32, device=device),
+        local_indices=torch.tensor([0, -1, -1, 1], dtype=torch.int32, device=device),
+        local_steps=(0, 3),
+    )
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(final, initial)
+    torch.testing.assert_close(local_initial[0], initial[0])
+    torch.testing.assert_close(local_initial[1], initial[0])
+
+
+def test_kda_recompute_preserves_public_return_contract(monkeypatch):
+    from sgl_kernel_npu.fla import kda_prefill
+
+    expected = tuple(torch.empty(0) for _ in range(3))
+
+    def fake_head_major(**kwargs):
+        assert kwargs["beta"].shape == (1, 2, 4)
+        return expected
+
+    monkeypatch.setattr(kda_prefill, "recompute_w_u_fwd_head_major", fake_head_major)
+    result = kda_prefill.recompute_w_u_fwd_npu(
+        k=torch.empty(1, 4, 2, 8),
+        v=torch.empty(1, 4, 2, 8),
+        beta=torch.empty(1, 4, 2),
+        A=torch.empty(1, 4, 2, 4),
+        gk=torch.empty(1, 4, 2, 8),
+    )
+
+    assert result == expected

--- a/tests/python/sgl_kernel_npu/test_kda_cp_affine.py
+++ b/tests/python/sgl_kernel_npu/test_kda_cp_affine.py
@@ -13,10 +13,9 @@ requires_npu = pytest.mark.skipif(
 
 
 @requires_npu
-@pytest.mark.parametrize("key_dim", [64, 128, 192, 256])
-def test_kda_cp_affine_preprocess_identity(key_dim):
+def test_kda_cp_affine_preprocess_identity():
     device = torch.device("npu")
-    batch, tokens, heads, value_dim = 1, 128, 2, 128
+    batch, tokens, heads, key_dim, value_dim = 1, 128, 2, 128, 128
     k = torch.zeros(
         (batch, tokens, heads, key_dim), dtype=torch.bfloat16, device=device
     )


### PR DESCRIPTION
## Summary

- add the KDA head-major recomputation used by the validated NPU prefill path
- add compact affine `H`/`M` construction and fused ordered-merge kernels
- preserve the existing three-value `recompute_w_u_fwd_npu` public API while using the new head-major implementation internally
- add affine identity, merge-plan, and public-API contract coverage

The compact representation communicates recurrent-state transforms rather than full token activations.

## SGLang integration

- https://github.com/sgl-project/sglang/pull/36819

## Validation

- Ruff and Python compilation passed
- public API contract test passed against the installed kernel library
- NPU kernel tests remain in `tests/python/sgl_kernel_npu/test_kda_cp_affine.py`; the clean worktree does not contain a rebuilt `.so`

The PR is intentionally left as Draft pending NPU CI.