### PR TITLE
[DeepEP] [fix] Null-check attr pointers before dereferencing them in tiling

### DIFF
--- a/csrc/deepep/ops/op_host/moe_distribute_combine_v2_ccu_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_combine_v2_ccu_tiling.cpp
@@ -129,8 +129,12 @@ inline ge::graphStatus CheckEpRankId(const gert::TilingContext *context)
 {
     auto attrs = context->GetAttrs();
     const char *nodeName = context->GetNodeName();
+    OP_TILING_CHECK(attrs == nullptr, OP_LOGE(nodeName, "The context attrs is null."), return ge::GRAPH_FAILED);
     auto epWorldSizePtr = attrs->GetAttrPointer<int64_t>(ATTRS_EP_WORLD_SIZE_INDEX);
     auto epRankIdPtr = attrs->GetAttrPointer<int64_t>(ATTRS_EP_RANK_ID_INDEX);
+    OP_TILING_CHECK(epWorldSizePtr == nullptr, OP_LOGE(nodeName, "The epWorldSizePtr is null."),
+                    return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(epRankIdPtr == nullptr, OP_LOGE(nodeName, "The epRankIdPtr is null."), return ge::GRAPH_FAILED);
     OP_TILING_CHECK((*epRankIdPtr < 0) || (*epRankIdPtr >= *epWorldSizePtr),
                     OP_LOGE(nodeName, "The valid range of epRankId is [0, %ld), but actually got epRankId=%ld.",
                             *epWorldSizePtr, *epRankIdPtr),
@@ -142,9 +146,13 @@ inline ge::graphStatus CheckTpRankId(const gert::TilingContext *context)
 {
     auto attrs = context->GetAttrs();
     const char *nodeName = context->GetNodeName();
+    OP_TILING_CHECK(attrs == nullptr, OP_LOGE(nodeName, "The context attrs is null."), return ge::GRAPH_FAILED);
     auto tpWorldSizePtr = attrs->GetAttrPointer<int64_t>(ATTRS_TP_WORLD_SIZE_INDEX);
     auto tpRankIdPtr = attrs->GetAttrPointer<int64_t>(ATTRS_TP_RANK_ID_INDEX);
     auto groupTpPtr = attrs->GetAttrPointer<char>(static_cast<int>(ATTRS_GROUP_TP_INDEX));
+    OP_TILING_CHECK(tpWorldSizePtr == nullptr, OP_LOGE(nodeName, "The tpWorldSizePtr is null."),
+                    return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(tpRankIdPtr == nullptr, OP_LOGE(nodeName, "The tpRankIdPtr is null."), return ge::GRAPH_FAILED);
     if (*tpWorldSizePtr > 1) {
         OP_TILING_CHECK((*tpRankIdPtr < 0) || (*tpRankIdPtr >= *tpWorldSizePtr),
                         OP_LOGE(nodeName, "The valid range of tpRankId is [0, %ld), but actually got tpRankId=%ld.",
@@ -171,10 +179,17 @@ inline ge::graphStatus CheckSharedExpertAttrs(const gert::TilingContext *context
 {
     auto attrs = context->GetAttrs();
     const char *nodeName = context->GetNodeName();
+    OP_TILING_CHECK(attrs == nullptr, OP_LOGE(nodeName, "The context attrs is null."), return ge::GRAPH_FAILED);
     auto sharedExpertRankNumPtr = attrs->GetAttrPointer<int64_t>(ATTRS_SHARED_EXPERT_RANK_NUM_INDEX);
     auto epWorldSizePtr = attrs->GetAttrPointer<int64_t>(ATTRS_EP_WORLD_SIZE_INDEX);
     auto sharedExpertNumPtr = attrs->GetAttrPointer<int64_t>(static_cast<int>(ATTRS_SHARED_EXPERT_NUM_INDEX));
 
+    OP_TILING_CHECK(sharedExpertRankNumPtr == nullptr, OP_LOGE(nodeName, "The sharedExpertRankNumPtr is null."),
+                    return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(epWorldSizePtr == nullptr, OP_LOGE(nodeName, "The epWorldSizePtr is null."),
+                    return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(sharedExpertNumPtr == nullptr, OP_LOGE(nodeName, "The sharedExpertNumPtr is null."),
+                    return ge::GRAPH_FAILED);
     OP_TILING_CHECK(
         (*sharedExpertRankNumPtr < 0) || (*sharedExpertRankNumPtr >= *epWorldSizePtr),
         OP_LOGE(nodeName,

--- a/csrc/deepep/ops/op_host/moe_distribute_combine_v2_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_combine_v2_tiling.cpp
@@ -410,7 +410,10 @@ static bool CheckOptionalInputTensorDim(const gert::TilingContext *context, cons
     const gert::StorageShape *sharedExpertX = context->GetOptionalInputShape(SHARED_EXPERT_X_INDEX);
     if (sharedExpertX != nullptr) {
         auto attrs = context->GetAttrs();
+        OP_TILING_CHECK(attrs == nullptr, OP_LOGE(nodeName, "attrs is null."), return false);
         auto sharedExpertRankNumPtr = attrs->GetAttrPointer<int64_t>(ATTR_SHARED_EXPERT_RANK_NUM_INDEX);
+        OP_TILING_CHECK(sharedExpertRankNumPtr == nullptr, OP_LOGE(nodeName, "sharedExpertRankNum is null."),
+                        return false);
         OP_TILING_CHECK(*sharedExpertRankNumPtr != 0,
                         OP_LOGE(nodeName,
                                 "sharedExpertX only support input None "

--- a/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_ccu_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_ccu_tiling.cpp
@@ -350,8 +350,14 @@ static ge::graphStatus GetContextAttrs(const gert::TilingContext *context, const
 inline uint32_t CheckQuantModeAndExpandXType(const gert::TilingContext *context, const char *nodeName)
 {
     auto attrs = context->GetAttrs();
+    OP_TILING_CHECK(attrs == nullptr, OP_LOGE(nodeName, "The attrs is nullptr."),
+                    return static_cast<uint32_t>(RealModeA5::INVALID_MODE));
     auto quantModePtr = attrs->GetAttrPointer<int64_t>(ATTR_QUANT_MODE_INDEX);
+    OP_TILING_CHECK(quantModePtr == nullptr, OP_LOGE(nodeName, "The quantModePtr is null."),
+                    return static_cast<uint32_t>(RealModeA5::INVALID_MODE));
     auto expandXDesc = context->GetOutputDesc(OUTPUT_EXPAND_X_INDEX);
+    OP_TILING_CHECK(expandXDesc == nullptr, OP_LOGE(nodeName, "Failed to get expandX datatype."),
+                    return static_cast<uint32_t>(RealModeA5::INVALID_MODE));
     QuantModeA5 quantMode = static_cast<QuantModeA5>(*quantModePtr);
     auto modeToFind = QUANT_MODE_MAP.find({quantMode, static_cast<ge::DataType>(expandXDesc->GetDataType())});
     OP_TILING_CHECK(modeToFind == QUANT_MODE_MAP.end(),

--- a/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
@@ -789,6 +789,10 @@ static ge::graphStatus GetAttrAndSetTilingData(const gert::TilingContext *contex
     auto sharedExpertRankNumPtr = attrs->GetAttrPointer<int64_t>(ATTR_SHARED_EXPERT_RANK_NUM_INDEX);
     auto moeExpertNumPtr = attrs->GetAttrPointer<int64_t>(ATTR_MOE_EXPERT_NUM_INDEX);
 
+    OP_TILING_CHECK(epWorldSizePtr == nullptr, OP_LOGE(nodeName, "epWorldSizePtr is null."), return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(sharedExpertRankNumPtr == nullptr, OP_LOGE(nodeName, "sharedExpertRankNumPtr is null."),
+                    return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(moeExpertNumPtr == nullptr, OP_LOGE(nodeName, "moeExpertNumPtr is null."), return ge::GRAPH_FAILED);
     int64_t moeExpertNum = *moeExpertNumPtr;
     int64_t epWorldSize = *epWorldSizePtr;
     int64_t sharedExpertRankNum = *sharedExpertRankNumPtr;
@@ -954,6 +958,12 @@ static ge::graphStatus CheckTensorShape(const gert::TilingContext *context, cons
     auto copyExpertNumPtr = attrs->GetAttrPointer<int64_t>(static_cast<int>(ATTR_COPY_EXPERT_NUM_INDEX));
     auto constExpertNumPtr = attrs->GetAttrPointer<int64_t>(static_cast<int>(ATTR_CONST_EXPERT_NUM_INDEX));
 
+    OP_TILING_CHECK(zeroExpertNumPtr == nullptr, OP_LOGE(nodeName, "zeroExpertNumPtr is null."),
+                    return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(copyExpertNumPtr == nullptr, OP_LOGE(nodeName, "copyExpertNumPtr is null."),
+                    return ge::GRAPH_FAILED);
+    OP_TILING_CHECK(constExpertNumPtr == nullptr, OP_LOGE(nodeName, "constExpertNumPtr is null."),
+                    return ge::GRAPH_FAILED);
     int64_t zeroExpertNum = *zeroExpertNumPtr;
     int64_t copyExpertNum = *copyExpertNumPtr;
     int64_t constExpertNum = *constExpertNumPtr;

--- a/csrc/deepep/ops2/op_host/moe_distribute_combine_v2_tiling.cc
+++ b/csrc/deepep/ops2/op_host/moe_distribute_combine_v2_tiling.cc
@@ -361,7 +361,10 @@ static bool CheckOptionalInputTensorDim(const gert::TilingContext *context, cons
     const gert::StorageShape *sharedExpertX = context->GetOptionalInputShape(SHARED_EXPERT_X_INDEX);
     if (sharedExpertX != nullptr) {
         auto attrs = context->GetAttrs();
+        OP_TILING_CHECK(attrs == nullptr, OP_LOGE(nodeName, "attrs is null."), return false);
         auto sharedExpertRankNumPtr = attrs->GetAttrPointer<int64_t>(ATTR_SHARED_EXPERT_RANK_NUM_INDEX);
+        OP_TILING_CHECK(sharedExpertRankNumPtr == nullptr, OP_LOGE(nodeName, "sharedExpertRankNum is null."),
+                        return false);
         OP_TILING_CHECK(*sharedExpertRankNumPtr != 0,
                         OP_LOGE(nodeName,
                                 "sharedExpertX only support input None "


### PR DESCRIPTION
Addresses #433.

## What

`OP_TILING_CHECK(xPtr == nullptr, ...)` guards in the MoE distribute tiling code sit **after** the pointer has already been dereferenced, so as written they cannot stop the dereference they guard. Others are missing entirely. #723 fixed three of the functions the issue lists (`CheckAndSetGroupInfo`, `CheckAndSetExpertInfo`, `CheckAndSetSpecialExpertInfo` in `moe_distribute_dispatch_v2_tiling.cpp`); this PR covers the rest.

I swept `csrc/` for every `GetAttrPointer<>` result whose first dereference is not preceded by a null check — 16 sites in 5 files.

## Scope, stated honestly: this is hardening, not a live crash fix

**On every current call path, each of these pointers is already validated upstream.** I traced all 16:

| Site | Already validated by | Why it holds |
|---|---|---|
| `dispatch_v2_tiling.cpp` `GetAttrAndSetTilingData` — `epWorldSizePtr`, `sharedExpertRankNumPtr`, `moeExpertNumPtr` | `CheckAndSetExpertInfo`, called earlier in the same function (L780) | it validates all three unconditionally at its top (L645-665) and returns `GRAPH_FAILED` |
| `dispatch_v2_tiling.cpp` `CheckTensorShape` — `zeroExpertNumPtr`, `copyExpertNumPtr`, `constExpertNumPtr` | `CheckAndSetSpecialExpertInfo`, reached through `GetAttrAndSetTilingData` (L1341) | unconditional at L714-726; `CheckTensorShape` runs later at L1364 in the same entry function |
| `combine_v2_ccu_tiling.cpp` `CheckEpRankId` / `CheckTpRankId` / `CheckSharedExpertAttrs` — 7 pointers plus `attrs` | their only caller, `GetAttrAndSetTilingData` | it validates `attrs` and all eight pointers before the three calls |
| `dispatch_v2_ccu_tiling.cpp` `CheckQuantModeAndExpandXType` — `attrs`, `quantModePtr`, `expandXDesc` | `GetContextAttrs`, called immediately before | validates `attrs` and `quantModePtr`; `expandXDesc` is validated in `CheckOutputDataType`, which `GetContextAttrs` calls |
| `combine_v2_tiling.cpp` and its `ops2` counterpart, `CheckOptionalInputTensorDim` — `sharedExpertRankNumPtr`, `attrs` | `GetAttrAndSetTilingData` (L1141 / L890) | runs before `TilingCheckMoeDistributeCombine` (L1180 / L900), which is what reaches this function |

Each helper is `static`/`inline` in one translation unit with a single call site, and `attrs->GetAttrPointer<T>(INDEX)` is deterministic for a given `attrs` and index — so none of the new guards can fire today.

What the PR therefore buys:

- The static-analysis report behind #433 goes quiet without a reviewer having to re-derive the inter-procedural argument each time.
- Each function becomes independently safe instead of depending on its caller's ordering, so a future reorder or a second caller cannot silently turn these into real dereferences.
- It matches what the file already does: `CheckAndSetExpertInfo` re-validates `epWorldSizePtr` even though `CheckAndSetGroupInfo` validated it moments earlier.

What it costs: ~37 lines whose failure branch is currently unreachable. **If you'd rather close #433 as a false positive of the checker than carry the extra guards, that's a reasonable call and I'm happy to close this.**

Guard style, log wording and the failure return value (`ge::GRAPH_FAILED` / `false` / `RealModeA5::INVALID_MODE`) follow whatever each file already uses.

## Test

Built and ran the DeepEP intranode suite on real hardware, on both platforms this PR touches — `ops/` (A3) and `ops2/` (A2). Both from this branch, CANN 9.1.0.

**Atlas A3, 16 ranks (`Ascend910_9382`)** — `bash build.sh -a deepep` → build OK, wheel `deep_ep-1.0.0+cann.9.1.0.b243`. Then, mirroring `pr-test-deepep-npu.yml`:

| `tests/python/deepep/test_intranode.py` | config | result |
|---|---|---|
| default | `num_tokens=4096, hidden=7168, num_topk=8` | exit 0 |
| `--num-tokens=4` | `num_tokens=4, hidden=7168, num_topk=8` | exit 0 |
| `--num-processes=2` | `num_tokens=4096, hidden=7168, num_topk=8` | exit 0 |
| `--num-processes=2 --num-topk=1 --num-experts=2` | `num_tokens=4096, hidden=7168, num_topk=1` | exit 0 |

**Atlas A2, 8 ranks (`910B2`)** — `bash build.sh -a deepep2` → build OK. Configs mirroring the `test-build-deepep-a2` job:

| `tests/python/deepep/test_intranode.py` | config | result |
|---|---|---|
| `--num-processes=8` | `num_tokens=4096, hidden=7168, num_topk=8` | exit 0 |
| `--num-tokens=1 --num-processes=8` | `num_tokens=1, hidden=7168, num_topk=8` | exit 0 |
| `--num-processes=2` | `num_tokens=4096, hidden=7168, num_topk=8` | exit 0 |
| `--num-tokens=8000 --num-processes=8` | `num_tokens=8000, hidden=7168, num_topk=8` | exit 0 |

Every rank reported `PASSED` on both platforms, dispatch/combine accuracy unchanged (`max_diff` ~3.9e-03 quantised, exactly `0.00000000` for BF16). Given the analysis above that is the only possible outcome — the run is identical to `main` — so treat it as a no-regression check, not as evidence the guards do anything.

`clang-format` 18.1.8 with `csrc/.clang-format` reports all five files unchanged.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests). — N/A: no reachable behaviour change; covered by the existing DeepEP intranode suite.
