### PR TITLE
[DeepEP] [feat] Fused moe a5 optimize: Combine two stages into one stage && FP4 weight NZ format supported

### DIFF
--- a/csrc/deepep/ops/op_host/fused_deep_moe_a5/fused_deep_moe_tiling.cpp
+++ b/csrc/deepep/ops/op_host/fused_deep_moe_a5/fused_deep_moe_tiling.cpp
@@ -27,7 +27,9 @@ constexpr uint32_t CUBE_WORKSPACE_STAGE = 4;
 constexpr uint32_t X2_READY_MAX_ROUTED_EXPERTS = 256;
 constexpr uint32_t X2_READY_SLOT_SIZE = 512;
 constexpr uint32_t X2_READY_SIZE = X2_READY_SLOT_SIZE * X2_READY_MAX_ROUTED_EXPERTS;
-constexpr uint32_t RESERVED_WORKSPACE_SIZE = X2_READY_SIZE;
+constexpr uint32_t RESERVED_WORKSPACE_TOTAL_SIZE = 256 * 1024;
+constexpr uint32_t RESERVED_WORKSPACE_REMAINING_SIZE = RESERVED_WORKSPACE_TOTAL_SIZE - X2_READY_SIZE;
+static_assert(X2_READY_SIZE <= RESERVED_WORKSPACE_TOTAL_SIZE);
 
 constexpr uint32_t INPUT_X_INDEX = 0;
 constexpr uint32_t INPUT_EXPERT_IDS_INDEX = 1;
@@ -786,7 +788,7 @@ static ge::graphStatus SetWorkSpace(gert::TilingContext &context, const char *no
     uint64_t shareX1MxScaleNum = x1MxScaleNum;
     uint64_t x2MxScaleNum = CeilUp(Ceil(gmm2HLen, 32), 2);
     uint64_t shareX2MxScaleNum = CeilUp(Ceil(shareGmm2HLen, 32), 2);
-    ;
+
     maxTokenNum = globalBs * std::min(topK, moeExpertNumPerRank);
     bool isMxFp4 = tilingData.fusedDeepMoeInfo.mxActStorageFp4 == MX_FP4_QUANT_MODE;
 
@@ -811,7 +813,7 @@ static ge::graphStatus SetWorkSpace(gert::TilingContext &context, const char *no
     size_t groupListSize = CeilUp(moeExpertNumPerRank * sizeof(int64_t), GM_ALIGN_SIZE);
     size_t expandIdxSize = CeilUp(batchSize * topK * sizeof(int32_t), GM_ALIGN_SIZE);
     size_t epSendCountSize = CeilUp(epRankSize * moeExpertNumPerRank * sizeof(int32_t), GM_ALIGN_SIZE);
-    size_t reservedSize = CeilUp(RESERVED_WORKSPACE_SIZE, GM_ALIGN_SIZE);
+    size_t reservedSize = CeilUp(X2_READY_SIZE + RESERVED_WORKSPACE_REMAINING_SIZE, GM_ALIGN_SIZE);
     size_t offset = 0;
 #ifdef ENABLE_REUSE_MEMORY
     // Shared quant runs after GMM1, but routed quant now overlaps GMM1 and must not overwrite routed X1.

--- a/csrc/deepep/ops/op_host/fused_deep_moe_a5/fused_deep_moe_tiling.cpp
+++ b/csrc/deepep/ops/op_host/fused_deep_moe_a5/fused_deep_moe_tiling.cpp
@@ -24,7 +24,10 @@ constexpr uint32_t GM_ALIGN_SIZE = 512;
 constexpr uint32_t TOKEN_DTYPE_BYTE_SIZE = 2;
 constexpr uint32_t L1_TILE_BYTE_SIZE = 32 * 1024;
 constexpr uint32_t CUBE_WORKSPACE_STAGE = 4;
-constexpr uint32_t RESERVED_WORKSPACE_SIZE = 256 * 1024;
+constexpr uint32_t X2_READY_MAX_ROUTED_EXPERTS = 256;
+constexpr uint32_t X2_READY_SLOT_SIZE = 512;
+constexpr uint32_t X2_READY_SIZE = X2_READY_SLOT_SIZE * X2_READY_MAX_ROUTED_EXPERTS;
+constexpr uint32_t RESERVED_WORKSPACE_SIZE = X2_READY_SIZE;
 
 constexpr uint32_t INPUT_X_INDEX = 0;
 constexpr uint32_t INPUT_EXPERT_IDS_INDEX = 1;
@@ -237,28 +240,48 @@ static ge::graphStatus CheckGmm1ScaleShape(gert::TilingContext &context, const F
                return ge::GRAPH_FAILED);
     auto gmm1ScaleFirstTensorElementShape = gmm1ScaleFirstTensorElement->GetOriginShape();
     uint32_t elementDims = gmm1ScaleFirstTensorElementShape.GetDimNum();
-    OPS_ERR_IF(elementDims != 1 && elementDims != 2, OPS_LOG_E(nodeName, "gmm1WeightScale shape is invalid."),
-               return ge::GRAPH_FAILED);
     if (gmm1ScaleListLen > 1) {  // List
         OPS_ERR_IF(gmm1ScaleListLen != localExpertNum,
                    OPS_LOG_E(nodeName, "gmm1scale listlen does not equals to localExpertNum."),
                    return ge::GRAPH_FAILED);
-        OPS_ERR_IF(n != gmm1ScaleFirstTensorElementShape.GetDim(0),
-                   OPS_LOG_E(nodeName, "gmm1Scale length does not equals to gmm1 hidden size."),
-                   return ge::GRAPH_FAILED);
+        if (elementDims == 1) {
+            OPS_ERR_IF(n != gmm1ScaleFirstTensorElementShape.GetDim(0),
+                       OPS_LOG_E(nodeName, "gmm1Scale length does not equals to gmm1 hidden size."),
+                       return ge::GRAPH_FAILED);
+        } else if (elementDims == 2) {
+            OPS_ERR_IF(n != gmm1ScaleFirstTensorElementShape.GetDim(0),
+                       OPS_LOG_E(nodeName, "gmm1Scale length does not equals to gmm1 hidden size."),
+                       return ge::GRAPH_FAILED);
+        } else {
+            OPS_ERR_IF(elementDims != 3 ||
+                           gmm1ScaleFirstTensorElementShape.GetDim(0) !=
+                               static_cast<int64_t>(Ceil(tilingData.fusedDeepMoeInfo.h, 64)) ||
+                           gmm1ScaleFirstTensorElementShape.GetDim(1) != static_cast<int64_t>(n) ||
+                           gmm1ScaleFirstTensorElementShape.GetDim(2) != 2,
+                       OPS_LOG_E(nodeName, "gmm1WeightScale MX list shape is invalid."), return ge::GRAPH_FAILED);
+        }
         listFlag = true;
     } else {                     // Single
         if (elementDims == 1) {  // one localExpert perRank
             OPS_ERR_IF(n != gmm1ScaleFirstTensorElementShape.GetDim(0),
                        OPS_LOG_E(nodeName, "gmm1Scale length does not equals to gmm1 hidden size."),
                        return ge::GRAPH_FAILED);
-        } else {  // multi localExperts perRank
+        } else if (elementDims == 2) {  // multi localExperts perRank
             OPS_ERR_IF(localExpertNum != gmm1ScaleFirstTensorElementShape.GetDim(0),
                        OPS_LOG_E(nodeName, "gmm1Scale does not match local expert number perRank."),
                        return ge::GRAPH_FAILED);
             OPS_ERR_IF(n != gmm1ScaleFirstTensorElementShape.GetDim(1),
                        OPS_LOG_E(nodeName, "gmm1Scale length does not equals to gmm1 hidden size."),
                        return ge::GRAPH_FAILED);
+        } else if (elementDims == 4) {
+            OPS_ERR_IF(gmm1ScaleFirstTensorElementShape.GetDim(0) != static_cast<int64_t>(localExpertNum) ||
+                           gmm1ScaleFirstTensorElementShape.GetDim(1) !=
+                               static_cast<int64_t>(Ceil(tilingData.fusedDeepMoeInfo.h, 64)) ||
+                           gmm1ScaleFirstTensorElementShape.GetDim(2) != static_cast<int64_t>(n) ||
+                           gmm1ScaleFirstTensorElementShape.GetDim(3) != 2,
+                       OPS_LOG_E(nodeName, "gmm1WeightScale MX flat shape is invalid."), return ge::GRAPH_FAILED);
+        } else {
+            OPS_ERR_IF(true, OPS_LOG_E(nodeName, "gmm1WeightScale shape is invalid."), return ge::GRAPH_FAILED);
         }
     }
     OPS_ERR_IF(listFlag != tilingData.fusedDeepMoeInfo.isTensorList,
@@ -275,6 +298,8 @@ static ge::graphStatus CheckGmm2Shape(const gert::TilingContext &context, const 
     uint32_t n = tilingData.fusedDeepMoeInfo.gmm1HLen;
     uint32_t epRankId = tilingData.fusedDeepMoeInfo.epRankId;
     uint32_t localExpertNum = moeExpertNumPerRank;
+    bool isMxFp4 = tilingData.fusedDeepMoeInfo.mxActStorageFp4 == MX_FP4_QUANT_MODE;
+    uint32_t expectedWeightN = isMxFp4 ? h / 2 : h;
     bool listFlag = false;
 
     uint32_t gmm2ListLen = CountTensorListLen(context, INPUT_GMM2_WEIGHT_INDEX);
@@ -289,21 +314,21 @@ static ge::graphStatus CheckGmm2Shape(const gert::TilingContext &context, const 
                    OPS_LOG_E(nodeName, "gmm2 does not match local expert number perRank."), return ge::GRAPH_FAILED);
         OPS_ERR_IF(n / 2 != gmm2FirstTensorElementShape.GetDim(0),
                    OPS_LOG_E(nodeName, "gmm2 does not match half of gmm1 hidden size."), return ge::GRAPH_FAILED);
-        OPS_ERR_IF(h != gmm2FirstTensorElementShape.GetDim(1),
+        OPS_ERR_IF(expectedWeightN != gmm2FirstTensorElementShape.GetDim(1),
                    OPS_LOG_E(nodeName, "gmm2 does not match token hidden size."), return ge::GRAPH_FAILED);
         listFlag = true;
     } else {                            // Single
         if (elementDims == TWO_DIMS) {  // one localExpert perRank
             OPS_ERR_IF(n / 2 != gmm2FirstTensorElementShape.GetDim(0),
                        OPS_LOG_E(nodeName, "gmm2 does not match half of gmm1 hidden size."), return ge::GRAPH_FAILED);
-            OPS_ERR_IF(h != gmm2FirstTensorElementShape.GetDim(1),
+            OPS_ERR_IF(expectedWeightN != gmm2FirstTensorElementShape.GetDim(1),
                        OPS_LOG_E(nodeName, "gmm2 does not match token hidden size."), return ge::GRAPH_FAILED);
         } else {  // multi localExperts perRank
             OPS_ERR_IF(localExpertNum != gmm2FirstTensorElementShape.GetDim(0),
                        OPS_LOG_E(nodeName, "gmm2 does not match local expert num perRank."), return ge::GRAPH_FAILED);
             OPS_ERR_IF(n / 2 != gmm2FirstTensorElementShape.GetDim(1),
                        OPS_LOG_E(nodeName, "gmm2 does not match half of gmm1 hidden size."), return ge::GRAPH_FAILED);
-            OPS_ERR_IF(h != gmm2FirstTensorElementShape.GetDim(2),
+            OPS_ERR_IF(expectedWeightN != gmm2FirstTensorElementShape.GetDim(2),
                        OPS_LOG_E(nodeName, "gmm2 does not match token hidden size."), return ge::GRAPH_FAILED);
         }
     }
@@ -328,25 +353,44 @@ static ge::graphStatus CheckGmm2ScaleShape(gert::TilingContext &context, const F
                return ge::GRAPH_FAILED);
     auto gmm2ScaleFirstTensorElementShape = gmm2ScaleFirstTensorElement->GetOriginShape();
     uint32_t elementDims = gmm2ScaleFirstTensorElementShape.GetDimNum();
-    OPS_ERR_IF(elementDims != 1 && elementDims != 2, OPS_LOG_E(nodeName, "gmm2WeightScale shape is invalid."),
-               return ge::GRAPH_FAILED);
     if (gmm2ScaleListLen > 1) {  // List
         OPS_ERR_IF(gmm2ScaleListLen != localExpertNum,
                    OPS_LOG_E(nodeName, "gmm2scale listlen does not equals to localExpertNum."),
                    return ge::GRAPH_FAILED);
-        OPS_ERR_IF(h != gmm2ScaleFirstTensorElementShape.GetDim(0),
-                   OPS_LOG_E(nodeName, "gmm2Scale does not match token hidden size."), return ge::GRAPH_FAILED);
+        if (elementDims == 1) {
+            OPS_ERR_IF(h != gmm2ScaleFirstTensorElementShape.GetDim(0),
+                       OPS_LOG_E(nodeName, "gmm2Scale does not match token hidden size."), return ge::GRAPH_FAILED);
+        } else if (elementDims == 2) {
+            OPS_ERR_IF(h != gmm2ScaleFirstTensorElementShape.GetDim(0),
+                       OPS_LOG_E(nodeName, "gmm2Scale does not match token hidden size."), return ge::GRAPH_FAILED);
+        } else {
+            const uint32_t gmm2K = tilingData.fusedDeepMoeInfo.gmm1HLen / 2;
+            OPS_ERR_IF(elementDims != 3 ||
+                           gmm2ScaleFirstTensorElementShape.GetDim(0) != static_cast<int64_t>(Ceil(gmm2K, 64)) ||
+                           gmm2ScaleFirstTensorElementShape.GetDim(1) != static_cast<int64_t>(h) ||
+                           gmm2ScaleFirstTensorElementShape.GetDim(2) != 2,
+                       OPS_LOG_E(nodeName, "gmm2WeightScale MX list shape is invalid."), return ge::GRAPH_FAILED);
+        }
         listFlag = true;
     } else {                     // Single
         if (elementDims == 1) {  // one localExpert perRank
             OPS_ERR_IF(h != gmm2ScaleFirstTensorElementShape.GetDim(0),
                        OPS_LOG_E(nodeName, "gmm2Scale does not match token hidden size."), return ge::GRAPH_FAILED);
-        } else {  // multi localExperts perRank
+        } else if (elementDims == 2) {  // multi localExperts perRank
             OPS_ERR_IF(localExpertNum != gmm2ScaleFirstTensorElementShape.GetDim(0),
                        OPS_LOG_E(nodeName, "gmm2Scale does not match local expert number perRank."),
                        return ge::GRAPH_FAILED);
             OPS_ERR_IF(h != gmm2ScaleFirstTensorElementShape.GetDim(1),
                        OPS_LOG_E(nodeName, "gmm2Scale does not match token hidden size."), return ge::GRAPH_FAILED);
+        } else if (elementDims == 4) {
+            const uint32_t gmm2K = tilingData.fusedDeepMoeInfo.gmm1HLen / 2;
+            OPS_ERR_IF(gmm2ScaleFirstTensorElementShape.GetDim(0) != static_cast<int64_t>(localExpertNum) ||
+                           gmm2ScaleFirstTensorElementShape.GetDim(1) != static_cast<int64_t>(Ceil(gmm2K, 64)) ||
+                           gmm2ScaleFirstTensorElementShape.GetDim(2) != static_cast<int64_t>(h) ||
+                           gmm2ScaleFirstTensorElementShape.GetDim(3) != 2,
+                       OPS_LOG_E(nodeName, "gmm2WeightScale MX flat shape is invalid."), return ge::GRAPH_FAILED);
+        } else {
+            OPS_ERR_IF(true, OPS_LOG_E(nodeName, "gmm2WeightScale shape is invalid."), return ge::GRAPH_FAILED);
         }
     }
     OPS_ERR_IF(listFlag != tilingData.fusedDeepMoeInfo.isTensorList,
@@ -431,6 +475,133 @@ ge::graphStatus CheckSmoothScales(const gert::TilingContext &context, const char
 static bool IsMxFp4GmmWeight(ge::DataType dtype)
 {
     return dtype == ge::DT_FLOAT4_E2M1 || dtype == ge::DT_FLOAT4_E1M2;
+}
+
+static bool IsWeightNz(const gert::Tensor *tensor)
+{
+    return tensor != nullptr && tensor->GetStorageFormat() == ge::FORMAT_FRACTAL_NZ;
+}
+
+static bool IsFp4Weight(ge::DataType dtype)
+{
+    return dtype == ge::DT_FLOAT4_E2M1 || dtype == ge::DT_FLOAT4_E1M2;
+}
+
+static ge::graphStatus CheckFp4NzListDescriptor(const char *nodeName, const gert::Tensor *tensor,
+                                                const char *weightName)
+{
+    const auto originShape = tensor->GetOriginShape();
+    OPS_ERR_IF(originShape.GetDimNum() != TWO_DIMS,
+               OPS_LOG_E(nodeName, "%s FP4-NZ tensor-list element must have a 2-D logical descriptor, got %lu-D.",
+                         weightName, originShape.GetDimNum()),
+               return ge::GRAPH_FAILED);
+    return ge::GRAPH_SUCCESS;
+}
+
+static ge::graphStatus CheckFlatFp4NzDescriptor(const char *nodeName, const gert::Tensor *tensor,
+                                                uint64_t localExpertNum, uint64_t logicalK, uint64_t logicalN,
+                                                const char *weightName, uint64_t &expertStrideBytes)
+{
+    const auto originShape = tensor->GetOriginShape();
+    const uint64_t expectedNBlocks = Ceil(logicalN, 64);
+    const uint64_t expectedKBlocks = Ceil(logicalK, 16);
+    OPS_ERR_IF(originShape.GetDimNum() != THREE_DIMS || originShape.GetDim(0) != static_cast<int64_t>(localExpertNum),
+               OPS_LOG_E(nodeName,
+                         "%s flat FP4-NZ must have a 3-D logical descriptor with %lu experts, got %lu-D "
+                         "with dim0=%ld.",
+                         weightName, localExpertNum, originShape.GetDimNum(),
+                         originShape.GetDimNum() > 0 ? originShape.GetDim(0) : -1),
+               return ge::GRAPH_FAILED);
+
+    const uint64_t physicalValuesPerExpert = expectedNBlocks * expectedKBlocks * 16U * 64U;
+    OPS_ERR_IF((physicalValuesPerExpert & 1U) != 0U,
+               OPS_LOG_E(nodeName, "%s flat FP4-NZ physical storage is not FP4-packable.", weightName),
+               return ge::GRAPH_FAILED);
+    expertStrideBytes = physicalValuesPerExpert / 2U;
+    return ge::GRAPH_SUCCESS;
+}
+
+static ge::graphStatus CheckWeightLayout(gert::TilingContext &context, FusedDeepMoeTilingData &tilingData)
+{
+    const char *nodeName = context.GetNodeName();
+    auto gmm1 = context.GetDynamicInputTensor(INPUT_GMM1_WEIGHT_INDEX, 0);
+    auto gmm2 = context.GetDynamicInputTensor(INPUT_GMM2_WEIGHT_INDEX, 0);
+    OPS_ERR_IF(gmm1 == nullptr || gmm2 == nullptr, OPS_LOG_E(nodeName, "GMM weight tensor is null."),
+               return ge::GRAPH_FAILED);
+
+    const bool gmm1Nz = IsWeightNz(gmm1);
+    const bool gmm2Nz = IsWeightNz(gmm2);
+    OPS_ERR_IF(gmm1Nz != gmm2Nz,
+               OPS_LOG_E(nodeName, "GMM1 and GMM2 weight formats must both be ND or both be FRACTAL_NZ."),
+               return ge::GRAPH_FAILED);
+    OPS_ERR_IF(gmm1->GetDataType() != gmm2->GetDataType(),
+               OPS_LOG_E(nodeName, "GMM1 and GMM2 weight dtypes must match, got %d and %d.",
+                         static_cast<int>(gmm1->GetDataType()), static_cast<int>(gmm2->GetDataType())),
+               return ge::GRAPH_FAILED);
+
+    // The kernel selects one layout at compile time for both GEMMs. Validate
+    // every dynamic-list element so a malformed list cannot mix ND/NZ storage
+    // or dtypes behind the first descriptor.
+    const uint32_t gmm1ListLen = CountTensorListLen(context, INPUT_GMM1_WEIGHT_INDEX);
+    const uint32_t gmm2ListLen = CountTensorListLen(context, INPUT_GMM2_WEIGHT_INDEX);
+    OPS_ERR_IF(
+        gmm1ListLen != gmm2ListLen,
+        OPS_LOG_E(nodeName, "GMM1/GMM2 weight list lengths must match, got %u and %u.", gmm1ListLen, gmm2ListLen),
+        return ge::GRAPH_FAILED);
+    for (uint32_t i = 0; i < gmm1ListLen; ++i) {
+        auto gmm1Item = context.GetDynamicInputTensor(INPUT_GMM1_WEIGHT_INDEX, i);
+        auto gmm2Item = context.GetDynamicInputTensor(INPUT_GMM2_WEIGHT_INDEX, i);
+        OPS_ERR_IF(IsWeightNz(gmm1Item) != gmm1Nz || IsWeightNz(gmm2Item) != gmm2Nz ||
+                       gmm1Item->GetDataType() != gmm1->GetDataType() || gmm2Item->GetDataType() != gmm2->GetDataType(),
+                   OPS_LOG_E(nodeName, "GMM weight list element %u does not match the selected layout/dtype.", i),
+                   return ge::GRAPH_FAILED);
+    }
+
+    auto shareGmm1 = context.GetOptionalInputTensor(INPUT_SHARE_GMM1_WEIGHT_INDEX);
+    auto shareGmm2 = context.GetOptionalInputTensor(INPUT_SHARE_GMM2_WEIGHT_INDEX);
+    if (shareGmm1 != nullptr || shareGmm2 != nullptr) {
+        OPS_ERR_IF(shareGmm1 == nullptr || shareGmm2 == nullptr || IsWeightNz(shareGmm1) != gmm1Nz ||
+                       IsWeightNz(shareGmm2) != gmm2Nz || shareGmm1->GetDataType() != gmm1->GetDataType() ||
+                       shareGmm2->GetDataType() != gmm2->GetDataType(),
+                   OPS_LOG_E(nodeName, "shared GMM weights must use the same format and dtype as routed weights."),
+                   return ge::GRAPH_FAILED);
+    }
+
+    tilingData.fusedDeepMoeInfo.weightLayoutMode = gmm1Nz ? WEIGHT_LAYOUT_NZ : WEIGHT_LAYOUT_ND;
+    tilingData.fusedDeepMoeInfo.gmm1WeightExpertStrideBytes = 0U;
+    tilingData.fusedDeepMoeInfo.gmm2WeightExpertStrideBytes = 0U;
+    if (!gmm1Nz || !IsFp4Weight(gmm1->GetDataType())) {
+        return ge::GRAPH_SUCCESS;
+    }
+
+    OPS_ERR_IF(tilingData.fusedDeepMoeInfo.gmm1HLen % 128 != 0 || tilingData.fusedDeepMoeInfo.h % 128 != 0 ||
+                   tilingData.fusedDeepMoeInfo.gmm1HLen == 1 || tilingData.fusedDeepMoeInfo.h == 1 ||
+                   tilingData.fusedDeepMoeInfo.gmm1HLen / 2 == 1,
+               OPS_LOG_E(nodeName, "FP4-NZ requires non-unit logical GMM K/N dimensions and 128-aligned logical N."),
+               return ge::GRAPH_FAILED);
+
+    if (tilingData.fusedDeepMoeInfo.isTensorList) {
+        OPS_ERR_IF(CheckFp4NzListDescriptor(nodeName, gmm1, "gmm1Weight") != ge::GRAPH_SUCCESS,
+                   OPS_LOG_E(nodeName, "invalid gmm1 FP4-NZ tensor-list descriptor."), return ge::GRAPH_FAILED);
+        OPS_ERR_IF(CheckFp4NzListDescriptor(nodeName, gmm2, "gmm2Weight") != ge::GRAPH_SUCCESS,
+                   OPS_LOG_E(nodeName, "invalid gmm2 FP4-NZ tensor-list descriptor."), return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    OPS_ERR_IF(shareGmm1 != nullptr || shareGmm2 != nullptr,
+               OPS_LOG_E(nodeName, "flat FP4-NZ routed weights do not support shared expert weights."),
+               return ge::GRAPH_FAILED);
+    OPS_ERR_IF(
+        CheckFlatFp4NzDescriptor(nodeName, gmm1, tilingData.fusedDeepMoeInfo.moeExpertNumPerRank,
+                                 tilingData.fusedDeepMoeInfo.h, tilingData.fusedDeepMoeInfo.gmm1HLen, "gmm1Weight",
+                                 tilingData.fusedDeepMoeInfo.gmm1WeightExpertStrideBytes) != ge::GRAPH_SUCCESS,
+        OPS_LOG_E(nodeName, "invalid flat gmm1 FP4-NZ descriptor."), return ge::GRAPH_FAILED);
+    OPS_ERR_IF(
+        CheckFlatFp4NzDescriptor(nodeName, gmm2, tilingData.fusedDeepMoeInfo.moeExpertNumPerRank,
+                                 tilingData.fusedDeepMoeInfo.gmm1HLen / 2, tilingData.fusedDeepMoeInfo.h, "gmm2Weight",
+                                 tilingData.fusedDeepMoeInfo.gmm2WeightExpertStrideBytes) != ge::GRAPH_SUCCESS,
+        OPS_LOG_E(nodeName, "invalid flat gmm2 FP4-NZ descriptor."), return ge::GRAPH_FAILED);
+    return ge::GRAPH_SUCCESS;
 }
 
 static ge::graphStatus SetMxActStorageFromGmmWeight(const gert::TilingContext &context, const char *nodeName,
@@ -525,6 +696,9 @@ static ge::graphStatus GetAttrAndSetTilingData(const gert::TilingContext &contex
     OPS_ERR_IF(moeExpertNumPerRank * epRankSize > MAX_MOE_EXERT_NUM,
                OPS_LOG_E(nodeName, "moeExpertNumPerRank * epRankSize must <= %u.", MAX_MOE_EXERT_NUM),
                return ge::GRAPH_FAILED);
+    OPS_ERR_IF(moeExpertNumPerRank > X2_READY_MAX_ROUTED_EXPERTS,
+               OPS_LOG_E(nodeName, "local routed expert count must <= %u.", X2_READY_MAX_ROUTED_EXPERTS),
+               return ge::GRAPH_FAILED);
     OPS_ERR_IF(moeExpertNum <= 0, OPS_LOG_E(nodeName, "moeExpertNum must > 0."), return ge::GRAPH_FAILED);
     OPS_ERR_IF((moeExpertNum % epRankSize) != 0, OPS_LOG_E(nodeName, "moeExpertNum must be divisible by epRankSize."),
                return ge::GRAPH_FAILED);
@@ -612,19 +786,26 @@ static ge::graphStatus SetWorkSpace(gert::TilingContext &context, const char *no
     uint64_t shareX1MxScaleNum = x1MxScaleNum;
     uint64_t x2MxScaleNum = CeilUp(Ceil(gmm2HLen, 32), 2);
     uint64_t shareX2MxScaleNum = CeilUp(Ceil(shareGmm2HLen, 32), 2);
+    ;
     maxTokenNum = globalBs * std::min(topK, moeExpertNumPerRank);
     bool isMxFp4 = tilingData.fusedDeepMoeInfo.mxActStorageFp4 == MX_FP4_QUANT_MODE;
 
-    size_t x1TokenSize = MxActStorageBytes(shareExpertTokenNum * h + maxTokenNum * h, isMxFp4);
-    size_t x2TokenSize = MxActStorageBytes(shareExpertTokenNum * shareGmm2HLen + maxTokenNum * gmm2HLen, isMxFp4);
-    size_t maxTokenSize = CeilUp(x1TokenSize < x2TokenSize ? x2TokenSize : x1TokenSize, GM_ALIGN_SIZE);
-    size_t x1MxScaleSize = (shareExpertTokenNum * shareX1MxScaleNum + maxTokenNum * x1MxScaleNum) * sizeof(fp8_e8m0_t);
-    size_t x2MxScaleSize = (shareExpertTokenNum * shareX2MxScaleNum + maxTokenNum * x2MxScaleNum) * sizeof(fp8_e8m0_t);
-    size_t maxMxScaleSize = CeilUp(x1MxScaleSize < x2MxScaleSize ? x2MxScaleSize : x1MxScaleSize, GM_ALIGN_SIZE);
+    size_t shareX1TokenSize = MxActStorageBytes(shareExpertTokenNum * h, isMxFp4);
+    size_t routedX1TokenSize = MxActStorageBytes(maxTokenNum * h, isMxFp4);
+    size_t shareX2TokenSize = MxActStorageBytes(shareExpertTokenNum * shareGmm2HLen, isMxFp4);
+    size_t routedX2TokenSize = MxActStorageBytes(maxTokenNum * gmm2HLen, isMxFp4);
+    size_t sharedTokenReuseSize = std::max(shareX1TokenSize, shareX2TokenSize);
+    size_t shareX1MxScaleSize = shareExpertTokenNum * shareX1MxScaleNum * sizeof(fp8_e8m0_t);
+    size_t routedX1MxScaleSize = maxTokenNum * x1MxScaleNum * sizeof(fp8_e8m0_t);
+    size_t shareX2MxScaleSize = shareExpertTokenNum * shareX2MxScaleNum * sizeof(fp8_e8m0_t);
+    size_t routedX2MxScaleSize = maxTokenNum * x2MxScaleNum * sizeof(fp8_e8m0_t);
+    size_t sharedMxScaleReuseSize = std::max(shareX1MxScaleSize, shareX2MxScaleSize);
     size_t gmm1SwapSize = (maxTokenNum * gmm1HLen + shareExpertTokenNum * shareGmm1HLen) * sizeof(float);
-    size_t swigluOutSize = (maxTokenNum * gmm1HLen + shareExpertTokenNum * shareGmm1HLen) * sizeof(float);
+    size_t shareSwigluOutSize = shareExpertTokenNum * shareGmm1HLen * sizeof(float);
+    size_t swigluOutFullSize = maxTokenNum * gmm1HLen * sizeof(float);
     size_t gmm2SwapSize = (maxTokenNum * h + shareExpertTokenNum * h) * sizeof(float);
-    size_t maxSwapSwigluSize = CeilUp(gmm1SwapSize < gmm2SwapSize ? gmm2SwapSize : gmm1SwapSize, GM_ALIGN_SIZE);
+    size_t gmm1SwapSwigluSize = CeilUp(gmm1SwapSize, GM_ALIGN_SIZE);
+    size_t gmm2SwapAlignedSize = CeilUp(gmm2SwapSize, GM_ALIGN_SIZE);
     size_t gmm2DepOutSize =
         CeilUp(moeExpertNumPerRank > 1 ? 0 : maxTokenNum * h * TOKEN_DTYPE_BYTE_SIZE, GM_ALIGN_SIZE);
     size_t groupListSize = CeilUp(moeExpertNumPerRank * sizeof(int64_t), GM_ALIGN_SIZE);
@@ -633,49 +814,56 @@ static ge::graphStatus SetWorkSpace(gert::TilingContext &context, const char *no
     size_t reservedSize = CeilUp(RESERVED_WORKSPACE_SIZE, GM_ALIGN_SIZE);
     size_t offset = 0;
 #ifdef ENABLE_REUSE_MEMORY
+    // Shared quant runs after GMM1, but routed quant now overlaps GMM1 and must not overwrite routed X1.
     tilingData.workSpaceOffset.shareX1TokenOffset = offset;
     tilingData.workSpaceOffset.shareX2TokenOffset = offset;
-    tilingData.workSpaceOffset.x1TokenOffset = offset + MxActStorageBytes(shareExpertTokenNum * h, isMxFp4);
-    tilingData.workSpaceOffset.x2TokenOffset = offset + MxActStorageBytes(shareExpertTokenNum * shareGmm2HLen, isMxFp4);
-    offset += maxTokenSize;
+    offset += CeilUp(sharedTokenReuseSize, GM_ALIGN_SIZE);
+    tilingData.workSpaceOffset.x1TokenOffset = offset;
+    offset += CeilUp(routedX1TokenSize, GM_ALIGN_SIZE);
+    tilingData.workSpaceOffset.x2TokenOffset = offset;
+    offset += CeilUp(routedX2TokenSize, GM_ALIGN_SIZE);
+    // The same lifetime constraint applies to routed MX scales.
     tilingData.workSpaceOffset.shareX1ScaleOffset = offset;
     tilingData.workSpaceOffset.shareX2ScaleOffset = offset;
-    tilingData.workSpaceOffset.x1ScaleOffset = offset + shareExpertTokenNum * shareX1MxScaleNum * sizeof(fp8_e8m0_t);
-    tilingData.workSpaceOffset.x2ScaleOffset = offset + shareExpertTokenNum * shareX2MxScaleNum * sizeof(fp8_e8m0_t);
-    offset += maxMxScaleSize;
+    offset += CeilUp(sharedMxScaleReuseSize, GM_ALIGN_SIZE);
+    tilingData.workSpaceOffset.x1ScaleOffset = offset;
+    offset += CeilUp(routedX1MxScaleSize, GM_ALIGN_SIZE);
+    tilingData.workSpaceOffset.x2ScaleOffset = offset;
+    offset += CeilUp(routedX2MxScaleSize, GM_ALIGN_SIZE);
     tilingData.workSpaceOffset.shareMm1SwapSpaceOffset = offset;
     tilingData.workSpaceOffset.gmm1SwapSpaceOffset = offset + shareExpertTokenNum * shareGmm1HLen * sizeof(float);
     tilingData.workSpaceOffset.shareSwigluOffset = offset;
     tilingData.workSpaceOffset.swigluOffset = offset + shareExpertTokenNum * shareGmm1HLen * sizeof(float);
+    offset += gmm1SwapSwigluSize;
     tilingData.workSpaceOffset.shareMm2SwapSpaceOffset = offset;
     tilingData.workSpaceOffset.gmm2SwapSpaceOffset = offset + shareExpertTokenNum * h * sizeof(float);
-    offset += maxSwapSwigluSize;
+    offset += gmm2SwapAlignedSize;
     tilingData.workSpaceOffset.y2TokenOffset = offset;
 #else
     tilingData.workSpaceOffset.shareX1TokenOffset = offset;
-    offset += CeilUp(MxActStorageBytes(shareExpertTokenNum * h, isMxFp4), GM_ALIGN_SIZE);
+    offset += CeilUp(shareX1TokenSize, GM_ALIGN_SIZE);
     tilingData.workSpaceOffset.shareX2TokenOffset = offset;
-    offset += CeilUp(MxActStorageBytes(shareExpertTokenNum * shareGmm2HLen, isMxFp4), GM_ALIGN_SIZE);
+    offset += CeilUp(shareX2TokenSize, GM_ALIGN_SIZE);
     tilingData.workSpaceOffset.x1TokenOffset = offset;
-    offset += CeilUp(MxActStorageBytes(maxTokenNum * h, isMxFp4), GM_ALIGN_SIZE);
+    offset += CeilUp(routedX1TokenSize, GM_ALIGN_SIZE);
     tilingData.workSpaceOffset.x2TokenOffset = offset;
-    offset += CeilUp(MxActStorageBytes(maxTokenNum * gmm2HLen, isMxFp4), GM_ALIGN_SIZE);
+    offset += CeilUp(routedX2TokenSize, GM_ALIGN_SIZE);
     tilingData.workSpaceOffset.shareX1ScaleOffset = offset;
-    offset += CeilUp(shareExpertTokenNum * x1MxScaleNum * sizeof(fp8_e8m0_t), GM_ALIGN_SIZE);
+    offset += CeilUp(shareX1MxScaleSize, GM_ALIGN_SIZE);
     tilingData.workSpaceOffset.shareX2ScaleOffset = offset;
-    offset += CeilUp(shareExpertTokenNum * x2MxScaleNum * sizeof(fp8_e8m0_t), GM_ALIGN_SIZE);
+    offset += CeilUp(shareX2MxScaleSize, GM_ALIGN_SIZE);
     tilingData.workSpaceOffset.x1ScaleOffset = offset;
-    offset += CeilUp(maxTokenNum * x1MxScaleNum * sizeof(fp8_e8m0_t), GM_ALIGN_SIZE);
+    offset += CeilUp(routedX1MxScaleSize, GM_ALIGN_SIZE);
     tilingData.workSpaceOffset.x2ScaleOffset = offset;
-    offset += CeilUp(maxTokenNum * x2MxScaleNum * sizeof(fp8_e8m0_t), GM_ALIGN_SIZE);
+    offset += CeilUp(routedX2MxScaleSize, GM_ALIGN_SIZE);
     tilingData.workSpaceOffset.shareMm1SwapSpaceOffset = offset;
     offset += CeilUp(shareExpertTokenNum * shareGmm1HLen * sizeof(float), GM_ALIGN_SIZE);
     tilingData.workSpaceOffset.gmm1SwapSpaceOffset = offset;
     offset += CeilUp(maxTokenNum * gmm1HLen * sizeof(float), GM_ALIGN_SIZE);
     tilingData.workSpaceOffset.shareSwigluOffset = offset;
-    offset += CeilUp(shareExpertTokenNum * shareGmm1HLen * sizeof(float), GM_ALIGN_SIZE);
+    offset += CeilUp(shareSwigluOutSize, GM_ALIGN_SIZE);
     tilingData.workSpaceOffset.swigluOffset = offset;
-    offset += CeilUp(swigluOutSize, GM_ALIGN_SIZE);
+    offset += CeilUp(swigluOutFullSize, GM_ALIGN_SIZE);
     tilingData.workSpaceOffset.shareMm2SwapSpaceOffset = offset;
     offset += CeilUp(shareExpertTokenNum * h * sizeof(float), GM_ALIGN_SIZE);
     tilingData.workSpaceOffset.gmm2SwapSpaceOffset = offset;
@@ -729,11 +917,22 @@ static ge::graphStatus FusedDeepMoeTilingFuncImpl(gert::TilingContext &context)
                OPS_LOG_E(nodeName, "Set mx act storage from gmm weight failed."), return ge::GRAPH_FAILED);
     OPS_ERR_IF(CheckWeightTensorList(context, *tilingData) != ge::GRAPH_SUCCESS,
                OPS_LOG_E(nodeName, "CheckWeightTensorList failed."), return ge::GRAPH_FAILED);
+    OPS_ERR_IF(CheckGmm2Shape(context, *tilingData) != ge::GRAPH_SUCCESS, OPS_LOG_E(nodeName, "CheckGmm2Shape failed."),
+               return ge::GRAPH_FAILED);
+    OPS_ERR_IF(CheckWeightLayout(context, *tilingData) != ge::GRAPH_SUCCESS,
+               OPS_LOG_E(nodeName, "CheckWeightLayout failed."), return ge::GRAPH_FAILED);
+    OPS_ERR_IF(CheckGmm1ScaleShape(context, *tilingData) != ge::GRAPH_SUCCESS,
+               OPS_LOG_E(nodeName, "CheckGmm1ScaleShape failed."), return ge::GRAPH_FAILED);
+    OPS_ERR_IF(CheckGmm2ScaleShape(context, *tilingData) != ge::GRAPH_SUCCESS,
+               OPS_LOG_E(nodeName, "CheckGmm2ScaleShape failed."), return ge::GRAPH_FAILED);
     OPS_ERR_IF(CheckHcclBufferSize(nodeName, *tilingData) != ge::GRAPH_SUCCESS,
                OPS_LOG_E(nodeName, "CheckHcclBuffSize failed."), return ge::GRAPH_FAILED);
     auto ascendcPlatform = platform_ascendc::PlatformAscendC(context.GetPlatformInfo());
     uint32_t aicNum = ascendcPlatform.GetCoreNumAic();
     uint32_t aivNum = ascendcPlatform.GetCoreNumAiv();
+    OPS_ERR_IF(aicNum == 0 || aivNum != aicNum * 2,
+               OPS_LOG_E(nodeName, "A5 fused requires 1C2V, but got aicNum=%u and aivNum=%u.", aicNum, aivNum),
+               return ge::GRAPH_FAILED);
     tilingData->fusedDeepMoeInfo.aicNum = aicNum;
     tilingData->fusedDeepMoeInfo.aivNum = aivNum;
     OPS_ERR_IF(CheckData(nodeName, *tilingData) != ge::GRAPH_SUCCESS, OPS_LOG_E(nodeName, "CheckData failed."),

--- a/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/fused_deep_moe_utils.h
+++ b/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/fused_deep_moe_utils.h
@@ -8,6 +8,22 @@ namespace CVSoftSync {
 constexpr uint32_t SOFT_SYNC_SPACE_SIZE = 512;
 }
 
+namespace FusedDeepMoeSync {
+constexpr uint64_t GROUP_TOKEN_NUM_OFFSET = 932 * 1024;
+constexpr uint32_t GROUP_INFO_SIZE = 32;
+constexpr uint32_t INT32_COUNT_PER_BLOCK = 32 / sizeof(int32_t);
+constexpr uint32_t X2_READY_SLOT_SIZE = 512;
+constexpr uint32_t X2_READY_MAX_ROUTED_EXPERTS = 256;
+constexpr uint32_t X2_READY_SIZE = X2_READY_SLOT_SIZE * X2_READY_MAX_ROUTED_EXPERTS;
+constexpr uint32_t X2_READY_COUNTER_INDEX = 0;
+static_assert(X2_READY_SLOT_SIZE % INT32_COUNT_PER_BLOCK == 0);
+static_assert(X2_READY_SIZE == 128 * 1024);
+constexpr uint32_t SHARED_X2_DONE_COUNT_INDEX = 16;
+static_assert(GROUP_INFO_SIZE % INT32_COUNT_PER_BLOCK == 0);
+static_assert(SHARED_X2_DONE_COUNT_INDEX % INT32_COUNT_PER_BLOCK == 0);
+static_assert(SHARED_X2_DONE_COUNT_INDEX + INT32_COUNT_PER_BLOCK <= GROUP_INFO_SIZE);
+}  // namespace FusedDeepMoeSync
+
 template <typename T>
 __aicore__ inline T FlushAndGetValue(AscendC::GlobalTensor<T> &globalTensor, uint64_t index)
 {

--- a/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/gemm/kernel/dispatch_mx_gmm1_swiglu.h
+++ b/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/gemm/kernel/dispatch_mx_gmm1_swiglu.h
@@ -23,7 +23,7 @@
 constexpr uint32_t STATE_OFFSET = 512;
 constexpr uint64_t WIN_STATE_OFFSET = 512 * 1024;
 constexpr uint64_t STATE_WIN_OFFSET = 900 * 1024;
-constexpr uint64_t GROUP_TOKEN_NUM_OFFSET = 932 * 1024;
+constexpr uint64_t GROUP_TOKEN_NUM_OFFSET = FusedDeepMoeSync::GROUP_TOKEN_NUM_OFFSET;
 constexpr uint64_t SOFT_SYNC_OFFSET = 964 * 1024;
 constexpr uint64_t SHARE_QUANT_SOFT_SYNC_OFFSET = 1000 * 1024;
 constexpr uint32_t SELF_STATE_OFFSET = 256 * 1024;
@@ -41,6 +41,7 @@ constexpr uint32_t TOKEN_RESERVED_FLAG_INDEX = 1;
 static_assert(TOKEN_RESERVED_FLAG_INDEX == TOKEN_READY_FLAG_INDEX + 1);
 constexpr uint8_t DISPATCH_SEND_PRIVATE_FORMAT_V1 = 1;
 constexpr uint8_t DISPATCH_RECV_PRIVATE_FORMAT_V1 = 1;
+constexpr uint32_t GROUP_INFO_SIZE = FusedDeepMoeSync::GROUP_INFO_SIZE;
 #define OPT_RANK_OFFSET 512
 
 #define CEIL_UP(x) ((x + UB_ALIGN - 1) / UB_ALIGN * UB_ALIGN)
@@ -56,7 +57,6 @@ constexpr uint8_t DISPATCH_RECV_PRIVATE_FORMAT_V1 = 1;
 #define SELF_COUNT_INDEX 3
 #define TOTAL_COUNT_INDEX 4
 #define GROUP_TOKEN_COUNT 3  // equal to SELF_COUNT_INDEX
-#define GROUP_INFO_SIZE 32
 
 using namespace Cam;
 namespace Catlass::Gemm::Kernel {
@@ -142,6 +142,7 @@ public:
         GM_ADDR gmExpandIdx;
         GM_ADDR gmEpSendCount;
         GM_ADDR gmExpertTokenNums;
+        GM_ADDR gmX2ReadyState;
         FusedDeepMoeProfileWriter *profile;
 
         uint32_t epRankSize;
@@ -154,6 +155,7 @@ public:
         uint32_t topK;
         uint32_t tokenLen;
         uint32_t shareN;
+        uint64_t weightExpertStrideBytes;
         // Methods
         CATLASS_HOST_DEVICE
         Params() {}
@@ -168,7 +170,7 @@ public:
                LayoutMxScaleB layoutShareMxScaleB_, GM_ADDR ptrShareC_, LayoutC const &layoutShareC_,
                GM_ADDR gmShareSwigluOut_, GM_ADDR ptrShareX2_, GM_ADDR gmShareX2Scale_, GM_ADDR gmX_,
                GM_ADDR gmExpertIds_, GM_ADDR gmXActiveMask_, GM_ADDR gmMoeSmoothScales_, GM_ADDR gmShareSmoothScales_,
-               GM_ADDR gmExpandIdx_, GM_ADDR gmEpSendCount_, GM_ADDR gmExpertTokenNums_,
+               GM_ADDR gmExpandIdx_, GM_ADDR gmEpSendCount_, GM_ADDR gmExpertTokenNums_, GM_ADDR gmX2ReadyState_,
                const FusedDeepMoeInfo &fusedDeepMoeInfo, FusedDeepMoeProfileWriter *profile_)
             : problemShape(problemShape_),
               problemCount(problemCount_),
@@ -206,6 +208,7 @@ public:
               gmExpandIdx(gmExpandIdx_),
               gmEpSendCount(gmEpSendCount_),
               gmExpertTokenNums(gmExpertTokenNums_),
+              gmX2ReadyState(gmX2ReadyState_),
               profile(profile_),
               epRankSize(fusedDeepMoeInfo.epRankSize),
               epRankId(fusedDeepMoeInfo.epRankId),
@@ -216,7 +219,8 @@ public:
               bs(fusedDeepMoeInfo.bs),
               topK(fusedDeepMoeInfo.k),
               tokenLen(fusedDeepMoeInfo.h),
-              shareN(fusedDeepMoeInfo.shareGmm1HLen)
+              shareN(fusedDeepMoeInfo.shareGmm1HLen),
+              weightExpertStrideBytes(fusedDeepMoeInfo.gmm1WeightExpertStrideBytes)
         {}
     };
 
@@ -288,6 +292,69 @@ public:
             }
             SPIN_WAIT_CYCLES();
         }
+    }
+
+    CATLASS_DEVICE
+    void NotifySharedX2Ready(uint32_t groupIdx, uint32_t counterIndex)
+    {
+        AscendC::GlobalTensor<int32_t> readyTensor;
+        readyTensor.SetGlobalBuffer((__gm__ int32_t *)(statusDataSpaceGm + GROUP_TOKEN_NUM_OFFSET) +
+                                    groupIdx * GROUP_INFO_SIZE + counterIndex);
+        AscendC::LocalTensor<int32_t> notifyLocalTensor = resource.ubBuf.template GetBufferByByte<int32_t>(0);
+        AscendC::Duplicate(notifyLocalTensor, static_cast<int32_t>(0), INT32_COUNT_PER_BLOCK);
+        AscendC::SetFlag<AscendC::HardEvent::V_S>(0);
+        AscendC::WaitFlag<AscendC::HardEvent::V_S>(0);
+        notifyLocalTensor.SetValue(0, 1);
+        AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(0);
+        AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(0);
+        AscendC::SetAtomicAdd<int32_t>();
+        AscendC::DataCopy(readyTensor, notifyLocalTensor, INT32_COUNT_PER_BLOCK);
+        AscendC::SetAtomicNone();
+        AscendC::PipeBarrier<PIPE_MTE3>();
+    }
+
+    CATLASS_DEVICE
+    void NotifyRoutedX2Ready(uint32_t groupIdx)
+    {
+        AscendC::GlobalTensor<int32_t> readyTensor;
+        readyTensor.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(
+            gmX2ReadyState + static_cast<uint64_t>(groupIdx) * FusedDeepMoeSync::X2_READY_SLOT_SIZE));
+        AscendC::LocalTensor<int32_t> notifyLocalTensor =
+            resource.ubBuf.template GetBufferByByte<int32_t>(ArchTag::UB_SIZE - UB_BLOCK_SIZE);
+        AscendC::Duplicate(notifyLocalTensor, static_cast<int32_t>(0), INT32_COUNT_PER_BLOCK);
+        AscendC::SetFlag<AscendC::HardEvent::V_S>(0);
+        AscendC::WaitFlag<AscendC::HardEvent::V_S>(0);
+        notifyLocalTensor.SetValue(FusedDeepMoeSync::X2_READY_COUNTER_INDEX, 1);
+        AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(0);
+        AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(0);
+        AscendC::PipeBarrier<PIPE_MTE3>();
+        AscendC::SetAtomicAdd<int32_t>();
+        AscendC::DataCopy(readyTensor, notifyLocalTensor, INT32_COUNT_PER_BLOCK);
+        AscendC::PipeBarrier<PIPE_MTE3>();
+        AscendC::SetAtomicNone();
+        AscendC::PipeBarrier<PIPE_ALL>();
+    }
+
+    CATLASS_DEVICE
+    void CleanRoutedX2ReadyState()
+    {
+        AscendC::LocalTensor<int32_t> zeroLocalTensor =
+            resource.ubBuf.template GetBufferByByte<int32_t>(ArchTag::UB_SIZE - UB_BLOCK_SIZE);
+        AscendC::Duplicate(zeroLocalTensor, static_cast<int32_t>(0), INT32_COUNT_PER_BLOCK);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(0);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(0);
+        // On AIV, GetBlockIdx() already identifies the logical AIV worker.
+        // Do not multiply by the AIC/AIV subblock count: that skips slots and
+        // leaves some ready counters uncleared before the next dispatch.
+        uint32_t workerIdx = AscendC::GetBlockIdx();
+        uint32_t workerCount = AscendC::GetBlockNum();
+        for (uint32_t slotIdx = workerIdx; slotIdx < problemCount; slotIdx += workerCount) {
+            AscendC::GlobalTensor<int32_t> readyTensor;
+            readyTensor.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(
+                gmX2ReadyState + static_cast<uint64_t>(slotIdx) * FusedDeepMoeSync::X2_READY_SLOT_SIZE));
+            AscendC::DataCopy(readyTensor, zeroLocalTensor, INT32_COUNT_PER_BLOCK);
+        }
+        AscendC::PipeBarrier<PIPE_MTE3>();
     }
 
     __aicore__ inline GM_ADDR GetWindStateAddrByRankId(int64_t rankId)
@@ -419,7 +486,14 @@ public:
                     gmB.SetGlobalBuffer(gmBlistTensorDesc.GetDataPtr<ElementB>(groupIdx));
                     gmMxScaleB.SetGlobalBuffer(gmBScalelistTensorDesc.GetDataPtr<ElementMxScaleB>(groupIdx));
                 } else {
-                    gmB.SetGlobalBuffer(gmBlistTensorDesc.GetDataPtr<ElementB>(0) + gmGroupOffsetB);
+                    if (params.weightExpertStrideBytes != 0U) {
+                        auto *weightBase =
+                            reinterpret_cast<__gm__ uint8_t *>(gmBlistTensorDesc.GetDataPtr<ElementB>(0));
+                        gmB.SetGlobalBuffer(reinterpret_cast<__gm__ ElementB *>(
+                            weightBase + static_cast<uint64_t>(groupIdx) * params.weightExpertStrideBytes));
+                    } else {
+                        gmB.SetGlobalBuffer(gmBlistTensorDesc.GetDataPtr<ElementB>(0) + gmGroupOffsetB);
+                    }
                     gmMxScaleB.SetGlobalBuffer(gmBScalelistTensorDesc.GetDataPtr<ElementMxScaleB>(0) +
                                                gmGroupOffsetMxScaleB);
                 }
@@ -493,12 +567,14 @@ public:
                 totalM += inGroupProblemShape.m();
 
                 if constexpr (!(EXEC_FLAG & EXEC_FLAG_TENSOR_LIST)) {
-                    if constexpr (AscendC::Std::is_one_of_v<ElementB, float4_e2m1x2_t, float4_e1m2x2_t>) {
-                        gmGroupOffsetB += std::is_same_v<LayoutB, layout::ColumnMajor>
-                                              ? CeilDiv<2>(inGroupProblemShape.k()) * inGroupProblemShape.n()
-                                              : CeilDiv<2>(inGroupProblemShape.n()) * inGroupProblemShape.k();
-                    } else {
-                        gmGroupOffsetB += inGroupProblemShape.k() * inGroupProblemShape.n();
+                    if (params.weightExpertStrideBytes == 0U) {
+                        if constexpr (AscendC::Std::is_one_of_v<ElementB, float4_e2m1x2_t, float4_e1m2x2_t>) {
+                            gmGroupOffsetB += std::is_same_v<LayoutB, layout::ColumnMajor>
+                                                  ? CeilDiv<2>(inGroupProblemShape.k()) * inGroupProblemShape.n()
+                                                  : CeilDiv<2>(inGroupProblemShape.n()) * inGroupProblemShape.k();
+                        } else {
+                            gmGroupOffsetB += inGroupProblemShape.k() * inGroupProblemShape.n();
+                        }
                     }
                     gmGroupOffsetMxScaleB += mxScaleAlignedK * inGroupProblemShape.n();
                 }
@@ -516,7 +592,9 @@ public:
         }
 
         AscendC::PipeBarrier<PIPE_ALL>();
-        AscendC::SyncAll<false>();
+        if constexpr (!(EXEC_FLAG & EXEC_FLAG_DEEP_FUSE)) {
+            AscendC::SyncAll<false>();
+        }
     }
 
     CATLASS_DEVICE
@@ -662,7 +740,7 @@ public:
     }
 
     CATLASS_DEVICE
-    uint32_t SendToMoeExpert(GM_ADDR gmX, GM_ADDR gmExpandIdx, GM_ADDR gmMoeSmoothScales)
+    uint32_t SendToMoeExprt(GM_ADDR gmX, GM_ADDR gmExpandIdx, GM_ADDR gmMoeSmoothScales)
     {
         uint32_t sendTokenNum = expertIdsCnt / sendToMoeAivNum;
         uint32_t remainderTokenNum = expertIdsCnt % sendToMoeAivNum;
@@ -819,7 +897,7 @@ public:
         CalAndSendTokenCount();
         AscendC::PipeBarrier<PIPE_ALL>();
         sendToMoeAivNum = sendCoreNum;
-        uint32_t sendValidTokenCount = SendToMoeExpert(gmX, gmExpandIdx, gmMoeSmoothScales);
+        uint32_t sendValidTokenCount = SendToMoeExprt(gmX, gmExpandIdx, gmMoeSmoothScales);
         AscendC::PipeBarrier<PIPE_ALL>();
         if (profile != nullptr) {
             auto dispatchSendPayload = Cam::ToProfilePrivatePayloadRaw(Cam::MakeDispatchSendPrivatePayloadV1(
@@ -1092,6 +1170,9 @@ public:
         uint32_t preExpertToken = 0;
         for (uint32_t groupId = 0; groupId < localExpertNum; ++groupId) {
             uint64_t profDispatchRecvStart = 0;
+            uint64_t profDispatchRecvEnd = 0;
+            uint64_t profDispatchRecvNotifyStart = 0;
+            uint64_t profDispatchRecvNotifyEnd = 0;
             if (profile != nullptr) {
                 profDispatchRecvStart = profile->Now();
             }
@@ -1129,19 +1210,41 @@ public:
             }
             // recv finish, inform AIC
             AscendC::PipeBarrier<PIPE_ALL>();
-            notifyCubeTensor.SetValue(CV_FLAG_INDEX, vToCFlag);
-            notifyCubeTensor.SetValue(GROUP_ID_INDEX, groupId);
-            notifyCubeTensor.SetValue(SELF_COUNT_INDEX, coreTokenCount);
-            AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(0);
+            if (profile != nullptr) {
+                profDispatchRecvEnd = profile->Now();
+                profDispatchRecvNotifyStart = profile->Now();
+            }
+            uint32_t idleCoreNum = recvCoreNum - useCoreNum;
+            bool hasToken = coreTokenCount > 0;
+            bool isIdleOwner = recvCoreIdx == 0 && idleCoreNum > 0;
+            uint32_t notifyCoreCount = hasToken ? 1U : 0U;
+            if (isIdleOwner) {
+                notifyCoreCount += idleCoreNum;
+            }
 
-            AscendC::GlobalTensor<int32_t> groupTokenNumStateTensor;
-            groupTokenNumStateTensor.SetGlobalBuffer((__gm__ int32_t *)(statusDataSpaceGm + GROUP_TOKEN_NUM_OFFSET));
-            AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(0);
-            AscendC::SetAtomicAdd<int32_t>();
-            AscendC::DataCopy(groupTokenNumStateTensor[groupId * GROUP_INFO_SIZE], notifyCubeTensor,
-                              INT32_COUNT_PER_BLOCK);
-            AscendC::SetAtomicNone();
-            AscendC::PipeBarrier<PIPE_ALL>();
+            if (notifyCoreCount > 0) {
+                for (uint32_t index = 0; index < INT32_COUNT_PER_BLOCK; ++index) {
+                    notifyCubeTensor.SetValue(index, 0);
+                }
+                uint32_t cvFlagContribution = static_cast<uint32_t>(vToCFlag) * notifyCoreCount;
+                notifyCubeTensor.SetValue(CV_FLAG_INDEX, static_cast<int32_t>(cvFlagContribution));
+                notifyCubeTensor.SetValue(GROUP_ID_INDEX, groupId * notifyCoreCount);
+                notifyCubeTensor.SetValue(SELF_COUNT_INDEX, coreTokenCount);
+                AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(0);
+
+                AscendC::GlobalTensor<int32_t> groupTokenNumStateTensor;
+                groupTokenNumStateTensor.SetGlobalBuffer(
+                    (__gm__ int32_t *)(statusDataSpaceGm + GROUP_TOKEN_NUM_OFFSET));
+                AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(0);
+                AscendC::SetAtomicAdd<int32_t>();
+                AscendC::DataCopy(groupTokenNumStateTensor[groupId * GROUP_INFO_SIZE], notifyCubeTensor,
+                                  INT32_COUNT_PER_BLOCK);
+                AscendC::SetAtomicNone();
+                AscendC::PipeBarrier<PIPE_ALL>();
+            }
+            if (profile != nullptr) {
+                profDispatchRecvNotifyEnd = profile->Now();
+            }
 
             startCoreIdx = (startCoreIdx + currentM) % recvCoreNum;
             preExpertToken += currentM;
@@ -1149,8 +1252,10 @@ public:
                 auto dispatchRecvPayload = Cam::ToProfilePrivatePayloadRaw(Cam::MakeDispatchRecvPrivatePayloadV1(
                     Cam::PROFILE_PRIVATE_DATA_VALID, DISPATCH_RECV_PRIVATE_FORMAT_V1,
                     static_cast<uint64_t>(coreTokenCount)));
-                profile->Record(FusedDeepMoeProfileStage::DispatchRecv, groupId, profDispatchRecvStart, profile->Now(),
-                                dispatchRecvPayload);
+                profile->Record(FusedDeepMoeProfileStage::DispatchRecv, groupId, profDispatchRecvStart,
+                                profDispatchRecvEnd, dispatchRecvPayload);
+                profile->Record(FusedDeepMoeProfileStage::DispatchRecvNotify, groupId, profDispatchRecvNotifyStart,
+                                profDispatchRecvNotifyEnd, dispatchRecvPayload);
             }
         }
 
@@ -1186,6 +1291,8 @@ public:
     CATLASS_DEVICE
     void AivInitParams(Params const &params)
     {
+        problemCount = params.problemCount;
+        gmX2ReadyState = params.gmX2ReadyState;
         moeExpertNumPerRank = params.moeExpertNumPerRank;
 
         epRankSize = params.epRankSize;
@@ -1229,8 +1336,74 @@ public:
     }
 
     CATLASS_DEVICE
+    void AivOnlySync()
+    {
+        AscendC::PipeBarrier<PIPE_ALL>();
+        AscendC::SyncAll<true>();
+        AscendC::PipeBarrier<PIPE_ALL>();
+    }
+
+    CATLASS_DEVICE
+    void FinalizeGroupMetaAfterRecv(__gm__ ElementGroupList_ *ptrGroupList, GM_ADDR gmEpSendCount,
+                                    GM_ADDR gmExpertTokenNums)
+    {
+        if (aivNum > 0) {
+            uint32_t expertPerCore = localExpertNum / aivNum;
+            uint32_t remainExpert = localExpertNum % aivNum;
+            uint32_t expertStart = expertPerCore * aivIdx + ((aivIdx < remainExpert) ? aivIdx : remainExpert);
+            uint32_t expertCount = expertPerCore + ((aivIdx < remainExpert) ? 1 : 0);
+            if (expertCount == 0) {
+                return;
+            }
+
+            AscendC::GlobalTensor<int64_t> expertTokenNumsOutGMTensor_;
+            expertTokenNumsOutGMTensor_.SetGlobalBuffer((__gm__ int64_t *)(ptrGroupList));
+            AscendC::GlobalTensor<int32_t> sendCountsGlobal;
+            sendCountsGlobal.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(gmEpSendCount));
+            AscendC::GlobalTensor<int64_t> nonCumSumExpertTokenNumsTensor;
+            nonCumSumExpertTokenNumsTensor.SetGlobalBuffer((__gm__ int64_t *)gmExpertTokenNums);
+
+            int64_t metaUbOffset = 0;
+            uint32_t groupListLocalBytes =
+                static_cast<uint32_t>(CEIL_UP(expertCount * static_cast<uint32_t>(sizeof(int64_t))));
+            AscendC::LocalTensor<int64_t> groupListLocalTensor =
+                resource.ubBuf.template GetBufferByByte<int64_t>(metaUbOffset);
+            metaUbOffset += groupListLocalBytes;
+            AscendC::LocalTensor<int64_t> expertTokenNumsLocalTensor =
+                resource.ubBuf.template GetBufferByByte<int64_t>(metaUbOffset);
+            metaUbOffset += groupListLocalBytes;
+
+            uint32_t prevTokenNum = 0;
+            if (expertStart > 0) {
+                prevTokenNum =
+                    FlushAndGetValue<int32_t>(sendCountsGlobal, (expertStart - 1) * epRankSize + epRankSize - 1);
+            }
+
+            for (uint32_t expertOffset = 0; expertOffset < expertCount; ++expertOffset) {
+                uint32_t localMoeIndex = expertStart + expertOffset;
+                uint32_t tokenNum =
+                    FlushAndGetValue<int32_t>(sendCountsGlobal, localMoeIndex * epRankSize + epRankSize - 1);
+                groupListLocalTensor.SetValue(expertOffset, static_cast<int64_t>(tokenNum));
+                expertTokenNumsLocalTensor.SetValue(expertOffset, static_cast<int64_t>(tokenNum - prevTokenNum));
+                prevTokenNum = tokenNum;
+            }
+
+            AscendC::DataCopyExtParams copyOutParams = {1U, static_cast<uint32_t>(expertCount * sizeof(int64_t)), 0U,
+                                                        0U, 0U};
+            AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(0);
+            AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(0);
+            AscendC::DataCopyPad(expertTokenNumsOutGMTensor_[expertStart], groupListLocalTensor, copyOutParams);
+            AscendC::DataCopyPad(nonCumSumExpertTokenNumsTensor[expertStart], expertTokenNumsLocalTensor,
+                                 copyOutParams);
+        }
+    }
+
+    CATLASS_DEVICE
     void UpdateAndCleanInfo(__gm__ ElementGroupList_ *ptrGroupList, GM_ADDR gmEpSendCount, GM_ADDR gmExpertTokenNums)
     {
+        (void)ptrGroupList;
+        (void)gmEpSendCount;
+        (void)gmExpertTokenNums;
         if (isCompCore && AscendC::GetSubBlockIdx() == 0) {
             AscendC::GlobalTensor<int32_t> softSyncTensor;
             softSyncTensor.SetGlobalBuffer((__gm__ int32_t *)(statusDataSpaceGm + SOFT_SYNC_OFFSET));
@@ -1241,44 +1414,226 @@ public:
             AscendC::DataCopy(softSyncTensor[compCoreIdx * CVSoftSync::SOFT_SYNC_SPACE_SIZE / sizeof(int32_t)],
                               tmpZeroLocalTensor, INT32_COUNT_PER_BLOCK);
         }
-        if constexpr (!(EXEC_FLAG & EXEC_FLAG_DEEP_FUSE)) {
+        if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
+            if (aivIdx == aiCoreGroupNum * subBlockNum - 1) {
+                AscendC::LocalTensor<int32_t> tmpZeroLocalTensor =
+                    resource.ubBuf.template GetBufferByByte<int32_t>(512);
+                AscendC::Duplicate(tmpZeroLocalTensor, (int32_t)0, INT32_COUNT_PER_BLOCK);
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(0);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(0);
+                if constexpr (EXEC_FLAG & EXEC_FLAG_SHARED_EXPERT) {
+                    AscendC::GlobalTensor<int32_t> shareQuantTokenStateTensor;
+                    shareQuantTokenStateTensor.SetGlobalBuffer(
+                        (__gm__ int32_t *)(statusDataSpaceGm + SHARE_QUANT_SOFT_SYNC_OFFSET));
+                    AscendC::DataCopy(shareQuantTokenStateTensor, tmpZeroLocalTensor, INT32_COUNT_PER_BLOCK);
+                }
+            }
+        }
+    }
+
+    CATLASS_DEVICE
+    uint32_t GetAssignedLoopCount(uint32_t coreLoops, uint32_t coreNum, uint32_t producerCore, uint32_t startCoreIdx)
+    {
+        uint32_t startLoopIdx = (producerCore + coreNum - startCoreIdx) % coreNum;
+        if (startLoopIdx >= coreLoops) {
+            return 0;
+        }
+        return 1 + (coreLoops - 1 - startLoopIdx) / coreNum;
+    }
+
+    CATLASS_DEVICE
+    uint32_t GetBlockLoopIdx(uint32_t mLoops, uint32_t nLoops, uint32_t mBlock, uint32_t nBlock)
+    {
+        if constexpr (GMM1_SWIZZLE_DIRECTION == 0) {
+            uint32_t tileBlockIdx = mBlock / GMM1_SWIZZLE_OFFSET;
+            uint32_t tileBlockLoop = CEIL(mLoops, GMM1_SWIZZLE_OFFSET);
+            uint32_t nRow = GMM1_SWIZZLE_OFFSET;
+            if (tileBlockIdx == tileBlockLoop - 1) {
+                nRow = mLoops - GMM1_SWIZZLE_OFFSET * tileBlockIdx;
+            }
+            uint32_t inTileBlockRow = mBlock - tileBlockIdx * GMM1_SWIZZLE_OFFSET;
+            uint32_t nInnerIdx = (tileBlockIdx % 2 == 1) ? (nLoops - nBlock - 1) : nBlock;
+            return tileBlockIdx * (GMM1_SWIZZLE_OFFSET * nLoops) + nInnerIdx * nRow + inTileBlockRow;
+        } else {
+            uint32_t tileBlockIdx = nBlock / GMM1_SWIZZLE_OFFSET;
+            uint32_t tileBlockLoop = CEIL(nLoops, GMM1_SWIZZLE_OFFSET);
+            uint32_t nCol = GMM1_SWIZZLE_OFFSET;
+            if (tileBlockIdx == tileBlockLoop - 1) {
+                nCol = nLoops - GMM1_SWIZZLE_OFFSET * tileBlockIdx;
+            }
+            uint32_t mInnerIdx = (tileBlockIdx % 2 == 1) ? (mLoops - mBlock - 1) : mBlock;
+            uint32_t nInTileBlock = nBlock - tileBlockIdx * GMM1_SWIZZLE_OFFSET;
+            return tileBlockIdx * (GMM1_SWIZZLE_OFFSET * mLoops) + mInnerIdx * nCol + nInTileBlock;
+        }
+    }
+
+    CATLASS_DEVICE
+    int32_t GetProducerCoreForLoop(uint32_t loopIdx, uint32_t coreNum, uint32_t startCoreIdx)
+    {
+        return static_cast<int32_t>((startCoreIdx + loopIdx) % coreNum);
+    }
+
+    CATLASS_DEVICE
+    uint32_t GetTargetForLoop(uint32_t completedCount, uint32_t loopIdx, uint32_t coreNum)
+    {
+        return completedCount + loopIdx / coreNum + 1;
+    }
+
+    CATLASS_DEVICE
+    void SyncSwigluOutBeforeMul()
+    {
+        // BlockEpilogue publishes its final GM write with MTE3_V(0). Consume
+        // that event before Mul/Quant starts reading swigluOut from GM. The
+        // event is then re-armed for the next BlockEpilogue stage (or the
+        // BlockEpilogue destructor when this is the final stage).
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(0);
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(0);
+    }
+
+    CATLASS_DEVICE
+    void ProcessMulAndQuantFromSwigluOut(__gm__ ElementC *swigluOutAddr, __gm__ ElementA *x2Addr,
+                                         __gm__ ElementMxScaleA *x2ScaleAddr, uint32_t maxTokenNum, uint32_t gmm1HLen,
+                                         uint32_t gmm2HLen, uint32_t rowOffset, uint32_t leftColOffset,
+                                         uint32_t rightColOffset, GemmCoord const &leftActualBlockShape,
+                                         GemmCoord const &rightActualBlockShape)
+    {
+        constexpr uint32_t MUL_TILE_M = 8;
+        constexpr uint32_t MUL_TILE_N = L1_TILE_N;
+        constexpr uint32_t MX_GROUP_SIZE = 32;
+        constexpr uint32_t MUL_TILE_ELEMENT_COUNT = MUL_TILE_M * MUL_TILE_N;
+        constexpr uint32_t QUANT_ROW_SCALE_COUNT = MUL_TILE_N / MX_GROUP_SIZE;
+        constexpr uint32_t EPILOGUE_UB_SIZE = BlockEpilogue::UB_STAGES * BlockEpilogue::TILE_COUNT *
+                                              (sizeof(ElementC) + sizeof(XType) + sizeof(ElementC));
+        constexpr uint32_t MUL_UB_SIZE = 2 * MUL_TILE_M * MUL_TILE_N * sizeof(ElementC);
+        constexpr uint32_t MUL_BUFFER_SIZE = MUL_TILE_M * MUL_TILE_N * sizeof(ElementC);
+        constexpr uint32_t QUANT_INPUT_SIZE = MUL_TILE_ELEMENT_COUNT * sizeof(XType);
+        constexpr uint32_t QUANT_OUTPUT_SIZE = MxCount2Byte<ElementA>(MUL_TILE_N);
+        constexpr uint32_t QUANT_SCALE_SIZE = CEIL_UP(QUANT_ROW_SCALE_COUNT * sizeof(ElementMxScaleA));
+        constexpr uint32_t QUANT_SCRATCH_SIZE = CEIL_UP(QUANT_ROW_SCALE_COUNT * 2 * sizeof(float));
+        constexpr uint32_t QUANT_WORKSPACE_SIZE =
+            QUANT_INPUT_SIZE + QUANT_OUTPUT_SIZE + QUANT_SCALE_SIZE + QUANT_SCRATCH_SIZE;
+        static_assert(L1_TILE_N % MX_GROUP_SIZE == 0, "Routed quant tile must contain complete MX groups");
+        static_assert((L1_TILE_N / MX_GROUP_SIZE) % 2 == 0,
+                      "Routed quant tile must contain an even number of MX groups per row");
+        static_assert(EPILOGUE_UB_SIZE + MUL_UB_SIZE <= ArchTag::UB_SIZE,
+                      "Swiglu epilogue and routed mul buffers exceed UB capacity");
+        static_assert(QUANT_WORKSPACE_SIZE <= MUL_BUFFER_SIZE,
+                      "Routed quant workspace does not fit in the reusable right mul buffer");
+
+        uint32_t actualPairM = leftActualBlockShape.m();
+        uint32_t actualPairN = (leftActualBlockShape.n() < rightActualBlockShape.n()) ? leftActualBlockShape.n()
+                                                                                      : rightActualBlockShape.n();
+        if (actualPairM == 0 || actualPairN == 0) {
             return;
         }
-        if (aivIdx == aiCoreGroupNum * subBlockNum - 1) {
-            // clean
-            AscendC::GlobalTensor<int32_t> groupTokenNumStateTensor;
-            groupTokenNumStateTensor.SetGlobalBuffer((__gm__ int32_t *)(statusDataSpaceGm + GROUP_TOKEN_NUM_OFFSET));
-            AscendC::LocalTensor<int32_t> tmpZeroLocalTensor = resource.ubBuf.template GetBufferByByte<int32_t>(512);
-            AscendC::Duplicate(tmpZeroLocalTensor, (int32_t)0, GROUP_INFO_SIZE * localExpertNum);
-            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(0);
-            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(0);
-            AscendC::DataCopy(groupTokenNumStateTensor, tmpZeroLocalTensor, GROUP_INFO_SIZE * localExpertNum);
-            if constexpr (EXEC_FLAG & EXEC_FLAG_SHARED_EXPERT) {
-                AscendC::GlobalTensor<int32_t> shareQuantTokenStateTensor;
-                shareQuantTokenStateTensor.SetGlobalBuffer(
-                    (__gm__ int32_t *)(statusDataSpaceGm + SHARE_QUANT_SOFT_SYNC_OFFSET));
-                AscendC::DataCopy(shareQuantTokenStateTensor, tmpZeroLocalTensor, 8);
-            }
-        }
 
-        if (isRecvCore && recvCoreIdx == (recvCoreNum - 1)) {
-            // record token count for each local expert
-            AscendC::GlobalTensor<int64_t> expertTokenNumsOutGMTensor_;
-            expertTokenNumsOutGMTensor_.SetGlobalBuffer((__gm__ int64_t *)(ptrGroupList));
-            AscendC::GlobalTensor<int32_t> sendCountsGlobal;
-            sendCountsGlobal.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(gmEpSendCount));
-            AscendC::GlobalTensor<int64_t> nonCumSumExpertTokenNumsTensor;
-            nonCumSumExpertTokenNumsTensor.SetGlobalBuffer((__gm__ int64_t *)gmExpertTokenNums);
-            uint32_t tmpTokenNum = 0;
-            for (uint32_t localMoeIndex = 0; localMoeIndex < localExpertNum; ++localMoeIndex) {
-                uint32_t tokenNum =
-                    FlushAndGetValue<int32_t>(sendCountsGlobal, localMoeIndex * epRankSize + epRankSize - 1);
-                SetValueAndFlush<int64_t>(expertTokenNumsOutGMTensor_, localMoeIndex, tokenNum);
-                uint32_t nonCumSumTokenNum = tokenNum - tmpTokenNum;
-                SetValueAndFlush<int64_t>(nonCumSumExpertTokenNumsTensor, localMoeIndex, nonCumSumTokenNum);
-                tmpTokenNum = tokenNum;
+        auto tileShape = MakeCoord(BlockEpilogue::TILE_M, BlockEpilogue::TILE_N);
+        Catlass::Epilogue::Tile::EpilogueHorizontalTileSwizzle epilogueTileSwizzle(MakeCoord(actualPairM, actualPairN),
+                                                                                   tileShape);
+        uint32_t tileLoops = epilogueTileSwizzle.GetLoops();
+        uint32_t subblockIdx = AscendC::GetSubBlockIdx();
+        uint32_t subblockNum = AscendC::GetSubBlockNum();
+
+        uint32_t ubOffset = EPILOGUE_UB_SIZE;
+        AscendC::LocalTensor<ElementC> leftLocalTensor = resource.ubBuf.template GetBufferByByte<ElementC>(ubOffset);
+        ubOffset += MUL_BUFFER_SIZE;
+        AscendC::LocalTensor<ElementC> rightLocalTensor = resource.ubBuf.template GetBufferByByte<ElementC>(ubOffset);
+        // Mul no longer needs the right operand, so quant reuses that 8 KiB region.
+        uint32_t quantUbOffset = ubOffset;
+        AscendC::LocalTensor<XType> quantInputLocalTensor =
+            resource.ubBuf.template GetBufferByByte<XType>(quantUbOffset);
+        quantUbOffset += QUANT_INPUT_SIZE;
+        AscendC::LocalTensor<ElementA> quantOutputLocalTensor =
+            resource.ubBuf.template GetBufferByByte<ElementA>(quantUbOffset);
+        quantUbOffset += QUANT_OUTPUT_SIZE + QUANT_SCALE_SIZE;
+        AscendC::LocalTensor<float> quantScratchLocalTensor =
+            resource.ubBuf.template GetBufferByByte<float>(quantUbOffset);
+
+        AscendC::GlobalTensor<ElementC> gmSwigluOutTensor;
+        gmSwigluOutTensor.SetGlobalBuffer(swigluOutAddr);
+        AscendC::GlobalTensor<ElementA> gmX2Tensor;
+        gmX2Tensor.SetGlobalBuffer(x2Addr);
+        AscendC::GlobalTensor<uint8_t> gmX2ScaleTensor;
+        gmX2ScaleTensor.SetGlobalBuffer(reinterpret_cast<__gm__ uint8_t *>(x2ScaleAddr));
+
+        auto fullLayout = tla::MakeLayout<ElementC, Catlass::layout::RowMajor>(maxTokenNum, gmm1HLen);
+        auto fullTensor = tla::MakeTensor(gmSwigluOutTensor, fullLayout, Arch::PositionGM{});
+
+        auto leftBlockTensor = GetTile(fullTensor, tla::MakeCoord(rowOffset, leftColOffset),
+                                       tla::MakeShape(actualPairM, leftActualBlockShape.n()));
+        auto rightBlockTensor = GetTile(fullTensor, tla::MakeCoord(rowOffset, rightColOffset),
+                                        tla::MakeShape(actualPairM, rightActualBlockShape.n()));
+        uint32_t mxScaleNumPerToken = CeilDiv(CeilDiv(gmm2HLen, MX_GROUP_SIZE), 2) * 2;
+
+        constexpr int32_t MUL_EVENT_ID = 2;  // Need to be distinguished from the event in blockEpilogue
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(MUL_EVENT_ID);
+        for (uint32_t loopIdx = subblockIdx; loopIdx < tileLoops; loopIdx += subblockNum) {
+            auto tileCoord = epilogueTileSwizzle.GetTileCoord(loopIdx);
+            auto actualTileShape = epilogueTileSwizzle.GetActualTileShape(tileCoord);
+            MatrixCoord tileOffsetInBlock = tileCoord * tileShape;
+            uint32_t tileOffsetInBlockRow = tileOffsetInBlock.row();
+            uint32_t tileOffsetInBlockColumn = tileOffsetInBlock.column();
+
+            for (uint32_t rowInTile = 0; rowInTile < actualTileShape.row(); rowInTile += MUL_TILE_M) {
+                uint32_t actualMulM =
+                    (actualTileShape.row() - rowInTile < MUL_TILE_M) ? (actualTileShape.row() - rowInTile) : MUL_TILE_M;
+                uint32_t actualMulN = actualTileShape.column();
+                uint32_t count = actualMulM * actualMulN;
+                uint32_t subTileRow = tileOffsetInBlockRow + rowInTile;
+
+                auto leftSubTensor = GetTile(leftBlockTensor, tla::MakeCoord(subTileRow, tileOffsetInBlockColumn),
+                                             tla::MakeShape(actualMulM, actualMulN));
+                auto rightSubTensor = GetTile(rightBlockTensor, tla::MakeCoord(subTileRow, tileOffsetInBlockColumn),
+                                              tla::MakeShape(actualMulM, actualMulN));
+                auto layoutUb =
+                    tla::MakeLayout(tla::MakeShape(actualMulM, actualMulN), tla::MakeStride(actualMulN, tla::Int<1>{}));
+                auto leftUbTensor = tla::MakeTensor(leftLocalTensor, layoutUb, Arch::PositionUB{});
+                auto rightUbTensor = tla::MakeTensor(rightLocalTensor, layoutUb, Arch::PositionUB{});
+
+                using CopyGmToUb = typename Catlass::Epilogue::Tile::CopyGm2UbTla<ArchTag, decltype(leftSubTensor),
+                                                                                  decltype(leftUbTensor)>;
+                CopyGmToUb copyGmToUb;
+
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(MUL_EVENT_ID);
+                copyGmToUb(leftUbTensor, leftSubTensor);
+                copyGmToUb(rightUbTensor, rightSubTensor);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(MUL_EVENT_ID);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(MUL_EVENT_ID);
+                AscendC::Mul(leftLocalTensor, leftLocalTensor, rightLocalTensor, count);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::Cast(quantInputLocalTensor, leftLocalTensor, AscendC::RoundMode::CAST_RINT, count);
+                AscendC::PipeBarrier<PIPE_V>();
+                uint32_t mxScaleNumPerRow = actualMulN / MX_GROUP_SIZE;
+                uint32_t outputColOffset = leftColOffset + tileOffsetInBlockColumn;
+                uint32_t outputScaleColOffset = outputColOffset / MX_GROUP_SIZE;
+                AscendC::DataCopyExtParams mxScaleCopyParams = {
+                    1U, static_cast<uint32_t>(mxScaleNumPerRow * sizeof(ElementMxScaleA)), 0U, 0U, 0U};
+                // UB-to-GM DataCopyPad advances source blocks at 32-byte granularity, so emit each 8-byte scale row
+                // from the aligned single-row quant output instead of treating tightly packed rows as a 2D source.
+                for (uint32_t rowIdx = 0; rowIdx < actualMulM; ++rowIdx) {
+                    if (rowIdx > 0) {
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(MUL_EVENT_ID);
+                    }
+                    AscendC::LocalTensor<XType> quantInputRowTensor = quantInputLocalTensor[rowIdx * actualMulN];
+                    QuantDynamicMx(quantOutputLocalTensor, quantInputRowTensor, quantScratchLocalTensor, actualMulN,
+                                   mxScaleNumPerRow);
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(MUL_EVENT_ID);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(MUL_EVENT_ID);
+
+                    AscendC::LocalTensor<uint8_t> mxScaleLocalTensor =
+                        quantOutputLocalTensor[actualMulN].template ReinterpretCast<uint8_t>();
+                    uint32_t outputRow = rowOffset + subTileRow + rowIdx;
+                    AscendC::DataCopy(gmX2Tensor[outputRow * gmm2HLen + outputColOffset], quantOutputLocalTensor,
+                                      actualMulN);
+                    AscendC::DataCopyPad(gmX2ScaleTensor[outputRow * mxScaleNumPerToken + outputScaleColOffset],
+                                         mxScaleLocalTensor, mxScaleCopyParams);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(MUL_EVENT_ID);
+                }
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(MUL_EVENT_ID);
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(MUL_EVENT_ID);
             }
         }
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(MUL_EVENT_ID);
     }
 
     CATLASS_DEVICE
@@ -1365,9 +1720,11 @@ public:
                 RecvCoreFunc((GM_ADDR)params.ptrA, (GM_ADDR)params.ptrMxScaleA, (GM_ADDR)params.gmEpSendCount,
                              params.profile);
             }
+            CleanRoutedX2ReadyState();
+            AivOnlySync();
+            FinalizeGroupMetaAfterRecv(params.ptrGroupList, params.gmEpSendCount, params.gmExpertTokenNums);
+            AivOnlySync();
         }
-
-        uint32_t totalTokenNum = 0;
 
         uint32_t coreIdx = AscendC::GetBlockIdx() / AscendC::GetSubBlockNum();
         uint32_t coreNum = AscendC::GetBlockNum();
@@ -1375,81 +1732,25 @@ public:
         AscendC::GlobalTensor<ElementC> gmC;
         AscendC::GlobalTensor<ElementC> gmSwigluOutTensor;
         AscendC::GlobalTensor<ElementC> gmShareSwigluOutTensor;
-
-        BlockEpilogue blockEpilogue(resource);
         uint32_t startCoreIdx = 0;
-        uint32_t currentM = 0;
-        uint32_t target = 1;
 
-        if constexpr (EXEC_FLAG & EXEC_FLAG_SHARED_EXPERT) {
-            currentM = axisBS;
-            gmC.SetGlobalBuffer(params.ptrShareC);
-            gmShareSwigluOutTensor.SetGlobalBuffer(params.gmShareSwigluOut);
-
-            auto tensorC = tla::MakeTensor(gmC, params.layoutShareC, Arch::PositionGM{});
-            auto tensorD = tla::MakeTensor(gmShareSwigluOutTensor, params.layoutShareC, Arch::PositionGM{});
-
-            GemmCoord inGroupProblemShape{currentM, params.shareProblemShape.n(), params.shareProblemShape.k()};
-            BlockScheduler matmulBlockScheduler(inGroupProblemShape, MakeCoord(L1_TILE_M, L1_TILE_N));
-            uint32_t coreLoops = matmulBlockScheduler.GetCoreLoops();
-
-            uint32_t startLoopIdx;
-            if (coreIdx < startCoreIdx) {
-                startLoopIdx = coreIdx + coreNum - startCoreIdx;
-            } else {
-                startLoopIdx = coreIdx - startCoreIdx;
-            }
-
-            for (uint32_t loopIdx = startLoopIdx; loopIdx < coreLoops; loopIdx += coreNum) {
-                GemmCoord blockCoord = matmulBlockScheduler.GetBlockCoord(loopIdx);
-                GemmCoord actualBlockShape = matmulBlockScheduler.GetActualBlockShape(blockCoord);
-
-                auto tensorBlockC =
-                    GetTile(tensorC, tla::MakeCoord(blockCoord.m() * L1_TILE_M, blockCoord.n() * L1_TILE_N),
-                            tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-
-                auto tensorBlockD =
-                    GetTile(tensorD, tla::MakeCoord(blockCoord.m() * L1_TILE_M, blockCoord.n() * L1_TILE_N),
-                            tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
-
-                bool isLeft = (blockCoord.n() * L1_TILE_N < params.shareProblemShape.n() / 2);
-                CheckSyncFlag(reinterpret_cast<__gm__ int32_t *>(statusDataSpaceGm + SOFT_SYNC_OFFSET),
-                              static_cast<int32_t>(compCoreIdx), target);
-                target += 1;
-                blockEpilogue(tensorBlockC, tensorBlockD, actualBlockShape, isLeft);
-            }
-            startCoreIdx = (startCoreIdx + coreLoops) % coreNum;
-        }
+        // Keep the BlockEpilogue lifetime bounded to the GMM1/Swiglu stage.
+        // Its destructor drains the event-0 pipeline before the later
+        // global synchronization and status cleanup stages.
         {
-            int64_t totalM = 0;
-            uint32_t coreNumPerGroup = recvCoreNum;
-            gmC.SetGlobalBuffer(params.ptrC);
-            gmSwigluOutTensor.SetGlobalBuffer(params.gmSwigluOut);
-            AscendC::GlobalTensor<ElementGroupList> groupList;
-            groupList.SetGlobalBuffer(params.ptrGroupList);
+            BlockEpilogue blockEpilogue(resource);
+            uint32_t currentM = 0;
+            uint32_t target = 1;
 
-            auto tensorC = tla::MakeTensor(gmC, params.layoutC, Arch::PositionGM{});
-            auto tensorD = tla::MakeTensor(gmSwigluOutTensor, params.layoutC, Arch::PositionGM{});
-            AscendC::GlobalTensor<int32_t> groupTokenNumStateTensor;
+            if constexpr (EXEC_FLAG & EXEC_FLAG_SHARED_EXPERT) {
+                currentM = axisBS;
+                gmC.SetGlobalBuffer(params.ptrShareC);
+                gmShareSwigluOutTensor.SetGlobalBuffer(params.gmShareSwigluOut);
 
-            for (uint32_t groupIdx = 0; groupIdx < params.problemCount; ++groupIdx) {
-                uint64_t profSwigluStart = 0;
-                if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
-                    groupTokenNumStateTensor.SetGlobalBuffer(
-                        (__gm__ int32_t *)(statusDataSpaceGm + GROUP_TOKEN_NUM_OFFSET) + groupIdx * GROUP_INFO_SIZE);
-                    CheckSyncFlag(reinterpret_cast<__gm__ int32_t *>(statusDataSpaceGm + SOFT_SYNC_OFFSET),
-                                  static_cast<int32_t>(compCoreIdx), target);
-                    target += 1;
-                    currentM = FlushAndGetValue<int32_t>(groupTokenNumStateTensor, GROUP_TOKEN_COUNT);
-                } else {
-                    currentM = (groupIdx == 0) ? groupList.GetValue(groupIdx)
-                                               : (groupList.GetValue(groupIdx) - groupList.GetValue(groupIdx - 1));
-                }
-                if (params.profile != nullptr) {
-                    profSwigluStart = params.profile->Now();
-                }
-                totalTokenNum += currentM;
-                GemmCoord inGroupProblemShape{currentM, params.problemShape.n(), params.problemShape.k()};
+                auto tensorC = tla::MakeTensor(gmC, params.layoutShareC, Arch::PositionGM{});
+                auto tensorD = tla::MakeTensor(gmShareSwigluOutTensor, params.layoutShareC, Arch::PositionGM{});
+
+                GemmCoord inGroupProblemShape{currentM, params.shareProblemShape.n(), params.shareProblemShape.k()};
                 BlockScheduler matmulBlockScheduler(inGroupProblemShape, MakeCoord(L1_TILE_M, L1_TILE_N));
                 uint32_t coreLoops = matmulBlockScheduler.GetCoreLoops();
 
@@ -1464,33 +1765,166 @@ public:
                     GemmCoord blockCoord = matmulBlockScheduler.GetBlockCoord(loopIdx);
                     GemmCoord actualBlockShape = matmulBlockScheduler.GetActualBlockShape(blockCoord);
 
-                    auto tensorBlockC = GetTile(
-                        tensorC, tla::MakeCoord(totalM + blockCoord.m() * L1_TILE_M, blockCoord.n() * L1_TILE_N),
-                        tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                    auto tensorBlockC =
+                        GetTile(tensorC, tla::MakeCoord(blockCoord.m() * L1_TILE_M, blockCoord.n() * L1_TILE_N),
+                                tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
 
-                    auto tensorBlockD = GetTile(
-                        tensorD, tla::MakeCoord(totalM + blockCoord.m() * L1_TILE_M, blockCoord.n() * L1_TILE_N),
-                        tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
+                    auto tensorBlockD =
+                        GetTile(tensorD, tla::MakeCoord(blockCoord.m() * L1_TILE_M, blockCoord.n() * L1_TILE_N),
+                                tla::MakeShape(actualBlockShape.m(), actualBlockShape.n()));
 
-                    bool isLeft = (blockCoord.n() * L1_TILE_N < params.problemShape.n() / 2);
+                    bool isLeft = (blockCoord.n() * L1_TILE_N < params.shareProblemShape.n() / 2);
                     CheckSyncFlag(reinterpret_cast<__gm__ int32_t *>(statusDataSpaceGm + SOFT_SYNC_OFFSET),
                                   static_cast<int32_t>(compCoreIdx), target);
                     target += 1;
                     blockEpilogue(tensorBlockC, tensorBlockD, actualBlockShape, isLeft);
                 }
-
-                totalM += inGroupProblemShape.m();
-
                 startCoreIdx = (startCoreIdx + coreLoops) % coreNum;
-                if (params.profile != nullptr) {
-                    params.profile->Record(FusedDeepMoeProfileStage::Swiglu, groupIdx, profSwigluStart,
-                                           params.profile->Now());
-                }
             }
-            AscendC::PipeBarrier<PIPE_ALL>();
+            {
+                int64_t totalM = 0;
+                gmC.SetGlobalBuffer(params.ptrC);
+                gmSwigluOutTensor.SetGlobalBuffer(params.gmSwigluOut);
+                AscendC::GlobalTensor<ElementGroupList> groupList;
+                groupList.SetGlobalBuffer(params.ptrGroupList);
+
+                auto tensorC = tla::MakeTensor(gmC, params.layoutC, Arch::PositionGM{});
+                auto tensorD = tla::MakeTensor(gmSwigluOutTensor, params.layoutC, Arch::PositionGM{});
+                AscendC::GlobalTensor<int32_t> groupTokenNumStateTensor;
+                constexpr uint32_t MAX_PRODUCER_CORE_NUM = 256;
+                uint32_t producerCompletedCount[MAX_PRODUCER_CORE_NUM];
+                for (uint32_t producerCore = 0; producerCore < MAX_PRODUCER_CORE_NUM; ++producerCore) {
+                    producerCompletedCount[producerCore] = 0;
+                }
+                if constexpr (EXEC_FLAG & EXEC_FLAG_SHARED_EXPERT) {
+                    GemmCoord sharedProblemShape{axisBS, params.shareProblemShape.n(), params.shareProblemShape.k()};
+                    BlockScheduler sharedBlockScheduler(sharedProblemShape, MakeCoord(L1_TILE_M, L1_TILE_N));
+                    uint32_t sharedCoreLoops = sharedBlockScheduler.GetCoreLoops();
+                    for (uint32_t producerCore = 0; producerCore < coreNum; ++producerCore) {
+                        producerCompletedCount[producerCore] +=
+                            GetAssignedLoopCount(sharedCoreLoops, coreNum, producerCore, 0);
+                    }
+                }
+
+                for (uint32_t groupIdx = 0; groupIdx < params.problemCount; ++groupIdx) {
+                    if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
+                        groupTokenNumStateTensor.SetGlobalBuffer(
+                            (__gm__ int32_t *)(statusDataSpaceGm + GROUP_TOKEN_NUM_OFFSET) +
+                            groupIdx * GROUP_INFO_SIZE);
+                        CheckSyncFlag(reinterpret_cast<__gm__ int32_t *>(statusDataSpaceGm + SOFT_SYNC_OFFSET),
+                                      static_cast<int32_t>(compCoreIdx), target);
+                        target += 1;
+                        currentM = FlushAndGetValue<int32_t>(groupTokenNumStateTensor, GROUP_TOKEN_COUNT);
+                        for (uint32_t producerCore = 0; producerCore < coreNum; ++producerCore) {
+                            producerCompletedCount[producerCore] += 1;
+                        }
+                    } else {
+                        currentM = (groupIdx == 0) ? groupList.GetValue(groupIdx)
+                                                   : (groupList.GetValue(groupIdx) - groupList.GetValue(groupIdx - 1));
+                    }
+                    GemmCoord inGroupProblemShape{currentM, params.problemShape.n(), params.problemShape.k()};
+                    BlockScheduler matmulBlockScheduler(inGroupProblemShape, MakeCoord(L1_TILE_M, L1_TILE_N));
+                    uint32_t coreLoops = matmulBlockScheduler.GetCoreLoops();
+                    uint32_t groupStartCoreIdx = startCoreIdx;
+                    uint32_t mLoops = CEIL(currentM, L1_TILE_M);
+                    uint32_t nLoops = CEIL(params.problemShape.n(), L1_TILE_N);
+                    uint32_t routedHalfN = params.problemShape.n() / 2;
+
+                    uint32_t startLoopIdx;
+                    if (coreIdx < startCoreIdx) {
+                        startLoopIdx = coreIdx + coreNum - startCoreIdx;
+                    } else {
+                        startLoopIdx = coreIdx - startCoreIdx;
+                    }
+
+                    for (uint32_t loopIdx = startLoopIdx; loopIdx < coreLoops; loopIdx += coreNum) {
+                        GemmCoord rightBlockCoord = matmulBlockScheduler.GetBlockCoord(loopIdx);
+                        uint32_t rightColOffset = rightBlockCoord.n() * L1_TILE_N;
+                        if (rightColOffset < routedHalfN) {
+                            continue;
+                        }
+
+                        uint32_t leftColOffset = rightColOffset - routedHalfN;
+                        uint32_t leftNBlock = leftColOffset / L1_TILE_N;
+                        GemmCoord leftBlockCoord{rightBlockCoord.m(), leftNBlock, 0};
+                        GemmCoord rightActualBlockShape = matmulBlockScheduler.GetActualBlockShape(rightBlockCoord);
+                        GemmCoord leftActualBlockShape = matmulBlockScheduler.GetActualBlockShape(leftBlockCoord);
+
+                        uint32_t leftLoopIdx = GetBlockLoopIdx(mLoops, nLoops, leftBlockCoord.m(), leftBlockCoord.n());
+                        int32_t leftProducerCore = GetProducerCoreForLoop(leftLoopIdx, coreNum, groupStartCoreIdx);
+                        int32_t rightProducerCore = GetProducerCoreForLoop(loopIdx, coreNum, groupStartCoreIdx);
+                        uint32_t leftTarget =
+                            GetTargetForLoop(producerCompletedCount[leftProducerCore], leftLoopIdx, coreNum);
+                        uint32_t rightTarget =
+                            GetTargetForLoop(producerCompletedCount[rightProducerCore], loopIdx, coreNum);
+
+                        auto tensorLeftBlockC =
+                            GetTile(tensorC, tla::MakeCoord(totalM + leftBlockCoord.m() * L1_TILE_M, leftColOffset),
+                                    tla::MakeShape(leftActualBlockShape.m(), leftActualBlockShape.n()));
+                        auto tensorLeftBlockD =
+                            GetTile(tensorD, tla::MakeCoord(totalM + leftBlockCoord.m() * L1_TILE_M, leftColOffset),
+                                    tla::MakeShape(leftActualBlockShape.m(), leftActualBlockShape.n()));
+                        auto tensorRightBlockC =
+                            GetTile(tensorC, tla::MakeCoord(totalM + rightBlockCoord.m() * L1_TILE_M, rightColOffset),
+                                    tla::MakeShape(rightActualBlockShape.m(), rightActualBlockShape.n()));
+                        auto tensorRightBlockD =
+                            GetTile(tensorD, tla::MakeCoord(totalM + rightBlockCoord.m() * L1_TILE_M, rightColOffset),
+                                    tla::MakeShape(rightActualBlockShape.m(), rightActualBlockShape.n()));
+
+                        uint64_t profSwigluStart = 0;
+                        if (params.profile != nullptr) {
+                            profSwigluStart = params.profile->Now();
+                        }
+                        CheckSyncFlag(reinterpret_cast<__gm__ int32_t *>(statusDataSpaceGm + SOFT_SYNC_OFFSET),
+                                      leftProducerCore, leftTarget);
+                        blockEpilogue(tensorLeftBlockC, tensorLeftBlockD, leftActualBlockShape, true);
+                        CheckSyncFlag(reinterpret_cast<__gm__ int32_t *>(statusDataSpaceGm + SOFT_SYNC_OFFSET),
+                                      rightProducerCore, rightTarget);
+                        blockEpilogue(tensorRightBlockC, tensorRightBlockD, rightActualBlockShape, false);
+                        SyncSwigluOutBeforeMul();
+
+                        if (params.profile != nullptr) {
+                            params.profile->Record(FusedDeepMoeProfileStage::Swiglu, groupIdx, profSwigluStart,
+                                                   params.profile->Now());
+                        }
+
+                        uint64_t profMulQuantStart = 0;
+                        if (params.profile != nullptr) {
+                            profMulQuantStart = params.profile->Now();
+                        }
+                        ProcessMulAndQuantFromSwigluOut(params.gmSwigluOut, params.ptrX2, params.gmX2Scale,
+                                                        params.problemShape.m(), params.problemShape.n(), routedHalfN,
+                                                        totalM + rightBlockCoord.m() * L1_TILE_M, leftColOffset,
+                                                        rightColOffset, leftActualBlockShape, rightActualBlockShape);
+
+                        if (params.profile != nullptr) {
+                            params.profile->Record(FusedDeepMoeProfileStage::Quant, groupIdx, profMulQuantStart,
+                                                   params.profile->Now());
+                        }
+                    }
+
+                    if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
+                        NotifyRoutedX2Ready(groupIdx);
+                    }
+
+                    totalM += inGroupProblemShape.m();
+                    target += GetAssignedLoopCount(coreLoops, coreNum, compCoreIdx, groupStartCoreIdx);
+                    for (uint32_t producerCore = 0; producerCore < coreNum; ++producerCore) {
+                        producerCompletedCount[producerCore] +=
+                            GetAssignedLoopCount(coreLoops, coreNum, producerCore, groupStartCoreIdx);
+                    }
+
+                    startCoreIdx = (startCoreIdx + coreLoops) % coreNum;
+                }
+                AscendC::PipeBarrier<PIPE_ALL>();
+            }
         }
         icache_preload(8);
-        AscendC::SyncAll<false>();
+        if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
+            AscendC::SyncAll<true>();
+        } else {
+            AscendC::SyncAll<false>();
+        }
         AscendC::PipeBarrier<PIPE_ALL>();
 
         UpdateAndCleanInfo(params.ptrGroupList, params.gmEpSendCount, params.gmExpertTokenNums);
@@ -1499,16 +1933,8 @@ public:
         if constexpr (EXEC_FLAG & EXEC_FLAG_SHARED_EXPERT) {
             PostSwigluDynamicQuant(params.gmShareSwigluOut, params.ptrShareX2, params.gmShareX2Scale, axisBS,
                                    params.shareProblemShape.n(), startCoreIdx);
-        }
-        {
-            uint64_t profQuantStart = 0;
-            if (params.profile != nullptr) {
-                profQuantStart = params.profile->Now();
-            }
-            PostSwigluDynamicQuant(params.gmSwigluOut, params.ptrX2, params.gmX2Scale, totalTokenNum,
-                                   params.problemShape.n(), startCoreIdx);
-            if (params.profile != nullptr) {
-                params.profile->Record(FusedDeepMoeProfileStage::Quant, profQuantStart, params.profile->Now());
+            if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
+                NotifySharedX2Ready(0, FusedDeepMoeSync::SHARED_X2_DONE_COUNT_INDEX);
             }
         }
     }
@@ -1560,6 +1986,8 @@ private:
     uint32_t tokenLength{0};
     uint32_t x1MxScaleNum{0};
     uint32_t x2MxScaleNum{0};
+    uint32_t problemCount{0};
+    GM_ADDR gmX2ReadyState{nullptr};
 
     // state info
     int32_t tokenFlag{0};    // token flag

--- a/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/gemm/kernel/dispatch_mx_gmm1_swiglu.h
+++ b/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/gemm/kernel/dispatch_mx_gmm1_swiglu.h
@@ -740,7 +740,7 @@ public:
     }
 
     CATLASS_DEVICE
-    uint32_t SendToMoeExprt(GM_ADDR gmX, GM_ADDR gmExpandIdx, GM_ADDR gmMoeSmoothScales)
+    uint32_t SendToMoeExpert(GM_ADDR gmX, GM_ADDR gmExpandIdx, GM_ADDR gmMoeSmoothScales)
     {
         uint32_t sendTokenNum = expertIdsCnt / sendToMoeAivNum;
         uint32_t remainderTokenNum = expertIdsCnt % sendToMoeAivNum;
@@ -897,7 +897,7 @@ public:
         CalAndSendTokenCount();
         AscendC::PipeBarrier<PIPE_ALL>();
         sendToMoeAivNum = sendCoreNum;
-        uint32_t sendValidTokenCount = SendToMoeExprt(gmX, gmExpandIdx, gmMoeSmoothScales);
+        uint32_t sendValidTokenCount = SendToMoeExpert(gmX, gmExpandIdx, gmMoeSmoothScales);
         AscendC::PipeBarrier<PIPE_ALL>();
         if (profile != nullptr) {
             auto dispatchSendPayload = Cam::ToProfilePrivatePayloadRaw(Cam::MakeDispatchSendPrivatePayloadV1(
@@ -1171,8 +1171,6 @@ public:
         for (uint32_t groupId = 0; groupId < localExpertNum; ++groupId) {
             uint64_t profDispatchRecvStart = 0;
             uint64_t profDispatchRecvEnd = 0;
-            uint64_t profDispatchRecvNotifyStart = 0;
-            uint64_t profDispatchRecvNotifyEnd = 0;
             if (profile != nullptr) {
                 profDispatchRecvStart = profile->Now();
             }
@@ -1212,7 +1210,6 @@ public:
             AscendC::PipeBarrier<PIPE_ALL>();
             if (profile != nullptr) {
                 profDispatchRecvEnd = profile->Now();
-                profDispatchRecvNotifyStart = profile->Now();
             }
             uint32_t idleCoreNum = recvCoreNum - useCoreNum;
             bool hasToken = coreTokenCount > 0;
@@ -1242,10 +1239,6 @@ public:
                 AscendC::SetAtomicNone();
                 AscendC::PipeBarrier<PIPE_ALL>();
             }
-            if (profile != nullptr) {
-                profDispatchRecvNotifyEnd = profile->Now();
-            }
-
             startCoreIdx = (startCoreIdx + currentM) % recvCoreNum;
             preExpertToken += currentM;
             if (profile != nullptr) {
@@ -1254,8 +1247,6 @@ public:
                     static_cast<uint64_t>(coreTokenCount)));
                 profile->Record(FusedDeepMoeProfileStage::DispatchRecv, groupId, profDispatchRecvStart,
                                 profDispatchRecvEnd, dispatchRecvPayload);
-                profile->Record(FusedDeepMoeProfileStage::DispatchRecvNotify, groupId, profDispatchRecvNotifyStart,
-                                profDispatchRecvNotifyEnd, dispatchRecvPayload);
             }
         }
 

--- a/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/gemm/kernel/mx_gmm2_cast_combine.h
+++ b/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/gemm/kernel/mx_gmm2_cast_combine.h
@@ -79,6 +79,9 @@ public:
 
         GemmCoord sharedProblemShape;
         void *combiner;
+        uint32_t expectedAivNum;
+        GM_ADDR gmX2ReadyState;
+        uint64_t weightExpertStrideBytes;
         FusedDeepMoeProfileWriter *profile;
 
         // Methods
@@ -93,6 +96,7 @@ public:
                LayoutA const &layoutSharedA_, GM_ADDR ptrSharedB_, LayoutB const &layoutSharedB_,
                GM_ADDR ptrSharedMxScaleA_, LayoutMxScaleA layoutSharedMxScaleA_, GM_ADDR ptrSharedMxScaleB_,
                LayoutMxScaleB layoutSharedMxScaleB_, GM_ADDR ptrSharedC_, GM_ADDR ptrSharedD_, void *combiner_,
+               uint32_t expectedAivNum_, GM_ADDR gmX2ReadyState_, uint64_t weightExpertStrideBytes_,
                FusedDeepMoeProfileWriter *profile_)
             : problemShape(problemShape_),
               problemCount(problemCount_),
@@ -120,6 +124,9 @@ public:
               ptrSharedC(reinterpret_cast<__gm__ ElementC *>(ptrSharedC_)),
               ptrSharedD(reinterpret_cast<__gm__ ElementD *>(ptrSharedD_)),
               combiner(combiner_),
+              expectedAivNum(expectedAivNum_),
+              gmX2ReadyState(gmX2ReadyState_),
+              weightExpertStrideBytes(weightExpertStrideBytes_),
               profile(profile_)
         {}
     };
@@ -135,9 +142,91 @@ public:
     template <int32_t CORE_TYPE = g_coreType>
     CATLASS_DEVICE void operator()(Params const &params);
 
+    CATLASS_DEVICE
+    void WaitSharedX2Ready(uint32_t groupIdx, uint32_t counterIndex, uint32_t expectedAivNum)
+    {
+        AscendC::GlobalTensor<int32_t> readyTensor;
+        readyTensor.SetGlobalBuffer((__gm__ int32_t *)(syncGmAddr + FusedDeepMoeSync::GROUP_TOKEN_NUM_OFFSET) +
+                                    groupIdx * FusedDeepMoeSync::GROUP_INFO_SIZE);
+        while (FlushAndGetValue<int32_t>(readyTensor, counterIndex) != static_cast<int32_t>(expectedAivNum)) {
+            SPIN_WAIT_CYCLES();
+        }
+        AscendC::PipeBarrier<PIPE_ALL>();
+    }
+
+    CATLASS_DEVICE
+    void WaitRoutedX2Ready(uint32_t groupIdx, uint32_t expectedAivNum)
+    {
+        AscendC::GlobalTensor<int32_t> readyTensor;
+        readyTensor.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(
+            gmX2ReadyState + static_cast<uint64_t>(groupIdx) * FusedDeepMoeSync::X2_READY_SLOT_SIZE));
+        while (true) {
+            int32_t actualCount = FlushAndGetValue<int32_t>(readyTensor, FusedDeepMoeSync::X2_READY_COUNTER_INDEX);
+            if (actualCount == static_cast<int32_t>(expectedAivNum)) {
+                break;
+            }
+            SPIN_WAIT_CYCLES();
+        }
+
+        AscendC::PipeBarrier<PIPE_ALL>();
+    }
+
+    CATLASS_DEVICE
+    void CleanRoutedX2ReadyState(uint32_t problemCount)
+    {
+        // This helper is called by the AIV specialization.  Its block index
+        // is already the logical AIV index; multiplying by subblock count
+        // would leave ready slots uncleared.
+        uint32_t workerIdx = AscendC::GetBlockIdx();
+        uint32_t workerCount = AscendC::GetBlockNum();
+        AscendC::LocalTensor<int32_t> zeroLocal = resource.ubBuf.template GetBufferByByte<int32_t>(0);
+        AscendC::Duplicate(zeroLocal, static_cast<int32_t>(0), GMM2::INT32_COUNT_PER_BLOCK);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(0);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(0);
+        for (uint32_t slotIdx = workerIdx; slotIdx < problemCount; slotIdx += workerCount) {
+            AscendC::GlobalTensor<int32_t> readyTensor;
+            readyTensor.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(
+                gmX2ReadyState + static_cast<uint64_t>(slotIdx) * FusedDeepMoeSync::X2_READY_SLOT_SIZE));
+            AscendC::DataCopy(readyTensor, zeroLocal, GMM2::INT32_COUNT_PER_BLOCK);
+        }
+        AscendC::PipeBarrier<PIPE_MTE3>();
+    }
+
+    CATLASS_DEVICE
+    void CleanGroupTokenInfo(uint32_t groupCount)
+    {
+        uint32_t cleanWorkerIdx = AscendC::GetBlockIdx() / AscendC::GetSubBlockNum();
+        uint32_t cleanWorkerCount = AscendC::GetBlockNum();
+        uint32_t stateGroupCount = groupCount;
+        if constexpr (EXEC_FLAG & EXEC_FLAG_SHARED_EXPERT) {
+            stateGroupCount = stateGroupCount == 0 ? 1U : stateGroupCount;
+        }
+        uint32_t totalCleanBlocks =
+            stateGroupCount * FusedDeepMoeSync::GROUP_INFO_SIZE / FusedDeepMoeSync::INT32_COUNT_PER_BLOCK;
+        uint32_t blocksPerWorker = totalCleanBlocks / cleanWorkerCount;
+        uint32_t remainBlocks = totalCleanBlocks % cleanWorkerCount;
+        // Only subblock 0 participates, so partition the state across physical AI Core groups.
+        uint32_t blockStart =
+            blocksPerWorker * cleanWorkerIdx + (cleanWorkerIdx < remainBlocks ? cleanWorkerIdx : remainBlocks);
+        uint32_t blockCount = blocksPerWorker + (cleanWorkerIdx < remainBlocks ? 1U : 0U);
+
+        AscendC::GlobalTensor<int32_t> groupStateTensor;
+        groupStateTensor.SetGlobalBuffer((__gm__ int32_t *)(syncGmAddr + FusedDeepMoeSync::GROUP_TOKEN_NUM_OFFSET));
+        AscendC::LocalTensor<int32_t> zeroLocalTensor = resource.ubBuf.template GetBufferByByte<int32_t>(0);
+        AscendC::Duplicate(zeroLocalTensor, static_cast<int32_t>(0), FusedDeepMoeSync::INT32_COUNT_PER_BLOCK);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(0);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(0);
+        for (uint32_t blockIdx = 0; blockIdx < blockCount; ++blockIdx) {
+            uint32_t gmOffset = (blockStart + blockIdx) * FusedDeepMoeSync::INT32_COUNT_PER_BLOCK;
+            AscendC::DataCopy(groupStateTensor[gmOffset], zeroLocalTensor, FusedDeepMoeSync::INT32_COUNT_PER_BLOCK);
+        }
+        AscendC::PipeBarrier<PIPE_MTE3>();
+    }
+
     template <>
     CATLASS_DEVICE void operator()<AscendC::AIC>(Params const &params)
     {
+        gmX2ReadyState = params.gmX2ReadyState;
         AscendC::ICachePreLoad(1);
 
         BlockScheduler blockScheduler;
@@ -176,17 +265,33 @@ public:
 
             for (uint32_t groupIdx = 0; groupIdx < params.problemCount; ++groupIdx) {
                 uint64_t profGroupStart = 0;
+                if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
+                    WaitRoutedX2Ready(groupIdx, params.expectedAivNum);
+                }
                 gmMxScaleA.SetGlobalBuffer(params.ptrMxScaleA + gmGroupOffsetMxScaleA);
                 if constexpr (EXEC_FLAG & EXEC_FLAG_TENSOR_LIST) {
                     gmB.SetGlobalBuffer(gmBlistTensorDesc.GetDataPtr<ElementB>(groupIdx));
                     gmMxScaleB.SetGlobalBuffer(gmBScalelistTensorDesc.GetDataPtr<ElementMxScaleB>(groupIdx));
                 } else {
-                    gmB.SetGlobalBuffer(gmBlistTensorDesc.GetDataPtr<ElementB>(0) + gmGroupOffsetB);
+                    if (params.weightExpertStrideBytes != 0U) {
+                        auto *weightBase =
+                            reinterpret_cast<__gm__ uint8_t *>(gmBlistTensorDesc.GetDataPtr<ElementB>(0));
+                        gmB.SetGlobalBuffer(reinterpret_cast<__gm__ ElementB *>(
+                            weightBase + static_cast<uint64_t>(groupIdx) * params.weightExpertStrideBytes));
+                    } else {
+                        gmB.SetGlobalBuffer(gmBlistTensorDesc.GetDataPtr<ElementB>(0) + gmGroupOffsetB);
+                    }
                     gmMxScaleB.SetGlobalBuffer(gmBScalelistTensorDesc.GetDataPtr<ElementMxScaleB>(0) +
                                                gmGroupOffsetMxScaleB);
                 }
-                currentM = (groupIdx == 0) ? groupList.GetValue(groupIdx)
-                                           : (groupList.GetValue(groupIdx) - groupList.GetValue(groupIdx - 1));
+                if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
+                    currentM = (groupIdx == 0) ? FlushAndGetValue<ElementGroupList>(groupList, groupIdx)
+                                               : (FlushAndGetValue<ElementGroupList>(groupList, groupIdx) -
+                                                  FlushAndGetValue<ElementGroupList>(groupList, groupIdx - 1));
+                } else {
+                    currentM = (groupIdx == 0) ? groupList.GetValue(groupIdx)
+                                               : (groupList.GetValue(groupIdx) - groupList.GetValue(groupIdx - 1));
+                }
                 if (params.profile != nullptr) {
                     profGroupStart = params.profile->Now();
                 }
@@ -245,12 +350,14 @@ public:
                 totalM += inGroupProblemShape.m();
 
                 if constexpr (!(EXEC_FLAG & EXEC_FLAG_TENSOR_LIST)) {
-                    if constexpr (AscendC::Std::is_one_of_v<ElementB, float4_e2m1x2_t, float4_e1m2x2_t>) {
-                        gmGroupOffsetB += std::is_same_v<LayoutB, layout::ColumnMajor>
-                                              ? CeilDiv<2>(inGroupProblemShape.k()) * inGroupProblemShape.n()
-                                              : CeilDiv<2>(inGroupProblemShape.n()) * inGroupProblemShape.k();
-                    } else {
-                        gmGroupOffsetB += inGroupProblemShape.k() * inGroupProblemShape.n();
+                    if (params.weightExpertStrideBytes == 0U) {
+                        if constexpr (AscendC::Std::is_one_of_v<ElementB, float4_e2m1x2_t, float4_e1m2x2_t>) {
+                            gmGroupOffsetB += std::is_same_v<LayoutB, layout::ColumnMajor>
+                                                  ? CeilDiv<2>(inGroupProblemShape.k()) * inGroupProblemShape.n()
+                                                  : CeilDiv<2>(inGroupProblemShape.n()) * inGroupProblemShape.k();
+                        } else {
+                            gmGroupOffsetB += inGroupProblemShape.k() * inGroupProblemShape.n();
+                        }
                     }
                     gmGroupOffsetMxScaleB += mxScaleAlignedK * inGroupProblemShape.n();
                 }
@@ -268,6 +375,9 @@ public:
             }
         }
         if constexpr (EXEC_FLAG & EXEC_FLAG_SHARED_EXPERT) {
+            if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
+                WaitSharedX2Ready(0, FusedDeepMoeSync::SHARED_X2_DONE_COUNT_INDEX, params.expectedAivNum);
+            }
             currentM = params.sharedProblemShape.m();
             gmA.SetGlobalBuffer(params.ptrSharedA);
             gmMxScaleA.SetGlobalBuffer(params.ptrSharedMxScaleA);
@@ -333,12 +443,17 @@ public:
                 blockMmad.template SynchronizeBlock<decltype(tensorC)>();
             }
         }
+        if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
+            // Sentinel lets the paired AIV prove this AIC is done even when every expert is empty.
+            callbackAfterFixpipe();
+        }
         AscendC::PipeBarrier<PIPE_ALL>();
     }
 
     template <>
     CATLASS_DEVICE void operator()<AscendC::AIV>(Params const &params)
     {
+        gmX2ReadyState = params.gmX2ReadyState;
         auto *combiner = (MoeDistributeCombineImpl::CamMoeDistributeCombine<TemplateMC2TypeFunc> *)params.combiner;
 
         uint32_t coreIdx = AscendC::GetBlockIdx() / AscendC::GetSubBlockNum();
@@ -352,16 +467,14 @@ public:
         AscendC::GlobalTensor<ElementD> gmD;
         gmD.SetGlobalBuffer(params.ptrD);
 
-        uint64_t profWeightSumStart = 0;
-
-        {
+        uint32_t target = 1;
+        do {
             if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
                 if (AscendC::GetSubBlockIdx() == 0) {
                     AscendC::CrossCoreSetFlag<0x0, PIPE_MTE3>(MoeDistributeCombineImpl::RECV_SYNC_EVENT_ID);
                 }
             }
             BlockEpilogue blockEpilogue(resource, combiner->GetCalcInfo());
-            uint32_t target = 1;
             uint32_t startCoreIdx = 0;
 
             int64_t mxScaleAlignedK =
@@ -375,8 +488,14 @@ public:
 
             for (uint32_t groupIdx = 0; groupIdx < params.problemCount; ++groupIdx) {
                 uint64_t profGroupStart = 0;
-                currentM = (groupIdx == 0) ? groupList.GetValue(groupIdx)
-                                           : (groupList.GetValue(groupIdx) - groupList.GetValue(groupIdx - 1));
+                if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
+                    currentM = (groupIdx == 0) ? FlushAndGetValue<ElementGroupList>(groupList, groupIdx)
+                                               : (FlushAndGetValue<ElementGroupList>(groupList, groupIdx) -
+                                                  FlushAndGetValue<ElementGroupList>(groupList, groupIdx - 1));
+                } else {
+                    currentM = (groupIdx == 0) ? groupList.GetValue(groupIdx)
+                                               : (groupList.GetValue(groupIdx) - groupList.GetValue(groupIdx - 1));
+                }
                 if (params.profile != nullptr) {
                     profGroupStart = params.profile->Now();
                 }
@@ -463,11 +582,8 @@ public:
                     AscendC::CrossCoreWaitFlag(MoeDistributeCombineImpl::RECV_SYNC_EVENT_ID);
                 }
             }
-        }
+        } while (false);
 
-        if (params.profile != nullptr) {
-            profWeightSumStart = params.profile->Now();
-        }
         icache_preload(4);
         if constexpr (EXEC_FLAG & EXEC_FLAG_SHARED_EXPERT) {
             if (AscendC::GetSubBlockIdx() == 1) {
@@ -479,17 +595,33 @@ public:
             }
         } else if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
             if (AscendC::GetSubBlockIdx() == 0) {
+                uint64_t profWeightSumAllToAllSendStart = 0;
+                if (params.profile != nullptr) {
+                    profWeightSumAllToAllSendStart = params.profile->Now();
+                }
                 resource.pipe.Init();
                 combiner->TPipeSet(&resource.pipe);
                 combiner->AllToAllSend();
                 combiner->TPipeSet(nullptr);
                 resource.pipe.Destroy();
+                if (params.profile != nullptr) {
+                    params.profile->Record(FusedDeepMoeProfileStage::WeightSumAllToAllSend,
+                                           profWeightSumAllToAllSendStart, params.profile->Now());
+                }
             } else {
+                uint64_t profWeightSumReducePermuteStart = 0;
+                if (params.profile != nullptr) {
+                    profWeightSumReducePermuteStart = params.profile->Now();
+                }
                 resource.pipe.Init();
                 combiner->TPipeSet(&resource.pipe);
                 combiner->ReducePermute();
                 combiner->TPipeSet(nullptr);
                 resource.pipe.Destroy();
+                if (params.profile != nullptr) {
+                    params.profile->Record(FusedDeepMoeProfileStage::WeightSumReducePermute,
+                                           profWeightSumReducePermuteStart, params.profile->Now());
+                }
             }
         } else {
             resource.pipe.Init();
@@ -498,7 +630,25 @@ public:
             combiner->TPipeSet(nullptr);
             resource.pipe.Destroy();
         }
+        if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
+            CleanRoutedX2ReadyState(params.problemCount);
+        }
+        if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
+            if (AscendC::GetSubBlockIdx() == 0) {
+                CheckSyncFlag(reinterpret_cast<__gm__ int32_t *>(syncGmAddr + GMM2::SOFT_SYNC_OFFSET),
+                              static_cast<int32_t>(coreIdx), target);
+            }
+            AscendC::PipeBarrier<PIPE_ALL>();
+            AscendC::SyncAll<true>();
+            AscendC::PipeBarrier<PIPE_ALL>();
+        }
         if (AscendC::GetSubBlockIdx() == 0) {
+            uint64_t profWeightSumCleanStart = 0;
+            if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
+                if (params.profile != nullptr) {
+                    profWeightSumCleanStart = params.profile->Now();
+                }
+            }
             AscendC::GlobalTensor<int32_t> softSyncTensor;
             softSyncTensor.SetGlobalBuffer((__gm__ int32_t *)(syncGmAddr + GMM2::SOFT_SYNC_OFFSET));
             AscendC::LocalTensor<int32_t> tmpZeroLocalTensor = resource.ubBuf.template GetBufferByByte<int32_t>(0);
@@ -507,9 +657,16 @@ public:
             AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(0);
             AscendC::DataCopy(softSyncTensor[coreIdx * CVSoftSync::SOFT_SYNC_SPACE_SIZE / sizeof(int32_t)],
                               tmpZeroLocalTensor, GMM2::INT32_COUNT_PER_BLOCK);
-        }
-        if (params.profile != nullptr) {
-            params.profile->Record(FusedDeepMoeProfileStage::WeightSum, profWeightSumStart, params.profile->Now());
+            if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
+                AscendC::PipeBarrier<PIPE_MTE3>();
+                CleanGroupTokenInfo(params.problemCount);
+            }
+            if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
+                if (params.profile != nullptr) {
+                    params.profile->Record(FusedDeepMoeProfileStage::WeightSumClean, profWeightSumCleanStart,
+                                           params.profile->Now());
+                }
+            }
         }
     }
 
@@ -534,6 +691,7 @@ private:
     AscendC::GlobalTensor<GM_ADDR> epWinContext_;
     __gm__ Mc2Kernel::HcclOpParam *winContext_;
     GM_ADDR syncGmAddr;
+    GM_ADDR gmX2ReadyState;
     Arch::Resource<ArchTag> resource;
 };
 

--- a/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/gemm/kernel/mx_gmm2_cast_combine.h
+++ b/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe/gemm/kernel/mx_gmm2_cast_combine.h
@@ -468,7 +468,7 @@ public:
         gmD.SetGlobalBuffer(params.ptrD);
 
         uint32_t target = 1;
-        do {
+        {
             if constexpr (EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) {
                 if (AscendC::GetSubBlockIdx() == 0) {
                     AscendC::CrossCoreSetFlag<0x0, PIPE_MTE3>(MoeDistributeCombineImpl::RECV_SYNC_EVENT_ID);
@@ -582,7 +582,7 @@ public:
                     AscendC::CrossCoreWaitFlag(MoeDistributeCombineImpl::RECV_SYNC_EVENT_ID);
                 }
             }
-        } while (false);
+        }
 
         icache_preload(4);
         if constexpr (EXEC_FLAG & EXEC_FLAG_SHARED_EXPERT) {

--- a/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe_a5.h
+++ b/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe_a5.h
@@ -64,8 +64,8 @@ CATLASS_DEVICE void DispatchMxGmm1SwigluQuantFunc(
     GM_ADDR gmShareBScale, GM_ADDR gmShareSwapSpace, GM_ADDR gmShareSwigluOut, GM_ADDR gmShareD, GM_ADDR gmShareDScale,
     // dispatch and quant, when EXEC_FLAG_DEEP_FUSE.
     GM_ADDR gmX, GM_ADDR gmExpertIds, GM_ADDR xActiveMask, GM_ADDR gmMoeSmoothScales, GM_ADDR gmShareSmoothScales,
-    GM_ADDR gmExpandIdx, GM_ADDR gmEpSendCount, GM_ADDR gmExpertTokenNums, const FusedDeepMoeInfo &fusedDeepMoeInfo,
-    FusedDeepMoeProfileWriter *profile)
+    GM_ADDR gmExpandIdx, GM_ADDR gmEpSendCount, GM_ADDR gmExpertTokenNums, GM_ADDR gmX2ReadyState,
+    const FusedDeepMoeInfo &fusedDeepMoeInfo, FusedDeepMoeProfileWriter *profile)
 {
     static_assert((std::is_same_v<ElementA, float8_e5m2_t> || std::is_same_v<ElementA, float8_e4m3_t> ||
                    std::is_same_v<ElementA, float4_e2m1x2_t> || std::is_same_v<ElementA, float4_e1m2x2_t>) &&
@@ -150,6 +150,7 @@ CATLASS_DEVICE void DispatchMxGmm1SwigluQuantFunc(
                                          gmExpandIdx,
                                          gmEpSendCount,
                                          gmExpertTokenNums,
+                                         gmX2ReadyState,
                                          fusedDeepMoeInfo,
                                          profile};
 
@@ -168,8 +169,8 @@ CATLASS_DEVICE void MxGmm2CastCombineFunc(
     GM_ADDR gmAScale, GM_ADDR gmBScale, GM_ADDR gmSwapSpace, GM_ADDR gmD,
     // shared expert, matmul
     Catlass::GemmCoord sharedProblemShape, GM_ADDR gmShareA, GM_ADDR gmShareB, GM_ADDR gmShareAScale,
-    GM_ADDR gmShareBScale, GM_ADDR gmShareSwapSpace, GM_ADDR gmShareD, void *combiner,
-    FusedDeepMoeProfileWriter *profile)
+    GM_ADDR gmShareBScale, GM_ADDR gmShareSwapSpace, GM_ADDR gmShareD, void *combiner, uint32_t expectedAivNum,
+    GM_ADDR gmX2ReadyState, uint64_t weightExpertStrideBytes, FusedDeepMoeProfileWriter *profile)
 {
     static_assert((std::is_same_v<ElementA, float8_e5m2_t> || std::is_same_v<ElementA, float8_e4m3_t> ||
                    std::is_same_v<ElementA, float4_e2m1x2_t> || std::is_same_v<ElementA, float4_e1m2x2_t>) &&
@@ -246,6 +247,9 @@ CATLASS_DEVICE void MxGmm2CastCombineFunc(
                                          gmShareSwapSpace /*ptrShareC*/,
                                          gmShareD,
                                          combiner,
+                                         expectedAivNum,
+                                         gmX2ReadyState,
+                                         weightExpertStrideBytes,
                                          profile};
 
     MatmulKernel kernel;
@@ -401,6 +405,7 @@ __aicore__ inline void FusedDeepMoe<TemplateMC2TypeFunc>::Process()
     GM_ADDR gmGroupList = workspaceGM_ + tilingData_->workSpaceOffset.groupListOffset;
     GM_ADDR gmExpandIdx = workspaceGM_ + tilingData_->workSpaceOffset.expandIdxOffset;
     GM_ADDR gmEpSendCount = workspaceGM_ + tilingData_->workSpaceOffset.epSendCountOffset;
+    GM_ADDR gmX2ReadyState = workspaceGM_ + tilingData_->workSpaceOffset.reservedOffset;
     FusedDeepMoeProfileWriter profileWriter;
     profileWriter.Init(profileBufferGM_, tilingData_->fusedDeepMoeInfo.profileEnable != 0,
                        static_cast<uint32_t>(tilingData_->fusedDeepMoeInfo.profileLaunchId),
@@ -412,18 +417,20 @@ __aicore__ inline void FusedDeepMoe<TemplateMC2TypeFunc>::Process()
         gmSwigluOut, gmX2, gmX2Scale, shareGmm1ProblemShape, gmShareX1, gmShareWeight1_, gmShareX1Scale,
         gmShareWeight1Scale_, gmShareMm1SwapSpace, gmShareSwigluOut, gmShareX2, gmShareX2Scale, gmX_, gmexpertIds_,
         xActiveMask_, gmSmoothScales_, gmShareSmoothScales_, gmExpandIdx, gmEpSendCount, gmExpertTokenNums_,
-        tilingData_->fusedDeepMoeInfo, &profileWriter);
+        gmX2ReadyState, tilingData_->fusedDeepMoeInfo, &profileWriter);
     uint64_t stageBarrierStart = 0U;
     if (profileWriter.enabled) {
         stageBarrierStart = profileWriter.Now();
     }
     AscendC::PipeBarrier<PIPE_ALL>();
-    Arch::CrossCoreFlag gmm1AivFinished{0};
-    if constexpr (g_coreType == AscendC::AIV) {
-        Arch::CrossCoreBarrier<0x0, PIPE_MTE3>();
-        Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(gmm1AivFinished);
-    } else {
-        Arch::CrossCoreWaitFlag(gmm1AivFinished);
+    if constexpr ((EXEC_FLAG & EXEC_FLAG_DEEP_FUSE) == 0) {
+        Arch::CrossCoreFlag gmm1AivFinished{0};
+        if constexpr (g_coreType == AscendC::AIV) {
+            Arch::CrossCoreBarrier<0x0, PIPE_MTE3>();
+            Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(gmm1AivFinished);
+        } else {
+            Arch::CrossCoreWaitFlag(gmm1AivFinished);
+        }
     }
     if (profileWriter.enabled) {
         profileWriter.Record(FusedDeepMoeProfileStage::StageBarrier, 0U, stageBarrierStart, profileWriter.Now());
@@ -437,6 +444,7 @@ __aicore__ inline void FusedDeepMoe<TemplateMC2TypeFunc>::Process()
                           Gmm2EpilogueTileShape, Gmm2BlockScheduler>(
         gmm2ProblemShape, groupCount_, gmGroupList, gmX2, gmWeight2_, gmX2Scale, gmScale2_, gmGmm2SwapSpace,
         gmGmm2DepOut, shareGmm2ProblemShape, gmShareX2, gmShareWeight2_, gmShareX2Scale, gmShareWeight2Scale_,
-        gmShareMm2SwapSpace, gmShareOutput_, &combiner, &profileWriter);
+        gmShareMm2SwapSpace, gmShareOutput_, &combiner, tilingData_->fusedDeepMoeInfo.aivNum, gmX2ReadyState,
+        tilingData_->fusedDeepMoeInfo.gmm2WeightExpertStrideBytes, &profileWriter);
 }
 #endif  // FUSED_DEEP_MOE_H

--- a/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe_a5_base.h
+++ b/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe_a5_base.h
@@ -20,7 +20,7 @@
 #define TemplateDispatchTypeFunc \
     XType, ExpandXOutType, StaticQuant, DynamicQuant, IsSmoothScaleExist, IsNeedAllgater, EXEC_FLAG
 
-constexpr int64_t SLEEP_CYCLE = 50;
+constexpr int64_t SLEEP_CYCLE = 200;
 
 __aicore__ inline void SPIN_WAIT_CYCLES()
 {

--- a/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe_a5_tiling.h
+++ b/csrc/deepep/ops/op_kernel/fused_deep_moe_a5/fused_deep_moe_a5_tiling.h
@@ -55,7 +55,10 @@ struct FusedDeepMoeInfo {
     uint64_t totalUbSize;
     uint64_t totalWinSize;
     uint64_t gmm1HLen;
-    uint64_t shareGmm1HLen;  // shared expert gmm1 hidden length
+    uint64_t shareGmm1HLen;     // shared expert gmm1 hidden length
+    uint32_t weightLayoutMode;  // 0: ND, 1: FRACTAL_NZ (shared by GMM1/GMM2)
+    uint64_t gmm1WeightExpertStrideBytes;
+    uint64_t gmm2WeightExpertStrideBytes;
     bool isTensorList;
 };
 
@@ -83,6 +86,8 @@ constexpr uint32_t GMM2_SWIZZLE_OFFSET = 3;
 constexpr uint32_t GMM2_SWIZZLE_DIRECTION = 0;
 
 constexpr uint32_t MX_FP4_QUANT_MODE = 4U;
+constexpr uint32_t WEIGHT_LAYOUT_ND = 0U;
+constexpr uint32_t WEIGHT_LAYOUT_NZ = 1U;
 
 constexpr uint32_t EXEC_FLAG_DEEP_FUSE = (1U << 0);
 constexpr uint32_t EXEC_FLAG_TENSOR_LIST = (1U << 1);

--- a/csrc/deepep/ops/op_kernel/profiling/adapters/fused_deep_moe_a5/fused_deep_moe_a5_profile_stage.h
+++ b/csrc/deepep/ops/op_kernel/profiling/adapters/fused_deep_moe_a5/fused_deep_moe_a5_profile_stage.h
@@ -17,8 +17,7 @@ enum class ProfileStage : uint32_t {
     WeightSumAllToAllSend = 8,
     WeightSumReducePermute = 9,
     WeightSumClean = 10,
-    DispatchRecvNotify = 11,
-    Count = 12,
+    Count = 11,
 };
 
 constexpr uint32_t kStageCount = static_cast<uint32_t>(ProfileStage::Count);

--- a/csrc/deepep/ops/op_kernel/profiling/adapters/fused_deep_moe_a5/fused_deep_moe_a5_profile_stage.h
+++ b/csrc/deepep/ops/op_kernel/profiling/adapters/fused_deep_moe_a5/fused_deep_moe_a5_profile_stage.h
@@ -14,8 +14,11 @@ enum class ProfileStage : uint32_t {
     StageBarrier = 5,
     Gmm2 = 6,
     Combine = 7,
-    WeightSum = 8,
-    Count = 9,
+    WeightSumAllToAllSend = 8,
+    WeightSumReducePermute = 9,
+    WeightSumClean = 10,
+    DispatchRecvNotify = 11,
+    Count = 12,
 };
 
 constexpr uint32_t kStageCount = static_cast<uint32_t>(ProfileStage::Count);

--- a/csrc/deepep/ops/utils/op_kernel/operator/gemm/kernel/grouped_matmul_slice_m_per_token_dequant_swiglu_quant_multistage_workspace.h
+++ b/csrc/deepep/ops/utils/op_kernel/operator/gemm/kernel/grouped_matmul_slice_m_per_token_dequant_swiglu_quant_multistage_workspace.h
@@ -883,7 +883,7 @@ public:
     }
 
     ACT_DEVICE
-    void SendToMoeExprt(GM_ADDR gmX, GM_ADDR gmExpandIdx)
+    void SendToMoeExpert(GM_ADDR gmX, GM_ADDR gmExpandIdx)
     {
         // 给路由专家发送token
         uint32_t sendTokenNum = expertIdsCnt / sendToMoeAivNum;
@@ -1021,7 +1021,7 @@ SendCoreFunc(GM_ADDR gmX, GM_ADDR gmExpertIds, GM_ADDR gmX1, GM_ADDR gmX1Scale, 
     if (hasShareExpert && sendCoreIdx >= sendToMoeAivNum) {
         SendToShareExprt(gmX, gmX1, gmX1Scale);
     } else {
-        SendToMoeExprt(gmX, gmExpandIdx);
+        SendToMoeExpert(gmX, gmExpandIdx);
     }
     AscendC::PipeBarrier<PIPE_ALL>();
 }

--- a/csrc/deepep/profiling/adapters/fused_deep_moe_a5/fused_deep_moe_a5_profile_stage.h
+++ b/csrc/deepep/profiling/adapters/fused_deep_moe_a5/fused_deep_moe_a5_profile_stage.h
@@ -17,8 +17,7 @@ enum class ProfileStage : uint32_t {
     WeightSumAllToAllSend = 8,
     WeightSumReducePermute = 9,
     WeightSumClean = 10,
-    DispatchRecvNotify = 11,
-    Count = 12,
+    Count = 11,
 };
 
 constexpr uint32_t kStageCount = static_cast<uint32_t>(ProfileStage::Count);

--- a/csrc/deepep/profiling/adapters/fused_deep_moe_a5/fused_deep_moe_a5_profile_stage.h
+++ b/csrc/deepep/profiling/adapters/fused_deep_moe_a5/fused_deep_moe_a5_profile_stage.h
@@ -14,8 +14,11 @@ enum class ProfileStage : uint32_t {
     StageBarrier = 5,
     Gmm2 = 6,
     Combine = 7,
-    WeightSum = 8,
-    Count = 9,
+    WeightSumAllToAllSend = 8,
+    WeightSumReducePermute = 9,
+    WeightSumClean = 10,
+    DispatchRecvNotify = 11,
+    Count = 12,
 };
 
 constexpr uint32_t kStageCount = static_cast<uint32_t>(ProfileStage::Count);

--- a/csrc/deepep/profiling/adapters/fused_deep_moe_a5/fused_deep_moe_a5_profile_traits.cpp
+++ b/csrc/deepep/profiling/adapters/fused_deep_moe_a5/fused_deep_moe_a5_profile_traits.cpp
@@ -65,8 +65,6 @@ const char *GetStageName(uint64_t stageId)
             return "weight_sum_reduce_permute";
         case ProfileStage::WeightSumClean:
             return "weight_sum_clean";
-        case ProfileStage::DispatchRecvNotify:
-            return "dispatch_recv_notify";
         default:
             return "unknown";
     }
@@ -78,9 +76,8 @@ std::string GetStageDisplayName(uint64_t stageId, uint64_t occurrenceId, const C
     oss << GetStageName(stageId);
     uint32_t stageOccurrenceCount = Cam::GetProfileStageOccurrenceCount(stageLayout, static_cast<uint32_t>(stageId));
     auto stage = static_cast<ProfileStage>(stageId);
-    if (stage == ProfileStage::DispatchRecv || stage == ProfileStage::DispatchRecvNotify ||
-        stage == ProfileStage::Gmm1 || stage == ProfileStage::Swiglu || stage == ProfileStage::Quant ||
-        stage == ProfileStage::Gmm2 || stage == ProfileStage::Combine) {
+    if (stage == ProfileStage::DispatchRecv || stage == ProfileStage::Gmm1 || stage == ProfileStage::Swiglu ||
+        stage == ProfileStage::Quant || stage == ProfileStage::Gmm2 || stage == ProfileStage::Combine) {
         oss << "[group=" << occurrenceId << "]";
     } else if (stageOccurrenceCount > 1U || occurrenceId != 0U) {
         oss << "[occ=" << occurrenceId << "]";
@@ -107,7 +104,7 @@ std::string GetPrivateDataJson(uint64_t stageId, uint64_t occurrenceId, const Ca
         oss << ",\"dispatch_send_per_token_bytes\":" << payload.perTokenCommBytes;
         return oss.str();
     }
-    if (stage == ProfileStage::DispatchRecv || stage == ProfileStage::DispatchRecvNotify) {
+    if (stage == ProfileStage::DispatchRecv) {
         const auto payload = Cam::AsDispatchRecvPrivatePayloadV1(record);
         if (Cam::GetProfilePrivateValidTag(payload.header) == Cam::PROFILE_PRIVATE_DATA_INVALID) {
             return {};
@@ -160,9 +157,6 @@ Cam::ProfileStageLayout BuildStageLayout(uint32_t groupCountCapacity)
     EP_HOST_ASSERT_S(
         Cam::SetProfileStageOccurrenceCount(layout, static_cast<uint32_t>(ProfileStage::WeightSumClean), 1U),
         "invalid weight sum clean occurrence capacity.");
-    EP_HOST_ASSERT_S(Cam::SetProfileStageOccurrenceCount(
-                         layout, static_cast<uint32_t>(ProfileStage::DispatchRecvNotify), groupCountCapacity),
-                     "invalid dispatch receive notify occurrence capacity.");
     return layout;
 }
 

--- a/csrc/deepep/profiling/adapters/fused_deep_moe_a5/fused_deep_moe_a5_profile_traits.cpp
+++ b/csrc/deepep/profiling/adapters/fused_deep_moe_a5/fused_deep_moe_a5_profile_traits.cpp
@@ -59,8 +59,14 @@ const char *GetStageName(uint64_t stageId)
             return "gmm2";
         case ProfileStage::Combine:
             return "combine";
-        case ProfileStage::WeightSum:
-            return "weight_sum";
+        case ProfileStage::WeightSumAllToAllSend:
+            return "weight_sum_all_to_all_send";
+        case ProfileStage::WeightSumReducePermute:
+            return "weight_sum_reduce_permute";
+        case ProfileStage::WeightSumClean:
+            return "weight_sum_clean";
+        case ProfileStage::DispatchRecvNotify:
+            return "dispatch_recv_notify";
         default:
             return "unknown";
     }
@@ -72,7 +78,8 @@ std::string GetStageDisplayName(uint64_t stageId, uint64_t occurrenceId, const C
     oss << GetStageName(stageId);
     uint32_t stageOccurrenceCount = Cam::GetProfileStageOccurrenceCount(stageLayout, static_cast<uint32_t>(stageId));
     auto stage = static_cast<ProfileStage>(stageId);
-    if (stage == ProfileStage::DispatchRecv || stage == ProfileStage::Gmm1 || stage == ProfileStage::Swiglu ||
+    if (stage == ProfileStage::DispatchRecv || stage == ProfileStage::DispatchRecvNotify ||
+        stage == ProfileStage::Gmm1 || stage == ProfileStage::Swiglu || stage == ProfileStage::Quant ||
         stage == ProfileStage::Gmm2 || stage == ProfileStage::Combine) {
         oss << "[group=" << occurrenceId << "]";
     } else if (stageOccurrenceCount > 1U || occurrenceId != 0U) {
@@ -100,7 +107,7 @@ std::string GetPrivateDataJson(uint64_t stageId, uint64_t occurrenceId, const Ca
         oss << ",\"dispatch_send_per_token_bytes\":" << payload.perTokenCommBytes;
         return oss.str();
     }
-    if (stage == ProfileStage::DispatchRecv) {
+    if (stage == ProfileStage::DispatchRecv || stage == ProfileStage::DispatchRecvNotify) {
         const auto payload = Cam::AsDispatchRecvPrivatePayloadV1(record);
         if (Cam::GetProfilePrivateValidTag(payload.header) == Cam::PROFILE_PRIVATE_DATA_INVALID) {
             return {};
@@ -133,8 +140,9 @@ Cam::ProfileStageLayout BuildStageLayout(uint32_t groupCountCapacity)
     EP_HOST_ASSERT_S(
         Cam::SetProfileStageOccurrenceCount(layout, static_cast<uint32_t>(ProfileStage::Swiglu), groupCountCapacity),
         "invalid swiglu occurrence capacity.");
-    EP_HOST_ASSERT_S(Cam::SetProfileStageOccurrenceCount(layout, static_cast<uint32_t>(ProfileStage::Quant), 1U),
-                     "invalid quant occurrence capacity.");
+    EP_HOST_ASSERT_S(
+        Cam::SetProfileStageOccurrenceCount(layout, static_cast<uint32_t>(ProfileStage::Quant), groupCountCapacity),
+        "invalid quant occurrence capacity.");
     EP_HOST_ASSERT_S(Cam::SetProfileStageOccurrenceCount(layout, static_cast<uint32_t>(ProfileStage::StageBarrier), 1U),
                      "invalid stage barrier occurrence capacity.");
     EP_HOST_ASSERT_S(
@@ -143,8 +151,18 @@ Cam::ProfileStageLayout BuildStageLayout(uint32_t groupCountCapacity)
     EP_HOST_ASSERT_S(
         Cam::SetProfileStageOccurrenceCount(layout, static_cast<uint32_t>(ProfileStage::Combine), groupCountCapacity),
         "invalid combine occurrence capacity.");
-    EP_HOST_ASSERT_S(Cam::SetProfileStageOccurrenceCount(layout, static_cast<uint32_t>(ProfileStage::WeightSum), 1U),
-                     "invalid weight sum occurrence capacity.");
+    EP_HOST_ASSERT_S(
+        Cam::SetProfileStageOccurrenceCount(layout, static_cast<uint32_t>(ProfileStage::WeightSumAllToAllSend), 1U),
+        "invalid weight sum all-to-all send occurrence capacity.");
+    EP_HOST_ASSERT_S(
+        Cam::SetProfileStageOccurrenceCount(layout, static_cast<uint32_t>(ProfileStage::WeightSumReducePermute), 1U),
+        "invalid weight sum reduce permute occurrence capacity.");
+    EP_HOST_ASSERT_S(
+        Cam::SetProfileStageOccurrenceCount(layout, static_cast<uint32_t>(ProfileStage::WeightSumClean), 1U),
+        "invalid weight sum clean occurrence capacity.");
+    EP_HOST_ASSERT_S(Cam::SetProfileStageOccurrenceCount(
+                         layout, static_cast<uint32_t>(ProfileStage::DispatchRecvNotify), groupCountCapacity),
+                     "invalid dispatch receive notify occurrence capacity.");
     return layout;
 }
 

--- a/tests/python/deepep/test_fused_deep_moe_a5.py
+++ b/tests/python/deepep/test_fused_deep_moe_a5.py
@@ -71,6 +71,7 @@ SMALL_FIRST_WARMUP_GMM_BURN_IN_REPEATS = 100
 SMALL_FIRST_WARMUP_MATMUL_DIM_SCALE = 4
 ACCURACY_ATOL = 2.0
 ACCURACY_RTOL = 0.02
+PROFILE_DEBUG_HEAD_BYTES = 32
 
 
 def get_mx_quant_config(args: argparse.Namespace) -> Dict[str, object]:
@@ -78,19 +79,61 @@ def get_mx_quant_config(args: argparse.Namespace) -> Dict[str, object]:
 
 
 def maybe_cast_weight_to_nz(
-    args: argparse.Namespace, weight: torch.Tensor
+    args: argparse.Namespace,
+    weight: torch.Tensor,
+    origin_dtype: torch.dtype,
+    logical_shape: Tuple[int, int, int],
 ) -> torch.Tensor:
-    """Convert supported quantized weights to A5 FRACTAL_NZ storage."""
+    """Convert a quantized weight to A5 FRACTAL_NZ storage.
+
+    FP4 quantization returns packed bytes whose subsequent view as float4 is a
+    recovery-format tensor.  CANN does not accept that recovery format as the
+    input to npu_format_cast, so the layout conversion must happen first.
+    """
     if args.weight_format != "NZ":
-        return weight
-    if args.quant == "fp4_e2m1":
-        raise ValueError("FP4 + NZ is not supported yet")
+        return weight.view(origin_dtype)
 
     # Prefer the public enum when available; keep numeric 29 as a compatibility
     # fallback for torch_npu versions that do not expose Format.FRACTAL_NZ.
     npu_format = getattr(torch_npu, "Format", None)
     fractal_nz = getattr(npu_format, "FRACTAL_NZ", 29)
-    return torch_npu.npu_format_cast(weight, fractal_nz)
+    try:
+        if args.quant == "fp4_e2m1":
+            weight = torch_npu.npu_format_cast(weight, fractal_nz)
+        else:
+            weight = torch_npu.npu_format_cast(weight.view(origin_dtype), fractal_nz)
+    except RuntimeError as exc:
+        if args.quant == "fp4_e2m1":
+            raise RuntimeError(
+                "FP4-NZ input construction is unavailable in this CANN/PTA "
+                "environment: packed FP4 npu_format_cast failed. "
+                "The fused kernel was not invoked."
+            ) from exc
+        raise
+
+    weight = weight.view(origin_dtype)
+    format_code = torch_npu.get_npu_format(weight)
+    if format_code != fractal_nz:
+        raise RuntimeError(
+            f"FP4/quantized NZ construction produced format {format_code}, "
+            f"expected FRACTAL_NZ({fractal_nz})"
+        )
+    if args.quant == "fp4_e2m1":
+        expected_bytes = (
+            ((logical_shape[2] + 63) // 64)
+            * ((logical_shape[1] + 15) // 16)
+            * 16
+            * 64
+            // 2
+            * logical_shape[0]
+        )
+        actual_bytes = weight.untyped_storage().nbytes()
+        if actual_bytes < expected_bytes:
+            raise RuntimeError(
+                f"FP4-NZ storage is too small: got {actual_bytes} bytes, "
+                f"expected at least {expected_bytes} for logical shape {logical_shape}"
+            )
+    return weight
 
 
 def log_quant_tensor(rank: int, enabled: bool, name: str, tensor: torch.Tensor):
@@ -163,8 +206,12 @@ def make_umdk_static_inputs(
     gmm1_weight, gmm1_scale_raw = torch_npu.npu_dynamic_mx_quant(
         gmm1_fp, dst_type=quant_cfg["quant_dst_type"], axis=1
     )
-    gmm1_weight = gmm1_weight.view(quant_cfg["origin_dtype"])
-    gmm1_weight = maybe_cast_weight_to_nz(args, gmm1_weight)
+    gmm1_weight = maybe_cast_weight_to_nz(
+        args,
+        gmm1_weight,
+        quant_cfg["origin_dtype"],
+        (local_experts, args.hidden, args.moe_intermediate_size * 2),
+    )
     gmm1_scale = gmm1_scale_raw.view(torch.float8_e8m0fnu)
 
     gmm2_fp = (
@@ -177,8 +224,12 @@ def make_umdk_static_inputs(
     gmm2_weight, gmm2_scale_raw = torch_npu.npu_dynamic_mx_quant(
         gmm2_fp, dst_type=quant_cfg["quant_dst_type"], axis=1
     )
-    gmm2_weight = gmm2_weight.view(quant_cfg["origin_dtype"])
-    gmm2_weight = maybe_cast_weight_to_nz(args, gmm2_weight)
+    gmm2_weight = maybe_cast_weight_to_nz(
+        args,
+        gmm2_weight,
+        quant_cfg["origin_dtype"],
+        (local_experts, args.moe_intermediate_size, args.hidden),
+    )
     gmm2_scale = gmm2_scale_raw.view(torch.float8_e8m0fnu)
 
     return {
@@ -244,6 +295,435 @@ def make_small_op_padded_inputs(
         "x_active_mask": x_active_mask,
         "padded_num_tokens": padded_num_tokens,
     }
+
+
+def make_random_profile_cases(
+    base_inputs: Dict[str, torch.Tensor],
+    rank: int,
+    world_size: int,
+    local_num_tokens: int,
+    padded_num_tokens: int,
+    args: argparse.Namespace,
+) -> List[Dict[str, object]]:
+    cases = []
+    total_case_count = args.num_warmups + args.num_tests
+    for case_idx in range(total_case_count):
+        case_seed = args.random_profile_seed + case_idx * world_size + rank
+        torch_generator = torch.Generator(device="npu")
+        torch_generator.manual_seed(case_seed)
+        routing_rng = random.Random(case_seed)
+
+        x = (
+            torch.rand(
+                (local_num_tokens, args.hidden),
+                dtype=torch.float32,
+                device="npu",
+                generator=torch_generator,
+            ).bfloat16()
+            * 2
+            - 1
+        )
+        expert_scales = torch.rand(
+            (local_num_tokens, args.num_topk),
+            dtype=torch.float32,
+            device="npu",
+            generator=torch_generator,
+        )
+        if local_num_tokens > 0:
+            sampled_rows = [
+                routing_rng.sample(range(args.num_experts), args.num_topk)
+                for _ in range(local_num_tokens)
+            ]
+            expert_ids = torch.tensor(sampled_rows, dtype=torch.int32).npu()
+        else:
+            expert_ids = torch.empty((0, args.num_topk), dtype=torch.int32).npu()
+
+        fused_inputs = {
+            **base_inputs,
+            "x": x,
+            "expert_ids": expert_ids,
+            "expert_scales": expert_scales,
+        }
+        cases.append(
+            {
+                "seed": case_seed,
+                "fused_inputs": fused_inputs,
+                "small_inputs": make_small_op_padded_inputs(
+                    fused_inputs, local_num_tokens, padded_num_tokens
+                ),
+            }
+        )
+    return cases
+
+
+def make_fixed_profile_cases(
+    base_inputs: Dict[str, torch.Tensor],
+    rank: int,
+    world_size: int,
+    local_num_tokens: int,
+    padded_num_tokens: int,
+    args: argparse.Namespace,
+) -> List[Dict[str, object]]:
+    """Create distinct tensor storage with identical values for every profile call.
+
+    This mode separates cross-iteration state corruption from input-dependent
+    numerical differences.  We intentionally clone only the per-call inputs;
+    quantized weights remain shared and immutable.
+    """
+    total_case_count = args.num_warmups + args.num_tests
+    source = make_random_profile_cases(
+        base_inputs,
+        rank,
+        world_size,
+        local_num_tokens,
+        padded_num_tokens,
+        argparse.Namespace(**{**vars(args), "num_warmups": 1, "num_tests": 0}),
+    )[0]
+    cases = []
+    for case_idx in range(total_case_count):
+        fused_inputs = dict(source["fused_inputs"])
+        for name in ("x", "expert_ids", "expert_scales"):
+            fused_inputs[name] = source["fused_inputs"][name].clone()
+        small_inputs = make_small_op_padded_inputs(
+            fused_inputs, local_num_tokens, padded_num_tokens
+        )
+        cases.append(
+            {
+                "seed": source["seed"],
+                "fused_inputs": fused_inputs,
+                "small_inputs": small_inputs,
+                "fixed_values": True,
+                "case_index": case_idx,
+            }
+        )
+    return cases
+
+
+def assert_unique_tensor_storage(tensors: List[torch.Tensor], name: str):
+    data_ptrs = [tensor.data_ptr() for tensor in tensors if tensor.numel() > 0]
+    if len(data_ptrs) != len(set(data_ptrs)):
+        raise AssertionError(
+            f"{name} must use distinct storage for every profile iteration"
+        )
+
+
+def format_tensor_head_bytes(
+    tensor: torch.Tensor, max_bytes: int = PROFILE_DEBUG_HEAD_BYTES
+) -> str:
+    """Return a compact raw-byte preview after all profiled work is complete."""
+    try:
+        byte_tensor = tensor.detach().contiguous().cpu().view(torch.uint8).flatten()
+        values = byte_tensor[:max_bytes].tolist()
+        return " ".join(f"{int(value):02x}" for value in values)
+    except Exception as exc:
+        return f"<unavailable: {exc}>"
+
+
+def print_profile_case_head_bytes(
+    profile_cases: List[Dict[str, object]],
+    small_results: List[Tuple[torch.Tensor, torch.Tensor]],
+    fused_results: List[Tuple[torch.Tensor, torch.Tensor]],
+    rank: int,
+):
+    """Print compact per-iteration input/output bytes for a failed profile."""
+    print(
+        f"[rank {rank}] profile debug tensor heads "
+        f"(first {PROFILE_DEBUG_HEAD_BYTES} bytes; values are raw storage bytes):",
+        flush=True,
+    )
+    input_names = ("x", "expert_ids", "expert_scales")
+    case_count = min(len(profile_cases), len(small_results), len(fused_results))
+    for case_idx in range(case_count):
+        case = profile_cases[case_idx]
+        print(
+            f"[rank {rank}] iteration={case_idx}, seed={case.get('seed')}, "
+            f"fixed={case.get('fixed_values', False)}",
+            flush=True,
+        )
+        for side, inputs in (
+            ("small_input", case.get("small_inputs", {})),
+            ("fused_input", case.get("fused_inputs", {})),
+        ):
+            for input_name in input_names:
+                tensor = inputs.get(input_name)
+                if tensor is None:
+                    continue
+                print(
+                    f"  {side}.{input_name}: dtype={tensor.dtype}, "
+                    f"shape={tuple(tensor.shape)}, data_ptr=0x{tensor.data_ptr():x}, "
+                    f"bytes={format_tensor_head_bytes(tensor)}",
+                    flush=True,
+                )
+        small_output, small_counts = small_results[case_idx]
+        fused_output, fused_counts = fused_results[case_idx]
+        for side, tensor in (
+            ("small_output", small_output),
+            ("fused_output", fused_output),
+            ("small_counts", small_counts),
+            ("fused_counts", fused_counts),
+        ):
+            print(
+                f"  {side}: dtype={tensor.dtype}, shape={tuple(tensor.shape)}, "
+                f"data_ptr=0x{tensor.data_ptr():x}, "
+                f"bytes={format_tensor_head_bytes(tensor)}",
+                flush=True,
+            )
+
+
+def validate_random_profile_results(
+    profile_cases: List[Dict[str, object]],
+    small_results: List[Tuple[torch.Tensor, torch.Tensor]],
+    fused_results: List[Tuple[torch.Tensor, torch.Tensor]],
+    rank: int,
+    world_size: int,
+    local_num_tokens: int,
+    padded_num_tokens: int,
+    local_experts: int,
+    args: argparse.Namespace,
+):
+    local_error = None
+    total_case_count = args.num_warmups + args.num_tests
+    try:
+        if len(profile_cases) != total_case_count:
+            raise AssertionError(
+                f"profile case count mismatch: expected={total_case_count}, actual={len(profile_cases)}"
+            )
+        if (
+            len(small_results) != total_case_count
+            or len(fused_results) != total_case_count
+        ):
+            raise AssertionError(
+                "profile result count mismatch: "
+                f"expected={total_case_count}, small={len(small_results)}, fused={len(fused_results)}"
+            )
+
+        for input_name in ("x", "expert_ids", "expert_scales"):
+            assert_unique_tensor_storage(
+                [case["fused_inputs"][input_name] for case in profile_cases],
+                f"random profile fused input {input_name}",
+            )
+            assert_unique_tensor_storage(
+                [case["small_inputs"][input_name] for case in profile_cases],
+                f"random profile small-op input {input_name}",
+            )
+        assert_unique_tensor_storage(
+            [result[0] for result in small_results], "random profile small-op output"
+        )
+        assert_unique_tensor_storage(
+            [result[0] for result in fused_results], "random profile fused output"
+        )
+        assert_unique_tensor_storage(
+            [result[1] for result in small_results], "random profile small-op counts"
+        )
+        assert_unique_tensor_storage(
+            [result[1] for result in fused_results], "random profile fused counts"
+        )
+
+        if profile_cases[0].get("fixed_values", False) and total_case_count > 1:
+            baseline_small = small_results[0][0][:local_num_tokens].float()
+            baseline_fused = fused_results[0][0][:local_num_tokens].float()
+            baseline_small_counts = small_results[0][1]
+            baseline_fused_counts = fused_results[0][1]
+            fixed_cross_mismatches = []
+            for case_idx in range(1, total_case_count):
+                small_value_error = None
+                fused_value_error = None
+                small_count_error = None
+                fused_count_error = None
+                current_small = small_results[case_idx][0][:local_num_tokens].float()
+                current_fused = fused_results[case_idx][0][:local_num_tokens].float()
+                try:
+                    torch.testing.assert_close(
+                        current_small, baseline_small, atol=0.0, rtol=0.0
+                    )
+                except Exception as exc:
+                    small_value_error = str(exc).splitlines()[0]
+                try:
+                    torch.testing.assert_close(
+                        current_fused, baseline_fused, atol=0.0, rtol=0.0
+                    )
+                except Exception as exc:
+                    fused_value_error = str(exc).splitlines()[0]
+                try:
+                    torch.testing.assert_close(
+                        small_results[case_idx][1], baseline_small_counts
+                    )
+                except Exception as exc:
+                    small_count_error = str(exc).splitlines()[0]
+                try:
+                    torch.testing.assert_close(
+                        fused_results[case_idx][1], baseline_fused_counts
+                    )
+                except Exception as exc:
+                    fused_count_error = str(exc).splitlines()[0]
+                if any(
+                    (
+                        small_value_error,
+                        fused_value_error,
+                        small_count_error,
+                        fused_count_error,
+                    )
+                ):
+                    small_avg, small_max, _ = summarize_output_diff(
+                        baseline_small, current_small
+                    )
+                    fused_avg, fused_max, _ = summarize_output_diff(
+                        baseline_fused, current_fused
+                    )
+                    fixed_cross_mismatches.append(
+                        "iteration="
+                        f"{case_idx}, seed={profile_cases[case_idx]['seed']}; "
+                        f"small(avg={small_avg:.6f}, max={small_max:.6f}, error={small_value_error!r}), "
+                        f"fused(avg={fused_avg:.6f}, max={fused_max:.6f}, error={fused_value_error!r}), "
+                        f"small_counts={small_count_error!r}, fused_counts={fused_count_error!r}"
+                    )
+            if fixed_cross_mismatches:
+                raise AssertionError(
+                    "fixed-value cross-iteration mismatches: "
+                    + " | ".join(fixed_cross_mismatches)
+                )
+
+        first_formal_small = None
+        first_formal_fused = None
+        first_formal_counts = None
+        first_formal_fused_counts = None
+        for test_idx in range(args.num_tests):
+            result_idx = args.num_warmups + test_idx
+            case = profile_cases[result_idx]
+            small_output, small_counts = small_results[result_idx]
+            fused_output, fused_counts = fused_results[result_idx]
+            valid_small_output = small_output[:local_num_tokens]
+            valid_fused_output = fused_output[:local_num_tokens]
+            small_nan_count = torch.isnan(small_output).sum().item()
+            fused_nan_count = torch.isnan(fused_output).sum().item()
+            avg_diff, max_diff, cosine_diff = summarize_output_diff(
+                valid_small_output, valid_fused_output
+            )
+            same_round_error = None
+
+            small_cross_error = None
+            fused_cross_error = None
+            counts_cross_error = None
+            fused_counts_cross_error = None
+            if case.get("fixed_values", False):
+                if first_formal_small is None:
+                    first_formal_small = valid_small_output.float().clone()
+                    first_formal_fused = valid_fused_output.float().clone()
+                    first_formal_counts = small_counts.clone()
+                    first_formal_fused_counts = fused_counts.clone()
+                else:
+                    try:
+                        torch.testing.assert_close(
+                            valid_small_output.float(),
+                            first_formal_small,
+                            atol=0.0,
+                            rtol=0.0,
+                        )
+                    except Exception as exc:
+                        small_cross_error = str(exc).splitlines()[0]
+                    try:
+                        torch.testing.assert_close(
+                            valid_fused_output.float(),
+                            first_formal_fused,
+                            atol=0.0,
+                            rtol=0.0,
+                        )
+                    except Exception as exc:
+                        fused_cross_error = str(exc).splitlines()[0]
+                    try:
+                        torch.testing.assert_close(small_counts, first_formal_counts)
+                    except Exception as exc:
+                        counts_cross_error = str(exc).splitlines()[0]
+                    try:
+                        torch.testing.assert_close(
+                            fused_counts, first_formal_fused_counts
+                        )
+                    except Exception as exc:
+                        fused_counts_cross_error = str(exc).splitlines()[0]
+
+            try:
+                assert small_output.shape == (padded_num_tokens, args.hidden)
+                assert fused_output.shape == (local_num_tokens, args.hidden)
+                assert small_output.dtype == torch.bfloat16
+                assert fused_output.dtype == torch.bfloat16
+                assert small_counts.shape == (local_experts,)
+                assert fused_counts.shape == (local_experts,)
+                assert small_nan_count == 0
+                assert fused_nan_count == 0
+                torch.testing.assert_close(small_counts, fused_counts)
+                if local_num_tokens > 0:
+                    try:
+                        torch.testing.assert_close(
+                            valid_small_output.float(),
+                            valid_fused_output.float(),
+                            atol=ACCURACY_ATOL,
+                            rtol=ACCURACY_RTOL,
+                        )
+                    except Exception as exc:
+                        same_round_error = str(exc).splitlines()[0]
+                        raise AssertionError(
+                            f"small_vs_fused mismatch: {same_round_error}"
+                        ) from exc
+                if (
+                    small_cross_error
+                    or fused_cross_error
+                    or counts_cross_error
+                    or fused_counts_cross_error
+                ):
+                    raise AssertionError(
+                        "fixed-value cross-iteration mismatch: "
+                        f"small={small_cross_error!r}, fused={fused_cross_error!r}, "
+                        f"small_counts={counts_cross_error!r}, "
+                        f"fused_counts={fused_counts_cross_error!r}"
+                    )
+            except Exception as exc:
+                local_error = (
+                    f"[rank {rank}] profile accuracy failed: "
+                    f"performance_iteration={test_idx}, result_index={result_idx}, "
+                    f"seed={case['seed']}, local_num_tokens={local_num_tokens}, "
+                    f"avg_diff={avg_diff:.6f}, max_diff={max_diff:.6f}, "
+                    f"calc_diff={cosine_diff:.6f}, small_nan_count={small_nan_count}, "
+                    f"fused_nan_count={fused_nan_count}, "
+                    f"expert_ids={case['fused_inputs']['expert_ids'].cpu().tolist()}, "
+                    f"small_counts={small_counts.cpu().tolist()}, "
+                    f"fused_counts={fused_counts.cpu().tolist()}, "
+                    f"comparison={'small_vs_fused' if same_round_error else 'profile'}: {exc}"
+                )
+                if (
+                    small_cross_error
+                    or fused_cross_error
+                    or counts_cross_error
+                    or fused_counts_cross_error
+                ):
+                    local_error += (
+                        f", fixed_cross_iteration={{small={small_cross_error!r}, "
+                        f"fused={fused_cross_error!r}, "
+                        f"small_counts={counts_cross_error!r}, "
+                        f"fused_counts={fused_counts_cross_error!r}}}"
+                    )
+                break
+    except Exception as exc:
+        local_error = f"[rank {rank}] random profile validation setup failed: {exc}"
+
+    failure_flag = torch.tensor(
+        [1 if local_error is not None else 0], dtype=torch.int32, device="npu"
+    )
+    dist.all_reduce(failure_flag, op=dist.ReduceOp.SUM)
+    if failure_flag.item() != 0:
+        if local_error is not None:
+            print(local_error, flush=True)
+            print_profile_case_head_bytes(
+                profile_cases, small_results, fused_results, rank
+            )
+        dist.barrier()
+        raise AssertionError(
+            f"Random profile accuracy validation failed on {failure_flag.item()} of {world_size} ranks"
+        )
+    if rank == 0:
+        print(
+            f"Random profile accuracy check passed for {args.num_tests} performance iterations.",
+            flush=True,
+        )
 
 
 def run_small_op_baseline(
@@ -814,6 +1294,7 @@ def run_rank(local_rank: int, num_processes: int, args: argparse.Namespace):
                 f"num_experts={args.num_experts}, "
                 f"num_topk={args.num_topk}, "
                 f"quant={args.quant}, "
+                f"weight_format={args.weight_format}, "
                 f"kernel_trace_dir={args.kernel_trace_dir}, "
                 f"num_warmups={args.num_warmups}, "
                 f"num_tests={args.num_tests}, "
@@ -951,6 +1432,31 @@ def run_rank(local_rank: int, num_processes: int, args: argparse.Namespace):
         small_stats = None
         small_breakdown_stats = None
         fused_stats = None
+        profile_cases = None
+        small_profile_results = []
+        fused_profile_results = []
+        if args.random_profile_cases or args.fixed_profile_cases:
+            case_builder = (
+                make_fixed_profile_cases
+                if args.fixed_profile_cases
+                else make_random_profile_cases
+            )
+            profile_cases = case_builder(
+                inputs,
+                rank,
+                world_size,
+                local_num_tokens,
+                padded_num_tokens,
+                args,
+            )
+            # Keep random input construction outside both profiler regions.
+            torch.npu.synchronize()
+            if rank == 0:
+                print(
+                    f"{'Fixed' if args.fixed_profile_cases else 'Random'} profile cases prepared: "
+                    f"count={len(profile_cases)}, seed={args.random_profile_seed}",
+                    flush=True,
+                )
 
         if True:
             small_trace_path = (
@@ -971,9 +1477,14 @@ def run_rank(local_rank: int, num_processes: int, args: argparse.Namespace):
                     if small_profile_call_idx == 0 and args.num_warmups > 0
                     else 1
                 )
+                profile_inputs = (
+                    profile_cases[small_profile_call_idx]["small_inputs"]
+                    if profile_cases is not None
+                    else small_op_inputs
+                )
                 small_profile_call_idx += 1
-                return run_small_op_baseline(
-                    small_op_inputs,
+                result = run_small_op_baseline(
+                    profile_inputs,
                     hcomm_name_small,
                     rank,
                     world_size,
@@ -982,6 +1493,9 @@ def run_rank(local_rank: int, num_processes: int, args: argparse.Namespace):
                     gmm_burn_in_repeats=gmm_burn_in_repeats,
                     warmup_burn_in_buffers=warmup_burn_in_buffers,
                 )
+                if profile_cases is not None:
+                    small_profile_results.append(result)
+                return result
 
             (
                 small_durations,
@@ -1044,14 +1558,22 @@ def run_rank(local_rank: int, num_processes: int, args: argparse.Namespace):
                     burn_in_lhs, burn_in_rhs = warmup_burn_in_buffers
                     for _ in range(SMALL_FIRST_WARMUP_GMM_BURN_IN_REPEATS):
                         _ = torch.matmul(burn_in_lhs, burn_in_rhs)
+                profile_inputs = (
+                    profile_cases[fused_profile_call_idx]["fused_inputs"]
+                    if profile_cases is not None
+                    else inputs
+                )
                 fused_profile_call_idx += 1
-                return run_buffer_fused(
+                result = run_buffer_fused(
                     buffer,
-                    inputs,
+                    profile_inputs,
                     padded_num_tokens,
                     args,
                     kernel_trace_dir=args.kernel_trace_dir,
                 )
+                if profile_cases is not None:
+                    fused_profile_results.append(result)
+                return result
 
             try:
                 (
@@ -1089,6 +1611,20 @@ def run_rank(local_rank: int, num_processes: int, args: argparse.Namespace):
                     )
                     buffer.runtime.end_profile()
         dist.barrier()
+
+        if profile_cases is not None:
+            validate_random_profile_results(
+                profile_cases,
+                small_profile_results,
+                fused_profile_results,
+                rank,
+                world_size,
+                local_num_tokens,
+                padded_num_tokens,
+                local_experts,
+                args,
+            )
+            dist.barrier()
 
         if small_stats is not None:
             small_stats_tensor = torch.tensor(
@@ -1293,6 +1829,28 @@ def main():
         help="Number of counted performance iterations when --profile-num-tests is not set.",
     )
     parser.add_argument(
+        "--random-profile-cases",
+        action="store_true",
+        help=(
+            "Use distinct randomized activation/routing inputs for every profiler "
+            "iteration and compare results afterward."
+        ),
+    )
+    parser.add_argument(
+        "--random-profile-seed",
+        type=int,
+        default=2026,
+        help="Base seed for deterministic per-iteration randomized profiler inputs.",
+    )
+    parser.add_argument(
+        "--fixed-profile-cases",
+        action="store_true",
+        help=(
+            "Use identical activation/routing values with distinct tensor storage "
+            "for every profiler iteration; implies profile-case validation."
+        ),
+    )
+    parser.add_argument(
         "--quant",
         choices=tuple(MX_QUANT_CONFIGS.keys()),
         default="fp8_e4m3",
@@ -1302,7 +1860,7 @@ def main():
         "--weight-format",
         choices=("ND", "NZ"),
         default="ND",
-        help="Storage format for quantized GMM weights; NZ is supported for FP8 only.",
+        help="Storage format for quantized GMM weights.",
     )
     parser.add_argument(
         "--trace-dir",
@@ -1358,9 +1916,11 @@ def main():
         parser.error("--num-warmups must be non-negative")
     if args.num_tests <= 0:
         parser.error("--num-tests must be positive")
-    if args.quant == "fp4_e2m1" and args.weight_format == "NZ":
+    if args.random_profile_seed < 0:
+        parser.error("--random-profile-seed must be non-negative")
+    if args.random_profile_cases and args.fixed_profile_cases:
         parser.error(
-            "--weight-format NZ is currently supported for FP8 quantization only"
+            "--random-profile-cases and --fixed-profile-cases are mutually exclusive"
         )
     if args.quant == "fp4_e2m1" and args.hidden % 2 != 0:
         parser.error("--hidden must be even when --quant is fp4_e2m1")


### PR DESCRIPTION
## Motivation

- The performance of the A5 FusedDeepMoe is optimized: After the element-wise multiplication of the left and right matrices and the mx quantization are fused into the GMM1 group, the utilization of computing resources in the AIC core can be further improved.
- A5 FusedDeepMoe supports weights in the MXFP4 (fp4_e2m1) data type with NZ data format.

## Modifications

- ops/op_host/fused_deep_moe_a5/
- ops/op_kernel/fused_deep_moe_a5/
- profiling/adaptor/fused_deep_moe_a5/
- tests/python/deepep/

## Testing

```
python3 tests/python/deepep/test_fused_deep_moe_a5.py --quant fp8_e4m3 --num-processes 4 --num-tokens  1 --hidden 7168 --moe-intermediate-size 3072 --num-topk 6  --num-experts 48 --weight-format ND --random-profile-cases
rank skew summary:
| Rank | Dispatch (us) | GMM1 (us) | SwiGLU (us) | Requant (us) | GMM2 (us) | Combine (us) | Small Total (us) | Fused (us) |
|-----:|--------------:|----------:|------------:|-------------:|----------:|-------------:|-----------------:|-----------:|
|    0 |         12.32 |    135.89 |        2.87 |         3.67 |     69.30 |        96.06 |           320.11 |     311.43 |
|    1 |         12.39 |    153.08 |        2.96 |         4.20 |     78.36 |        69.03 |           320.02 |     311.36 |
|    2 |         21.97 |    144.85 |        2.92 |         3.67 |     73.85 |        72.81 |           320.06 |     311.37 |
|    3 |         12.26 |    151.55 |        2.92 |         3.61 |     77.30 |        72.43 |           320.07 |     311.39 |
| mean |         14.74 |    146.34 |        2.92 |         3.79 |     74.70 |        77.58 |           320.06 |     311.39 |
communication overlap rate: ((320.06 - 311.39) / (14.74 + 77.58)) = 0.0940

python3 tests/python/deepep/test_fused_deep_moe_a5.py --quant fp8_e4m3 --num-processes 4 --num-tokens  1 --hidden 7168 --moe-intermediate-size 3072 --num-topk 6  --num-experts 48 --weight-format NZ --random-profile-cases
rank skew summary:
| Rank | Dispatch (us) | GMM1 (us) | SwiGLU (us) | Requant (us) | GMM2 (us) | Combine (us) | Small Total (us) | Fused (us) |
|-----:|--------------:|----------:|------------:|-------------:|----------:|-------------:|-----------------:|-----------:|
|    0 |         15.62 |    328.07 |        2.89 |         3.59 |    166.31 |         9.58 |           526.06 |     522.80 |
|    1 |         12.54 |    327.96 |        2.88 |         4.31 |    166.24 |        12.08 |           526.00 |     522.79 |
|    2 |         12.09 |      2.75 |        2.80 |         3.62 |      2.76 |       501.97 |           525.98 |     522.90 |
|    3 |         11.97 |      2.75 |        2.80 |         3.65 |      2.75 |       502.05 |           525.95 |     522.90 |
| mean |         13.05 |    165.38 |        2.84 |         3.79 |     84.51 |       256.42 |           526.00 |     522.85 |
communication overlap rate: ((526.00 - 522.85) / (13.05 + 256.42)) = 0.0117

python3 tests/python/deepep/test_fused_deep_moe_a5.py --quant fp4_e2m1 --num-processes 4 --num-tokens  1 --hidden 7168 --moe-intermediate-size 3072 --num-topk 6  --num-experts 48 --weight-format ND --random-profile-cases
rank skew summary:
| Rank | Dispatch (us) | GMM1 (us) | SwiGLU (us) | Requant (us) | GMM2 (us) | Combine (us) | Small Total (us) | Fused (us) |
|-----:|--------------:|----------:|------------:|-------------:|----------:|-------------:|-----------------:|-----------:|
|    0 |         12.08 |     78.61 |        2.91 |         3.33 |     40.92 |        59.41 |           197.26 |     194.69 |
|    1 |         12.10 |     86.36 |        2.93 |         3.11 |     43.79 |        48.92 |           197.21 |     194.62 |
|    2 |         17.98 |     82.86 |        2.94 |         3.27 |     43.70 |        46.51 |           197.25 |     194.63 |
|    3 |         12.07 |     87.33 |        2.94 |         3.32 |     45.60 |        45.94 |           197.20 |     194.65 |
| mean |         13.56 |     83.79 |        2.93 |         3.25 |     43.50 |        50.20 |           197.23 |     194.65 |
communication overlap rate: ((197.23 - 194.65) / (13.56 + 50.20)) = 0.0405

python3 tests/python/deepep/test_fused_deep_moe_a5.py --quant fp4_e2m1 --num-processes 4 --num-tokens  1 --hidden 7168 --moe-intermediate-size 3072 --num-topk 6  --num-experts 48 --weight-format NZ --random-profile-cases
rank skew summary:
| Rank | Dispatch (us) | GMM1 (us) | SwiGLU (us) | Requant (us) | GMM2 (us) | Combine (us) | Small Total (us) | Fused (us) |
|-----:|--------------:|----------:|------------:|-------------:|----------:|-------------:|-----------------:|-----------:|
|    0 |         12.04 |     68.55 |        2.93 |         3.27 |     36.02 |        53.23 |           176.04 |     180.52 |
|    1 |         12.01 |     76.72 |        2.94 |         3.09 |     40.50 |        40.73 |           175.99 |     180.48 |
|    2 |         16.76 |     72.76 |        2.92 |         3.24 |     38.39 |        41.93 |           176.01 |     180.50 |
|    3 |         12.12 |     76.40 |        2.96 |         3.24 |     40.34 |        40.91 |           175.98 |     180.47 |
| mean |         13.23 |     73.61 |        2.94 |         3.21 |     38.81 |        44.20 |           176.00 |     180.49 |
communication overlap rate: ((176.00 - 180.49) / (13.23 + 44.20)) = -0.0782
```

## Benchmarking and Profiling

as above

## Checklist

- [x] Format your code.
- [ ] Add unit tests.
- [ ] Update documentation.
- [x] Provide accuracy and speed benchmark results.