### PR TITLE
ci: trim redundant A2 single-node deepep test parameters

### DIFF
--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -563,12 +563,6 @@ jobs:
           HCCL_BUFFSIZE: 2300
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=1 --num-processes=8
-      - name: Run test intranode for big bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 4500
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=8000 --num-processes=8
       - name: Run test little processes intranode
         timeout-minutes: 10
         env:
@@ -582,7 +576,6 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=2048 --num-processes=8
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=4096 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=6144 --num-processes=8
       - name: Run test topk num intranode
         timeout-minutes: 10
         env:
@@ -664,8 +657,6 @@ jobs:
           HCCL_BUFFSIZE: 1913
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=2048 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=4096 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=6144 --num-processes=8
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=7168 --num-processes=8
       - name: Run test low latency for topk
         timeout-minutes: 10
@@ -712,7 +703,6 @@ jobs:
           HCCL_BUFFSIZE: 5000
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=1 --low-latency-num-tokens=1 --test-loop=100 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=8000 --low-latency-num-tokens=512 --test-loop=100 --num-processes=8
       - name: Run test mixed running for hidden
         timeout-minutes: 10
         env:
@@ -720,7 +710,6 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=2048 --test-loop=100 --num-processes=8
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=4096 --test-loop=100 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=6144 --test-loop=100 --num-processes=8
       - name: Run test mixed running for topk
         timeout-minutes: 10
         env:


### PR DESCRIPTION
## Summary

Phase 2: trim redundant A2 single-node DeepEP test parameters to shorten the `test-build-deepep-a2` job runtime. Both CANN 9.0.0 and 9.1.0 are kept, with no loss of coverage.

## Changes

- intranode: remove the `--num-tokens=8000` big-bs step (overlaps with multi-round long-sequence coverage)
- intranode hidden: 3 dims `2048/4096/6144` -> 2 dims `2048/4096`
- low_latency hidden: 4 dims `2048/4096/6144/7168` -> 2 dims `2048/7168`
- mixed: remove the `--normal-num-tokens=8000` big-bs combination
- mixed hidden: 3 dims `2048/4096/6144` -> 2 dims `2048/4096`

## Notes

- Only the PR single-node pipeline (`test-build-deepep-a2`) is changed; daily enumerate, build-cache, and multi-node are untouched.
- Both CANN 9.0.0 and 9.1.0 are kept.
- Other coverage (combine / experts / topk / dynamic tokens / int8 / active-ranks / diagnose / drop-percent / fewer processes) remains unchanged.
