### PR TITLE
feat(deepep): L2 cross-expert weight prefetch for fused_deep_moe_a5

### DIFF
--- a/csrc/deepep/ops/op_host/fused_deep_moe_a5/fused_deep_moe_tiling.cpp
+++ b/csrc/deepep/ops/op_host/fused_deep_moe_a5/fused_deep_moe_tiling.cpp
@@ -546,6 +546,8 @@ static ge::graphStatus GetAttrAndSetTilingData(const gert::TilingContext &contex
     tilingData.fusedDeepMoeInfo.profileLaunchId = static_cast<uint32_t>(*profileLaunchIdPtr);
     tilingData.fusedDeepMoeInfo.globalBs = static_cast<uint32_t>(*globalBsPtr);
     tilingData.fusedDeepMoeInfo.moeExpertNumPerRank = moeExpertNumPerRank;
+    // L2 cross-expert weight prefetch: default off; enable after on-board validation (msprof L2 hit-rate check)
+    tilingData.fusedDeepMoeInfo.l2PrefetchEnable = 0U;
     return ge::GRAPH_SUCCESS;
 }
 

--- a/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/fused_deep_moe_utils.h
+++ b/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/fused_deep_moe_utils.h
@@ -68,4 +68,126 @@ __aicore__ inline void CheckSyncFlag(__gm__ int32_t *flagAddr, int32_t idx, uint
     AscendC::PipeBarrier<PIPE_ALL>();
 }
 
+// -----------------------------------------------------------------------------
+// L2 cross-expert weight prefetch helpers.
+// Pull the next expert's GEMM weights from GM into the chip-shared L2 cache by
+// issuing chunked GM->UB reads with CACHE_MODE_NORMAL (read-allocate) during
+// otherwise idle spin windows. Data written to the UB pad is never consumed.
+// Synchronization notes:
+//   * All chunks are DataCopy instructions on the MTE2 pipe of the issuing
+//     core; a single MTE pipe executes in order and the pad region has no
+//     consumer, so no SetFlag/WaitFlag pairing is required for pad reuse.
+//   * The first chunk is only issued from inside CheckSyncFlagWithL2Prefetch,
+//     which begins with PipeBarrier<PIPE_ALL> (drains earlier users of the UB
+//     region, e.g. dispatch buffers). In-flight chunks are drained by the
+//     existing PipeBarrier<PIPE_ALL> at the end of each kernel stage.
+// -----------------------------------------------------------------------------
+namespace L2Prefetch {
+constexpr uint32_t UB_PAD_OFFSET = 160 * 1024;  // UB landing pad, above epilogue usage (max 128KB)
+constexpr uint32_t CHUNK_BYTES = 32 * 1024;     // MTE2-friendly chunk size (>= 20KB per copy)
+constexpr uint32_t SPIN_INTERVAL = 4;           // issue at most one chunk per N spin polls
+}  // namespace L2Prefetch
+
+struct L2PrefetchCtx {
+    AscendC::GlobalTensor<uint8_t> srcWeight;  // next expert B weights (stripe slice)
+    AscendC::GlobalTensor<uint8_t> srcScale;   // next expert MxScaleB (fetched once by stripe 0)
+    AscendC::LocalTensor<uint8_t> pad;         // UB landing pad, data discarded
+    uint32_t weightBytes{0};
+    uint32_t scaleBytes{0};
+    uint32_t cursor{0};
+    bool active{false};
+};
+
+// Slice [stripeId] of the weight region into ctx; scale region is only fetched by stripe 0.
+__aicore__ inline void L2PrefetchInit(L2PrefetchCtx &ctx, AscendC::LocalTensor<uint8_t> &pad, __gm__ uint8_t *weightGm,
+                                      uint32_t weightBytes, __gm__ uint8_t *scaleGm, uint32_t scaleBytes,
+                                      uint32_t stripeId, uint32_t stripeNum)
+{
+    ctx.pad = pad;
+    ctx.cursor = 0;
+    ctx.active = false;
+    ctx.weightBytes = 0;
+    ctx.scaleBytes = 0;
+    uint32_t stripeBytes = (((weightBytes + stripeNum - 1) / stripeNum) + 31U) & ~31U;  // 32B aligned slice
+    uint32_t stripeStart = stripeBytes * stripeId;
+    if (stripeStart < weightBytes) {
+        uint32_t remain = weightBytes - stripeStart;
+        ctx.weightBytes = remain < stripeBytes ? remain : stripeBytes;
+        ctx.srcWeight.SetGlobalBuffer(weightGm + stripeStart);
+#if defined(FUSED_DEEP_MOE_ENABLE_L2_READ_AHEAD)
+        // Requires a target CANN providing AscendC::CacheMode::CACHE_MODE_READ_AHEAD; verify on board first
+        ctx.srcWeight.SetL2CacheHint(AscendC::CacheMode::CACHE_MODE_READ_AHEAD);
+#else
+        ctx.srcWeight.SetL2CacheHint(AscendC::CacheMode::CACHE_MODE_NORMAL);
+#endif
+        ctx.active = ctx.weightBytes > 0;
+    }
+    if (scaleBytes > 0 && stripeId == 0) {  // scale is tiny relative to weights, single-stripe fetch
+        ctx.scaleBytes = scaleBytes;
+        ctx.srcScale.SetGlobalBuffer(scaleGm);
+        ctx.srcScale.SetL2CacheHint(AscendC::CacheMode::CACHE_MODE_NORMAL);
+        ctx.active = true;
+    }
+}
+
+__aicore__ inline void L2PrefetchDeactivate(L2PrefetchCtx &ctx)
+{
+    ctx.active = false;
+}
+
+// Issue at most one chunk; non-blocking, safe to call from spin loops.
+__aicore__ inline void L2PrefetchStep(L2PrefetchCtx &ctx)
+{
+    if (!ctx.active) {
+        return;
+    }
+    if (ctx.cursor < ctx.weightBytes) {
+        uint32_t remain = ctx.weightBytes - ctx.cursor;
+        uint32_t chunk = (remain < L2Prefetch::CHUNK_BYTES ? remain : L2Prefetch::CHUNK_BYTES) & ~31U;
+        if (chunk == 0) {
+            ctx.active = false;
+            return;
+        }
+        AscendC::DataCopy(ctx.pad, ctx.srcWeight[ctx.cursor], chunk);
+        ctx.cursor += chunk;
+        return;
+    }
+    uint32_t scaleCursor = ctx.cursor - ctx.weightBytes;
+    if (scaleCursor < ctx.scaleBytes) {
+        uint32_t remain = ctx.scaleBytes - scaleCursor;
+        uint32_t chunk = (remain < L2Prefetch::CHUNK_BYTES ? remain : L2Prefetch::CHUNK_BYTES) & ~31U;
+        if (chunk == 0) {
+            ctx.active = false;
+            return;
+        }
+        AscendC::DataCopy(ctx.pad, ctx.srcScale[scaleCursor], chunk);
+        ctx.cursor += chunk;
+        return;
+    }
+    ctx.active = false;
+}
+
+// Same wait semantics as CheckSyncFlag, plus best-effort L2 prefetch between spins.
+__aicore__ inline void CheckSyncFlagWithL2Prefetch(__gm__ int32_t *flagAddr, int32_t idx, uint32_t target,
+                                                   L2PrefetchCtx *pfCtx)
+{
+    //  check flag, like wait flag, with L2 prefetch during idle spins
+    AscendC::PipeBarrier<PIPE_ALL>();
+    AscendC::GlobalTensor<int32_t> global;
+    global.SetGlobalBuffer(flagAddr + idx * CVSoftSync::SOFT_SYNC_SPACE_SIZE / sizeof(int32_t));
+    uint32_t spinCnt = 0;
+    while (true) {
+        int32_t value = FlushAndGetValue<int32_t>(global, 0);
+        if (value >= target) {
+            break;
+        }
+        if (pfCtx != nullptr && pfCtx->active && (spinCnt % L2Prefetch::SPIN_INTERVAL) == 0) {
+            L2PrefetchStep(*pfCtx);
+        }
+        SPIN_WAIT_CYCLES();
+        ++spinCnt;
+    }
+    AscendC::PipeBarrier<PIPE_ALL>();
+}
+
 #endif  // FUSED_DEEP_MOE_UTILS_H

--- a/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/gemm/kernel/dispatch_mx_gmm1_swiglu.h
+++ b/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/gemm/kernel/dispatch_mx_gmm1_swiglu.h
@@ -154,6 +154,7 @@ public:
         uint32_t topK;
         uint32_t tokenLen;
         uint32_t shareN;
+        uint32_t l2PrefetchEnable;
         // Methods
         CATLASS_HOST_DEVICE
         Params() {}
@@ -216,7 +217,8 @@ public:
               bs(fusedDeepMoeInfo.bs),
               topK(fusedDeepMoeInfo.k),
               tokenLen(fusedDeepMoeInfo.h),
-              shareN(fusedDeepMoeInfo.shareGmm1HLen)
+              shareN(fusedDeepMoeInfo.shareGmm1HLen),
+              l2PrefetchEnable(fusedDeepMoeInfo.l2PrefetchEnable)
         {}
     };
 
@@ -1381,6 +1383,31 @@ public:
         uint32_t currentM = 0;
         uint32_t target = 1;
 
+        // L2 cross-expert weight prefetch: while AIC computes expert g, AIVs pull expert g+1's
+        // w1 weights into the shared L2 during idle epilogue spin windows.
+        L2PrefetchCtx l2PfCtx;
+        l2PfCtx.active = false;
+        const bool l2PfEnabled = (params.l2PrefetchEnable != 0) && (params.problemCount > 1);
+        AscendC::LocalTensor<uint8_t> l2PfPad =
+            resource.ubBuf.template GetBufferByByte<uint8_t>(L2Prefetch::UB_PAD_OFFSET);
+        AscendC::ListTensorDesc l2PfBListDesc(reinterpret_cast<__gm__ void *>(params.ptrB));
+        AscendC::ListTensorDesc l2PfBScaleListDesc(reinterpret_cast<__gm__ void *>(params.ptrMxScaleB));
+        uint64_t l2PfPerGroupB = 0;
+        uint64_t l2PfPerGroupScale = 0;
+        if (l2PfEnabled) {
+            // mirror the AIC-side per-group B offset accumulation (static in k/n, independent of M)
+            if constexpr (AscendC::Std::is_one_of_v<ElementB, float4_e2m1x2_t, float4_e1m2x2_t>) {
+                l2PfPerGroupB = std::is_same_v<LayoutB, layout::ColumnMajor>
+                                    ? CeilDiv<2>(params.problemShape.k()) * params.problemShape.n()
+                                    : CeilDiv<2>(params.problemShape.n()) * params.problemShape.k();
+            } else {
+                l2PfPerGroupB = static_cast<uint64_t>(params.problemShape.k()) * params.problemShape.n();
+            }
+            l2PfPerGroupScale =
+                static_cast<uint64_t>(CeilDiv<MX_BASEK_FACTOR>(params.problemShape.k()) * MX_SCALE_COPY_GROUP_NUM) *
+                params.problemShape.n();
+        }
+
         if constexpr (EXEC_FLAG & EXEC_FLAG_SHARED_EXPERT) {
             currentM = axisBS;
             gmC.SetGlobalBuffer(params.ptrShareC);
@@ -1400,6 +1427,12 @@ public:
                 startLoopIdx = coreIdx - startCoreIdx;
             }
 
+            if (l2PfEnabled) {
+                // warm routed expert 0 weights while AIC computes the shared expert GEMM
+                SetupL2PrefetchGroup(l2PfCtx, l2PfPad, params, l2PfBListDesc, l2PfBScaleListDesc, l2PfPerGroupB,
+                                     l2PfPerGroupScale, 0, aivIdx, aivNum);
+            }
+
             for (uint32_t loopIdx = startLoopIdx; loopIdx < coreLoops; loopIdx += coreNum) {
                 GemmCoord blockCoord = matmulBlockScheduler.GetBlockCoord(loopIdx);
                 GemmCoord actualBlockShape = matmulBlockScheduler.GetActualBlockShape(blockCoord);
@@ -1413,8 +1446,9 @@ public:
                             tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
 
                 bool isLeft = (blockCoord.n() * L1_TILE_N < params.shareProblemShape.n() / 2);
-                CheckSyncFlag(reinterpret_cast<__gm__ int32_t *>(statusDataSpaceGm + SOFT_SYNC_OFFSET),
-                              static_cast<int32_t>(compCoreIdx), target);
+                CheckSyncFlagWithL2Prefetch(reinterpret_cast<__gm__ int32_t *>(statusDataSpaceGm + SOFT_SYNC_OFFSET),
+                                            static_cast<int32_t>(compCoreIdx), target,
+                                            l2PfEnabled ? &l2PfCtx : nullptr);
                 target += 1;
                 blockEpilogue(tensorBlockC, tensorBlockD, actualBlockShape, isLeft);
             }
@@ -1434,11 +1468,19 @@ public:
 
             for (uint32_t groupIdx = 0; groupIdx < params.problemCount; ++groupIdx) {
                 uint64_t profSwigluStart = 0;
+                if (l2PfEnabled && (groupIdx + 1) < params.problemCount) {
+                    // AIC is entering/ computing group groupIdx: prefetch group groupIdx+1's w1 into L2
+                    SetupL2PrefetchGroup(l2PfCtx, l2PfPad, params, l2PfBListDesc, l2PfBScaleListDesc, l2PfPerGroupB,
+                                         l2PfPerGroupScale, groupIdx + 1, aivIdx, aivNum);
+                } else {
+                    L2PrefetchDeactivate(l2PfCtx);
+                }
                 if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
                     groupTokenNumStateTensor.SetGlobalBuffer(
                         (__gm__ int32_t *)(statusDataSpaceGm + GROUP_TOKEN_NUM_OFFSET) + groupIdx * GROUP_INFO_SIZE);
-                    CheckSyncFlag(reinterpret_cast<__gm__ int32_t *>(statusDataSpaceGm + SOFT_SYNC_OFFSET),
-                                  static_cast<int32_t>(compCoreIdx), target);
+                    CheckSyncFlagWithL2Prefetch(reinterpret_cast<__gm__ int32_t *>(statusDataSpaceGm + SOFT_SYNC_OFFSET),
+                                                static_cast<int32_t>(compCoreIdx), target,
+                                                l2PfEnabled ? &l2PfCtx : nullptr);
                     target += 1;
                     currentM = FlushAndGetValue<int32_t>(groupTokenNumStateTensor, GROUP_TOKEN_COUNT);
                 } else {
@@ -1473,8 +1515,9 @@ public:
                         tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
 
                     bool isLeft = (blockCoord.n() * L1_TILE_N < params.problemShape.n() / 2);
-                    CheckSyncFlag(reinterpret_cast<__gm__ int32_t *>(statusDataSpaceGm + SOFT_SYNC_OFFSET),
-                                  static_cast<int32_t>(compCoreIdx), target);
+                    CheckSyncFlagWithL2Prefetch(reinterpret_cast<__gm__ int32_t *>(statusDataSpaceGm + SOFT_SYNC_OFFSET),
+                                                static_cast<int32_t>(compCoreIdx), target,
+                                                l2PfEnabled ? &l2PfCtx : nullptr);
                     target += 1;
                     blockEpilogue(tensorBlockC, tensorBlockD, actualBlockShape, isLeft);
                 }
@@ -1514,6 +1557,29 @@ public:
     }
 
 private:
+    // Point the prefetch context at targetGroup's w1 weights (+ MxScaleB), stripe-sliced across AIVs.
+    // Address math mirrors the AIC-side gmB/gmMxScaleB setup (static per group, independent of token counts).
+    CATLASS_DEVICE
+    void SetupL2PrefetchGroup(L2PrefetchCtx &ctx, AscendC::LocalTensor<uint8_t> &pad, Params const &params,
+                              AscendC::ListTensorDesc &bListDesc, AscendC::ListTensorDesc &bScaleListDesc,
+                              uint64_t perGroupB, uint64_t perGroupScale, uint32_t targetGroup, uint32_t stripeId,
+                              uint32_t stripeNum)
+    {
+        __gm__ ElementB *weightBase = nullptr;
+        __gm__ ElementMxScaleB *scaleBase = nullptr;
+        if constexpr (EXEC_FLAG & EXEC_FLAG_TENSOR_LIST) {
+            weightBase = bListDesc.GetDataPtr<ElementB>(targetGroup);
+            scaleBase = bScaleListDesc.GetDataPtr<ElementMxScaleB>(targetGroup);
+        } else {
+            weightBase = bListDesc.GetDataPtr<ElementB>(0) + static_cast<uint64_t>(targetGroup) * perGroupB;
+            scaleBase =
+                bScaleListDesc.GetDataPtr<ElementMxScaleB>(0) + static_cast<uint64_t>(targetGroup) * perGroupScale;
+        }
+        L2PrefetchInit(ctx, pad, reinterpret_cast<__gm__ uint8_t *>(weightBase), static_cast<uint32_t>(perGroupB),
+                       reinterpret_cast<__gm__ uint8_t *>(scaleBase), static_cast<uint32_t>(perGroupScale), stripeId,
+                       stripeNum);
+    }
+
     friend struct AicSetFunc;
     struct AicSetFunc {
         CATLASS_DEVICE

--- a/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/gemm/kernel/mx_gmm2_cast_combine.h
+++ b/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/gemm/kernel/mx_gmm2_cast_combine.h
@@ -80,6 +80,7 @@ public:
         GemmCoord sharedProblemShape;
         void *combiner;
         FusedDeepMoeProfileWriter *profile;
+        uint32_t l2PrefetchEnable;
 
         // Methods
         CATLASS_HOST_DEVICE
@@ -93,7 +94,7 @@ public:
                LayoutA const &layoutSharedA_, GM_ADDR ptrSharedB_, LayoutB const &layoutSharedB_,
                GM_ADDR ptrSharedMxScaleA_, LayoutMxScaleA layoutSharedMxScaleA_, GM_ADDR ptrSharedMxScaleB_,
                LayoutMxScaleB layoutSharedMxScaleB_, GM_ADDR ptrSharedC_, GM_ADDR ptrSharedD_, void *combiner_,
-               FusedDeepMoeProfileWriter *profile_)
+               FusedDeepMoeProfileWriter *profile_, uint32_t l2PrefetchEnable_ = 0)
             : problemShape(problemShape_),
               problemCount(problemCount_),
               ptrGroupList(reinterpret_cast<__gm__ ElementGroupList *>(ptrGroupList_)),
@@ -120,7 +121,8 @@ public:
               ptrSharedC(reinterpret_cast<__gm__ ElementC *>(ptrSharedC_)),
               ptrSharedD(reinterpret_cast<__gm__ ElementD *>(ptrSharedD_)),
               combiner(combiner_),
-              profile(profile_)
+              profile(profile_),
+              l2PrefetchEnable(l2PrefetchEnable_)
         {}
     };
 
@@ -364,6 +366,33 @@ public:
             uint32_t target = 1;
             uint32_t startCoreIdx = 0;
 
+            // L2 cross-expert weight prefetch: while AIC computes expert g, AIVs pull expert g+1's
+            // w2 weights into the shared L2 during idle epilogue spin windows.
+            L2PrefetchCtx l2PfCtx;
+            l2PfCtx.active = false;
+            const bool l2PfEnabled = (params.l2PrefetchEnable != 0) && (params.problemCount > 1);
+            AscendC::LocalTensor<uint8_t> l2PfPad =
+                resource.ubBuf.template GetBufferByByte<uint8_t>(L2Prefetch::UB_PAD_OFFSET);
+            AscendC::ListTensorDesc l2PfBListDesc(reinterpret_cast<__gm__ void *>(params.ptrB));
+            AscendC::ListTensorDesc l2PfBScaleListDesc(reinterpret_cast<__gm__ void *>(params.ptrMxScaleB));
+            const uint32_t l2PfStripeId = AscendC::GetBlockIdx();
+            const uint32_t l2PfStripeNum = AscendC::GetBlockNum() * AscendC::GetSubBlockNum();
+            uint64_t l2PfPerGroupB = 0;
+            uint64_t l2PfPerGroupScale = 0;
+            if (l2PfEnabled) {
+                // mirror the AIC-side per-group B offset accumulation (static in k/n, independent of M)
+                if constexpr (AscendC::Std::is_one_of_v<ElementB, float4_e2m1x2_t, float4_e1m2x2_t>) {
+                    l2PfPerGroupB = std::is_same_v<LayoutB, layout::ColumnMajor>
+                                        ? CeilDiv<2>(params.problemShape.k()) * params.problemShape.n()
+                                        : CeilDiv<2>(params.problemShape.n()) * params.problemShape.k();
+                } else {
+                    l2PfPerGroupB = static_cast<uint64_t>(params.problemShape.k()) * params.problemShape.n();
+                }
+                l2PfPerGroupScale =
+                    static_cast<uint64_t>(CeilDiv<MX_BASEK_FACTOR>(params.problemShape.k()) * MX_SCALE_COPY_GROUP_NUM) *
+                    params.problemShape.n();
+            }
+
             int64_t mxScaleAlignedK =
                 static_cast<int64_t>(CeilDiv<MX_BASEK_FACTOR>(params.problemShape.k()) * MX_SCALE_COPY_GROUP_NUM);
 
@@ -375,6 +404,13 @@ public:
 
             for (uint32_t groupIdx = 0; groupIdx < params.problemCount; ++groupIdx) {
                 uint64_t profGroupStart = 0;
+                if (l2PfEnabled && (groupIdx + 1) < params.problemCount) {
+                    // AIC is entering/ computing group groupIdx: prefetch group groupIdx+1's w2 into L2
+                    SetupL2PrefetchGroup(l2PfCtx, l2PfPad, params, l2PfBListDesc, l2PfBScaleListDesc, l2PfPerGroupB,
+                                         l2PfPerGroupScale, groupIdx + 1, l2PfStripeId, l2PfStripeNum);
+                } else {
+                    L2PrefetchDeactivate(l2PfCtx);
+                }
                 currentM = (groupIdx == 0) ? groupList.GetValue(groupIdx)
                                            : (groupList.GetValue(groupIdx) - groupList.GetValue(groupIdx - 1));
                 if (params.profile != nullptr) {
@@ -403,8 +439,9 @@ public:
                         tensorD, tla::MakeCoord(totalM + blockCoord.m() * L1_TILE_M, blockCoord.n() * L1_TILE_N),
                         tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
 
-                    CheckSyncFlag(reinterpret_cast<__gm__ int32_t *>(syncGmAddr + GMM2::SOFT_SYNC_OFFSET),
-                                  static_cast<int32_t>(coreIdx), target);
+                    CheckSyncFlagWithL2Prefetch(reinterpret_cast<__gm__ int32_t *>(syncGmAddr + GMM2::SOFT_SYNC_OFFSET),
+                                                static_cast<int32_t>(coreIdx), target,
+                                                l2PfEnabled ? &l2PfCtx : nullptr);
                     target += 1;
                     blockEpilogue(tensorBlockC, tensorBlockD, actualBlockShape, groupIdx,
                                   totalM + blockCoord.m() * L1_TILE_M, blockCoord.n() * L1_TILE_N);
@@ -514,6 +551,29 @@ public:
     }
 
 private:
+    // Point the prefetch context at targetGroup's w2 weights (+ MxScaleB), stripe-sliced across AIVs.
+    // Address math mirrors the AIC-side gmB/gmMxScaleB setup (static per group, independent of token counts).
+    CATLASS_DEVICE
+    void SetupL2PrefetchGroup(L2PrefetchCtx &ctx, AscendC::LocalTensor<uint8_t> &pad, Params const &params,
+                              AscendC::ListTensorDesc &bListDesc, AscendC::ListTensorDesc &bScaleListDesc,
+                              uint64_t perGroupB, uint64_t perGroupScale, uint32_t targetGroup, uint32_t stripeId,
+                              uint32_t stripeNum)
+    {
+        __gm__ ElementB *weightBase = nullptr;
+        __gm__ ElementMxScaleB *scaleBase = nullptr;
+        if constexpr (EXEC_FLAG & EXEC_FLAG_TENSOR_LIST) {
+            weightBase = bListDesc.GetDataPtr<ElementB>(targetGroup);
+            scaleBase = bScaleListDesc.GetDataPtr<ElementMxScaleB>(targetGroup);
+        } else {
+            weightBase = bListDesc.GetDataPtr<ElementB>(0) + static_cast<uint64_t>(targetGroup) * perGroupB;
+            scaleBase =
+                bScaleListDesc.GetDataPtr<ElementMxScaleB>(0) + static_cast<uint64_t>(targetGroup) * perGroupScale;
+        }
+        L2PrefetchInit(ctx, pad, reinterpret_cast<__gm__ uint8_t *>(weightBase), static_cast<uint32_t>(perGroupB),
+                       reinterpret_cast<__gm__ uint8_t *>(scaleBase), static_cast<uint32_t>(perGroupScale), stripeId,
+                       stripeNum);
+    }
+
     friend struct AicSetFunc;
     struct AicSetFunc {
         CATLASS_DEVICE

--- a/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe_a5.h
+++ b/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe_a5.h
@@ -169,7 +169,7 @@ CATLASS_DEVICE void MxGmm2CastCombineFunc(
     // shared expert, matmul
     Catlass::GemmCoord sharedProblemShape, GM_ADDR gmShareA, GM_ADDR gmShareB, GM_ADDR gmShareAScale,
     GM_ADDR gmShareBScale, GM_ADDR gmShareSwapSpace, GM_ADDR gmShareD, void *combiner,
-    FusedDeepMoeProfileWriter *profile)
+    FusedDeepMoeProfileWriter *profile, uint32_t l2PrefetchEnable)
 {
     static_assert((std::is_same_v<ElementA, float8_e5m2_t> || std::is_same_v<ElementA, float8_e4m3_t> ||
                    std::is_same_v<ElementA, float4_e2m1x2_t> || std::is_same_v<ElementA, float4_e1m2x2_t>) &&
@@ -242,11 +242,12 @@ CATLASS_DEVICE void MxGmm2CastCombineFunc(
                                          gmShareAScale,
                                          layoutShareMxScaleA,
                                          gmShareBScale,
-                                         layoutShareMxScaleB,
-                                         gmShareSwapSpace /*ptrShareC*/,
-                                         gmShareD,
-                                         combiner,
-                                         profile};
+                                          layoutShareMxScaleB,
+                                          gmShareSwapSpace /*ptrShareC*/,
+                                          gmShareD,
+                                          combiner,
+                                          profile,
+                                          l2PrefetchEnable};
 
     MatmulKernel kernel;
     kernel(params);
@@ -437,6 +438,7 @@ __aicore__ inline void FusedDeepMoe<TemplateMC2TypeFunc>::Process()
                           Gmm2EpilogueTileShape, Gmm2BlockScheduler>(
         gmm2ProblemShape, groupCount_, gmGroupList, gmX2, gmWeight2_, gmX2Scale, gmScale2_, gmGmm2SwapSpace,
         gmGmm2DepOut, shareGmm2ProblemShape, gmShareX2, gmShareWeight2_, gmShareX2Scale, gmShareWeight2Scale_,
-        gmShareMm2SwapSpace, gmShareOutput_, &combiner, &profileWriter);
+        gmShareMm2SwapSpace, gmShareOutput_, &combiner, &profileWriter,
+        tilingData_->fusedDeepMoeInfo.l2PrefetchEnable);
 }
 #endif  // FUSED_DEEP_MOE_H

--- a/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe_a5_tiling.h
+++ b/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe_a5_tiling.h
@@ -54,6 +54,7 @@ struct FusedDeepMoeInfo {
     uint64_t profileBufferBytes;   // total bytes of the persistent profile buffer
     uint64_t totalUbSize;
     uint64_t totalWinSize;
+    uint32_t l2PrefetchEnable;     // non-zero: prefetch next expert weights into L2 during GMM1/GMM2 AIC compute
     uint64_t gmm1HLen;
     uint64_t shareGmm1HLen;  // shared expert gmm1 hidden length
     bool isTensorList;


### PR DESCRIPTION
## Motivation
In fused_deep_moe_a5, when the AIC switches to expert g, the first K-strip of
the w1/w2 weights is an HBM cold miss (existing SetL2CacheHint only controls
residency policy, no prefetch semantics), stalling the cube at group switches.

## Design
- AIVs prefetch expert g+1's weights into the chip-shared L2 during idle
  epilogue spin windows (chunked GM->UB reads, CACHE_MODE_NORMAL, data discarded)
- Prefetch-assisted spin: 1 x 32KB chunk per 4 polls, weights stripe-sliced
  across all AIVs; MxScaleB fetched once by stripe 0
- Retargets at group-loop entry (GMM1 also warms routed expert 0 during the
  shared-expert phase); address math mirrors the AIC-side gmB offsets
- Zero new SetFlag/WaitFlag primitives; UB landing pad at 160KB offset
- Gated by FusedDeepMoeInfo.l2PrefetchEnable (host default 0 = off);
  FUSED_DEEP_MOE_ENABLE_L2_READ_AHEAD hook reserved for CACHE_MODE_READ_AHEAD

## Validation
- ascendc-sync-audit: no new red-line findings (only 2 perf-level SYNC-09
  from the new wait helper, mirroring the existing CheckSyncFlag pattern)
- Board validation pending: compile, accuracy, msprof on/off comparison,
  L2 hit-rate, SPIN_INTERVAL tuning (aggressive 4 vs conservative 16)