### PR TITLE
Fix fused recurrent state pool indexing

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/fused_sigmoid_gating_recurrent.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/fused_sigmoid_gating_recurrent.py
@@ -2,7 +2,6 @@
 from typing import Optional
 
 import torch
-import torch.nn.functional as F
 import triton
 import triton.language as tl
 from sgl_kernel_npu.fla.utils import input_guard
@@ -107,9 +106,9 @@ def fused_sigmoid_gating_delta_rule_update_npu_kernel(
                         h0_source
                         + idx * HV * K * V
                         + i_hv * K * V
-                        + o_k[:, None] * V
-                        + o_v[None, :]
-                    )  # 128 * 64 * int32
+                        + o_v[None, :] * K
+                        + o_k[:, None]
+                    )  # State pool layout: [slot, HV, V, K]
                     b_h = tl.load(p_h0, mask=mask_h).to(tl.float32)
 
             # Compute g = -exp(A_log) * softplus(a + dt_bias)
@@ -158,9 +157,9 @@ def fused_sigmoid_gating_delta_rule_update_npu_kernel(
                         h0_source
                         + idx * HV * K * V
                         + i_hv * K * V
-                        + o_k[:, None] * V
-                        + o_v[None, :]
-                    )  # 128 * 64 * int32
+                        + o_v[None, :] * K
+                        + o_k[:, None]
+                    )  # State pool layout: [slot, HV, V, K]
                     tl.store(p_h0, b_h.to(p_h0.dtype.element_ty), mask=mask_h)
 
             tl.store(p_o + i * HV * V, b_o.to(p_o.dtype.element_ty), mask=mask_v)

--- a/tests/python/sgl_kernel_npu/test_fused_sigmoid_gating_recurrent.py
+++ b/tests/python/sgl_kernel_npu/test_fused_sigmoid_gating_recurrent.py
@@ -1,0 +1,134 @@
+import pytest
+import torch
+import torch.nn.functional as F
+import torch_npu  # noqa: F401  registers the torch.npu backend
+from sgl_kernel_npu.fla.fused_sigmoid_gating_recurrent import (
+    fused_sigmoid_gating_delta_rule_update_npu,
+)
+
+
+def _has_npu() -> bool:
+    return hasattr(torch, "npu") and torch.npu.is_available()
+
+
+pytestmark = pytest.mark.skipif(not _has_npu(), reason="NPU is required")
+
+
+def _reference(
+    A_log,
+    a,
+    dt_bias,
+    softplus_beta,
+    q,
+    k,
+    v,
+    b,
+    state,
+    state_indices,
+    scale,
+):
+    batch_size, num_tokens, num_query_heads, key_dim = k.shape
+    num_value_heads, value_dim = v.shape[2:]
+    output = torch.empty_like(v, dtype=torch.float32)
+    updated_state = state.float().clone()
+
+    for batch in range(batch_size):
+        slot = int(state_indices[batch])
+        for token in range(num_tokens):
+            for value_head in range(num_value_heads):
+                query_head = value_head // (num_value_heads // num_query_heads)
+                hidden = (
+                    torch.zeros(key_dim, value_dim, dtype=torch.float32)
+                    if slot < 0
+                    else updated_state[slot, value_head].transpose(0, 1).clone()
+                )
+                decay = -torch.exp(A_log[value_head]) * F.softplus(
+                    a[batch, token, value_head] + dt_bias[value_head],
+                    beta=softplus_beta,
+                )
+                hidden *= torch.exp(decay)
+                value = v[batch, token, value_head].float().clone()
+                value -= torch.sum(
+                    hidden * k[batch, token, query_head].float()[:, None], dim=0
+                )
+                value *= torch.sigmoid(b[batch, token, value_head].float())
+                hidden += k[batch, token, query_head].float()[:, None] * value[None, :]
+                output[batch, token, value_head] = torch.sum(
+                    hidden * (q[batch, token, query_head].float() * scale)[:, None],
+                    dim=0,
+                )
+                if slot >= 0:
+                    updated_state[slot, value_head] = hidden.transpose(0, 1)
+
+    return output, updated_state
+
+
+@pytest.mark.parametrize(
+    ("initial_state_kind", "state_index"),
+    [
+        pytest.param("zero", 1, id="zero-state"),
+        pytest.param("random", 1, id="random-state"),
+        pytest.param("random", -1, id="padding-slot"),
+    ],
+)
+@torch.no_grad()
+def test_state_pool_uses_v_major_k_minor_layout(initial_state_kind, state_index):
+    torch.manual_seed(640)
+    batch_size, num_tokens = 1, 2
+    num_query_heads, num_value_heads = 1, 2
+    key_dim, value_dim = 16, 8
+    scale = 1.0
+
+    A_log = torch.zeros(num_value_heads, dtype=torch.float32)
+    a = torch.full((batch_size, num_tokens, num_value_heads), -30.0)
+    dt_bias = torch.zeros(num_value_heads)
+    q = torch.randn(batch_size, num_tokens, num_query_heads, key_dim) * 0.1
+    k = torch.randn(batch_size, num_tokens, num_query_heads, key_dim) * 0.1
+    v = torch.randn(batch_size, num_tokens, num_value_heads, value_dim) * 0.1
+    b = torch.zeros(batch_size, num_tokens, num_value_heads)
+    state = (
+        torch.zeros(3, num_value_heads, value_dim, key_dim)
+        if initial_state_kind == "zero"
+        else torch.randn(3, num_value_heads, value_dim, key_dim) * 0.1
+    )
+    state_before = state.clone()
+    state_indices = torch.tensor([state_index], dtype=torch.int32)
+
+    expected_output, expected_state = _reference(
+        A_log,
+        a,
+        dt_bias,
+        1.0,
+        q,
+        k,
+        v,
+        b,
+        state,
+        state_indices,
+        scale,
+    )
+    state_npu = state.npu()
+    actual_output = fused_sigmoid_gating_delta_rule_update_npu(
+        A_log.npu(),
+        a.npu(),
+        dt_bias.npu(),
+        1.0,
+        20.0,
+        q.npu(),
+        k.npu(),
+        v.npu(),
+        b.npu(),
+        state_npu,
+        state_indices.npu(),
+        scale=scale,
+    )
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(
+        actual_output.cpu().float(), expected_output, rtol=0, atol=1e-3
+    )
+    torch.testing.assert_close(
+        state_npu.cpu().float(), expected_state, rtol=0, atol=1e-3
+    )
+    if state_index < 0:
+        torch.testing.assert_close(state_npu.cpu(), state_before, rtol=0, atol=0)


### PR DESCRIPTION
## Summary

The fused recurrent kernel receives its state pool in `[slot, HV, V, K]`
layout, but both the load and store pointers used a K-major offset. This change
uses `v * K + k` for both paths and adds an NPU regression test for zero state,
random state, and a padding slot (`state_index = -1`).

Fixes #640.

## Testing

- Ascend A3, unfixed baseline with the final test inputs:
  - zero state: state max abs error `2.82857325e-2`
  - random state: output/state max abs error `1.87530607e-1` / `3.4461692e-2`
  - padding slot: passed and left the pool unchanged
- Ascend A3, fixed code:
  - zero state and padding output max abs error `9.31322575e-10`
  - random state output/state max abs error `7.4505806e-9` / `1.49011612e-8`
  - repository pytest: `3 passed in 5.14s`
- Repository pre-commit hooks passed for both changed files.
