### PR TITLE
[NPU] Add optimized Kimi-K3 DSpark operators

### DIFF
--- a/python/sgl_kernel_npu/sgl_kernel_npu/activation/situ.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/activation/situ.py
@@ -265,15 +265,6 @@ def situ_and_mul_quant(
         raise NotImplementedError(
             "SituAndMul quantization is only implemented for d<=6144 (int8). "
         )
-        # _situ_and_mul_kernel[(num_vectorcore,)](
-        #     x_2d, group_list_arg, out,
-        #     TOTAL_COLS=h, HALF_COLS=half_cols,
-        #     NUM_EXPERTS=num_experts_arg, NUM_EXPERTS_ALGIN=num_experts_algin_arg,
-        #     GROUP_LIST_TYPE=gl_type_arg, N_ROWS=s, NUM_CORES=num_vectorcore,
-        #     HAS_GROUP_LIST=has_group_list, BETA=beta, INV_BETA=1.0 / beta,
-        #     DO_LINEAR_BETA=do_linear_beta, LINEAR_BETA=linear_beta_v,
-        #     INV_LINEAR_BETA=(1.0 / linear_beta_v) if do_linear_beta else 1.0,
-        # )
     return out.reshape(*x.shape[:-1], half_cols), scale
 
 

--- a/python/sgl_kernel_npu/sgl_kernel_npu/activation/situ.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/activation/situ.py
@@ -153,12 +153,10 @@ def _situ_and_mul_kernel(
         mask = h_idx < HALF_COLS
         # int64 row offsets prevent overflow for large routed-MoE buffers.
         row_off = row_idx.to(tl.int64) * TOTAL_COLS
-        gate = tl.load(x_ptr + row_off + h_idx, mask=mask, other=0.0).to(
+        gate = tl.load(x_ptr + row_off + h_idx, mask=mask, other=0.0).to(tl.float32)
+        up = tl.load(x_ptr + row_off + HALF_COLS + h_idx, mask=mask, other=0.0).to(
             tl.float32
         )
-        up = tl.load(
-            x_ptr + row_off + HALF_COLS + h_idx, mask=mask, other=0.0
-        ).to(tl.float32)
         situ_a = BETA * libdevice.tanh(gate * INV_BETA) * tl.sigmoid(gate)
         if DO_LINEAR_BETA:
             up = LINEAR_BETA * libdevice.tanh(up * INV_LINEAR_BETA)

--- a/python/sgl_kernel_npu/sgl_kernel_npu/activation/situ.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/activation/situ.py
@@ -64,6 +64,10 @@ def _situ_and_mul_quant_kernel(
         out = situ_a * up
 
         if SCALE:
+            # Preserve the unfused value pipeline: SituAndMul first
+            # materializes BF16, then npu_dynamic_quant computes its row scale.
+            # Avoid quantizing the higher-precision activation temporary.
+            out = out.to(x_ptr.dtype.element_ty).to(tl.float32)
             scale = tl.maximum(tl.max(tl.abs(out)) / DTYPE_MAX, 1e-30)
             tl.store(
                 scale_ptr + row_idx.to(tl.int64), scale.to(scale_ptr.dtype.element_ty)
@@ -74,7 +78,7 @@ def _situ_and_mul_quant_kernel(
                     out, offsets=(cb,), sizes=(COL_BLOCK_SIZE,), strides=(1,)
                 )
                 tmp = tmp.to(tl.float32) / scale
-                tmp = tl.floor(tmp + 0.5)
+                tmp = libdevice.rint(tmp)
                 tmp = tl.clamp(tmp, -128, 127).to(tl.int8)
                 c_idx = cb + tl.arange(0, COL_BLOCK_SIZE)
                 mask = c_idx < HALF_COLS
@@ -245,7 +249,7 @@ def situ_and_mul_quant(
             scale,
             TOTAL_COLS=h,
             HALF_COLS=half_cols,
-            COL_BLOCK_SIZE=half_cols,
+            COL_BLOCK_SIZE=min(half_cols, 1536),
             NUM_EXPERTS=num_experts_arg,
             NUM_EXPERTS_ALGIN=num_experts_algin_arg,
             GROUP_LIST_TYPE=gl_type_arg,

--- a/python/sgl_kernel_npu/sgl_kernel_npu/activation/situ.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/activation/situ.py
@@ -138,64 +138,36 @@ def _situ_and_mul_kernel(
     pid = tl.program_id(0)
     h_offs = tl.arange(0, BLOCK_H)
 
-    if not HAS_GROUP_LIST:
-        # Dense/shared SiTU has no cross-column dependency. Schedule whole
-        # hidden tiles across AIVs, but derive row/tile once per program tile.
-        # A flattened element schedule makes every lane pay div/mod and was
-        # slower than the row-persistent kernel at K3 verify shapes.
-        tiles_per_row: tl.constexpr = tl.cdiv(HALF_COLS, BLOCK_H)
-        total_tiles = N_ROWS * tiles_per_row
-        for tile_idx in range(pid, total_tiles, NUM_CORES):
-            row_idx = tile_idx // tiles_per_row
-            h_start = (tile_idx - row_idx * tiles_per_row) * BLOCK_H
-            h_idx = h_start + h_offs
-            mask = h_idx < HALF_COLS
-            row_off = row_idx.to(tl.int64) * TOTAL_COLS
-            gate = tl.load(x_ptr + row_off + h_idx, mask=mask, other=0.0).to(
-                tl.float32
-            )
-            up = tl.load(
-                x_ptr + row_off + HALF_COLS + h_idx, mask=mask, other=0.0
-            ).to(tl.float32)
-            situ_a = BETA * libdevice.tanh(gate * INV_BETA) * tl.sigmoid(gate)
-            if DO_LINEAR_BETA:
-                up = LINEAR_BETA * libdevice.tanh(up * INV_LINEAR_BETA)
-            out = situ_a * up
-            tl.store(
-                out_ptr + row_idx.to(tl.int64) * HALF_COLS + h_idx,
-                out.to(out_ptr.dtype.element_ty),
-                mask=mask,
-            )
-        return
-
-    # Grouped rows keep the row-persistent schedule because total_rows is
-    # device-resident in group_list and cannot size the launch grid on host.
-    block_size = (total_rows - 1) // NUM_CORES + 1
-    row_begin = pid * block_size
-    if row_begin >= total_rows:
-        return
-    row_end = tl.minimum((pid + 1) * block_size, total_rows)
-
-    # H-tile over the OUTPUT dim (HALF_COLS): out[i] only needs gate[i]=x[i] and
-    # up[i]=x[d+i], so every [h:h+BLOCK_H] tile is self-contained -- no full-row resident,
-    # which is what keeps large d (e.g. 33792) within UB. gate = first half, up = second half.
-    for row_idx in range(row_begin, row_end):
-        # int64 row offset: row_idx * stride stays int32 by default on triton-ascend
-        # (no auto-promote), which overflows when N*d is large (e.g. N=32768, d=33792).
+    # SiTU has no cross-column dependency.  Schedule whole hidden tiles across
+    # all AIVs for both dense and routed inputs.  In the routed path total_rows
+    # is device-resident, but it can still bound the persistent program loop;
+    # the fixed launch grid does not need a host synchronization.  Deriving the
+    # row and hidden tile once per program tile also avoids the per-lane div/mod
+    # cost of a flattened element schedule.
+    tiles_per_row: tl.constexpr = tl.cdiv(HALF_COLS, BLOCK_H)
+    total_tiles = total_rows * tiles_per_row
+    for tile_idx in range(pid, total_tiles, NUM_CORES):
+        row_idx = tile_idx // tiles_per_row
+        h_start = (tile_idx - row_idx * tiles_per_row) * BLOCK_H
+        h_idx = h_start + h_offs
+        mask = h_idx < HALF_COLS
+        # int64 row offsets prevent overflow for large routed-MoE buffers.
         row_off = row_idx.to(tl.int64) * TOTAL_COLS
-        gate_base = x_ptr + row_off
-        up_base = x_ptr + row_off + HALF_COLS
-        out_base = out_ptr + row_idx.to(tl.int64) * HALF_COLS
-        for h_start in range(0, HALF_COLS, BLOCK_H):
-            h_idx = h_start + h_offs
-            mask = h_idx < HALF_COLS
-            gate = tl.load(gate_base + h_idx, mask=mask, other=0.0).to(tl.float32)
-            up = tl.load(up_base + h_idx, mask=mask, other=0.0).to(tl.float32)
-            situ_a = BETA * libdevice.tanh(gate * INV_BETA) * tl.sigmoid(gate)
-            if DO_LINEAR_BETA:
-                up = LINEAR_BETA * libdevice.tanh(up * INV_LINEAR_BETA)
-            out = situ_a * up
-            tl.store(out_base + h_idx, out.to(out_ptr.dtype.element_ty), mask=mask)
+        gate = tl.load(x_ptr + row_off + h_idx, mask=mask, other=0.0).to(
+            tl.float32
+        )
+        up = tl.load(
+            x_ptr + row_off + HALF_COLS + h_idx, mask=mask, other=0.0
+        ).to(tl.float32)
+        situ_a = BETA * libdevice.tanh(gate * INV_BETA) * tl.sigmoid(gate)
+        if DO_LINEAR_BETA:
+            up = LINEAR_BETA * libdevice.tanh(up * INV_LINEAR_BETA)
+        out = situ_a * up
+        tl.store(
+            out_ptr + row_idx.to(tl.int64) * HALF_COLS + h_idx,
+            out.to(out_ptr.dtype.element_ty),
+            mask=mask,
+        )
 
 
 def situ_and_mul_quant(

--- a/python/sgl_kernel_npu/sgl_kernel_npu/activation/situ.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/activation/situ.py
@@ -135,9 +135,42 @@ def _situ_and_mul_kernel(
     else:
         total_rows = N_ROWS
 
-    # rows distributed across vector cores (manual split + early return for over-provision).
-    block_size = (total_rows - 1) // NUM_CORES + 1
     pid = tl.program_id(0)
+    h_offs = tl.arange(0, BLOCK_H)
+
+    if not HAS_GROUP_LIST:
+        # Dense/shared SiTU has no cross-column dependency. Schedule whole
+        # hidden tiles across AIVs, but derive row/tile once per program tile.
+        # A flattened element schedule makes every lane pay div/mod and was
+        # slower than the row-persistent kernel at K3 verify shapes.
+        tiles_per_row: tl.constexpr = tl.cdiv(HALF_COLS, BLOCK_H)
+        total_tiles = N_ROWS * tiles_per_row
+        for tile_idx in range(pid, total_tiles, NUM_CORES):
+            row_idx = tile_idx // tiles_per_row
+            h_start = (tile_idx - row_idx * tiles_per_row) * BLOCK_H
+            h_idx = h_start + h_offs
+            mask = h_idx < HALF_COLS
+            row_off = row_idx.to(tl.int64) * TOTAL_COLS
+            gate = tl.load(x_ptr + row_off + h_idx, mask=mask, other=0.0).to(
+                tl.float32
+            )
+            up = tl.load(
+                x_ptr + row_off + HALF_COLS + h_idx, mask=mask, other=0.0
+            ).to(tl.float32)
+            situ_a = BETA * libdevice.tanh(gate * INV_BETA) * tl.sigmoid(gate)
+            if DO_LINEAR_BETA:
+                up = LINEAR_BETA * libdevice.tanh(up * INV_LINEAR_BETA)
+            out = situ_a * up
+            tl.store(
+                out_ptr + row_idx.to(tl.int64) * HALF_COLS + h_idx,
+                out.to(out_ptr.dtype.element_ty),
+                mask=mask,
+            )
+        return
+
+    # Grouped rows keep the row-persistent schedule because total_rows is
+    # device-resident in group_list and cannot size the launch grid on host.
+    block_size = (total_rows - 1) // NUM_CORES + 1
     row_begin = pid * block_size
     if row_begin >= total_rows:
         return
@@ -146,7 +179,6 @@ def _situ_and_mul_kernel(
     # H-tile over the OUTPUT dim (HALF_COLS): out[i] only needs gate[i]=x[i] and
     # up[i]=x[d+i], so every [h:h+BLOCK_H] tile is self-contained -- no full-row resident,
     # which is what keeps large d (e.g. 33792) within UB. gate = first half, up = second half.
-    h_offs = tl.arange(0, BLOCK_H)
     for row_idx in range(row_begin, row_end):
         # int64 row offset: row_idx * stride stays int32 by default on triton-ascend
         # (no auto-promote), which overflows when N*d is large (e.g. N=32768, d=33792).

--- a/python/sgl_kernel_npu/sgl_kernel_npu/dspark/__init__.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/dspark/__init__.py
@@ -1,0 +1,3 @@
+from .top1 import select_global_top1_npu
+
+__all__ = ["select_global_top1_npu"]

--- a/python/sgl_kernel_npu/sgl_kernel_npu/dspark/__init__.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/dspark/__init__.py
@@ -1,3 +1,3 @@
-from .top1 import select_global_top1_npu
+from .top1 import select_global_top1_npu, select_local_top1_after_add_npu
 
-__all__ = ["select_global_top1_npu"]
+__all__ = ["select_global_top1_npu", "select_local_top1_after_add_npu"]

--- a/python/sgl_kernel_npu/sgl_kernel_npu/dspark/top1.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/dspark/top1.py
@@ -1,0 +1,48 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _select_global_top1_kernel(
+    candidates_ptr,
+    output_ptr,
+    TP_SIZE: tl.constexpr,
+    VOCAB_SIZE: tl.constexpr,
+    BLOCK_TP: tl.constexpr,
+):
+    row = tl.program_id(0)
+    rank_offsets = tl.arange(0, BLOCK_TP)
+    rank_mask = rank_offsets < TP_SIZE
+    row_base = row * TP_SIZE * 2
+    values = tl.load(
+        candidates_ptr + row_base + rank_offsets * 2,
+        mask=rank_mask,
+        other=float("-inf"),
+    )
+    token_ids = tl.load(
+        candidates_ptr + row_base + rank_offsets * 2 + 1,
+        mask=rank_mask,
+        other=VOCAB_SIZE,
+    ).to(tl.int32)
+    best_value = tl.max(values, axis=0)
+    best_token = tl.min(
+        tl.where(values == best_value, token_ids, VOCAB_SIZE), axis=0
+    )
+    tl.store(output_ptr + row, best_token.to(tl.int64))
+
+
+def select_global_top1_npu(
+    candidates: torch.Tensor, *, vocab_size: int
+) -> torch.Tensor:
+    batch_size, tp_size, pair_size = candidates.shape
+    assert pair_size == 2 and candidates.is_contiguous()
+    output = torch.empty(batch_size, dtype=torch.long, device=candidates.device)
+    _select_global_top1_kernel[(batch_size,)](
+        candidates,
+        output,
+        TP_SIZE=tp_size,
+        VOCAB_SIZE=vocab_size,
+        BLOCK_TP=triton.next_power_of_2(tp_size),
+    )
+    return output

--- a/python/sgl_kernel_npu/sgl_kernel_npu/dspark/top1.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/dspark/top1.py
@@ -35,9 +35,11 @@ def _select_local_top1_after_add_kernel(
             ).to(tl.float32)
             # F.linear and the base logits are BF16 on K3. Match eager's BF16
             # add rounding before comparing values, then reduce in FP32.
-            logits = (base + bias).to(
-                base_ptr.dtype.element_ty, fp_downcast_rounding="rtne"
-            ).to(tl.float32)
+            logits = (
+                (base + bias)
+                .to(base_ptr.dtype.element_ty, fp_downcast_rounding="rtne")
+                .to(tl.float32)
+            )
             chunk_value = tl.max(logits, axis=0)
             chunk_index = tl.argmax(logits, axis=0).to(tl.int64) + start
             # Strict comparison preserves the first (smallest) index on ties.
@@ -70,9 +72,7 @@ def _select_global_top1_kernel(
         other=VOCAB_SIZE,
     ).to(tl.int32)
     best_value = tl.max(values, axis=0)
-    best_token = tl.min(
-        tl.where(values == best_value, token_ids, VOCAB_SIZE), axis=0
-    )
+    best_token = tl.min(tl.where(values == best_value, token_ids, VOCAB_SIZE), axis=0)
     tl.store(output_ptr + row, best_token.to(tl.int64))
 
 

--- a/python/sgl_kernel_npu/sgl_kernel_npu/dspark/top1.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/dspark/top1.py
@@ -4,6 +4,50 @@ import triton.language as tl
 
 
 @triton.jit
+def _select_local_top1_after_add_kernel(
+    base_ptr,
+    bias_ptr,
+    output_ptr,
+    B,
+    V: tl.constexpr,
+    vocab_offset: tl.constexpr,
+    base_stride,
+    bias_stride,
+    BLOCK_V: tl.constexpr,
+):
+    row_pid = tl.program_id(0)
+    n_prog = tl.num_programs(0)
+    for row in tl.range(row_pid, B, n_prog):
+        best_value = tl.full((), float("-inf"), tl.float32)
+        best_index = tl.zeros((), tl.int64)
+        for start in range(0, V, BLOCK_V):
+            offsets = start + tl.arange(0, BLOCK_V)
+            mask = offsets < V
+            base = tl.load(
+                base_ptr + row * base_stride + offsets,
+                mask=mask,
+                other=float("-inf"),
+            ).to(tl.float32)
+            bias = tl.load(
+                bias_ptr + row * bias_stride + offsets,
+                mask=mask,
+                other=0.0,
+            ).to(tl.float32)
+            # F.linear and the base logits are BF16 on K3. Match eager's BF16
+            # add rounding before comparing values, then reduce in FP32.
+            logits = (base + bias).to(
+                base_ptr.dtype.element_ty, fp_downcast_rounding="rtne"
+            ).to(tl.float32)
+            chunk_value = tl.max(logits, axis=0)
+            chunk_index = tl.argmax(logits, axis=0).to(tl.int64) + start
+            # Strict comparison preserves the first (smallest) index on ties.
+            best_index = tl.where(chunk_value > best_value, chunk_index, best_index)
+            best_value = tl.maximum(best_value, chunk_value)
+        tl.store(output_ptr + row * 2, best_value)
+        tl.store(output_ptr + row * 2 + 1, (best_index + vocab_offset).to(tl.float32))
+
+
+@triton.jit
 def _select_global_top1_kernel(
     candidates_ptr,
     output_ptr,
@@ -44,5 +88,45 @@ def select_global_top1_npu(
         TP_SIZE=tp_size,
         VOCAB_SIZE=vocab_size,
         BLOCK_TP=triton.next_power_of_2(tp_size),
+    )
+    return output
+
+
+def select_local_top1_after_add_npu(
+    base: torch.Tensor,
+    bias: torch.Tensor,
+    *,
+    vocab_offset: int,
+) -> torch.Tensor:
+    """Fuse BF16 logits add and local top-1 candidate construction.
+
+    Both inputs are ``[batch, local_vocab]`` with a contiguous last dimension;
+    row strides may differ. The returned FP32 pair is ``(value, global_id)``
+    and can be passed directly to the TP candidate all-gather.
+    """
+    if (
+        base.ndim != 2
+        or bias.ndim != 2
+        or base.shape != bias.shape
+        or base.dtype != bias.dtype
+        or base.stride(1) != 1
+        or bias.stride(1) != 1
+    ):
+        raise ValueError("base and bias must be matching row-contiguous matrices")
+    if base.dtype != torch.bfloat16:
+        raise ValueError("base and bias must use bfloat16")
+    batch_size, local_vocab_size = base.shape
+    output = torch.empty((batch_size, 2), dtype=torch.float32, device=base.device)
+    block_v = min(2048, triton.next_power_of_2(local_vocab_size))
+    _select_local_top1_after_add_kernel[(batch_size,)](
+        base,
+        bias,
+        output,
+        batch_size,
+        V=local_vocab_size,
+        vocab_offset=vocab_offset,
+        base_stride=base.stride(0),
+        bias_stride=bias.stride(0),
+        BLOCK_V=block_v,
     )
     return output

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_ragged.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_ragged.py
@@ -96,6 +96,60 @@ def _gather_kda_verify_output_kernel(
     )
 
 
+@triton.jit
+def _gather_kda_verify_output_norm_kernel(
+    dense_ptr,
+    dense_indices_ptr,
+    gate_ptr,
+    weight_ptr,
+    packed_ptr,
+    packed_tokens,
+    dense_tokens,
+    eps,
+    HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    rows = tl.program_id(0) * BLOCK_T + tl.arange(0, BLOCK_T)
+    packed_row = rows // HEADS
+    head = rows - packed_row * HEADS
+    offsets = tl.arange(0, BLOCK_D)
+    row_mask = rows < packed_tokens * HEADS
+    dense_row = tl.load(
+        dense_indices_ptr + packed_row, mask=row_mask, other=dense_tokens
+    ).to(tl.int64)
+    valid_row = row_mask & (dense_row < dense_tokens)
+    dim_mask = offsets < HEAD_DIM
+    mask = valid_row[:, None] & dim_mask[None, :]
+
+    dense_offsets = (
+        (dense_row[:, None] * HEADS + head[:, None]) * HEAD_DIM
+        + offsets[None, :]
+    )
+    value = tl.load(
+        dense_ptr + dense_offsets,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    gate = tl.load(
+        gate_ptr + rows[:, None] * HEAD_DIM + offsets[None, :],
+        mask=row_mask[:, None] & dim_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    weight = tl.load(weight_ptr + offsets, mask=dim_mask, other=0.0).to(
+        tl.float32
+    )
+    value = tl.where(mask, value, 0.0)
+    rstd = tl.rsqrt(tl.sum(value * value, axis=1) / HEAD_DIM + eps)
+    output = value * rstd[:, None] * weight[None, :] * tl.sigmoid(gate)
+    tl.store(
+        packed_ptr + rows[:, None] * HEAD_DIM + offsets[None, :],
+        output,
+        mask=row_mask[:, None] & dim_mask[None, :],
+    )
+
+
 def scatter_kda_verify_inputs_npu(
     mixed_qkv: torch.Tensor,
     a: torch.Tensor,
@@ -185,3 +239,58 @@ def gather_kda_verify_output_npu(
         BLOCK=block,
     )
     return packed_2d.view(1, packed_tokens, *dense_output.shape[2:])
+
+
+def gather_kda_verify_output_norm_npu(
+    dense_output: torch.Tensor,
+    dense_token_indices: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    eps: float,
+) -> torch.Tensor:
+    """Gather ragged KDA output and apply sigmoid-gated RMSNorm in one kernel."""
+    if dense_output.ndim != 4 or dense_output.shape[0] != 1:
+        raise ValueError("dense_output must have shape [1, dense_tokens, H, D]")
+    dense_tokens, heads, head_dim = dense_output.shape[1:]
+    if dense_output.stride(-1) != 1:
+        raise ValueError("dense_output must be contiguous in the head dimension")
+    packed_tokens = dense_token_indices.numel()
+    if (
+        gate.numel() != packed_tokens * heads * head_dim
+        or gate.stride(-1) != 1
+    ):
+        raise ValueError(
+            "gate must be a row-contiguous packed [tokens, H * D] tensor"
+        )
+    if weight.numel() != head_dim or not weight.is_contiguous():
+        raise ValueError(
+            "weight must be contiguous with one value per head dimension"
+        )
+    if eps <= 0:
+        raise ValueError("eps must be positive")
+
+    packed = torch.empty(
+        (1, packed_tokens, heads, head_dim),
+        dtype=dense_output.dtype,
+        device=dense_output.device,
+    )
+    block_t = 32
+    _gather_kda_verify_output_norm_kernel[
+        (triton.cdiv(packed_tokens * heads, block_t),)
+    ](
+        dense_output,
+        dense_token_indices,
+        gate,
+        weight,
+        packed,
+        packed_tokens,
+        dense_tokens,
+        eps,
+        HEADS=heads,
+        HEAD_DIM=head_dim,
+        BLOCK_T=block_t,
+        BLOCK_D=triton.next_power_of_2(head_dim),
+        num_warps=4,
+    )
+    return packed

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_ragged.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_ragged.py
@@ -1,0 +1,187 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _scatter_kda_verify_inputs_kernel(
+    qkv_ptr,
+    a_ptr,
+    b_ptr,
+    query_start_loc_ptr,
+    dense_qkv_ptr,
+    dense_a_ptr,
+    dense_b_ptr,
+    packed_tokens,
+    qkv_stride,
+    a_stride,
+    b_stride,
+    QKV_WIDTH: tl.constexpr,
+    A_WIDTH: tl.constexpr,
+    B_WIDTH: tl.constexpr,
+    STEPS: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    dense_row = tl.program_id(0)
+    block = tl.program_id(1)
+    sequence = dense_row // STEPS
+    step = dense_row - sequence * STEPS
+    sequence_start = tl.load(query_start_loc_ptr + sequence).to(tl.int64)
+    sequence_end = tl.load(query_start_loc_ptr + sequence + 1).to(tl.int64)
+    source_row = sequence_start + step
+    valid_row = (source_row < sequence_end) & (source_row < packed_tokens)
+    offsets = block * BLOCK + tl.arange(0, BLOCK)
+
+    qkv_mask = valid_row & (offsets < QKV_WIDTH)
+    qkv = tl.load(
+        qkv_ptr + source_row * qkv_stride + offsets,
+        mask=qkv_mask,
+        other=0.0,
+    )
+    tl.store(
+        dense_qkv_ptr + dense_row * QKV_WIDTH + offsets,
+        qkv,
+        mask=offsets < QKV_WIDTH,
+    )
+
+    a_mask = valid_row & (offsets < A_WIDTH)
+    a = tl.load(
+        a_ptr + source_row * a_stride + offsets,
+        mask=a_mask,
+        other=0.0,
+    )
+    tl.store(
+        dense_a_ptr + dense_row * A_WIDTH + offsets,
+        a,
+        mask=offsets < A_WIDTH,
+    )
+
+    b_mask = valid_row & (offsets < B_WIDTH)
+    b = tl.load(
+        b_ptr + source_row * b_stride + offsets,
+        mask=b_mask,
+        other=0.0,
+    )
+    tl.store(
+        dense_b_ptr + dense_row * B_WIDTH + offsets,
+        b,
+        mask=offsets < B_WIDTH,
+    )
+
+
+@triton.jit
+def _gather_kda_verify_output_kernel(
+    dense_ptr,
+    dense_indices_ptr,
+    packed_ptr,
+    packed_tokens,
+    dense_tokens,
+    WIDTH: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    packed_row = tl.program_id(0)
+    offsets = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+    dense_row = tl.load(dense_indices_ptr + packed_row).to(tl.int64)
+    valid_row = dense_row < dense_tokens
+    mask = valid_row & (offsets < WIDTH)
+    value = tl.load(
+        dense_ptr + dense_row * WIDTH + offsets,
+        mask=mask,
+        other=0.0,
+    )
+    tl.store(
+        packed_ptr + packed_row * WIDTH + offsets,
+        value,
+        mask=(packed_row < packed_tokens) & (offsets < WIDTH),
+    )
+
+
+def scatter_kda_verify_inputs_npu(
+    mixed_qkv: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    *,
+    draft_token_num: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Map packed ragged KDA inputs to one fixed-width dense layout."""
+    if mixed_qkv.ndim != 2 or mixed_qkv.stride(1) != 1:
+        raise ValueError("mixed_qkv must be a row-contiguous matrix")
+    if a.shape[0] != 1 or b.shape[0] != 1:
+        raise ValueError("a and b must have a leading singleton dimension")
+    packed_tokens = mixed_qkv.shape[0]
+    a_2d = a.squeeze(0).reshape(packed_tokens, -1)
+    b_2d = b.squeeze(0).reshape(packed_tokens, -1)
+    if a_2d.stride(1) != 1 or b_2d.stride(1) != 1:
+        raise ValueError("a and b must be row-contiguous")
+
+    batch_size = query_start_loc.shape[0] - 1
+    dense_tokens = batch_size * draft_token_num
+    dense_qkv = torch.empty(
+        (dense_tokens, mixed_qkv.shape[1]),
+        dtype=mixed_qkv.dtype,
+        device=mixed_qkv.device,
+    )
+    dense_a_2d = torch.empty(
+        (dense_tokens, a_2d.shape[1]), dtype=a.dtype, device=a.device
+    )
+    dense_b_2d = torch.empty(
+        (dense_tokens, b_2d.shape[1]), dtype=b.dtype, device=b.device
+    )
+    block = 1024
+    max_width = max(mixed_qkv.shape[1], a_2d.shape[1], b_2d.shape[1])
+    grid = (dense_tokens, triton.cdiv(max_width, block))
+    _scatter_kda_verify_inputs_kernel[grid](
+        mixed_qkv,
+        a_2d,
+        b_2d,
+        query_start_loc,
+        dense_qkv,
+        dense_a_2d,
+        dense_b_2d,
+        packed_tokens,
+        mixed_qkv.stride(0),
+        a_2d.stride(0),
+        b_2d.stride(0),
+        QKV_WIDTH=mixed_qkv.shape[1],
+        A_WIDTH=a_2d.shape[1],
+        B_WIDTH=b_2d.shape[1],
+        STEPS=draft_token_num,
+        BLOCK=block,
+    )
+    return (
+        dense_qkv,
+        dense_a_2d.view(1, dense_tokens, *a.shape[2:]),
+        dense_b_2d.view(1, dense_tokens, *b.shape[2:]),
+    )
+
+
+def gather_kda_verify_output_npu(
+    dense_output: torch.Tensor,
+    dense_token_indices: torch.Tensor,
+) -> torch.Tensor:
+    """Map dense recurrent output back to the packed ragged token order."""
+    if dense_output.shape[0] != 1:
+        raise ValueError("dense_output must have a leading singleton dimension")
+    dense_tokens = dense_output.shape[1]
+    dense_2d = dense_output.squeeze(0).reshape(dense_tokens, -1)
+    if dense_2d.stride(1) != 1:
+        raise ValueError("dense_output must be row-contiguous")
+    packed_tokens = dense_token_indices.numel()
+    packed_2d = torch.empty(
+        (packed_tokens, dense_2d.shape[1]),
+        dtype=dense_output.dtype,
+        device=dense_output.device,
+    )
+    block = 1024
+    grid = (packed_tokens, triton.cdiv(dense_2d.shape[1], block))
+    _gather_kda_verify_output_kernel[grid](
+        dense_2d,
+        dense_token_indices,
+        packed_2d,
+        packed_tokens,
+        dense_tokens,
+        WIDTH=dense_2d.shape[1],
+        BLOCK=block,
+    )
+    return packed_2d.view(1, packed_tokens, *dense_output.shape[2:])

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_ragged.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_ragged.py
@@ -123,10 +123,9 @@ def _gather_kda_verify_output_norm_kernel(
     dim_mask = offsets < HEAD_DIM
     mask = valid_row[:, None] & dim_mask[None, :]
 
-    dense_offsets = (
-        (dense_row[:, None] * HEADS + head[:, None]) * HEAD_DIM
-        + offsets[None, :]
-    )
+    dense_offsets = (dense_row[:, None] * HEADS + head[:, None]) * HEAD_DIM + offsets[
+        None, :
+    ]
     value = tl.load(
         dense_ptr + dense_offsets,
         mask=mask,
@@ -137,9 +136,7 @@ def _gather_kda_verify_output_norm_kernel(
         mask=row_mask[:, None] & dim_mask[None, :],
         other=0.0,
     ).to(tl.float32)
-    weight = tl.load(weight_ptr + offsets, mask=dim_mask, other=0.0).to(
-        tl.float32
-    )
+    weight = tl.load(weight_ptr + offsets, mask=dim_mask, other=0.0).to(tl.float32)
     value = tl.where(mask, value, 0.0)
     rstd = tl.rsqrt(tl.sum(value * value, axis=1) / HEAD_DIM + eps)
     output = value * rstd[:, None] * weight[None, :] * tl.sigmoid(gate)
@@ -256,17 +253,10 @@ def gather_kda_verify_output_norm_npu(
     if dense_output.stride(-1) != 1:
         raise ValueError("dense_output must be contiguous in the head dimension")
     packed_tokens = dense_token_indices.numel()
-    if (
-        gate.numel() != packed_tokens * heads * head_dim
-        or gate.stride(-1) != 1
-    ):
-        raise ValueError(
-            "gate must be a row-contiguous packed [tokens, H * D] tensor"
-        )
+    if gate.numel() != packed_tokens * heads * head_dim or gate.stride(-1) != 1:
+        raise ValueError("gate must be a row-contiguous packed [tokens, H * D] tensor")
     if weight.numel() != head_dim or not weight.is_contiguous():
-        raise ValueError(
-            "weight must be contiguous with one value per head dimension"
-        )
+        raise ValueError("weight must be contiguous with one value per head dimension")
     if eps <= 0:
         raise ValueError("eps must be positive")
 

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_target_verify.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_target_verify.py
@@ -20,7 +20,20 @@ def _kda_target_verify_kernel(
     snapshot_indices_ptr,
     out_ptr,
     scale,
-    lower_bound,
+    stride_q_token: tl.constexpr,
+    stride_q_head: tl.constexpr,
+    stride_q_dim: tl.constexpr,
+    stride_k_token: tl.constexpr,
+    stride_k_head: tl.constexpr,
+    stride_k_dim: tl.constexpr,
+    stride_v_token: tl.constexpr,
+    stride_v_head: tl.constexpr,
+    stride_v_dim: tl.constexpr,
+    stride_a_token: tl.constexpr,
+    stride_a_head: tl.constexpr,
+    stride_a_dim: tl.constexpr,
+    stride_b_token: tl.constexpr,
+    stride_b_head: tl.constexpr,
     initial_stride_0,
     initial_stride_1,
     initial_stride_2,
@@ -39,7 +52,6 @@ def _kda_target_verify_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     GATES_ARE_PREACTIVATED: tl.constexpr,
-    USE_LOWER_BOUND: tl.constexpr,
 ):
     pid_batch = tl.program_id(0)
     pid_hv = tl.program_id(1)
@@ -83,26 +95,40 @@ def _kda_target_verify_kernel(
     for step in tl.static_range(0, STEPS):
         token = pid_batch * STEPS + step
         q = tl.load(
-            q_ptr + (token * H_Q + q_head) * K + offset_k,
+            q_ptr
+            + token * stride_q_token
+            + q_head * stride_q_head
+            + offset_k * stride_q_dim,
             mask=mask_k,
             other=0.0,
         ).to(tl.float32)
         k = tl.load(
-            k_ptr + (token * H_K + k_head) * K + offset_k,
+            k_ptr
+            + token * stride_k_token
+            + k_head * stride_k_head
+            + offset_k * stride_k_dim,
             mask=mask_k,
             other=0.0,
         ).to(tl.float32)
         value = tl.load(
-            v_ptr + (token * H_V + pid_hv) * V + offset_v,
+            v_ptr
+            + token * stride_v_token
+            + pid_hv * stride_v_head
+            + offset_v * stride_v_dim,
             mask=mask_v,
             other=0.0,
         ).to(tl.float32)
         a = tl.load(
-            a_ptr + (token * H_K + k_head) * K + offset_k,
+            a_ptr
+            + token * stride_a_token
+            + k_head * stride_a_head
+            + offset_k * stride_a_dim,
             mask=mask_k,
             other=0.0,
         ).to(tl.float32)
-        beta_input = tl.load(b_ptr + token * H_V + pid_hv).to(tl.float32)
+        beta_input = tl.load(
+            b_ptr + token * stride_b_token + pid_hv * stride_b_head
+        ).to(tl.float32)
 
         q = q / (tl.sqrt(tl.sum(q * q, axis=0)) + 1e-6)
         k = k / (tl.sqrt(tl.sum(k * k, axis=0)) + 1e-6)
@@ -113,16 +139,12 @@ def _kda_target_verify_kernel(
             beta = beta_input
         else:
             gate_input = a + dt_bias
-            if USE_LOWER_BOUND:
-                log_gate = lower_bound * tl.sigmoid(tl.exp(A_log) * gate_input)
-            else:
-                softplus = tl.where(
-                    gate_input <= 20.0,
-                    tl.log(1.0 + tl.exp(gate_input)),
-                    gate_input,
-                )
-                log_gate = -tl.exp(A_log) * softplus
-            gate = tl.exp(log_gate)
+            softplus = tl.where(
+                gate_input <= 20.0,
+                tl.log(1.0 + tl.exp(gate_input)),
+                gate_input,
+            )
+            gate = tl.exp(-tl.exp(A_log) * softplus)
             beta = 1.0 / (1.0 + tl.exp(-beta_input))
 
         state *= gate[None, :]
@@ -166,7 +188,6 @@ def kda_target_verify_npu(
     cache_steps: int,
     scale: Optional[float] = None,
     gates_are_preactivated: Optional[bool] = None,
-    lower_bound: Optional[float] = None,
 ) -> torch.Tensor:
     """KDA fixed-width target verification with per-step state snapshots.
 
@@ -213,10 +234,8 @@ def kda_target_verify_npu(
         raise ValueError("a must have shape [tokens, H_k, K]")
     if tuple(b.shape) != (q.shape[1], h_v):
         raise ValueError("b must have shape [tokens, H_v]")
-    # K3 stores A_log as [1, 1, H_k, 1] and dt_bias as [H_k * K].
-    # The kernel reads both as flat buffers, so validate element counts.
     if not gates_are_preactivated and (
-        A_log.numel() != h_k or dt_bias.numel() != h_k * key_dim
+        A_log.numel() != h_k or tuple(dt_bias.shape) != (h_k, key_dim)
     ):
         raise ValueError("A_log and dt_bias shapes do not match KDA heads")
     if initial_state_source.ndim != 4 or tuple(initial_state_source.shape[1:]) != (
@@ -237,8 +256,9 @@ def kda_target_verify_npu(
     ):
         raise ValueError("intermediate_state_indices must contain at least B entries")
 
-    # SGLang produces q/k/v as views of a packed QKV tensor. Normalize the
-    # read-only inputs here because this kernel uses a dense linear layout.
+    # SGLang produces q/k/v as views of a packed QKV tensor. The kernel consumes
+    # explicit strides so serving can avoid five per-layer materializations.
+    # The override retains the old dense path for correctness/perf A/B tests.
     tensors = [
         A_log,
         dt_bias,
@@ -256,11 +276,6 @@ def kda_target_verify_npu(
         raise ValueError("all tensors must be on the same device")
     A_log = A_log.contiguous()
     dt_bias = dt_bias.contiguous()
-    q = q.contiguous()
-    k = k.contiguous()
-    v = v.contiguous()
-    a = a.contiguous()
-    b = b.contiguous()
     initial_state_indices = initial_state_indices.contiguous()
     intermediate_state_indices = intermediate_state_indices.contiguous()
     if initial_state_source.dtype != intermediate_states_buffer.dtype:
@@ -274,10 +289,8 @@ def kda_target_verify_npu(
         scale = key_dim**-0.5
     if scale <= 0:
         raise ValueError("scale must be positive")
-    if gates_are_preactivated and lower_bound is not None:
-        raise ValueError("lower_bound must already be reflected in preactivated gates")
 
-    out = torch.empty_like(v)
+    out = torch.empty((1, q.shape[1], h_v, value_dim), dtype=v.dtype, device=v.device)
     bk = triton.next_power_of_2(key_dim)
     if bk > 256:
         raise ValueError("key dimensions greater than 256 are unsupported")
@@ -297,7 +310,20 @@ def kda_target_verify_npu(
         intermediate_state_indices,
         out,
         scale,
-        lower_bound if lower_bound is not None else 0.0,
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        k.stride(1),
+        k.stride(2),
+        k.stride(3),
+        v.stride(1),
+        v.stride(2),
+        v.stride(3),
+        a.stride(0),
+        a.stride(1),
+        a.stride(2),
+        b.stride(0),
+        b.stride(1),
         initial_state_source.stride(0),
         initial_state_source.stride(1),
         initial_state_source.stride(2),
@@ -316,7 +342,6 @@ def kda_target_verify_npu(
         BK=bk,
         BV=bv,
         GATES_ARE_PREACTIVATED=gates_are_preactivated,
-        USE_LOWER_BOUND=lower_bound is not None,
         num_warps=1,
         num_stages=3,
         multibuffer=False,

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_target_verify.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_target_verify.py
@@ -20,6 +20,7 @@ def _kda_target_verify_kernel(
     snapshot_indices_ptr,
     out_ptr,
     scale,
+    lower_bound: tl.constexpr,
     stride_q_token: tl.constexpr,
     stride_q_head: tl.constexpr,
     stride_q_dim: tl.constexpr,
@@ -52,6 +53,7 @@ def _kda_target_verify_kernel(
     BK: tl.constexpr,
     BV: tl.constexpr,
     GATES_ARE_PREACTIVATED: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
 ):
     pid_batch = tl.program_id(0)
     pid_hv = tl.program_id(1)
@@ -139,12 +141,17 @@ def _kda_target_verify_kernel(
             beta = beta_input
         else:
             gate_input = a + dt_bias
-            softplus = tl.where(
-                gate_input <= 20.0,
-                tl.log(1.0 + tl.exp(gate_input)),
-                gate_input,
-            )
-            gate = tl.exp(-tl.exp(A_log) * softplus)
+            exp_A = tl.exp(A_log)
+            if USE_LOWER_BOUND:
+                log_gate = lower_bound * tl.sigmoid(exp_A * gate_input)
+            else:
+                softplus = tl.where(
+                    gate_input <= 20.0,
+                    tl.log(1.0 + tl.exp(gate_input)),
+                    gate_input,
+                )
+                log_gate = -exp_A * softplus
+            gate = tl.exp(log_gate)
             beta = 1.0 / (1.0 + tl.exp(-beta_input))
 
         state *= gate[None, :]
@@ -188,6 +195,7 @@ def kda_target_verify_npu(
     cache_steps: int,
     scale: Optional[float] = None,
     gates_are_preactivated: Optional[bool] = None,
+    lower_bound: Optional[float] = None,
 ) -> torch.Tensor:
     """KDA fixed-width target verification with per-step state snapshots.
 
@@ -197,7 +205,9 @@ def kda_target_verify_npu(
     When ``gates_are_preactivated`` is true, ``a`` is the log-decay
     ``-exp(A_log) * softplus(raw_a + dt_bias)`` and ``b`` is already sigmoid
     activated. Both gate tensors may include the SGLang leading singleton.
-    When the flag is omitted, a paired leading singleton selects this mode.
+    When the flag is false, both activations are performed inside the recurrent
+    kernel. ``lower_bound`` selects the K3 safe-gate formula in that mode. When
+    the flag is omitted, a paired leading singleton selects preactivated mode.
     """
     if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
         raise ValueError("q, k, and v must have shape [1, tokens, heads, dim]")
@@ -310,6 +320,7 @@ def kda_target_verify_npu(
         intermediate_state_indices,
         out,
         scale,
+        lower_bound,
         q.stride(1),
         q.stride(2),
         q.stride(3),
@@ -342,6 +353,7 @@ def kda_target_verify_npu(
         BK=bk,
         BV=bv,
         GATES_ARE_PREACTIVATED=gates_are_preactivated,
+        USE_LOWER_BOUND=lower_bound is not None,
         num_warps=1,
         num_stages=3,
         multibuffer=False,

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_target_verify.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_target_verify.py
@@ -245,7 +245,7 @@ def kda_target_verify_npu(
     if tuple(b.shape) != (q.shape[1], h_v):
         raise ValueError("b must have shape [tokens, H_v]")
     if not gates_are_preactivated and (
-        A_log.numel() != h_k or tuple(dt_bias.shape) != (h_k, key_dim)
+        A_log.numel() != h_k or dt_bias.numel() != h_k * key_dim
     ):
         raise ValueError("A_log and dt_bias shapes do not match KDA heads")
     if initial_state_source.ndim != 4 or tuple(initial_state_source.shape[1:]) != (

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_target_verify.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_target_verify.py
@@ -303,7 +303,11 @@ def kda_target_verify_npu(
     bk = triton.next_power_of_2(key_dim)
     if bk > 256:
         raise ValueError("key dimensions greater than 256 are unsupported")
-    bv = min(64, triton.next_power_of_2(value_dim))
+    # K3's V=128 recurrent state is faster as four BV=32 programs than two
+    # BV=64 programs on Ascend. The smaller state tile lowers register pressure
+    # enough to outweigh the extra program, while two warps keep the V>=64
+    # case saturated. Preserve the lighter single-warp launch for small V.
+    bv = min(32, triton.next_power_of_2(value_dim))
     grid = (batch, h_v, triton.cdiv(value_dim, bv))
     _kda_target_verify_kernel[grid](
         A_log,
@@ -353,7 +357,7 @@ def kda_target_verify_npu(
         BV=bv,
         GATES_ARE_PREACTIVATED=gates_are_preactivated,
         USE_LOWER_BOUND=lower_bound is not None,
-        num_warps=1,
+        num_warps=2 if value_dim >= 64 else 1,
         num_stages=3,
         multibuffer=False,
     )

--- a/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_target_verify.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/fla/kda_target_verify.py
@@ -84,10 +84,10 @@ def _kda_target_verify_kernel(
         other=0.0,
     ).to(tl.float32)
 
-    A_log = tl.zeros((), dtype=tl.float32)
+    exp_A = tl.zeros((), dtype=tl.float32)
     dt_bias = tl.zeros((BK,), dtype=tl.float32)
     if not GATES_ARE_PREACTIVATED:
-        A_log = tl.load(A_log_ptr + k_head).to(tl.float32)
+        exp_A = tl.exp(tl.load(A_log_ptr + k_head).to(tl.float32))
         dt_bias = tl.load(
             dt_bias_ptr + k_head * K + offset_k,
             mask=mask_k,
@@ -141,7 +141,6 @@ def _kda_target_verify_kernel(
             beta = beta_input
         else:
             gate_input = a + dt_bias
-            exp_A = tl.exp(A_log)
             if USE_LOWER_BOUND:
                 log_gate = lower_bound * tl.sigmoid(exp_A * gate_input)
             else:

--- a/python/sgl_kernel_npu/sgl_kernel_npu/kimi_k3/attn_residual.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/kimi_k3/attn_residual.py
@@ -9,6 +9,7 @@ def _mix_fused_kernel(
     prefix_ptr,
     bank_ptr,
     cw_ptr,
+    out_norm_weight_ptr,
     out_ptr,
     N,
     B,
@@ -18,6 +19,8 @@ def _mix_fused_kernel(
     stride_om,
     H: tl.constexpr,
     EPS: tl.constexpr,
+    OUT_EPS: tl.constexpr,
+    FUSE_OUT_NORM: tl.constexpr,
     NUM_CORES: tl.constexpr,
     NB: tl.constexpr,
 ):
@@ -64,6 +67,16 @@ def _mix_fused_kernel(
             probability = tl.sum(tl.where(row_offsets == row, probabilities, 0.0))
             output += probability * value
 
+        if FUSE_OUT_NORM:
+            # Preserve the unfused pipeline: mix_fused materializes BF16 and
+            # the following RMSNorm consumes that rounded tensor.
+            output = output.to(out_ptr.dtype.element_ty).to(tl.float32)
+            inverse_rms = tl.rsqrt(tl.sum(output * output) / H + OUT_EPS)
+            out_norm_weight = tl.load(out_norm_weight_ptr + hidden_offsets).to(
+                tl.float32
+            )
+            output *= inverse_rms * out_norm_weight
+
         tl.store(
             out_ptr + token * stride_om + hidden_offsets,
             output.to(out_ptr.dtype.element_ty),
@@ -76,6 +89,8 @@ def mix_fused(
     num_valid_blocks: int,
     combined_weight: torch.Tensor,
     variance_epsilon: float,
+    out_norm_weight: torch.Tensor | None = None,
+    out_norm_epsilon: float = 0.0,
 ) -> torch.Tensor:
     """Ascend Kimi-K3 attention-residual score and combine pipeline.
 
@@ -88,6 +103,11 @@ def mix_fused(
         return prefix_sum
     if not 0 <= num_valid_blocks <= bank.shape[1]:
         raise ValueError("num_valid_blocks must fit within the residual bank")
+    if out_norm_weight is not None and (
+        out_norm_weight.numel() != hidden_size
+        or out_norm_weight.device != prefix_sum.device
+    ):
+        raise ValueError("out_norm_weight must match the hidden size and device")
 
     output = torch.empty_like(prefix_sum)
     _, num_vector_cores = get_device_properties()
@@ -98,6 +118,7 @@ def mix_fused(
         prefix_sum,
         bank,
         combined_weight,
+        out_norm_weight if out_norm_weight is not None else combined_weight,
         output,
         num_tokens,
         num_valid_blocks,
@@ -107,6 +128,8 @@ def mix_fused(
         output.stride(0),
         H=hidden_size,
         EPS=variance_epsilon,
+        OUT_EPS=out_norm_epsilon,
+        FUSE_OUT_NORM=out_norm_weight is not None,
         NUM_CORES=active_cores,
         NB=triton.next_power_of_2(num_valid_blocks + 1),
         multibuffer=True,

--- a/python/sgl_kernel_npu/sgl_kernel_npu/kimi_k3/attn_residual.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/kimi_k3/attn_residual.py
@@ -91,7 +91,10 @@ def mix_fused(
 
     output = torch.empty_like(prefix_sum)
     _, num_vector_cores = get_device_properties()
-    _mix_fused_kernel[(num_vector_cores,)](
+    # The persistent kernel assigns whole tokens to vector cores. Avoid
+    # launching idle cores for decode/verify shapes smaller than the AIV count.
+    active_cores = min(num_tokens, num_vector_cores)
+    _mix_fused_kernel[(active_cores,)](
         prefix_sum,
         bank,
         combined_weight,
@@ -104,7 +107,7 @@ def mix_fused(
         output.stride(0),
         H=hidden_size,
         EPS=variance_epsilon,
-        NUM_CORES=num_vector_cores,
+        NUM_CORES=active_cores,
         NB=triton.next_power_of_2(num_valid_blocks + 1),
         multibuffer=True,
     )

--- a/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d_verify.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/mamba/causal_conv1d_verify.py
@@ -36,6 +36,7 @@ def _causal_conv1d_linear_verify_kernel(
     HAS_BIAS: tl.constexpr,
     SILU: tl.constexpr,
     UPDATE_PERSISTENT_STATE: tl.constexpr,
+    MERGE_SNAPSHOT_STORES: tl.constexpr,
     BLOCK_C: tl.constexpr,
 ):
     pid_batch = tl.program_id(0)
@@ -119,6 +120,9 @@ def _causal_conv1d_linear_verify_kernel(
     else:
         bias = tl.zeros((BLOCK_C,), dtype=tl.float32)
 
+    step_offsets = tl.arange(0, STEPS)
+    snapshot_window_offsets = tl.arange(0, 4)
+    out_tile = tl.zeros((BLOCK_C, STEPS), dtype=tl.float32)
     for step in tl.static_range(0, STEPS):
         current = tl.load(
             x_ptr
@@ -177,13 +181,10 @@ def _causal_conv1d_linear_verify_kernel(
 
         if SILU:
             acc = acc / (1.0 + tl.exp(-acc))
-        tl.store(
-            out_ptr
-            + pid_batch * stride_out_batch
-            + channel * stride_out_channel
-            + step * stride_out_step,
-            acc,
-            mask=mask,
+        out_tile = tl.where(
+            step_offsets[None, :] == step,
+            acc[:, None],
+            out_tile,
         )
 
         snapshot_base = (
@@ -192,28 +193,56 @@ def _causal_conv1d_linear_verify_kernel(
             + step * stride_snapshot_step
             + channel * stride_snapshot_channel
         )
-        if KERNEL_WIDTH >= 2:
-            tl.store(snapshot_base, history0, mask=mask)
-        if KERNEL_WIDTH >= 3:
-            tl.store(snapshot_base + stride_snapshot_window, history1, mask=mask)
-        if KERNEL_WIDTH >= 4:
-            tl.store(
-                snapshot_base + 2 * stride_snapshot_window,
-                history2,
-                mask=mask,
+        if MERGE_SNAPSHOT_STORES:
+            snapshot_values = tl.where(
+                snapshot_window_offsets[None, :] == 0,
+                history0[:, None],
+                history2[:, None],
             )
-        if KERNEL_WIDTH >= 5:
-            tl.store(
-                snapshot_base + 3 * stride_snapshot_window,
-                history3,
-                mask=mask,
+            snapshot_values = tl.where(
+                snapshot_window_offsets[None, :] == 1,
+                history1[:, None],
+                snapshot_values,
             )
-        if KERNEL_WIDTH >= 6:
             tl.store(
-                snapshot_base + 4 * stride_snapshot_window,
-                history4,
-                mask=mask,
+                snapshot_base[:, None]
+                + snapshot_window_offsets[None, :] * stride_snapshot_window,
+                snapshot_values,
+                mask=mask[:, None]
+                & (snapshot_window_offsets[None, :] < KERNEL_WIDTH - 1),
             )
+        else:
+            if KERNEL_WIDTH >= 2:
+                tl.store(snapshot_base, history0, mask=mask)
+            if KERNEL_WIDTH >= 3:
+                tl.store(snapshot_base + stride_snapshot_window, history1, mask=mask)
+            if KERNEL_WIDTH >= 4:
+                tl.store(
+                    snapshot_base + 2 * stride_snapshot_window,
+                    history2,
+                    mask=mask,
+                )
+            if KERNEL_WIDTH >= 5:
+                tl.store(
+                    snapshot_base + 3 * stride_snapshot_window,
+                    history3,
+                    mask=mask,
+                )
+            if KERNEL_WIDTH >= 6:
+                tl.store(
+                    snapshot_base + 4 * stride_snapshot_window,
+                    history4,
+                    mask=mask,
+                )
+
+    tl.store(
+        out_ptr
+        + pid_batch * stride_out_batch
+        + channel[:, None] * stride_out_channel
+        + step_offsets[None, :] * stride_out_step,
+        out_tile,
+        mask=mask[:, None],
+    )
 
     if UPDATE_PERSISTENT_STATE:
         if KERNEL_WIDTH >= 2:
@@ -290,10 +319,15 @@ def causal_conv1d_linear_verify_npu(
     conv_state_indices = conv_state_indices.to(torch.int32).contiguous()
     intermediate_state_indices = intermediate_state_indices.to(torch.int32).contiguous()
     out = torch.zeros_like(x)
-    # Eight verify steps keep the full convolution history live. A 512-channel
-    # tile overflows the 192 KiB UB on Ascend 910; 256 leaves enough room for
-    # compiler-generated multi-buffer temporaries.
-    block_c = min(256, triton.next_power_of_2(channels))
+    # Offline profiling on the 40-vector-core Ascend target shows that the best
+    # channel tile is batch dependent for the captured verify batches (1..8).
+    if batch == 1:
+        max_block_c = 64
+    elif batch == 2 or 5 <= batch <= 6:
+        max_block_c = 128
+    else:
+        max_block_c = 256
+    block_c = min(max_block_c, triton.next_power_of_2(channels))
     grid = (batch, triton.cdiv(channels, block_c))
     _causal_conv1d_linear_verify_kernel[grid](
         x,
@@ -315,6 +349,7 @@ def causal_conv1d_linear_verify_npu(
         HAS_BIAS=bias is not None,
         SILU=activation in ("silu", "swish"),
         UPDATE_PERSISTENT_STATE=update_persistent_state,
+        MERGE_SNAPSHOT_STORES=batch in (2, 4, 8, 16) and kernel_width == 4,
         BLOCK_C=block_c,
     )
     return out

--- a/python/sgl_kernel_npu/sgl_kernel_npu/mamba/kda_state_commit.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/mamba/kda_state_commit.py
@@ -1,0 +1,268 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _scatter_kda_conv_snapshot_kernel(
+    dst_ptr,
+    src_ptr,
+    dst_indices_ptr,
+    src_indices_ptr,
+    step_indices_ptr,
+    dst_layer_stride,
+    dst_req_stride,
+    src_layer_stride,
+    src_req_stride,
+    src_step_stride,
+    NUM_LAYERS: tl.constexpr,
+    SRC_REQ_SIZE: tl.constexpr,
+    SRC_STEP_SIZE: tl.constexpr,
+    DST_REQ_SIZE: tl.constexpr,
+    TAIL_NUMEL: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Copy one accepted contiguous conv snapshot per request and layer."""
+    pid = tl.program_id(0)
+    layer_idx = pid % NUM_LAYERS
+    req_idx = pid // NUM_LAYERS
+    dst_idx = tl.load(dst_indices_ptr + req_idx).to(tl.int64)
+    src_idx = tl.load(src_indices_ptr + req_idx).to(tl.int64)
+    step_idx = tl.load(step_indices_ptr + req_idx).to(tl.int64)
+    valid = (
+        (dst_idx >= 0)
+        & (dst_idx < DST_REQ_SIZE)
+        & (src_idx >= 0)
+        & (src_idx < SRC_REQ_SIZE)
+        & (step_idx >= 0)
+        & (step_idx < SRC_STEP_SIZE)
+    )
+    safe_dst_idx = tl.maximum(dst_idx, 0)
+    safe_src_idx = tl.maximum(src_idx, 0)
+    safe_step_idx = tl.maximum(step_idx, 0)
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = valid & (offsets < TAIL_NUMEL)
+    src_offsets = (
+        layer_idx * src_layer_stride
+        + safe_src_idx * src_req_stride
+        + safe_step_idx * src_step_stride
+        + offsets
+    )
+    dst_offsets = layer_idx * dst_layer_stride + safe_dst_idx * dst_req_stride + offsets
+    value = tl.load(src_ptr + src_offsets, mask=mask, other=0.0)
+    tl.store(dst_ptr + dst_offsets, value, mask=mask)
+
+
+def scatter_kda_conv_snapshot(
+    dst: torch.Tensor,
+    src: torch.Tensor,
+    dst_indices: torch.Tensor,
+    src_indices: torch.Tensor,
+    step_indices: torch.Tensor,
+) -> bool:
+    """Fast path for KDA's contiguous NPU conv-snapshot layout.
+
+    The generic scatter splits Kimi-K3's 6,912-element snapshot into seven
+    1,024-element logical tiles per layer, then serializes those tiles over a
+    bounded 48-program grid. A single 8,192-element BF16 tile fits in A3 UB
+    and needs only one program per request/layer. Unsupported layouts return
+    ``False`` so callers can use the generic stride-aware fallback.
+    """
+    if (
+        dst.ndim != 4
+        or src.ndim != 5
+        or not dst.is_contiguous()
+        or not src.is_contiguous()
+        or dst.shape[0] != src.shape[0]
+        or dst.shape[2:] != src.shape[3:]
+    ):
+        return False
+    num_requests = int(step_indices.shape[0])
+    if num_requests == 0:
+        return True
+    if (
+        dst_indices.ndim != 1
+        or src_indices.ndim != 1
+        or step_indices.ndim != 1
+        or dst_indices.shape[0] != num_requests
+        or src_indices.shape[0] != num_requests
+        or any(
+            value.dtype != torch.int32
+            for value in (dst_indices, src_indices, step_indices)
+        )
+    ):
+        return False
+    tail_numel = int(dst.shape[2] * dst.shape[3])
+    block_size = triton.next_power_of_2(tail_numel)
+    if block_size > 8192:
+        return False
+    num_layers = int(dst.shape[0])
+    _scatter_kda_conv_snapshot_kernel[(num_requests * num_layers,)](
+        dst,
+        src,
+        dst_indices,
+        src_indices,
+        step_indices,
+        dst.stride(0),
+        dst.stride(1),
+        src.stride(0),
+        src.stride(1),
+        src.stride(2),
+        NUM_LAYERS=num_layers,
+        SRC_REQ_SIZE=src.shape[1],
+        SRC_STEP_SIZE=src.shape[2],
+        DST_REQ_SIZE=dst.shape[1],
+        TAIL_NUMEL=tail_numel,
+        BLOCK_SIZE=block_size,
+    )
+    return True
+
+
+@triton.jit
+def _move_kda_temporal_snapshot_kernel(
+    dst_ptr,
+    src_ptr,
+    dst_indices_ptr,
+    src_indices_ptr,
+    step_indices_ptr,
+    dst_layer_stride,
+    dst_req_stride,
+    dst_head_stride,
+    dst_v_stride,
+    dst_k_stride,
+    src_layer_stride,
+    src_req_stride,
+    src_step_stride,
+    src_head_stride,
+    src_v_stride,
+    src_k_stride,
+    src_req_size,
+    src_step_size,
+    dst_req_size,
+    head_dim,
+    dim_v,
+    dim_k,
+    NUM_LAYERS: tl.constexpr,
+    BLOCK_V: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Copy one KDA temporal snapshot with layer-level parallelism."""
+    pid = tl.program_id(0)
+    layer_idx = pid % NUM_LAYERS
+    req_idx = pid // NUM_LAYERS
+    dst_idx = tl.load(dst_indices_ptr + req_idx).to(tl.int64)
+    src_idx = tl.load(src_indices_ptr + req_idx).to(tl.int64)
+    step_idx = tl.load(step_indices_ptr + req_idx).to(tl.int64)
+    valid = (
+        (dst_idx >= 0)
+        & (dst_idx < dst_req_size)
+        & (src_idx >= 0)
+        & (src_idx < src_req_size)
+        & (step_idx >= 0)
+        & (step_idx < src_step_size)
+    )
+    if not valid:
+        return
+
+    v_offsets = tl.arange(0, BLOCK_V)
+    k_offsets = tl.arange(0, BLOCK_K)
+    num_v_tiles = tl.cdiv(dim_v, BLOCK_V)
+    num_tiles = head_dim * num_v_tiles
+    for tile_idx in tl.range(0, num_tiles):
+        head_idx = tile_idx // num_v_tiles
+        v_idx = (tile_idx % num_v_tiles) * BLOCK_V + v_offsets
+        mask = (v_idx[:, None] < dim_v) & (k_offsets[None, :] < dim_k)
+        src_offsets = (
+            layer_idx * src_layer_stride
+            + src_idx * src_req_stride
+            + step_idx * src_step_stride
+            + head_idx * src_head_stride
+            + v_idx[:, None] * src_v_stride
+            + k_offsets[None, :] * src_k_stride
+        )
+        dst_offsets = (
+            layer_idx * dst_layer_stride
+            + dst_idx * dst_req_stride
+            + head_idx * dst_head_stride
+            + v_idx[:, None] * dst_v_stride
+            + k_offsets[None, :] * dst_k_stride
+        )
+        value = tl.load(src_ptr + src_offsets, mask=mask, other=0.0)
+        tl.store(dst_ptr + dst_offsets, value, mask=mask)
+
+
+def move_kda_temporal_snapshot(
+    dst: torch.Tensor,
+    src: torch.Tensor,
+    dst_indices: torch.Tensor,
+    src_indices: torch.Tensor,
+    step_indices: torch.Tensor,
+) -> bool:
+    """Fast path for Kimi-K3's production temporal-state layout.
+
+    The generic mover assigns one program to a request, so batch size one
+    serializes every KDA layer and head. This path assigns one program per
+    request/layer while retaining a runtime loop over 32-row transpose tiles.
+    Unsupported layouts return ``False`` so callers can use the generic
+    stride-aware fallback.
+    """
+    if (
+        dst.ndim != 5
+        or src.ndim != 6
+        or dst.shape[0] != src.shape[0]
+        or dst.shape[2:] != src.shape[3:]
+        or dst.dtype != src.dtype
+        or not src.is_contiguous()
+    ):
+        return False
+    num_requests = int(step_indices.shape[0])
+    if num_requests == 0:
+        return True
+    if (
+        dst_indices.ndim != 1
+        or src_indices.ndim != 1
+        or step_indices.ndim != 1
+        or dst_indices.shape[0] != num_requests
+        or src_indices.shape[0] != num_requests
+        or any(
+            value.dtype != torch.int32
+            for value in (dst_indices, src_indices, step_indices)
+        )
+    ):
+        return False
+    dim_k = int(src.shape[-1])
+    block_k = triton.next_power_of_2(dim_k)
+    if block_k > 128:
+        return False
+    num_layers = int(src.shape[0])
+    _move_kda_temporal_snapshot_kernel[(num_requests * num_layers,)](
+        dst,
+        src,
+        dst_indices,
+        src_indices,
+        step_indices,
+        dst.stride(0),
+        dst.stride(1),
+        dst.stride(2),
+        dst.stride(3),
+        dst.stride(4),
+        src.stride(0),
+        src.stride(1),
+        src.stride(2),
+        src.stride(3),
+        src.stride(4),
+        src.stride(5),
+        src.shape[1],
+        src.shape[2],
+        dst.shape[1],
+        src.shape[3],
+        src.shape[4],
+        dim_k,
+        NUM_LAYERS=num_layers,
+        BLOCK_V=32,
+        BLOCK_K=block_k,
+    )
+    return True
+
+
+__all__ = ["move_kda_temporal_snapshot", "scatter_kda_conv_snapshot"]

--- a/python/sgl_kernel_npu/sgl_kernel_npu/mamba/kda_state_commit.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/mamba/kda_state_commit.py
@@ -53,6 +53,57 @@ def _scatter_kda_conv_snapshot_kernel(
     tl.store(dst_ptr + dst_offsets, value, mask=mask)
 
 
+@triton.jit
+def _commit_kda_extended_conv_state_kernel(
+    conv_states_ptr,
+    dst_indices_ptr,
+    src_indices_ptr,
+    step_indices_ptr,
+    layer_stride,
+    req_stride,
+    window_stride,
+    NUM_LAYERS: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    DRAFT_TOKEN_NUM: tl.constexpr,
+    TAIL_NUMEL: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Commit one accepted window from #35021's extended conv state."""
+    pid = tl.program_id(0)
+    layer_idx = pid % NUM_LAYERS
+    req_idx = pid // NUM_LAYERS
+    dst_idx = tl.load(dst_indices_ptr + req_idx).to(tl.int64)
+    src_idx = tl.load(src_indices_ptr + req_idx).to(tl.int64)
+    step_idx = tl.load(step_indices_ptr + req_idx).to(tl.int64)
+    valid = (
+        (dst_idx >= 0)
+        & (dst_idx < POOL_SIZE)
+        & (src_idx >= 0)
+        & (src_idx < POOL_SIZE)
+        & (step_idx >= 0)
+        & (step_idx < DRAFT_TOKEN_NUM)
+    )
+    safe_dst_idx = tl.maximum(dst_idx, 0)
+    safe_src_idx = tl.maximum(src_idx, 0)
+    safe_step_idx = tl.maximum(step_idx, 0)
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = valid & (offsets < TAIL_NUMEL)
+    src_offsets = (
+        layer_idx * layer_stride
+        + safe_src_idx * req_stride
+        + safe_step_idx * window_stride
+        + offsets
+    )
+    dst_offsets = (
+        layer_idx * layer_stride
+        + safe_dst_idx * req_stride
+        + (DRAFT_TOKEN_NUM - 1) * window_stride
+        + offsets
+    )
+    value = tl.load(conv_states_ptr + src_offsets, mask=mask, other=0.0)
+    tl.store(conv_states_ptr + dst_offsets, value, mask=mask)
+
+
 def scatter_kda_conv_snapshot(
     dst: torch.Tensor,
     src: torch.Tensor,
@@ -112,6 +163,66 @@ def scatter_kda_conv_snapshot(
         SRC_REQ_SIZE=src.shape[1],
         SRC_STEP_SIZE=src.shape[2],
         DST_REQ_SIZE=dst.shape[1],
+        TAIL_NUMEL=tail_numel,
+        BLOCK_SIZE=block_size,
+    )
+    return True
+
+
+def commit_kda_extended_conv_state(
+    conv_states: torch.Tensor,
+    dst_indices: torch.Tensor,
+    src_indices: torch.Tensor,
+    step_indices: torch.Tensor,
+    draft_token_num: int,
+) -> bool:
+    """Commit accepted KDA conv windows from #35021's extended state layout.
+
+    ``conv_states`` is ``[layers, pool, base_window + draft_tokens - 1, channels]``.
+    Each accepted state is an overlapping base-window slice beginning at its
+    step index. The kernel copies that slice directly to the persistent tail,
+    preserving #35021's CANN verify layout without the serial rollback loop.
+    """
+    if (
+        conv_states.ndim != 4
+        or not conv_states.is_contiguous()
+        or draft_token_num <= 0
+        or conv_states.shape[2] < draft_token_num
+    ):
+        return False
+    num_requests = int(step_indices.shape[0])
+    if num_requests == 0:
+        return True
+    if (
+        dst_indices.ndim != 1
+        or src_indices.ndim != 1
+        or step_indices.ndim != 1
+        or dst_indices.shape[0] != num_requests
+        or src_indices.shape[0] != num_requests
+        or any(
+            value.dtype != torch.int32
+            for value in (dst_indices, src_indices, step_indices)
+        )
+    ):
+        return False
+    base_window_size = int(conv_states.shape[2] - (draft_token_num - 1))
+    num_dims = int(conv_states.shape[3])
+    tail_numel = base_window_size * num_dims
+    block_size = triton.next_power_of_2(tail_numel)
+    if base_window_size <= 0 or block_size > 8192:
+        return False
+    num_layers = int(conv_states.shape[0])
+    _commit_kda_extended_conv_state_kernel[(num_requests * num_layers,)](
+        conv_states,
+        dst_indices,
+        src_indices,
+        step_indices,
+        conv_states.stride(0),
+        conv_states.stride(1),
+        conv_states.stride(2),
+        NUM_LAYERS=num_layers,
+        POOL_SIZE=conv_states.shape[1],
+        DRAFT_TOKEN_NUM=draft_token_num,
         TAIL_NUMEL=tail_numel,
         BLOCK_SIZE=block_size,
     )
@@ -265,4 +376,8 @@ def move_kda_temporal_snapshot(
     return True
 
 
-__all__ = ["move_kda_temporal_snapshot", "scatter_kda_conv_snapshot"]
+__all__ = [
+    "commit_kda_extended_conv_state",
+    "move_kda_temporal_snapshot",
+    "scatter_kda_conv_snapshot",
+]

--- a/python/sgl_kernel_npu/sgl_kernel_npu/mamba/replay_metadata.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/mamba/replay_metadata.py
@@ -1,0 +1,71 @@
+"""Graph-recordable Kimi-K3 hybrid-attention replay metadata update."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _replay_metadata_kernel(
+    req_pool_indices_ptr,
+    seq_lens_ptr,
+    mamba_index_mapping_ptr,
+    state_indices_ptr,
+    query_start_loc_ptr,
+    BS: tl.constexpr,
+    QUERY_STEP: tl.constexpr,
+    META_BLOCK: tl.constexpr,
+):
+    offs = tl.arange(0, META_BLOCK)
+    row_mask = offs < BS
+    seq_len = tl.load(seq_lens_ptr + offs, mask=row_mask, other=0)
+    valid = row_mask & (seq_len != 0)
+
+    # Graph padding is suffix-only. Count the live prefix once and use it for
+    # both state-slot masking and the static query indptr.
+    valid_bs = tl.sum(valid.to(tl.int32), axis=0)
+    req_idx = tl.load(req_pool_indices_ptr + offs, mask=valid, other=0)
+    state_idx = tl.load(mamba_index_mapping_ptr + req_idx, mask=valid, other=0)
+    tl.store(state_indices_ptr + offs, state_idx.to(tl.int32), mask=valid)
+    tl.store(state_indices_ptr + offs, 0, mask=row_mask & ~valid)
+    tl.store(req_pool_indices_ptr + offs, 0, mask=row_mask & ~valid)
+
+    query_mask = offs <= BS
+    query_row = tl.where(offs < valid_bs, offs, valid_bs)
+    tl.store(
+        query_start_loc_ptr + offs,
+        query_row.to(tl.int32) * QUERY_STEP,
+        mask=query_mask,
+    )
+
+
+def update_replay_metadata(
+    req_pool_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    mamba_index_mapping: torch.Tensor,
+    state_indices: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    *,
+    query_step: int,
+) -> None:
+    """Refresh graph-stable Mamba slots and query indptr in one launch.
+
+    This function is intended for ``init_forward_metadata_in_graph``: the
+    launch is captured once and reads the replay input buffers thereafter.
+    Padded rows are identified from the graph-stable ``seq_lens`` buffer.
+    """
+    bs = state_indices.numel()
+    if req_pool_indices.numel() < bs or seq_lens.numel() < bs:
+        raise ValueError("replay input buffers are shorter than state_indices")
+    if query_start_loc.numel() != bs + 1:
+        raise ValueError("query_start_loc must have exactly bs + 1 entries")
+    _replay_metadata_kernel[(1,)](
+        req_pool_indices,
+        seq_lens,
+        mamba_index_mapping,
+        state_indices,
+        query_start_loc,
+        BS=bs,
+        QUERY_STEP=query_step,
+        META_BLOCK=triton.next_power_of_2(bs + 1),
+    )

--- a/python/sgl_kernel_npu/sgl_kernel_npu/moe/add3.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/moe/add3.py
@@ -1,7 +1,6 @@
 import torch
 import triton
 import triton.language as tl
-
 from sgl_kernel_npu.utils.triton_utils import get_device_properties
 
 

--- a/python/sgl_kernel_npu/sgl_kernel_npu/moe/add3.py
+++ b/python/sgl_kernel_npu/sgl_kernel_npu/moe/add3.py
@@ -1,0 +1,74 @@
+import torch
+import triton
+import triton.language as tl
+
+from sgl_kernel_npu.utils.triton_utils import get_device_properties
+
+
+@triton.jit
+def _add3_bf16_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    output_ptr,
+    n_rows: tl.constexpr,
+    hidden_size: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row_start = tl.program_id(0)
+    row_step = tl.num_programs(0)
+    cols = tl.arange(0, BLOCK_SIZE)
+    valid_mask = cols < hidden_size
+    offsets = row_start * hidden_size + cols
+
+    for row_idx in tl.range(row_start, n_rows, row_step):
+        a = tl.load(a_ptr + offsets, mask=valid_mask, other=0.0).to(tl.float32)
+        b = tl.load(b_ptr + offsets, mask=valid_mask, other=0.0).to(tl.float32)
+        c = tl.load(c_ptr + offsets, mask=valid_mask, other=0.0).to(tl.float32)
+
+        # Preserve eager's two bf16 kernels exactly: the first add is rounded
+        # before c participates in the second add.
+        ab = (a + b).to(tl.bfloat16)
+        output = ab.to(tl.float32) + c
+        tl.store(output_ptr + offsets, output, mask=valid_mask)
+        offsets += row_step * hidden_size
+
+
+def add3_bf16_covered(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor) -> bool:
+    return (
+        a.dtype == b.dtype == c.dtype == torch.bfloat16
+        and a.shape == b.shape == c.shape
+        and a.ndim >= 1
+        and a.shape[-1] > 0
+        and a.is_contiguous()
+        and b.is_contiguous()
+        and c.is_contiguous()
+        and a.device.type == "npu"
+    )
+
+
+def add3_bf16(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    c: torch.Tensor,
+) -> torch.Tensor:
+    """Return ``bf16(bf16(a + b) + c)`` with one NPU kernel launch."""
+    if not add3_bf16_covered(a, b, c):
+        raise ValueError("add3_bf16 requires same-shape contiguous NPU bf16 tensors")
+
+    _, num_vectorcore = get_device_properties()
+    hidden_size = a.shape[-1]
+    n_rows = a.numel() // hidden_size
+    block_size = triton.next_power_of_2(hidden_size)
+    grid_rows = min(n_rows, num_vectorcore)
+    output = torch.empty_like(a)
+    _add3_bf16_kernel[(grid_rows, 1, 1)](
+        a,
+        b,
+        c,
+        output,
+        n_rows,
+        hidden_size,
+        block_size,
+    )
+    return output

--- a/tests/python/sgl_kernel_npu/test_add3.py
+++ b/tests/python/sgl_kernel_npu/test_add3.py
@@ -1,5 +1,4 @@
 import torch
-
 from sgl_kernel_npu.moe.add3 import add3_bf16, add3_bf16_covered
 
 
@@ -27,6 +26,4 @@ def test_add3_bf16_matches_eager_and_graph_replay():
     c.copy_(torch.randn_like(c))
     graph.replay()
     torch.npu.synchronize()
-    torch.testing.assert_close(
-        replay_actual, _eager_add3(a, b, c), rtol=0, atol=0
-    )
+    torch.testing.assert_close(replay_actual, _eager_add3(a, b, c), rtol=0, atol=0)

--- a/tests/python/sgl_kernel_npu/test_add3.py
+++ b/tests/python/sgl_kernel_npu/test_add3.py
@@ -1,0 +1,32 @@
+import torch
+
+from sgl_kernel_npu.moe.add3 import add3_bf16, add3_bf16_covered
+
+
+def _eager_add3(a: torch.Tensor, b: torch.Tensor, c: torch.Tensor) -> torch.Tensor:
+    return (a + b) + c
+
+
+def test_add3_bf16_matches_eager_and_graph_replay():
+    torch.manual_seed(0)
+    device = torch.device("npu")
+    shape = (1, 7168)
+    a = torch.randn(shape, dtype=torch.bfloat16, device=device)
+    b = torch.randn_like(a)
+    c = torch.randn_like(a)
+
+    assert add3_bf16_covered(a, b, c)
+    actual = add3_bf16(a, b, c)
+    torch.testing.assert_close(actual, _eager_add3(a, b, c), rtol=0, atol=0)
+
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        replay_actual = add3_bf16(a, b, c)
+    a.copy_(torch.randn_like(a))
+    b.copy_(torch.randn_like(b))
+    c.copy_(torch.randn_like(c))
+    graph.replay()
+    torch.npu.synchronize()
+    torch.testing.assert_close(
+        replay_actual, _eager_add3(a, b, c), rtol=0, atol=0
+    )

--- a/tests/python/sgl_kernel_npu/test_dspark_top1.py
+++ b/tests/python/sgl_kernel_npu/test_dspark_top1.py
@@ -1,0 +1,36 @@
+import torch
+
+from sgl_kernel_npu.dspark.top1 import select_global_top1_npu
+
+
+def test_tp_top1_selector_matches_argmax_under_graph_replay():
+    device = torch.device("npu")
+    candidates = torch.tensor(
+        [
+            [[1.0, 8.0], [2.0, 7.0], [2.0, 3.0], [0.0, 1.0]],
+            [[-1.0, 9.0], [-2.0, 4.0], [-3.0, 5.0], [-4.0, 6.0]],
+        ],
+        dtype=torch.float32,
+        device=device,
+    )
+    expected = torch.tensor([3, 9], dtype=torch.long, device=device)
+    actual = select_global_top1_npu(candidates, vocab_size=16)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        graph_actual = select_global_top1_npu(candidates, vocab_size=16)
+    candidates.copy_(
+        torch.tensor(
+            [
+                [[4.0, 8.0], [3.0, 7.0], [2.0, 3.0], [1.0, 1.0]],
+                [[0.0, 9.0], [5.0, 11.0], [5.0, 6.0], [4.0, 2.0]],
+            ],
+            dtype=torch.float32,
+            device=device,
+        )
+    )
+    graph.replay()
+    torch.npu.synchronize()
+    expected_after_replay = torch.tensor([8, 6], dtype=torch.long, device=device)
+    torch.testing.assert_close(graph_actual, expected_after_replay, rtol=0, atol=0)

--- a/tests/python/sgl_kernel_npu/test_dspark_top1.py
+++ b/tests/python/sgl_kernel_npu/test_dspark_top1.py
@@ -1,6 +1,43 @@
 import torch
 
-from sgl_kernel_npu.dspark.top1 import select_global_top1_npu
+from sgl_kernel_npu.dspark.top1 import (
+    select_global_top1_npu,
+    select_local_top1_after_add_npu,
+)
+
+
+def test_local_top1_after_add_matches_bf16_eager_under_graph_replay():
+    device = torch.device("npu")
+    # Slice the proposal dimension to exercise the non-contiguous row stride
+    # used by base_logits[:, step_idx, :].
+    base_storage = torch.randn(3, 4, 10240, dtype=torch.bfloat16, device=device)
+    base = base_storage[:, 2, :]
+    bias = torch.randn_like(base)
+    vocab_offset = 30720
+
+    expected_value, expected_index = (base + bias).max(dim=-1)
+    expected = torch.stack(
+        (expected_value.float(), (expected_index + vocab_offset).float()), dim=-1
+    )
+    actual = select_local_top1_after_add_npu(
+        base, bias, vocab_offset=vocab_offset
+    )
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        graph_actual = select_local_top1_after_add_npu(
+            base, bias, vocab_offset=vocab_offset
+        )
+    base.copy_(torch.randn_like(base))
+    bias.copy_(torch.randn_like(bias))
+    graph.replay()
+    torch.npu.synchronize()
+    replay_value, replay_index = (base + bias).max(dim=-1)
+    replay_expected = torch.stack(
+        (replay_value.float(), (replay_index + vocab_offset).float()), dim=-1
+    )
+    torch.testing.assert_close(graph_actual, replay_expected, rtol=0, atol=0)
 
 
 def test_tp_top1_selector_matches_argmax_under_graph_replay():

--- a/tests/python/sgl_kernel_npu/test_dspark_top1.py
+++ b/tests/python/sgl_kernel_npu/test_dspark_top1.py
@@ -1,5 +1,4 @@
 import torch
-
 from sgl_kernel_npu.dspark.top1 import (
     select_global_top1_npu,
     select_local_top1_after_add_npu,
@@ -19,9 +18,7 @@ def test_local_top1_after_add_matches_bf16_eager_under_graph_replay():
     expected = torch.stack(
         (expected_value.float(), (expected_index + vocab_offset).float()), dim=-1
     )
-    actual = select_local_top1_after_add_npu(
-        base, bias, vocab_offset=vocab_offset
-    )
+    actual = select_local_top1_after_add_npu(base, bias, vocab_offset=vocab_offset)
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
     graph = torch.npu.NPUGraph()

--- a/tests/python/sgl_kernel_npu/test_k3_attn_residual_active_cores.py
+++ b/tests/python/sgl_kernel_npu/test_k3_attn_residual_active_cores.py
@@ -1,7 +1,6 @@
 import pytest
 import torch
 import torch_npu  # noqa: F401
-
 from sgl_kernel_npu.kimi_k3.attn_residual import mix_fused
 
 
@@ -15,16 +14,12 @@ def _reference(prefix, bank, num_valid_blocks, combined_weight, eps):
     return (probabilities[..., None] * values).sum(dim=1).to(prefix.dtype)
 
 
-@pytest.mark.parametrize(
-    "tokens,num_valid_blocks", [(1, 1), (12, 4), (16, 8), (49, 8)]
-)
+@pytest.mark.parametrize("tokens,num_valid_blocks", [(1, 1), (12, 4), (16, 8), (49, 8)])
 @torch.no_grad()
 def test_mix_fused_small_token_grid_matches_reference(tokens, num_valid_blocks):
     hidden = 7168
     torch.manual_seed(101 + tokens)
-    prefix = (torch.randn(tokens, hidden) * 0.25).to(
-        dtype=torch.bfloat16, device="npu"
-    )
+    prefix = (torch.randn(tokens, hidden) * 0.25).to(dtype=torch.bfloat16, device="npu")
     bank = (torch.randn(tokens, 8, hidden) * 0.25).to(
         dtype=torch.bfloat16, device="npu"
     )
@@ -38,14 +33,10 @@ def test_mix_fused_small_token_grid_matches_reference(tokens, num_valid_blocks):
 
 @pytest.mark.parametrize("tokens,num_valid_blocks", [(1, 1), (16, 4), (16, 8)])
 @torch.no_grad()
-def test_mix_fused_out_norm_matches_materialized_pipeline(
-    tokens, num_valid_blocks
-):
+def test_mix_fused_out_norm_matches_materialized_pipeline(tokens, num_valid_blocks):
     hidden = 7168
     torch.manual_seed(701 + tokens + num_valid_blocks)
-    prefix = (torch.randn(tokens, hidden) * 0.25).to(
-        dtype=torch.bfloat16, device="npu"
-    )
+    prefix = (torch.randn(tokens, hidden) * 0.25).to(dtype=torch.bfloat16, device="npu")
     bank = (torch.randn(tokens, 8, hidden) * 0.25).to(
         dtype=torch.bfloat16, device="npu"
     )
@@ -55,9 +46,7 @@ def test_mix_fused_out_norm_matches_materialized_pipeline(
     out_norm_weight = torch.randn(hidden, device="npu", dtype=torch.bfloat16)
     eps = 1e-6
 
-    materialized = mix_fused(
-        prefix, bank, num_valid_blocks, combined_weight, eps
-    )
+    materialized = mix_fused(prefix, bank, num_valid_blocks, combined_weight, eps)
     expected = materialized.float()
     expected *= torch.rsqrt(expected.square().mean(dim=-1, keepdim=True) + eps)
     expected *= out_norm_weight.float()

--- a/tests/python/sgl_kernel_npu/test_k3_attn_residual_active_cores.py
+++ b/tests/python/sgl_kernel_npu/test_k3_attn_residual_active_cores.py
@@ -1,0 +1,36 @@
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from sgl_kernel_npu.kimi_k3.attn_residual import mix_fused
+
+
+def _reference(prefix, bank, num_valid_blocks, combined_weight, eps):
+    values = torch.cat(
+        [bank[:, :num_valid_blocks].float(), prefix[:, None].float()], dim=1
+    )
+    inverse_rms = torch.rsqrt(values.square().mean(dim=-1) + eps)
+    scores = (values * inverse_rms[..., None] * combined_weight.float()).sum(dim=-1)
+    probabilities = torch.softmax(scores, dim=1)
+    return (probabilities[..., None] * values).sum(dim=1).to(prefix.dtype)
+
+
+@pytest.mark.parametrize(
+    "tokens,num_valid_blocks", [(1, 1), (12, 4), (16, 8), (49, 8)]
+)
+@torch.no_grad()
+def test_mix_fused_small_token_grid_matches_reference(tokens, num_valid_blocks):
+    hidden = 7168
+    torch.manual_seed(101 + tokens)
+    prefix = (torch.randn(tokens, hidden) * 0.25).to(
+        dtype=torch.bfloat16, device="npu"
+    )
+    bank = (torch.randn(tokens, 8, hidden) * 0.25).to(
+        dtype=torch.bfloat16, device="npu"
+    )
+    weight = torch.randn(hidden, device="npu", dtype=torch.float32) / hidden**0.5
+
+    actual = mix_fused(prefix, bank, num_valid_blocks, weight, 1e-6)
+    expected = _reference(prefix, bank, num_valid_blocks, weight, 1e-6)
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), atol=4e-3, rtol=1e-2)

--- a/tests/python/sgl_kernel_npu/test_k3_attn_residual_active_cores.py
+++ b/tests/python/sgl_kernel_npu/test_k3_attn_residual_active_cores.py
@@ -34,3 +34,43 @@ def test_mix_fused_small_token_grid_matches_reference(tokens, num_valid_blocks):
     expected = _reference(prefix, bank, num_valid_blocks, weight, 1e-6)
 
     torch.testing.assert_close(actual.cpu(), expected.cpu(), atol=4e-3, rtol=1e-2)
+
+
+@pytest.mark.parametrize("tokens,num_valid_blocks", [(1, 1), (16, 4), (16, 8)])
+@torch.no_grad()
+def test_mix_fused_out_norm_matches_materialized_pipeline(
+    tokens, num_valid_blocks
+):
+    hidden = 7168
+    torch.manual_seed(701 + tokens + num_valid_blocks)
+    prefix = (torch.randn(tokens, hidden) * 0.25).to(
+        dtype=torch.bfloat16, device="npu"
+    )
+    bank = (torch.randn(tokens, 8, hidden) * 0.25).to(
+        dtype=torch.bfloat16, device="npu"
+    )
+    combined_weight = (
+        torch.randn(hidden, device="npu", dtype=torch.float32) / hidden**0.5
+    )
+    out_norm_weight = torch.randn(hidden, device="npu", dtype=torch.bfloat16)
+    eps = 1e-6
+
+    materialized = mix_fused(
+        prefix, bank, num_valid_blocks, combined_weight, eps
+    )
+    expected = materialized.float()
+    expected *= torch.rsqrt(expected.square().mean(dim=-1, keepdim=True) + eps)
+    expected *= out_norm_weight.float()
+    expected = expected.to(prefix.dtype)
+
+    actual = mix_fused(
+        prefix,
+        bank,
+        num_valid_blocks,
+        combined_weight,
+        eps,
+        out_norm_weight=out_norm_weight,
+        out_norm_epsilon=eps,
+    )
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), atol=4e-3, rtol=1e-2)

--- a/tests/python/sgl_kernel_npu/test_k3_situ_dense_tile.py
+++ b/tests/python/sgl_kernel_npu/test_k3_situ_dense_tile.py
@@ -1,0 +1,28 @@
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from sgl_kernel_npu.activation.situ import situ_and_mul
+
+
+def _reference(x: torch.Tensor) -> torch.Tensor:
+    gate, up = x.float().chunk(2, dim=-1)
+    gate = 4.0 * torch.tanh(gate / 4.0) * torch.sigmoid(gate)
+    up = 25.0 * torch.tanh(up / 25.0)
+    return (gate * up).to(x.dtype)
+
+
+@pytest.mark.parametrize(
+    ("tokens", "intermediate"),
+    [(1, 3072), (16, 3072), (1, 33792), (16, 33792), (64, 33792)],
+)
+@torch.no_grad()
+def test_situ_dense_tile_matches_reference(tokens: int, intermediate: int):
+    torch.manual_seed(20260820 + tokens)
+    host = torch.randn(tokens, 2 * intermediate, dtype=torch.float32).clamp_(-8, 8)
+    x = host.to(dtype=torch.bfloat16, device="npu")
+
+    actual = situ_and_mul(x, beta=4.0, linear_beta=25.0)
+    expected = _reference(host.to(torch.bfloat16))
+
+    torch.testing.assert_close(actual.cpu(), expected, atol=3e-2, rtol=1e-2)

--- a/tests/python/sgl_kernel_npu/test_k3_situ_dense_tile.py
+++ b/tests/python/sgl_kernel_npu/test_k3_situ_dense_tile.py
@@ -26,3 +26,30 @@ def test_situ_dense_tile_matches_reference(tokens: int, intermediate: int):
     expected = _reference(host.to(torch.bfloat16))
 
     torch.testing.assert_close(actual.cpu(), expected, atol=3e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("tokens", [1, 3, 16, 49])
+@torch.no_grad()
+def test_situ_grouped_hidden_tiles_match_reference(tokens: int):
+    intermediate = 33792
+    padded_rows = 64
+    torch.manual_seed(20260821 + tokens)
+    host = torch.randn(
+        padded_rows, 2 * intermediate, dtype=torch.float32
+    ).clamp_(-8, 8)
+    x = host.to(dtype=torch.bfloat16, device="npu")
+    counts = torch.zeros(64, dtype=torch.int32, device="npu")
+    counts[0] = tokens
+
+    actual = situ_and_mul(
+        x,
+        group_list=counts,
+        group_list_type=1,
+        beta=4.0,
+        linear_beta=25.0,
+    )
+    expected = _reference(host[:tokens].to(torch.bfloat16))
+
+    torch.testing.assert_close(
+        actual[:tokens].cpu(), expected, atol=3e-2, rtol=1e-2
+    )

--- a/tests/python/sgl_kernel_npu/test_k3_situ_dense_tile.py
+++ b/tests/python/sgl_kernel_npu/test_k3_situ_dense_tile.py
@@ -1,7 +1,6 @@
 import pytest
 import torch
 import torch_npu  # noqa: F401
-
 from sgl_kernel_npu.activation.situ import situ_and_mul
 
 
@@ -34,9 +33,7 @@ def test_situ_grouped_hidden_tiles_match_reference(tokens: int):
     intermediate = 33792
     padded_rows = 64
     torch.manual_seed(20260821 + tokens)
-    host = torch.randn(
-        padded_rows, 2 * intermediate, dtype=torch.float32
-    ).clamp_(-8, 8)
+    host = torch.randn(padded_rows, 2 * intermediate, dtype=torch.float32).clamp_(-8, 8)
     x = host.to(dtype=torch.bfloat16, device="npu")
     counts = torch.zeros(64, dtype=torch.int32, device="npu")
     counts[0] = tokens
@@ -50,6 +47,4 @@ def test_situ_grouped_hidden_tiles_match_reference(tokens: int):
     )
     expected = _reference(host[:tokens].to(torch.bfloat16))
 
-    torch.testing.assert_close(
-        actual[:tokens].cpu(), expected, atol=3e-2, rtol=1e-2
-    )
+    torch.testing.assert_close(actual[:tokens].cpu(), expected, atol=3e-2, rtol=1e-2)

--- a/tests/python/sgl_kernel_npu/test_kda_ragged.py
+++ b/tests/python/sgl_kernel_npu/test_kda_ragged.py
@@ -1,0 +1,78 @@
+import torch
+
+from sgl_kernel_npu.fla.kda_ragged import (
+    gather_kda_verify_output_npu,
+    scatter_kda_verify_inputs_npu,
+)
+
+
+def _dense_indices(query_start_loc: torch.Tensor, packed_tokens: int, steps: int):
+    positions = torch.arange(packed_tokens, dtype=torch.int32, device="npu")
+    slots = torch.searchsorted(query_start_loc[1:], positions, right=True)
+    return slots * steps + (positions - query_start_loc[slots]).long()
+
+
+def test_kda_ragged_io_matches_eager_under_graph_replay():
+    device = torch.device("npu")
+    steps = 4
+    query_start_loc = torch.tensor([0, 3, 4], dtype=torch.int32, device=device)
+    qkv = torch.randn(4, 17, dtype=torch.bfloat16, device=device)
+    a = torch.randn(1, 4, 2, 5, dtype=torch.bfloat16, device=device)
+    b = torch.randn(1, 4, 2, dtype=torch.bfloat16, device=device)
+
+    dense_qkv, dense_a, dense_b = scatter_kda_verify_inputs_npu(
+        qkv, a, b, query_start_loc, draft_token_num=steps
+    )
+    expected_qkv = torch.zeros(8, 17, dtype=qkv.dtype, device=device)
+    expected_a = torch.zeros(1, 8, 2, 5, dtype=a.dtype, device=device)
+    expected_b = torch.zeros(1, 8, 2, dtype=b.dtype, device=device)
+    expected_qkv[[0, 1, 2, 4]] = qkv
+    expected_a[:, [0, 1, 2, 4]] = a
+    expected_b[:, [0, 1, 2, 4]] = b
+    torch.testing.assert_close(dense_qkv, expected_qkv, rtol=0, atol=0)
+    torch.testing.assert_close(dense_a, expected_a, rtol=0, atol=0)
+    torch.testing.assert_close(dense_b, expected_b, rtol=0, atol=0)
+
+    dense_output = torch.randn(1, 8, 2, 5, dtype=torch.bfloat16, device=device)
+    indices = _dense_indices(query_start_loc, qkv.shape[0], steps)
+    packed_output = gather_kda_verify_output_npu(dense_output, indices)
+    torch.testing.assert_close(
+        packed_output, dense_output[:, [0, 1, 2, 4]], rtol=0, atol=0
+    )
+
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        graph_qkv, graph_a, graph_b = scatter_kda_verify_inputs_npu(
+            qkv, a, b, query_start_loc, draft_token_num=steps
+        )
+    query_start_loc.copy_(
+        torch.tensor([0, 2, 4], dtype=torch.int32, device=device)
+    )
+    qkv.copy_(torch.randn_like(qkv))
+    a.copy_(torch.randn_like(a))
+    b.copy_(torch.randn_like(b))
+    graph.replay()
+    torch.npu.synchronize()
+    replay_qkv = torch.zeros_like(expected_qkv)
+    replay_a = torch.zeros_like(expected_a)
+    replay_b = torch.zeros_like(expected_b)
+    replay_qkv[[0, 1, 4, 5]] = qkv
+    replay_a[:, [0, 1, 4, 5]] = a
+    replay_b[:, [0, 1, 4, 5]] = b
+    torch.testing.assert_close(graph_qkv, replay_qkv, rtol=0, atol=0)
+    torch.testing.assert_close(graph_a, replay_a, rtol=0, atol=0)
+    torch.testing.assert_close(graph_b, replay_b, rtol=0, atol=0)
+
+    gather_graph = torch.npu.NPUGraph()
+    with torch.npu.graph(gather_graph):
+        graph_indices = _dense_indices(query_start_loc, qkv.shape[0], steps)
+        graph_packed = gather_kda_verify_output_npu(dense_output, graph_indices)
+    query_start_loc.copy_(
+        torch.tensor([0, 3, 4], dtype=torch.int32, device=device)
+    )
+    dense_output.copy_(torch.randn_like(dense_output))
+    gather_graph.replay()
+    torch.npu.synchronize()
+    torch.testing.assert_close(
+        graph_packed, dense_output[:, [0, 1, 2, 4]], rtol=0, atol=0
+    )

--- a/tests/python/sgl_kernel_npu/test_kda_ragged.py
+++ b/tests/python/sgl_kernel_npu/test_kda_ragged.py
@@ -1,6 +1,7 @@
 import torch
 
 from sgl_kernel_npu.fla.kda_ragged import (
+    gather_kda_verify_output_norm_npu,
     gather_kda_verify_output_npu,
     scatter_kda_verify_inputs_npu,
 )
@@ -75,4 +76,47 @@ def test_kda_ragged_io_matches_eager_under_graph_replay():
     torch.npu.synchronize()
     torch.testing.assert_close(
         graph_packed, dense_output[:, [0, 1, 2, 4]], rtol=0, atol=0
+    )
+
+
+def test_kda_ragged_gather_norm_matches_eager_under_graph_replay():
+    device = torch.device("npu")
+    dense_output = torch.randn(1, 8, 2, 5, dtype=torch.bfloat16, device=device)
+    indices = torch.tensor([0, 4, 8], dtype=torch.int64, device=device)
+    gate = torch.randn(3, 10, dtype=torch.bfloat16, device=device)
+    weight = torch.randn(5, dtype=torch.bfloat16, device=device)
+    eps = 1e-5
+
+    def eager_reference():
+        covered = indices < dense_output.shape[1]
+        safe_indices = indices.clamp(max=dense_output.shape[1] - 1)
+        gathered = dense_output[:, safe_indices].float()
+        gathered = torch.where(covered.view(1, -1, 1, 1), gathered, 0.0)
+        rstd = torch.rsqrt(gathered.square().mean(dim=-1, keepdim=True) + eps)
+        return (
+            gathered
+            * rstd
+            * weight.float()
+            * gate.view(1, 3, 2, 5).float().sigmoid()
+        ).to(torch.bfloat16)
+
+    actual = gather_kda_verify_output_norm_npu(
+        dense_output, indices, gate, weight, eps=eps
+    )
+    torch.testing.assert_close(
+        actual.float(), eager_reference().float(), atol=2e-2, rtol=2e-2
+    )
+
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        graph_output = gather_kda_verify_output_norm_npu(
+            dense_output, indices, gate, weight, eps=eps
+        )
+    dense_output.copy_(torch.randn_like(dense_output))
+    gate.copy_(torch.randn_like(gate))
+    indices.copy_(torch.tensor([2, 6, 8], dtype=torch.int64, device=device))
+    graph.replay()
+    torch.npu.synchronize()
+    torch.testing.assert_close(
+        graph_output.float(), eager_reference().float(), atol=2e-2, rtol=2e-2
     )

--- a/tests/python/sgl_kernel_npu/test_kda_ragged.py
+++ b/tests/python/sgl_kernel_npu/test_kda_ragged.py
@@ -1,5 +1,4 @@
 import torch
-
 from sgl_kernel_npu.fla.kda_ragged import (
     gather_kda_verify_output_norm_npu,
     gather_kda_verify_output_npu,
@@ -46,9 +45,7 @@ def test_kda_ragged_io_matches_eager_under_graph_replay():
         graph_qkv, graph_a, graph_b = scatter_kda_verify_inputs_npu(
             qkv, a, b, query_start_loc, draft_token_num=steps
         )
-    query_start_loc.copy_(
-        torch.tensor([0, 2, 4], dtype=torch.int32, device=device)
-    )
+    query_start_loc.copy_(torch.tensor([0, 2, 4], dtype=torch.int32, device=device))
     qkv.copy_(torch.randn_like(qkv))
     a.copy_(torch.randn_like(a))
     b.copy_(torch.randn_like(b))
@@ -68,9 +65,7 @@ def test_kda_ragged_io_matches_eager_under_graph_replay():
     with torch.npu.graph(gather_graph):
         graph_indices = _dense_indices(query_start_loc, qkv.shape[0], steps)
         graph_packed = gather_kda_verify_output_npu(dense_output, graph_indices)
-    query_start_loc.copy_(
-        torch.tensor([0, 3, 4], dtype=torch.int32, device=device)
-    )
+    query_start_loc.copy_(torch.tensor([0, 3, 4], dtype=torch.int32, device=device))
     dense_output.copy_(torch.randn_like(dense_output))
     gather_graph.replay()
     torch.npu.synchronize()
@@ -94,10 +89,7 @@ def test_kda_ragged_gather_norm_matches_eager_under_graph_replay():
         gathered = torch.where(covered.view(1, -1, 1, 1), gathered, 0.0)
         rstd = torch.rsqrt(gathered.square().mean(dim=-1, keepdim=True) + eps)
         return (
-            gathered
-            * rstd
-            * weight.float()
-            * gate.view(1, 3, 2, 5).float().sigmoid()
+            gathered * rstd * weight.float() * gate.view(1, 3, 2, 5).float().sigmoid()
         ).to(torch.bfloat16)
 
     actual = gather_kda_verify_output_norm_npu(

--- a/tests/python/sgl_kernel_npu/test_kda_state_commit.py
+++ b/tests/python/sgl_kernel_npu/test_kda_state_commit.py
@@ -1,6 +1,7 @@
 import torch
 
 from sgl_kernel_npu.mamba.kda_state_commit import (
+    commit_kda_extended_conv_state,
     move_kda_temporal_snapshot,
     scatter_kda_conv_snapshot,
 )
@@ -104,3 +105,77 @@ def test_conv_production_layout_matches_under_graph_replay():
     graph.replay()
     torch.npu.synchronize()
     assert torch.all(dst == -17.0).item()
+
+
+def test_extended_conv_state_view_matches_under_graph_replay():
+    device = torch.device("npu")
+    layers, pool_size, steps, channels, window = 69, 4, 8, 2304, 3
+    extended = torch.randn(
+        layers,
+        pool_size,
+        steps + window - 1,
+        channels,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    original = extended.clone()
+    destination = extended[:, :, -window:, :].transpose(-1, -2)
+    primary_indices = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    primary_steps = torch.tensor([2, 5], dtype=torch.int32, device=device)
+    track_dst_indices = torch.tensor([2, 3], dtype=torch.int32, device=device)
+    track_src_indices = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    track_steps = torch.tensor([4, -1], dtype=torch.int32, device=device)
+
+    # Match the framework order: tracking slots read the unmodified primary
+    # windows, then primary slots are committed in place.
+    assert commit_kda_extended_conv_state(
+        extended, track_dst_indices, track_src_indices, track_steps, steps
+    )
+    assert commit_kda_extended_conv_state(
+        extended, primary_indices, primary_indices, primary_steps, steps
+    )
+    torch.npu.synchronize()
+    torch.testing.assert_close(
+        destination[:, 0], original[:, 0, 2:5].transpose(-1, -2), rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        destination[:, 1], original[:, 1, 5:8].transpose(-1, -2), rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        destination[:, 2], original[:, 0, 4:7].transpose(-1, -2), rtol=0, atol=0
+    )
+    torch.testing.assert_close(extended[:, 3], original[:, 3], rtol=0, atol=0)
+    ordinary = extended.clone()
+
+    extended.copy_(original)
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        captured_track = commit_kda_extended_conv_state(
+            extended, track_dst_indices, track_src_indices, track_steps, steps
+        )
+        captured_primary = commit_kda_extended_conv_state(
+            extended, primary_indices, primary_indices, primary_steps, steps
+        )
+    assert captured_track and captured_primary
+
+    extended.copy_(original)
+    graph.replay()
+    torch.npu.synchronize()
+    torch.testing.assert_close(extended, ordinary, rtol=0, atol=0)
+
+    # Runtime indices and steps must remain live under graph replay.
+    extended.copy_(original)
+    primary_steps.copy_(torch.tensor([7, 1], dtype=torch.int32, device=device))
+    track_steps.copy_(torch.tensor([-1, 3], dtype=torch.int32, device=device))
+    graph.replay()
+    torch.npu.synchronize()
+    torch.testing.assert_close(
+        destination[:, 0], original[:, 0, 7:10].transpose(-1, -2), rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        destination[:, 1], original[:, 1, 1:4].transpose(-1, -2), rtol=0, atol=0
+    )
+    torch.testing.assert_close(extended[:, 2], original[:, 2], rtol=0, atol=0)
+    torch.testing.assert_close(
+        destination[:, 3], original[:, 1, 3:6].transpose(-1, -2), rtol=0, atol=0
+    )

--- a/tests/python/sgl_kernel_npu/test_kda_state_commit.py
+++ b/tests/python/sgl_kernel_npu/test_kda_state_commit.py
@@ -1,0 +1,106 @@
+import torch
+
+from sgl_kernel_npu.mamba.kda_state_commit import (
+    move_kda_temporal_snapshot,
+    scatter_kda_conv_snapshot,
+)
+
+
+def test_temporal_production_layout_matches_under_graph_replay():
+    device = torch.device("npu")
+    layers, pool_size, steps, heads, dim_v, dim_k = 69, 3, 2, 6, 128, 128
+    src = torch.randn(
+        layers,
+        1,
+        steps,
+        heads,
+        dim_v,
+        dim_k,
+        dtype=torch.float32,
+        device=device,
+    )
+    dst_storage = torch.full(
+        (layers, pool_size, heads, dim_k, dim_v),
+        -17.0,
+        dtype=torch.float32,
+        device=device,
+    )
+    dst = dst_storage.transpose(-1, -2)
+    dst_indices = torch.tensor([2], dtype=torch.int32, device=device)
+    src_indices = torch.tensor([0], dtype=torch.int32, device=device)
+    step_indices = torch.tensor([0], dtype=torch.int32, device=device)
+
+    assert move_kda_temporal_snapshot(
+        dst, src, dst_indices, src_indices, step_indices
+    )
+    torch.npu.synchronize()
+    torch.testing.assert_close(dst[:, 2], src[:, 0, 0], rtol=0, atol=0)
+
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        captured = move_kda_temporal_snapshot(
+            dst, src, dst_indices, src_indices, step_indices
+        )
+    assert captured
+
+    dst.fill_(-17.0)
+    step_indices.fill_(1)
+    graph.replay()
+    torch.npu.synchronize()
+    torch.testing.assert_close(dst[:, 2], src[:, 0, 1], rtol=0, atol=0)
+    assert torch.all(dst[:, :2] == -17.0).item()
+
+    dst.fill_(-17.0)
+    step_indices.fill_(-1)
+    graph.replay()
+    torch.npu.synchronize()
+    assert torch.all(dst == -17.0).item()
+
+
+def test_conv_production_layout_matches_under_graph_replay():
+    device = torch.device("npu")
+    layers, pool_size, steps, channels, window = 69, 3, 8, 2304, 3
+    src = torch.randn(
+        layers,
+        1,
+        steps,
+        channels,
+        window,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    dst = torch.full(
+        (layers, pool_size, channels, window),
+        -17.0,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    dst_indices = torch.tensor([2], dtype=torch.int32, device=device)
+    src_indices = torch.tensor([0], dtype=torch.int32, device=device)
+    step_indices = torch.tensor([1], dtype=torch.int32, device=device)
+
+    assert scatter_kda_conv_snapshot(
+        dst, src, dst_indices, src_indices, step_indices
+    )
+    torch.npu.synchronize()
+    torch.testing.assert_close(dst[:, 2], src[:, 0, 1], rtol=0, atol=0)
+
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph):
+        captured = scatter_kda_conv_snapshot(
+            dst, src, dst_indices, src_indices, step_indices
+        )
+    assert captured
+
+    dst.fill_(-17.0)
+    step_indices.fill_(5)
+    graph.replay()
+    torch.npu.synchronize()
+    torch.testing.assert_close(dst[:, 2], src[:, 0, 5], rtol=0, atol=0)
+    assert torch.all(dst[:, :2] == -17.0).item()
+
+    dst.fill_(-17.0)
+    step_indices.fill_(-1)
+    graph.replay()
+    torch.npu.synchronize()
+    assert torch.all(dst == -17.0).item()

--- a/tests/python/sgl_kernel_npu/test_kda_state_commit.py
+++ b/tests/python/sgl_kernel_npu/test_kda_state_commit.py
@@ -1,5 +1,4 @@
 import torch
-
 from sgl_kernel_npu.mamba.kda_state_commit import (
     commit_kda_extended_conv_state,
     move_kda_temporal_snapshot,
@@ -31,9 +30,7 @@ def test_temporal_production_layout_matches_under_graph_replay():
     src_indices = torch.tensor([0], dtype=torch.int32, device=device)
     step_indices = torch.tensor([0], dtype=torch.int32, device=device)
 
-    assert move_kda_temporal_snapshot(
-        dst, src, dst_indices, src_indices, step_indices
-    )
+    assert move_kda_temporal_snapshot(dst, src, dst_indices, src_indices, step_indices)
     torch.npu.synchronize()
     torch.testing.assert_close(dst[:, 2], src[:, 0, 0], rtol=0, atol=0)
 
@@ -80,9 +77,7 @@ def test_conv_production_layout_matches_under_graph_replay():
     src_indices = torch.tensor([0], dtype=torch.int32, device=device)
     step_indices = torch.tensor([1], dtype=torch.int32, device=device)
 
-    assert scatter_kda_conv_snapshot(
-        dst, src, dst_indices, src_indices, step_indices
-    )
+    assert scatter_kda_conv_snapshot(dst, src, dst_indices, src_indices, step_indices)
     torch.npu.synchronize()
     torch.testing.assert_close(dst[:, 2], src[:, 0, 1], rtol=0, atol=0)
 

--- a/tests/python/sgl_kernel_npu/test_kda_target_verify.py
+++ b/tests/python/sgl_kernel_npu/test_kda_target_verify.py
@@ -1,5 +1,4 @@
 import torch
-
 from sgl_kernel_npu.fla.kda_gate import fused_kda_gate_npu
 from sgl_kernel_npu.fla.kda_target_verify import kda_target_verify_npu
 
@@ -10,13 +9,9 @@ def test_kda_target_verify_raw_gates_match_preactivated_gates():
     tokens = batch * steps
     q = torch.randn(1, tokens, heads, key_dim, dtype=torch.bfloat16, device=device)
     k = torch.randn_like(q)
-    v = torch.randn(
-        1, tokens, heads, value_dim, dtype=torch.bfloat16, device=device
-    )
+    v = torch.randn(1, tokens, heads, value_dim, dtype=torch.bfloat16, device=device)
     raw_a = torch.randn_like(q)
-    raw_b = torch.randn(
-        1, tokens, heads, dtype=torch.bfloat16, device=device
-    )
+    raw_b = torch.randn(1, tokens, heads, dtype=torch.bfloat16, device=device)
     A_log = torch.randn(1, 1, heads, 1, dtype=torch.float32, device=device)
     dt_bias = torch.randn(heads * key_dim, dtype=torch.float32, device=device)
     initial_state = torch.randn(

--- a/tests/python/sgl_kernel_npu/test_kda_target_verify.py
+++ b/tests/python/sgl_kernel_npu/test_kda_target_verify.py
@@ -1,0 +1,83 @@
+import torch
+
+from sgl_kernel_npu.fla.kda_gate import fused_kda_gate_npu
+from sgl_kernel_npu.fla.kda_target_verify import kda_target_verify_npu
+
+
+def test_kda_target_verify_raw_gates_match_preactivated_gates():
+    device = torch.device("npu")
+    batch, steps, heads, key_dim, value_dim = 2, 3, 2, 8, 8
+    tokens = batch * steps
+    q = torch.randn(1, tokens, heads, key_dim, dtype=torch.bfloat16, device=device)
+    k = torch.randn_like(q)
+    v = torch.randn(
+        1, tokens, heads, value_dim, dtype=torch.bfloat16, device=device
+    )
+    raw_a = torch.randn_like(q)
+    raw_b = torch.randn(
+        1, tokens, heads, dtype=torch.bfloat16, device=device
+    )
+    A_log = torch.randn(1, 1, heads, 1, dtype=torch.float32, device=device)
+    dt_bias = torch.randn(heads * key_dim, dtype=torch.float32, device=device)
+    initial_state = torch.randn(
+        batch, heads, value_dim, key_dim, dtype=torch.bfloat16, device=device
+    )
+    initial_indices = torch.arange(batch, dtype=torch.int32, device=device)
+    intermediate_indices = torch.arange(batch, dtype=torch.int32, device=device)
+    raw_scratch = torch.empty(
+        batch,
+        steps,
+        heads,
+        value_dim,
+        key_dim,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    preactivated_scratch = torch.empty_like(raw_scratch)
+    lower_bound = -5.0
+
+    raw_output = kda_target_verify_npu(
+        A_log=A_log,
+        dt_bias=dt_bias,
+        q=q,
+        k=k,
+        v=v,
+        a=raw_a,
+        b=raw_b,
+        initial_state_source=initial_state,
+        initial_state_indices=initial_indices,
+        intermediate_states_buffer=raw_scratch,
+        intermediate_state_indices=intermediate_indices,
+        cache_steps=steps,
+        gates_are_preactivated=False,
+        lower_bound=lower_bound,
+    )
+    preactivated_a = fused_kda_gate_npu(
+        raw_a.flatten(-2),
+        A_log,
+        key_dim,
+        gate_bias=dt_bias,
+        lower_bound=lower_bound,
+    )
+    preactivated_b = raw_b.float().sigmoid()
+    preactivated_output = kda_target_verify_npu(
+        A_log=A_log,
+        dt_bias=dt_bias,
+        q=q,
+        k=k,
+        v=v,
+        a=preactivated_a,
+        b=preactivated_b,
+        initial_state_source=initial_state,
+        initial_state_indices=initial_indices,
+        intermediate_states_buffer=preactivated_scratch,
+        intermediate_state_indices=intermediate_indices,
+        cache_steps=steps,
+        gates_are_preactivated=True,
+    )
+    torch.testing.assert_close(
+        raw_output.float(), preactivated_output.float(), rtol=2e-2, atol=2e-2
+    )
+    torch.testing.assert_close(
+        raw_scratch.float(), preactivated_scratch.float(), rtol=2e-2, atol=2e-2
+    )

--- a/tests/python/sgl_kernel_npu/test_situ_quant.py
+++ b/tests/python/sgl_kernel_npu/test_situ_quant.py
@@ -1,15 +1,12 @@
 import torch
 import torch_npu
-
 from sgl_kernel_npu.activation.situ import situ_and_mul, situ_and_mul_quant
 
 
 def test_situ_and_mul_quant_matches_materialized_bf16():
     torch.manual_seed(42)
     for rows, half_cols in ((8, 768), (16, 384)):
-        x = torch.randn(
-            (rows, 2 * half_cols), dtype=torch.bfloat16, device="npu"
-        )
+        x = torch.randn((rows, 2 * half_cols), dtype=torch.bfloat16, device="npu")
         activated = situ_and_mul(x, beta=4.0, linear_beta=25.0)
         expected, expected_scale = torch_npu.npu_dynamic_quant(activated)
 

--- a/tests/python/sgl_kernel_npu/test_situ_quant.py
+++ b/tests/python/sgl_kernel_npu/test_situ_quant.py
@@ -1,0 +1,28 @@
+import torch
+import torch_npu
+
+from sgl_kernel_npu.activation.situ import situ_and_mul, situ_and_mul_quant
+
+
+def test_situ_and_mul_quant_matches_materialized_bf16():
+    torch.manual_seed(42)
+    for rows, half_cols in ((8, 768), (16, 384)):
+        x = torch.randn(
+            (rows, 2 * half_cols), dtype=torch.bfloat16, device="npu"
+        )
+        activated = situ_and_mul(x, beta=4.0, linear_beta=25.0)
+        expected, expected_scale = torch_npu.npu_dynamic_quant(activated)
+
+        actual, actual_scale = situ_and_mul_quant(
+            x,
+            beta=4.0,
+            linear_beta=25.0,
+            need_quant=True,
+        )
+
+        torch.testing.assert_close(
+            actual_scale, expected_scale.flatten(), rtol=1e-6, atol=1e-8
+        )
+        quant_error = (actual.to(torch.int16) - expected.to(torch.int16)).abs()
+        assert quant_error.max().item() <= 1
+        assert (quant_error != 0).float().mean().item() <= 1e-3


### PR DESCRIPTION
## Summary

- add NPU kernels used by the optimized Kimi-K3 + DSpark inference path
- add direct KDA state commit, ragged KDA verify I/O, fused gate/output-normalization paths, DSpark local top-1, and capture-safe hybrid replay metadata update
- retile K3 SiTU/residual and verify recurrence kernels for the decode shapes used by Kimi-K3
- add focused parity and unit tests for the new operators

## Four-node benchmark

This kernel branch is paired with `McZyWu/sgl-sglang:wzy/k3-main-tpot85` at framework SHA `3b497c4841`.

- benchmarked kernel SHA: `d8a6cbea85`
- PR head: `f97f95e` (formatting-only follow-up; no kernel semantics changed)
- 4 nodes / 64 NPUs, DP=4, TP=64
- random 8K input / exactly 1K output, radix cache disabled
- initial seeds 42-46 mean TPoT: **8.120 ms**
- initial mean TTFT: **2815.584 ms**
- initial mean accept length: **8.424**
- all five requests generated exactly 1000 tokens

Two additional five-run sets were repeated with the same seeds after a fresh four-node service startup:

| set | mean TPoT (ms) | TPoT std (ms) | mean TTFT (ms) | mean accept |
| --- | ---: | ---: | ---: | ---: |
| original | 8.120 | 0.624 | 2815.584 | 8.424 |
| repeat A | 8.292 | 0.516 | 2815.800 | 8.360 |
| repeat B | 8.250 | 0.593 | 2813.668 | 8.412 |
| combined 15 | 8.221 | 0.584 | 2815.017 | 8.399 |

The combined TPoT P90 is 8.878 ms. Same-seed standard deviations are 0.082-0.164 ms, showing that most of the overall spread follows accept-length/workload differences rather than one-time compilation. All 15 measured requests generated exactly 1000 tokens.

## Validation status

- [x] focused operator parity/unit tests
- [x] NPU graph capture/replay smoke validation
- [x] one strict cache-off five-run performance set
- [x] two additional stability sets and variance report
- [ ] five-run mean TPoT below 8 ms
- [ ] GSM8K-1319 and GPQA accuracy regressions

This is a draft until the performance target and end-to-end accuracy gates complete. Paired framework PR: https://github.com/sgl-project/sglang/pull/36947
