### PR TITLE
[DeepEP] Normal dispatch: architecture-aware quant mode via use_fp8/use_mxfp4/use_mxfp8 bool flags

### DIFF
--- a/python/deep_ep/README.md
+++ b/python/deep_ep/README.md
@@ -179,7 +179,7 @@ buffer.dispatch(x=data, quant_mode="mx_fp4_e2m1", ...)
 # or: buffer.dispatch(x=data, use_mxfp4=True, ...)
 ```
 
-> **Quantization selection priority:** `quant_mode` (explicit) > `use_fp8`/`use_mxfp4`/`use_mxfp8` bool flags (architecture-aware) > `DEEP_NORMAL_MODE_USE_INT8_QUANT` env var (deprecated) > BF16. The device architecture (A5 vs A2/A3) is auto-detected at `Buffer` initialization via `acl.rt.get_device_info(0, 601)`. See [Normal Mode API — Quantization Selection Priority](doc/NORMAL_API.md#quantization-selection-priority) for details.
+> **Quantization selection priority:** `use_fp8`/`use_mxfp4`/`use_mxfp8` bool flags (architecture-aware) > `DEEP_NORMAL_MODE_USE_INT8_QUANT` env var (deprecated) > BF16. See [Normal Mode API — Quantization Selection Priority](doc/NORMAL_API.md#quantization-selection-priority) for details.
 
 #### Low-Latency Mode (Decode)
 
@@ -446,7 +446,7 @@ normal_dispatch 量化模式（通过 `quant_mode` 参数指定）：
 | Scalar FP8 | `"pertoken_fp8_e4m3"` | `float8_e4m3fn` | `float32` | per-token | 仅 A5 |
 | MXFP4 | `"mx_fp4_e2m1"` | `float4_e2m1fn_x2` | `float8_e8m0fnu` | 每 32 元素 | 仅 A5 |
 
-> **量化选择优先级：** `quant_mode`（显式）> `use_fp8`/`use_mxfp4`/`use_mxfp8` 布尔标志（架构感知）> `DEEP_NORMAL_MODE_USE_INT8_QUANT` 环境变量（已弃用）> BF16。设备架构（A5 vs A2/A3）在 `Buffer` 初始化时通过 `acl.rt.get_device_info(0, 601)` 自动检测。详见 [Normal 模式 API — 量化模式选择优先级](doc/NORMAL_API.md#量化模式选择优先级)（含各路径差异）。
+> **量化选择优先级：** `use_fp8`/`use_mxfp4`/`use_mxfp8` 布尔标志（架构感知）> `DEEP_NORMAL_MODE_USE_INT8_QUANT` 环境变量（已弃用）> BF16。详见 [Normal 模式 API — 量化模式选择优先级](doc/NORMAL_API.md#量化模式选择优先级)（含各路径差异）。
 
 #### Low-Latency 模式（Decode）
 

--- a/python/deep_ep/README.md
+++ b/python/deep_ep/README.md
@@ -168,15 +168,18 @@ buffer.dispatch(x=data, quant_mode="int8", ...)
 
 # Scalar FP8 per-token quantization (A5 only)
 buffer.dispatch(x=data, quant_mode="pertoken_fp8_e4m3", ...)
+# or: buffer.dispatch(x=data, use_fp8=True, ...)  # auto-detects A5 vs A2/A3
 
 # MXFP8 per-block quantization (A5 only)
 buffer.dispatch(x=data, quant_mode="mx_fp8_e4m3", ...)
+# or: buffer.dispatch(x=data, use_mxfp8=True, ...)
 
 # MXFP4 quantization (A5 only)
 buffer.dispatch(x=data, quant_mode="mx_fp4_e2m1", ...)
+# or: buffer.dispatch(x=data, use_mxfp4=True, ...)
 ```
 
-> **Quantization selection priority:** `quant_mode` (explicit) > `DEEP_NORMAL_MODE_USE_INT8_QUANT` env var > BF16. See [Normal Mode API — Quantization Selection Priority](doc/NORMAL_API.md#quantization-selection-priority) for details and per-path differences.
+> **Quantization selection priority:** `quant_mode` (explicit) > `use_fp8`/`use_mxfp4`/`use_mxfp8` bool flags (architecture-aware) > `DEEP_NORMAL_MODE_USE_INT8_QUANT` env var (deprecated) > BF16. The device architecture (A5 vs A2/A3) is auto-detected at `Buffer` initialization via `acl.rt.get_device_info(0, 601)`. See [Normal Mode API — Quantization Selection Priority](doc/NORMAL_API.md#quantization-selection-priority) for details.
 
 #### Low-Latency Mode (Decode)
 
@@ -213,7 +216,7 @@ See [Fused Deep MoE API](doc/FUSED_DEEP_MOE.md) for details.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DEEP_USE_MODE` | `default` | Normal mode strategy and Low-latency mode strategy: `default`, `ops`, or `alltoall`. |
-| `DEEP_NORMAL_MODE_USE_INT8_QUANT` | `0` | **Deprecated for `default` strategy.** INT8 quantization is now specified via `quant_mode="int8"` parameter in `dispatch()`. For `alltoall` strategy, this env var is still the only way to enable INT8. MXFP8/MXFP4 per-block quantization (A5 only, intranode only) is specified via `quant_mode` parameter (e.g., `quant_mode="mx_fp8_e4m3"`); see [Normal Mode quantization](#normal-mode-prefill--training) for supported values. |
+| `DEEP_NORMAL_MODE_USE_INT8_QUANT` | `0` | **Deprecated.** INT8 quantization is now specified via `quant_mode="int8"` or `use_fp8=True` in `dispatch()`. This env var remains as a backward-compatible fallback when `quant_mode=None` and no bool flags are set. |
 | `SGLANG_DEEPEP_BF16_DISPATCH` | `0` | Disable quantization in `low_latency_dispatch` (BF16 dispatch). Set to `1` to disable; only effective in decode phase. **Configured by SGLang framework**, not read by deep_ep directly. |
 | `MOE_EXPERT_TOKEN_NUMS_TYPE` | `1` | Dispatch return type for `num_recv_tokens_per_expert_list`: `1` = per-expert token count, `0` = prefix sum. |
 | `MOE_SHARED_EXPERT_RANK_NUM` | `0` | Number of shared expert ranks (used by ops strategy). |
@@ -443,7 +446,7 @@ normal_dispatch 量化模式（通过 `quant_mode` 参数指定）：
 | Scalar FP8 | `"pertoken_fp8_e4m3"` | `float8_e4m3fn` | `float32` | per-token | 仅 A5 |
 | MXFP4 | `"mx_fp4_e2m1"` | `float4_e2m1fn_x2` | `float8_e8m0fnu` | 每 32 元素 | 仅 A5 |
 
-> **量化选择优先级：** `quant_mode`（显式）> `DEEP_NORMAL_MODE_USE_INT8_QUANT` 环境变量 > BF16。详见 [Normal 模式 API — 量化模式选择优先级](doc/NORMAL_API.md#量化模式选择优先级)（含各路径差异）。
+> **量化选择优先级：** `quant_mode`（显式）> `use_fp8`/`use_mxfp4`/`use_mxfp8` 布尔标志（架构感知）> `DEEP_NORMAL_MODE_USE_INT8_QUANT` 环境变量（已弃用）> BF16。设备架构（A5 vs A2/A3）在 `Buffer` 初始化时通过 `acl.rt.get_device_info(0, 601)` 自动检测。详见 [Normal 模式 API — 量化模式选择优先级](doc/NORMAL_API.md#量化模式选择优先级)（含各路径差异）。
 
 #### Low-Latency 模式（Decode）
 
@@ -480,7 +483,7 @@ low_latency_dispatch 量化模式。`quant_mode` 字符串参数仅对 `default`
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
 | `DEEP_USE_MODE` | `default` | Normal 模式策略 and Low-latency 模式策略：`default`、`ops` 或 `alltoall`。 |
-| `DEEP_NORMAL_MODE_USE_INT8_QUANT` | `0` | **对 `default` 策略已弃用。** INT8 量化现通过 `dispatch()` 的 `quant_mode="int8"` 参数指定。对于 `alltoall` 策略，此环境变量仍是启用 INT8 的唯一方式。MXFP8/MXFP4 per-block 量化（仅 A5，仅 intranode）通过 `quant_mode` 参数指定（如 `quant_mode="mx_fp8_e4m3"`），支持的值见 [Normal 模式量化](#normal-模式prefill--训练)。 |
+| `DEEP_NORMAL_MODE_USE_INT8_QUANT` | `0` | **已弃用。** INT8 量化现通过 `dispatch()` 的 `quant_mode="int8"` 或 `use_fp8=True` 指定。此环境变量作为向后兼容回退，仅在 `quant_mode=None` 且无布尔标志时生效。 |
 | `SGLANG_DEEPEP_BF16_DISPATCH` | `0` | 在 `low_latency_dispatch` 中关闭量化（BF16 dispatch）。设为 `1` 关闭量化；仅在 Decode 阶段生效。**由 SGLang 框架配置**，deep_ep 不直接读取。 |
 | `MOE_EXPERT_TOKEN_NUMS_TYPE` | `1` | dispatch 返回的 `num_recv_tokens_per_expert_list` 类型：`1` = 各专家 token 数，`0` = 前缀和。 |
 | `MOE_SHARED_EXPERT_RANK_NUM` | `0` | 共享专家 rank 数（ops 策略使用）。 |

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -15,7 +15,7 @@ from .ep_strategy import (
     get_low_latency_strategy,
     get_normal_strategy,
 )
-from .utils import EventOverlap, log_parameters, resolve_normal_quant_mode
+from .utils import EventOverlap, _resolve_normal_quant_mode, log_parameters
 
 
 class FuseMode(IntEnum):
@@ -372,7 +372,7 @@ class Buffer:
         config = self.get_dispatch_config(self.group_size) if config is None else config
 
         # Resolve quant_mode from bool flags + device architecture
-        quant_mode = resolve_normal_quant_mode(use_fp8, use_mxfp4, use_mxfp8)
+        quant_mode = _resolve_normal_quant_mode(use_fp8, use_mxfp4, use_mxfp8)
 
         # Delegate to normal strategy
         return self.normal_strategy.dispatch(

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from enum import IntEnum
 from typing import Callable, List, Optional, Tuple, Union
@@ -8,7 +9,9 @@ import torch.distributed as dist
 import torch_npu
 from deep_ep_cpp import Config, EventHandle
 
+from .device_info import get_device_arch
 from .ep_strategy import (
+    VALID_QUANT_MODES,
     LowLatencyStrategy,
     NormalStrategy,
     StrategyMap,
@@ -16,6 +19,8 @@ from .ep_strategy import (
     get_normal_strategy,
 )
 from .utils import EventOverlap, log_parameters
+
+logger = logging.getLogger(__name__)
 
 
 class FuseMode(IntEnum):
@@ -82,6 +87,9 @@ class Buffer:
             moe_all_to_all_group_name,
         )
 
+        # Detect device architecture family ("A5" or "A2/A3")
+        self.device_arch = get_device_arch()
+
         # set strategy by env
         deep_mode = os.getenv("DEEP_USE_MODE")
 
@@ -124,6 +132,65 @@ class Buffer:
             init_kwargs["comm_alg"] = comm_alg
 
         self.low_latency_strategy = strategy_cls(**init_kwargs)
+
+    def _resolve_normal_quant_mode(
+        self,
+        quant_mode: Optional[str],
+        use_fp8: bool,
+        use_mxfp4: bool,
+        use_mxfp8: bool,
+    ) -> Optional[str]:
+        """Resolve the effective ``quant_mode`` for normal dispatch.
+
+        Priority:
+        1. Explicit ``quant_mode`` (when not ``None``) — used directly.
+        2. ``use_mxfp4`` / ``use_mxfp8`` / ``use_fp8`` bool flags combined
+           with the detected device architecture:
+           - ``use_mxfp4``  → A5: ``mx_fp4_e2m1``;  A2/A3: not supported.
+           - ``use_mxfp8``  → A5: ``mx_fp8_e4m3``;  A2/A3: not supported.
+           - ``use_fp8``    → A5: ``pertoken_fp8_e4m3``;  A2/A3: ``int8`` (warning).
+        3. ``DEEP_NORMAL_MODE_USE_INT8_QUANT=1`` env var (deprecated fallback).
+        4. ``None`` (BF16, no quantization).
+        """
+        if quant_mode is not None:
+            if quant_mode not in VALID_QUANT_MODES:
+                raise ValueError(
+                    f"Invalid quant_mode: {quant_mode}. "
+                    f"Valid options: {VALID_QUANT_MODES}"
+                )
+            return quant_mode
+
+        is_a5 = self.device_arch == "A5"
+
+        if use_mxfp4:
+            if is_a5:
+                return "mx_fp4_e2m1"
+            raise NotImplementedError(
+                "use_mxfp4 is not supported on A2/A3 devices; "
+                "only A5 supports MXFP4 quantization."
+            )
+
+        if use_mxfp8:
+            if is_a5:
+                return "mx_fp8_e4m3"
+            raise NotImplementedError(
+                "use_mxfp8 is not supported on A2/A3 devices; "
+                "only A5 supports MXFP8 quantization."
+            )
+
+        if use_fp8:
+            if is_a5:
+                return "pertoken_fp8_e4m3"
+            logger.warning(
+                "use_fp8 is converted to int8 on A2/A3 devices."
+            )
+            return "int8"
+
+        # Deprecated env-var fallback for backward compatibility
+        if os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT") == "1":
+            return "int8"
+
+        return None
 
     @staticmethod
     def get_dispatch_config(num_ranks: int) -> Config:
@@ -302,6 +369,9 @@ class Buffer:
         allocate_on_comm_stream: bool = False,
         dispatch_wait_recv_cost_stats: Optional[torch.Tensor] = None,
         quant_mode: Optional[str] = None,
+        use_fp8: bool = False,
+        use_mxfp4: bool = False,
+        use_mxfp8: bool = False,
     ) -> Tuple[
         Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor],
         Optional[torch.Tensor],
@@ -317,13 +387,9 @@ class Buffer:
             index should be visible via RDMA.
 
         Arguments:
-            x: input tokens. Supports two formats:
-                - `torch.Tensor` with `torch.bfloat16`, shaped `[num_tokens, hidden]`. Quantization is controlled by
-                  the `DEEP_NORMAL_MODE_USE_INT8_QUANT` environment variable (set to `1` for INT8 quantization, **deprecated**).
-                - Tuple of two `torch.Tensor`: for MXFP8 quantization, the first element is shaped `[num_tokens, hidden]`
-                  with `torch.float8_e4m3fn` (pre-quantized data), the second is shaped `[num_tokens, hidden // 32]`
-                  with `torch.float8_e8m0fnu` (per-block E8M0 scales). On NPU, this triggers MXFP8 per-block quantization
-                  (quant_mode=3) inside the dispatch kernel.
+            x: input tokens, ``torch.Tensor`` with ``torch.bfloat16``, shaped ``[num_tokens, hidden]``.
+                The dtype of ``x`` is no longer used for quantization-mode detection; use
+                ``quant_mode`` or the ``use_fp8`` / ``use_mxfp4`` / ``use_mxfp8`` bool flags instead.
             handle: an optional communication handle, if set, the CPU will reuse the layout information to save some time.
             num_tokens_per_rank: `[num_ranks]` with `torch.int`, the number of tokens to be sent to each rank.
             num_tokens_per_rdma_rank: `[num_rdma_ranks]` with `torch.int`, the number of tokens to be sent to each RDMA
@@ -342,15 +408,29 @@ class Buffer:
             allocate_on_comm_stream: control whether all the allocated tensors' ownership to be on the communication stream.
             dispatch_wait_recv_cost_stats: `[num_ranks]` with `torch.int`, record the time it takes for the dispatch phase
                 to receive all tokens from each slave rank in the current rank.
+            quant_mode: explicit quantization mode string (highest priority). Supported values:
+                ``None`` (BF16), ``"int8"``, ``"pertoken_fp8_e4m3"`` (A5), ``"mx_fp8_e4m3"`` (A5),
+                ``"mx_fp4_e2m1"`` (A5). When set, the bool flags below are ignored.
+            use_fp8: enable FP8-family quantization. On A5 → ``pertoken_fp8_e4m3``;
+                on A2/A3 → ``int8`` (with a warning). Ignored when ``quant_mode`` is set.
+            use_mxfp4: enable MXFP4 per-block quantization → ``mx_fp4_e2m1`` (A5 only).
+                Raises ``NotImplementedError`` on A2/A3. Ignored when ``quant_mode`` is set.
+            use_mxfp8: enable MXFP8 per-block quantization → ``mx_fp8_e4m3`` (A5 only).
+                Raises ``NotImplementedError`` on A2/A3. Ignored when ``quant_mode`` is set.
 
         Returns:
             recv_x: received tokens. The format depends on quantization mode:
                 - BF16 (no quantization): a `torch.Tensor` shaped `[received_token_count, hidden]` with `torch.bfloat16`.
-                - INT8 (`DEEP_NORMAL_MODE_USE_INT8_QUANT=1`, **deprecated**): a tuple, first element shaped `[received_token_count, hidden]`
+                - INT8: a tuple, first element shaped `[received_token_count, hidden]`
                   with `torch.int8`, second element shaped `[received_token_count]` with `torch.float32` (per-token scales).
-                - MXFP8 (tuple input with `float8_e4m3fn` + `float8_e8m0fnu`, A5/C310 only): a tuple, first element shaped
-                  `[received_token_count, hidden]` with `torch.float8_e4m3fn`, second element shaped
+                - PerToken FP8 (A5): a tuple, first element shaped `[received_token_count, hidden]`
+                  with `torch.float8_e4m3fn`, second element shaped `[received_token_count]` with `torch.float32`.
+                - MXFP8 (A5): a tuple, first element shaped `[received_token_count, hidden]`
+                  with `torch.float8_e4m3fn`, second element shaped
                   `[received_token_count, hidden // 32]` with `torch.float8_e8m0fnu` (per-block E8M0 scales).
+                - MXFP4 (A5): a tuple, first element shaped `[received_token_count, hidden / 2]`
+                  with `torch.float4_e2m1fn_x2`, second element shaped
+                  `[received_token_count, hidden // 32]` with `torch.float8_e8m0fnu`.
             recv_topk_idx: received expert indices.
             recv_topk_weights: received expert weights.
             num_recv_tokens_per_expert_list: Python list shaped `[num_local_experts]`, the received token count by
@@ -361,6 +441,11 @@ class Buffer:
         """
         # Default config
         config = self.get_dispatch_config(self.group_size) if config is None else config
+
+        # Resolve quant_mode from bool flags + device architecture when not explicitly set
+        quant_mode = self._resolve_normal_quant_mode(
+            quant_mode, use_fp8, use_mxfp4, use_mxfp8
+        )
 
         # Delegate to normal strategy
         return self.normal_strategy.dispatch(

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -321,7 +321,7 @@ class Buffer:
         Arguments:
             x: input tokens, ``torch.Tensor`` with ``torch.bfloat16``, shaped ``[num_tokens, hidden]``.
                 The dtype of ``x`` is no longer used for quantization-mode detection; use
-                ``quant_mode`` or the ``use_fp8`` / ``use_mxfp4`` / ``use_mxfp8`` bool flags instead.
+                the ``use_fp8`` / ``use_mxfp4`` / ``use_mxfp8`` bool flags instead.
             handle: an optional communication handle, if set, the CPU will reuse the layout information to save some time.
             num_tokens_per_rank: `[num_ranks]` with `torch.int`, the number of tokens to be sent to each rank.
             num_tokens_per_rdma_rank: `[num_rdma_ranks]` with `torch.int`, the number of tokens to be sent to each RDMA

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -8,7 +8,6 @@ import torch.distributed as dist
 import torch_npu
 from deep_ep_cpp import Config, EventHandle
 
-from .device_info import get_device_arch
 from .ep_strategy import (
     LowLatencyStrategy,
     NormalStrategy,
@@ -82,9 +81,6 @@ class Buffer:
             low_latency_mode,
             moe_all_to_all_group_name,
         )
-
-        # Detect device architecture family ("A5" or "A2/A3")
-        self.device_arch = get_device_arch()
 
         # set strategy by env
         deep_mode = os.getenv("DEEP_USE_MODE")
@@ -376,9 +372,7 @@ class Buffer:
         config = self.get_dispatch_config(self.group_size) if config is None else config
 
         # Resolve quant_mode from bool flags + device architecture
-        quant_mode = resolve_normal_quant_mode(
-            use_fp8, use_mxfp4, use_mxfp8, self.device_arch
-        )
+        quant_mode = resolve_normal_quant_mode(use_fp8, use_mxfp4, use_mxfp8)
 
         # Delegate to normal strategy
         return self.normal_strategy.dispatch(

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from enum import IntEnum
 from typing import Callable, List, Optional, Tuple, Union
@@ -11,16 +10,13 @@ from deep_ep_cpp import Config, EventHandle
 
 from .device_info import get_device_arch
 from .ep_strategy import (
-    VALID_QUANT_MODES,
     LowLatencyStrategy,
     NormalStrategy,
     StrategyMap,
     get_low_latency_strategy,
     get_normal_strategy,
 )
-from .utils import EventOverlap, log_parameters
-
-logger = logging.getLogger(__name__)
+from .utils import EventOverlap, log_parameters, resolve_normal_quant_mode
 
 
 class FuseMode(IntEnum):
@@ -132,63 +128,6 @@ class Buffer:
             init_kwargs["comm_alg"] = comm_alg
 
         self.low_latency_strategy = strategy_cls(**init_kwargs)
-
-    def _resolve_normal_quant_mode(
-        self,
-        quant_mode: Optional[str],
-        use_fp8: bool,
-        use_mxfp4: bool,
-        use_mxfp8: bool,
-    ) -> Optional[str]:
-        """Resolve the effective ``quant_mode`` for normal dispatch.
-
-        Priority:
-        1. Explicit ``quant_mode`` (when not ``None``) — used directly.
-        2. ``use_mxfp4`` / ``use_mxfp8`` / ``use_fp8`` bool flags combined
-           with the detected device architecture:
-           - ``use_mxfp4``  → A5: ``mx_fp4_e2m1``;  A2/A3: not supported.
-           - ``use_mxfp8``  → A5: ``mx_fp8_e4m3``;  A2/A3: not supported.
-           - ``use_fp8``    → A5: ``pertoken_fp8_e4m3``;  A2/A3: ``int8`` (warning).
-        3. ``DEEP_NORMAL_MODE_USE_INT8_QUANT=1`` env var (deprecated fallback).
-        4. ``None`` (BF16, no quantization).
-        """
-        if quant_mode is not None:
-            if quant_mode not in VALID_QUANT_MODES:
-                raise ValueError(
-                    f"Invalid quant_mode: {quant_mode}. "
-                    f"Valid options: {VALID_QUANT_MODES}"
-                )
-            return quant_mode
-
-        is_a5 = self.device_arch == "A5"
-
-        if use_mxfp4:
-            if is_a5:
-                return "mx_fp4_e2m1"
-            raise NotImplementedError(
-                "use_mxfp4 is not supported on A2/A3 devices; "
-                "only A5 supports MXFP4 quantization."
-            )
-
-        if use_mxfp8:
-            if is_a5:
-                return "mx_fp8_e4m3"
-            raise NotImplementedError(
-                "use_mxfp8 is not supported on A2/A3 devices; "
-                "only A5 supports MXFP8 quantization."
-            )
-
-        if use_fp8:
-            if is_a5:
-                return "pertoken_fp8_e4m3"
-            logger.warning("use_fp8 is converted to int8 on A2/A3 devices.")
-            return "int8"
-
-        # Deprecated env-var fallback for backward compatibility
-        if os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT") == "1":
-            return "int8"
-
-        return None
 
     @staticmethod
     def get_dispatch_config(num_ranks: int) -> Config:
@@ -410,7 +349,7 @@ class Buffer:
                 ``None`` (BF16), ``"int8"``, ``"pertoken_fp8_e4m3"`` (A5), ``"mx_fp8_e4m3"`` (A5),
                 ``"mx_fp4_e2m1"`` (A5). When set, the bool flags below are ignored.
             use_fp8: enable FP8-family quantization. On A5 → ``pertoken_fp8_e4m3``;
-                on A2/A3 → ``int8`` (with a warning). Ignored when ``quant_mode`` is set.
+                on A2/A3 → ``int8``. Ignored when ``quant_mode`` is set.
             use_mxfp4: enable MXFP4 per-block quantization → ``mx_fp4_e2m1`` (A5 only).
                 Raises ``NotImplementedError`` on A2/A3. Ignored when ``quant_mode`` is set.
             use_mxfp8: enable MXFP8 per-block quantization → ``mx_fp8_e4m3`` (A5 only).
@@ -441,8 +380,8 @@ class Buffer:
         config = self.get_dispatch_config(self.group_size) if config is None else config
 
         # Resolve quant_mode from bool flags + device architecture when not explicitly set
-        quant_mode = self._resolve_normal_quant_mode(
-            quant_mode, use_fp8, use_mxfp4, use_mxfp8
+        quant_mode = resolve_normal_quant_mode(
+            quant_mode, use_fp8, use_mxfp4, use_mxfp8, self.device_arch
         )
 
         # Delegate to normal strategy

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -305,7 +305,6 @@ class Buffer:
         async_finish: bool = False,
         allocate_on_comm_stream: bool = False,
         dispatch_wait_recv_cost_stats: Optional[torch.Tensor] = None,
-        quant_mode: Optional[str] = None,
         use_fp8: bool = False,
         use_mxfp4: bool = False,
         use_mxfp8: bool = False,
@@ -345,15 +344,12 @@ class Buffer:
             allocate_on_comm_stream: control whether all the allocated tensors' ownership to be on the communication stream.
             dispatch_wait_recv_cost_stats: `[num_ranks]` with `torch.int`, record the time it takes for the dispatch phase
                 to receive all tokens from each slave rank in the current rank.
-            quant_mode: explicit quantization mode string (highest priority). Supported values:
-                ``None`` (BF16), ``"int8"``, ``"pertoken_fp8_e4m3"`` (A5), ``"mx_fp8_e4m3"`` (A5),
-                ``"mx_fp4_e2m1"`` (A5). When set, the bool flags below are ignored.
             use_fp8: enable FP8-family quantization. On A5 → ``pertoken_fp8_e4m3``;
-                on A2/A3 → ``int8``. Ignored when ``quant_mode`` is set.
+                on A2/A3 → ``int8``.
             use_mxfp4: enable MXFP4 per-block quantization → ``mx_fp4_e2m1`` (A5 only).
-                Raises ``NotImplementedError`` on A2/A3. Ignored when ``quant_mode`` is set.
+                Raises ``NotImplementedError`` on A2/A3.
             use_mxfp8: enable MXFP8 per-block quantization → ``mx_fp8_e4m3`` (A5 only).
-                Raises ``NotImplementedError`` on A2/A3. Ignored when ``quant_mode`` is set.
+                Raises ``NotImplementedError`` on A2/A3.
 
         Returns:
             recv_x: received tokens. The format depends on quantization mode:
@@ -379,9 +375,9 @@ class Buffer:
         # Default config
         config = self.get_dispatch_config(self.group_size) if config is None else config
 
-        # Resolve quant_mode from bool flags + device architecture when not explicitly set
+        # Resolve quant_mode from bool flags + device architecture
         quant_mode = resolve_normal_quant_mode(
-            quant_mode, use_fp8, use_mxfp4, use_mxfp8, self.device_arch
+            use_fp8, use_mxfp4, use_mxfp8, self.device_arch
         )
 
         # Delegate to normal strategy

--- a/python/deep_ep/deep_ep/buffer.py
+++ b/python/deep_ep/deep_ep/buffer.py
@@ -181,9 +181,7 @@ class Buffer:
         if use_fp8:
             if is_a5:
                 return "pertoken_fp8_e4m3"
-            logger.warning(
-                "use_fp8 is converted to int8 on A2/A3 devices."
-            )
+            logger.warning("use_fp8 is converted to int8 on A2/A3 devices.")
             return "int8"
 
         # Deprecated env-var fallback for backward compatibility

--- a/python/deep_ep/deep_ep/device_info.py
+++ b/python/deep_ep/deep_ep/device_info.py
@@ -1,0 +1,77 @@
+"""Device architecture detection utilities for NPU.
+
+The first return value of ``acl.rt.get_device_info(0, 601)`` gives the SoC
+version code.  A lookup table maps each known code to an architecture family
+("A5" or "A2/A3") so that callers can select the correct quantization path
+without hard-coding version checks everywhere.
+"""
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# SoC version code -> architecture family.
+# A5 family (Ascend910C / C310 / 950DT):  9301, 9201, 3510
+# A2/A3 family:                            2201, 1001, 2002, 3002
+DEVICE_VERSION_TABLE = {
+    9301: "A5",
+    9201: "A5",
+    3510: "A5",
+    2201: "A2/A3",
+    1001: "A2/A3",
+    2002: "A2/A3",
+    3002: "A2/A3",
+}
+
+# All A5 version codes (convenience set)
+A5_VERSION_CODES = frozenset(v for v, arch in DEVICE_VERSION_TABLE.items() if arch == "A5")
+
+_cached_arch: Optional[str] = None
+
+
+def get_device_version() -> int:
+    """Return the SoC version code via the ACL runtime API.
+
+    ``acl.rt.get_device_info(device_id, 601)`` returns a tuple whose first
+    element is the version code.
+    """
+    import acl
+
+    return acl.rt.get_device_info(0, 601)[0]
+
+
+def get_device_arch() -> str:
+    """Detect and cache the current device architecture family.
+
+    Returns ``"A5"`` for Ascend910C / C310 / 950DT devices, or
+    ``"A2/A3"`` for other Ascend devices.  On failure, defaults to
+    ``"A2/A3"`` so that callers fall back to the safer (int8) path.
+    """
+    global _cached_arch
+    if _cached_arch is not None:
+        return _cached_arch
+
+    try:
+        version = get_device_version()
+        arch = DEVICE_VERSION_TABLE.get(version)
+        if arch is None:
+            logger.warning(
+                "Unknown device version code %s, defaulting to A2/A3.",
+                version,
+            )
+            arch = "A2/A3"
+        _cached_arch = arch
+    except Exception as e:
+        logger.warning(
+            "Failed to detect device architecture: %s. Defaulting to A2/A3.",
+            e,
+        )
+        _cached_arch = "A2/A3"
+
+    return _cached_arch
+
+
+def is_a5_device() -> bool:
+    """Return ``True`` when the current device belongs to the A5 family."""
+    return get_device_arch() == "A5"

--- a/python/deep_ep/deep_ep/device_info.py
+++ b/python/deep_ep/deep_ep/device_info.py
@@ -7,27 +7,61 @@ without hard-coding version checks everywhere.
 """
 
 import logging
-from typing import Optional
+from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
 # SoC version code -> architecture family.
 # A5 family (Ascend910C / C310 / 950DT):  9301, 9201, 3510
-# A2/A3 family:                            2201, 1001, 2002, 3002
+# A2/A3:                                  2201
+# V100:                                    1001
+# V200:                                    2002
+# V300:                                    3002
 DEVICE_VERSION_TABLE = {
     9301: "A5",
     9201: "A5",
     3510: "A5",
     2201: "A2/A3",
-    1001: "A2/A3",
-    2002: "A2/A3",
-    3002: "A2/A3",
+    1001: "V100",
+    2002: "V200",
+    3002: "V300",
 }
 
 # All A5 version codes (convenience set)
 A5_VERSION_CODES = frozenset(
     v for v, arch in DEVICE_VERSION_TABLE.items() if arch == "A5"
 )
+
+# Quantization mode lookup table.
+# Key: (param_type, version_code) where param_type is one of
+#   "use_fp8", "use_mxfp4", "use_mxfp8" and version_code is from DEVICE_VERSION_TABLE.
+# Value: the resolved quant_mode string, or None if the combination is not supported.
+QUANT_MODE_TABLE = {
+    # --- use_fp8 ---
+    ("use_fp8", 9301): "pertoken_fp8_e4m3",
+    ("use_fp8", 9201): "pertoken_fp8_e4m3",
+    ("use_fp8", 3510): "pertoken_fp8_e4m3",
+    ("use_fp8", 2201): "int8",
+    ("use_fp8", 1001): "int8",
+    ("use_fp8", 2002): "int8",
+    ("use_fp8", 3002): "int8",
+    # --- use_mxfp4 (A5 only) ---
+    ("use_mxfp4", 9301): "mx_fp4_e2m1",
+    ("use_mxfp4", 9201): "mx_fp4_e2m1",
+    ("use_mxfp4", 3510): "mx_fp4_e2m1",
+    ("use_mxfp4", 2201): None,
+    ("use_mxfp4", 1001): None,
+    ("use_mxfp4", 2002): None,
+    ("use_mxfp4", 3002): None,
+    # --- use_mxfp8 (A5 only) ---
+    ("use_mxfp8", 9301): "mx_fp8_e4m3",
+    ("use_mxfp8", 9201): "mx_fp8_e4m3",
+    ("use_mxfp8", 3510): "mx_fp8_e4m3",
+    ("use_mxfp8", 2201): None,
+    ("use_mxfp8", 1001): None,
+    ("use_mxfp8", 2002): None,
+    ("use_mxfp8", 3002): None,
+}
 
 _cached_arch: Optional[str] = None
 
@@ -77,3 +111,17 @@ def get_device_arch() -> str:
 def is_a5_device() -> bool:
     """Return ``True`` when the current device belongs to the A5 family."""
     return get_device_arch() == "A5"
+
+
+def lookup_quant_mode(param_type: str, version_code: int) -> Optional[str]:
+    """Look up the quantization mode for a given (param_type, version_code) pair.
+
+    Arguments:
+        param_type: one of ``"use_fp8"``, ``"use_mxfp4"``, ``"use_mxfp8"``.
+        version_code: SoC version code from ``DEVICE_VERSION_TABLE``.
+
+    Returns:
+        The resolved quant_mode string, or ``None`` if the combination is
+        not supported on this hardware.
+    """
+    return QUANT_MODE_TABLE.get((param_type, version_code))

--- a/python/deep_ep/deep_ep/device_info.py
+++ b/python/deep_ep/deep_ep/device_info.py
@@ -25,7 +25,9 @@ DEVICE_VERSION_TABLE = {
 }
 
 # All A5 version codes (convenience set)
-A5_VERSION_CODES = frozenset(v for v, arch in DEVICE_VERSION_TABLE.items() if arch == "A5")
+A5_VERSION_CODES = frozenset(
+    v for v, arch in DEVICE_VERSION_TABLE.items() if arch == "A5"
+)
 
 _cached_arch: Optional[str] = None
 

--- a/python/deep_ep/deep_ep/device_info.py
+++ b/python/deep_ep/deep_ep/device_info.py
@@ -1,22 +1,7 @@
-"""Device architecture detection utilities for NPU.
+"""Device architecture detection utilities for NPU."""
 
-The first return value of ``acl.rt.get_device_info(0, 601)`` gives the SoC
-version code.  A lookup table maps each known code to an architecture family
-("A5" or "A2/A3") so that callers can select the correct quantization path
-without hard-coding version checks everywhere.
-"""
+from typing import Optional
 
-import logging
-from typing import Optional, Tuple
-
-logger = logging.getLogger(__name__)
-
-# SoC version code -> architecture family.
-# A5 family (Ascend910C / C310 / 950DT):  9301, 9201, 3510
-# A2/A3:                                  2201
-# V100:                                    1001
-# V200:                                    2002
-# V300:                                    3002
 DEVICE_VERSION_TABLE = {
     9301: "A5",
     9201: "A5",
@@ -27,17 +12,7 @@ DEVICE_VERSION_TABLE = {
     3002: "V300",
 }
 
-# All A5 version codes (convenience set)
-A5_VERSION_CODES = frozenset(
-    v for v, arch in DEVICE_VERSION_TABLE.items() if arch == "A5"
-)
-
-# Quantization mode lookup table.
-# Key: (param_type, version_code) where param_type is one of
-#   "use_fp8", "use_mxfp4", "use_mxfp8" and version_code is from DEVICE_VERSION_TABLE.
-# Value: the resolved quant_mode string, or None if the combination is not supported.
 QUANT_MODE_TABLE = {
-    # --- use_fp8 ---
     ("use_fp8", 9301): "pertoken_fp8_e4m3",
     ("use_fp8", 9201): "pertoken_fp8_e4m3",
     ("use_fp8", 3510): "pertoken_fp8_e4m3",
@@ -45,7 +20,6 @@ QUANT_MODE_TABLE = {
     ("use_fp8", 1001): "int8",
     ("use_fp8", 2002): "int8",
     ("use_fp8", 3002): "int8",
-    # --- use_mxfp4 (A5 only) ---
     ("use_mxfp4", 9301): "mx_fp4_e2m1",
     ("use_mxfp4", 9201): "mx_fp4_e2m1",
     ("use_mxfp4", 3510): "mx_fp4_e2m1",
@@ -53,7 +27,6 @@ QUANT_MODE_TABLE = {
     ("use_mxfp4", 1001): None,
     ("use_mxfp4", 2002): None,
     ("use_mxfp4", 3002): None,
-    # --- use_mxfp8 (A5 only) ---
     ("use_mxfp8", 9301): "mx_fp8_e4m3",
     ("use_mxfp8", 9201): "mx_fp8_e4m3",
     ("use_mxfp8", 3510): "mx_fp8_e4m3",
@@ -63,65 +36,9 @@ QUANT_MODE_TABLE = {
     ("use_mxfp8", 3002): None,
 }
 
-_cached_arch: Optional[str] = None
-
 
 def get_device_version() -> int:
-    """Return the SoC version code via the ACL runtime API.
-
-    ``acl.rt.get_device_info(device_id, 601)`` returns a tuple whose first
-    element is the version code.
-    """
+    """Return the SoC version code via the ACL runtime API."""
     import acl
 
     return acl.rt.get_device_info(0, 601)[0]
-
-
-def get_device_arch() -> str:
-    """Detect and cache the current device architecture family.
-
-    Returns ``"A5"`` for Ascend910C / C310 / 950DT devices, or
-    ``"A2/A3"`` for other Ascend devices.  On failure, defaults to
-    ``"A2/A3"`` so that callers fall back to the safer (int8) path.
-    """
-    global _cached_arch
-    if _cached_arch is not None:
-        return _cached_arch
-
-    try:
-        version = get_device_version()
-        arch = DEVICE_VERSION_TABLE.get(version)
-        if arch is None:
-            logger.warning(
-                "Unknown device version code %s, defaulting to A2/A3.",
-                version,
-            )
-            arch = "A2/A3"
-        _cached_arch = arch
-    except Exception as e:
-        logger.warning(
-            "Failed to detect device architecture: %s. Defaulting to A2/A3.",
-            e,
-        )
-        _cached_arch = "A2/A3"
-
-    return _cached_arch
-
-
-def is_a5_device() -> bool:
-    """Return ``True`` when the current device belongs to the A5 family."""
-    return get_device_arch() == "A5"
-
-
-def lookup_quant_mode(param_type: str, version_code: int) -> Optional[str]:
-    """Look up the quantization mode for a given (param_type, version_code) pair.
-
-    Arguments:
-        param_type: one of ``"use_fp8"``, ``"use_mxfp4"``, ``"use_mxfp8"``.
-        version_code: SoC version code from ``DEVICE_VERSION_TABLE``.
-
-    Returns:
-        The resolved quant_mode string, or ``None`` if the combination is
-        not supported on this hardware.
-    """
-    return QUANT_MODE_TABLE.get((param_type, version_code))

--- a/python/deep_ep/deep_ep/device_info.py
+++ b/python/deep_ep/deep_ep/device_info.py
@@ -7,9 +7,6 @@ DEVICE_VERSION_TABLE = {
     9201: "A5",
     3510: "A5",
     2201: "A2/A3",
-    1001: "V100",
-    2002: "V200",
-    3002: "V300",
 }
 
 QUANT_MODE_TABLE = {
@@ -17,23 +14,14 @@ QUANT_MODE_TABLE = {
     ("use_fp8", 9201): "pertoken_fp8_e4m3",
     ("use_fp8", 3510): "pertoken_fp8_e4m3",
     ("use_fp8", 2201): "int8",
-    ("use_fp8", 1001): "int8",
-    ("use_fp8", 2002): "int8",
-    ("use_fp8", 3002): "int8",
     ("use_mxfp4", 9301): "mx_fp4_e2m1",
     ("use_mxfp4", 9201): "mx_fp4_e2m1",
     ("use_mxfp4", 3510): "mx_fp4_e2m1",
     ("use_mxfp4", 2201): None,
-    ("use_mxfp4", 1001): None,
-    ("use_mxfp4", 2002): None,
-    ("use_mxfp4", 3002): None,
     ("use_mxfp8", 9301): "mx_fp8_e4m3",
     ("use_mxfp8", 9201): "mx_fp8_e4m3",
     ("use_mxfp8", 3510): "mx_fp8_e4m3",
     ("use_mxfp8", 2201): None,
-    ("use_mxfp8", 1001): None,
-    ("use_mxfp8", 2002): None,
-    ("use_mxfp8", 3002): None,
 }
 
 

--- a/python/deep_ep/deep_ep/strategies/normal_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/normal_strategy.py
@@ -3,7 +3,6 @@ Normal mode EP communication strategies.
 All normal mode strategy implementations are in this file.
 """
 
-import os
 from typing import Callable, List, Optional, Tuple, Union
 
 import torch
@@ -115,6 +114,7 @@ class DefaultNormalCommStrategy(NormalEPCommStrategy):
                 previous_event,
                 async_finish,
                 allocate_on_comm_stream,
+                quant_mode,
             )
 
         return self._intranode_dispatch(
@@ -160,50 +160,22 @@ class DefaultNormalCommStrategy(NormalEPCommStrategy):
         Tuple,
         EventOverlap,
     ]:
-        # Determine quant type from quant_mode
-        if quant_mode is None:
-            if isinstance(x, torch.Tensor):
-                # BF16 no quant
-                data = x
-                x_scales = None
-                quant_type = "bf16"
-                use_quant = False
-            elif isinstance(x, tuple) and len(x) == 2:
-                data, quant_type_tensor = x
-                if quant_type_tensor.dtype == torch.float8_e4m3fn:
-                    quant_type = "mx_fp8_e4m3"
-                    use_quant = True
-                elif quant_type_tensor.dtype == torch.float8_e5m2:
-                    quant_type = "mx_fp8_e5m2"
-                    use_quant = True
-                elif quant_type_tensor.dtype == torch.int8:
-                    quant_type = "int8"
-                    use_quant = True
-                elif quant_type_tensor.dtype == torch.float4_e2m1fn_x2:
-                    quant_type = "mx_fp4_e2m1"
-                    use_quant = True
-                else:
-                    raise TypeError(
-                        f"Unsupported quantized dtype: {quant_type_tensor.dtype}"
-                    )
-                x_scales = None
-            else:
-                raise TypeError(f"Unsupported x type: {type(x)}")
-
-            if not use_quant:
-                use_quant = os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT") == "1"
-                if use_quant:
-                    quant_type = "int8"
+        # Resolve quant parameters from the (already-resolved) quant_mode.
+        # The Buffer layer resolves quant_mode from bool flags + device architecture,
+        # so we no longer inspect x[1].dtype for quantization type detection.
+        data = x[0] if isinstance(x, tuple) else x
+        x_scales = None
+        if quant_mode is None or quant_mode == "bf16":
+            quant_type = "bf16"
+            use_quant = False
         else:
-            # New API: explicit quant_mode
             if quant_mode not in VALID_QUANT_MODES:
                 raise ValueError(
-                    f"Invalid quant_mode: {quant_mode}. Valid options: {VALID_QUANT_MODES}"
+                    f"Invalid quant_mode: {quant_mode}. "
+                    f"Valid options: {VALID_QUANT_MODES}"
                 )
-            data = x
-            x_scales = None
             quant_type = quant_mode
-            use_quant = quant_mode != "bf16"
+            use_quant = True
 
         if handle is not None:
             raise NotImplementedError(
@@ -285,6 +257,7 @@ class DefaultNormalCommStrategy(NormalEPCommStrategy):
         previous_event: Optional[EventOverlap],
         async_finish: bool,
         allocate_on_comm_stream: bool,
+        quant_mode: Optional[str] = None,
     ) -> Tuple[
         Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor],
         Optional[torch.Tensor],
@@ -294,7 +267,14 @@ class DefaultNormalCommStrategy(NormalEPCommStrategy):
         EventOverlap,
     ]:
         x, x_scales = x if isinstance(x, tuple) else (x, None)
-        use_quant = os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT") == "1"
+
+        # Internode dispatch only supports BF16 and INT8 quantization.
+        if quant_mode is not None and quant_mode not in ("bf16", "int8"):
+            raise NotImplementedError(
+                f"quant_mode '{quant_mode}' is not supported by internode dispatch; "
+                f"only 'bf16' and 'int8' are supported."
+            )
+        use_quant = quant_mode == "int8"
 
         if handle is not None:
             raise NotImplementedError(
@@ -610,14 +590,13 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
         num_experts = layout["num_experts"]
         topk_idx_int = topk_idx.to(torch.int32)
 
-        # Determine quant type from quant_mode
-        VALID_QUANT_MODES = {
-            "bf16",
-            "int8",
-        }
+        # quant_mode is resolved by the Buffer layer (from bool flags + device
+        # architecture, or explicit value).  The alltoall strategy only supports
+        # BF16 and INT8; FP8/FP4 modes require the default strategy.
+        ALLTOALL_QUANT_MODES = {"bf16", "int8"}
         if quant_mode is None:
             quant_mode = "bf16"
-        if quant_mode not in VALID_QUANT_MODES:
+        if quant_mode not in ALLTOALL_QUANT_MODES:
             raise NotImplementedError(
                 f"quant_mode '{quant_mode}' is not supported by the alltoall strategy. "
                 f"Only 'bf16' and 'int8' are supported; use the default strategy for "
@@ -626,9 +605,6 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
         hidden_shape = x.shape
 
         use_quant = 1 if quant_mode == "int8" else -1
-        is_quant_env = os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT")
-        if is_quant_env is not None and quant_mode is None:
-            use_quant = 1 if is_quant_env == "1" else -1
 
         (permutated_tokens, reversed_local_mapping, _, dynamic_scale) = (
             torch_npu.npu_moe_init_routing_v2(

--- a/python/deep_ep/deep_ep/strategies/normal_strategy.py
+++ b/python/deep_ep/deep_ep/strategies/normal_strategy.py
@@ -447,6 +447,8 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
     Internode and intranode use the same implementation.
     """
 
+    _SUPPORTED_QUANT_MODES = frozenset({"bf16", "int8"})
+
     def __init__(self, runtime, group: dist.ProcessGroup):
         super().__init__(group)
         self.runtime = runtime
@@ -590,13 +592,9 @@ class AlltoAllNormalCommStrategy(NormalEPCommStrategy):
         num_experts = layout["num_experts"]
         topk_idx_int = topk_idx.to(torch.int32)
 
-        # quant_mode is resolved by the Buffer layer (from bool flags + device
-        # architecture, or explicit value).  The alltoall strategy only supports
-        # BF16 and INT8; FP8/FP4 modes require the default strategy.
-        ALLTOALL_QUANT_MODES = {"bf16", "int8"}
         if quant_mode is None:
             quant_mode = "bf16"
-        if quant_mode not in ALLTOALL_QUANT_MODES:
+        if quant_mode not in self._SUPPORTED_QUANT_MODES:
             raise NotImplementedError(
                 f"quant_mode '{quant_mode}' is not supported by the alltoall strategy. "
                 f"Only 'bf16' and 'int8' are supported; use the default strategy for "

--- a/python/deep_ep/deep_ep/utils.py
+++ b/python/deep_ep/deep_ep/utils.py
@@ -8,7 +8,7 @@ import torch
 import torch_npu
 from deep_ep_cpp import Config, EventHandle
 
-from .device_info import DEVICE_VERSION_TABLE, get_device_version
+from .device_info import DEVICE_VERSION_TABLE, QUANT_MODE_TABLE, get_device_version
 
 
 class EventOverlap:
@@ -119,7 +119,6 @@ def resolve_normal_quant_mode(
     use_fp8: bool,
     use_mxfp4: bool,
     use_mxfp8: bool,
-    device_arch: str,
 ) -> Optional[str]:
     """Resolve the effective ``quant_mode`` for normal dispatch.
 
@@ -132,8 +131,6 @@ def resolve_normal_quant_mode(
     2. ``DEEP_NORMAL_MODE_USE_INT8_QUANT=1`` env var (deprecated fallback).
     3. ``None`` (BF16, no quantization).
     """
-    from .device_info import QUANT_MODE_TABLE
-
     try:
         version_code = get_device_version()
     except Exception:

--- a/python/deep_ep/deep_ep/utils.py
+++ b/python/deep_ep/deep_ep/utils.py
@@ -115,7 +115,7 @@ def log_parameters(input_name_full_tensor=None, output_idx_full_tensor=None):
     return log_parameters_decorator
 
 
-def resolve_normal_quant_mode(
+def _resolve_normal_quant_mode(
     use_fp8: bool,
     use_mxfp4: bool,
     use_mxfp8: bool,

--- a/python/deep_ep/deep_ep/utils.py
+++ b/python/deep_ep/deep_ep/utils.py
@@ -8,7 +8,7 @@ import torch
 import torch_npu
 from deep_ep_cpp import Config, EventHandle
 
-from .ep_strategy import VALID_QUANT_MODES
+from .device_info import DEVICE_VERSION_TABLE, get_device_version
 
 
 class EventOverlap:
@@ -116,7 +116,6 @@ def log_parameters(input_name_full_tensor=None, output_idx_full_tensor=None):
 
 
 def resolve_normal_quant_mode(
-    quant_mode: Optional[str],
     use_fp8: bool,
     use_mxfp4: bool,
     use_mxfp8: bool,
@@ -124,46 +123,36 @@ def resolve_normal_quant_mode(
 ) -> Optional[str]:
     """Resolve the effective ``quant_mode`` for normal dispatch.
 
+    Looks up ``QUANT_MODE_TABLE[(param_type, version_code)]`` for the first
+    active bool flag.  ``None`` in the table means the combination is not
+    supported on that hardware.
+
     Priority:
-    1. Explicit ``quant_mode`` (when not ``None``) — used directly.
-    2. ``use_mxfp4`` / ``use_mxfp8`` / ``use_fp8`` bool flags combined
-       with the detected device architecture:
-       - ``use_mxfp4``  → A5: ``mx_fp4_e2m1``;  A2/A3: not supported.
-       - ``use_mxfp8``  → A5: ``mx_fp8_e4m3``;  A2/A3: not supported.
-       - ``use_fp8``    → A5: ``pertoken_fp8_e4m3``;  A2/A3: ``int8``.
-    3. ``DEEP_NORMAL_MODE_USE_INT8_QUANT=1`` env var (deprecated fallback).
-    4. ``None`` (BF16, no quantization).
+    1. ``use_mxfp4`` / ``use_mxfp8`` / ``use_fp8`` bool flags (table lookup).
+    2. ``DEEP_NORMAL_MODE_USE_INT8_QUANT=1`` env var (deprecated fallback).
+    3. ``None`` (BF16, no quantization).
     """
-    if quant_mode is not None:
-        if quant_mode not in VALID_QUANT_MODES:
-            raise ValueError(
-                f"Invalid quant_mode: {quant_mode}. "
-                f"Valid options: {VALID_QUANT_MODES}"
-            )
-        return quant_mode
+    from .device_info import QUANT_MODE_TABLE
 
-    is_a5 = device_arch == "A5"
+    try:
+        version_code = get_device_version()
+    except Exception:
+        version_code = None
 
-    if use_mxfp4:
-        if is_a5:
-            return "mx_fp4_e2m1"
+    for param_type, flag in (
+        ("use_mxfp4", use_mxfp4),
+        ("use_mxfp8", use_mxfp8),
+        ("use_fp8", use_fp8),
+    ):
+        if not flag:
+            continue
+        quant_mode = QUANT_MODE_TABLE.get((param_type, version_code))
+        if quant_mode is not None:
+            return quant_mode
         raise NotImplementedError(
-            "use_mxfp4 is not supported on A2/A3 devices; "
-            "only A5 supports MXFP4 quantization."
+            f"{param_type} is not supported on device version {version_code} "
+            f"({DEVICE_VERSION_TABLE.get(version_code, 'unknown')})."
         )
-
-    if use_mxfp8:
-        if is_a5:
-            return "mx_fp8_e4m3"
-        raise NotImplementedError(
-            "use_mxfp8 is not supported on A2/A3 devices; "
-            "only A5 supports MXFP8 quantization."
-        )
-
-    if use_fp8:
-        if is_a5:
-            return "pertoken_fp8_e4m3"
-        return "int8"
 
     # Deprecated env-var fallback for backward compatibility
     if os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT") == "1":

--- a/python/deep_ep/deep_ep/utils.py
+++ b/python/deep_ep/deep_ep/utils.py
@@ -8,6 +8,8 @@ import torch
 import torch_npu
 from deep_ep_cpp import Config, EventHandle
 
+from .ep_strategy import VALID_QUANT_MODES
+
 
 class EventOverlap:
 
@@ -111,3 +113,60 @@ def log_parameters(input_name_full_tensor=None, output_idx_full_tensor=None):
         return wrapper
 
     return log_parameters_decorator
+
+
+def resolve_normal_quant_mode(
+    quant_mode: Optional[str],
+    use_fp8: bool,
+    use_mxfp4: bool,
+    use_mxfp8: bool,
+    device_arch: str,
+) -> Optional[str]:
+    """Resolve the effective ``quant_mode`` for normal dispatch.
+
+    Priority:
+    1. Explicit ``quant_mode`` (when not ``None``) — used directly.
+    2. ``use_mxfp4`` / ``use_mxfp8`` / ``use_fp8`` bool flags combined
+       with the detected device architecture:
+       - ``use_mxfp4``  → A5: ``mx_fp4_e2m1``;  A2/A3: not supported.
+       - ``use_mxfp8``  → A5: ``mx_fp8_e4m3``;  A2/A3: not supported.
+       - ``use_fp8``    → A5: ``pertoken_fp8_e4m3``;  A2/A3: ``int8``.
+    3. ``DEEP_NORMAL_MODE_USE_INT8_QUANT=1`` env var (deprecated fallback).
+    4. ``None`` (BF16, no quantization).
+    """
+    if quant_mode is not None:
+        if quant_mode not in VALID_QUANT_MODES:
+            raise ValueError(
+                f"Invalid quant_mode: {quant_mode}. "
+                f"Valid options: {VALID_QUANT_MODES}"
+            )
+        return quant_mode
+
+    is_a5 = device_arch == "A5"
+
+    if use_mxfp4:
+        if is_a5:
+            return "mx_fp4_e2m1"
+        raise NotImplementedError(
+            "use_mxfp4 is not supported on A2/A3 devices; "
+            "only A5 supports MXFP4 quantization."
+        )
+
+    if use_mxfp8:
+        if is_a5:
+            return "mx_fp8_e4m3"
+        raise NotImplementedError(
+            "use_mxfp8 is not supported on A2/A3 devices; "
+            "only A5 supports MXFP8 quantization."
+        )
+
+    if use_fp8:
+        if is_a5:
+            return "pertoken_fp8_e4m3"
+        return "int8"
+
+    # Deprecated env-var fallback for backward compatibility
+    if os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT") == "1":
+        return "int8"
+
+    return None

--- a/python/deep_ep/doc/NORMAL_API.md
+++ b/python/deep_ep/doc/NORMAL_API.md
@@ -75,7 +75,7 @@ dispatch(
 | **allocate_on_comm_stream** | `bool` | No | `False` | Currently unused. |
 | **dispatch_wait_recv_cost_stats** | `torch.Tensor` (`int64`) | No | `None` | Shape `[num_ranks]`, recording the time cost for the current rank to receive all tokens from each rank (statistics). |
 | **quant_mode** | `Optional[str]` | No | `None` | Explicit quantization mode (highest priority). Supported: `None` (BF16), `"int8"`, `"pertoken_fp8_e4m3"` (A5), `"mx_fp8_e4m3"` (A5), `"mx_fp4_e2m1"` (A5). When set, the bool flags below are ignored. |
-| **use_fp8** | `bool` | No | `False` | Enable FP8-family quantization. On A5 → `pertoken_fp8_e4m3`; on A2/A3 → `int8` (with warning). |
+| **use_fp8** | `bool` | No | `False` | Enable FP8-family quantization. On A5 → `pertoken_fp8_e4m3`; on A2/A3 → `int8`. |
 | **use_mxfp4** | `bool` | No | `False` | Enable MXFP4 per-block quantization → `mx_fp4_e2m1` (A5 only). Raises `NotImplementedError` on A2/A3. |
 | **use_mxfp8** | `bool` | No | `False` | Enable MXFP8 per-block quantization → `mx_fp8_e4m3` (A5 only). Raises `NotImplementedError` on A2/A3. |
 
@@ -124,7 +124,7 @@ The quantization mode for `dispatch` is resolved in `Buffer._resolve_normal_quan
 2. **`use_mxfp4` / `use_mxfp8` / `use_fp8` bool flags** — consulted only when `quant_mode=None`. The device architecture is auto-detected at `Buffer` initialization time via `acl.rt.get_device_info(0, 601)`:
    - `use_mxfp4=True` → A5: `"mx_fp4_e2m1"`; A2/A3: `NotImplementedError`.
    - `use_mxfp8=True` → A5: `"mx_fp8_e4m3"`; A2/A3: `NotImplementedError`.
-   - `use_fp8=True` → A5: `"pertoken_fp8_e4m3"`; A2/A3: `"int8"` (with warning log).
+   - `use_fp8=True` → A5: `"pertoken_fp8_e4m3"`; A2/A3: `"int8"`.
 3. **`DEEP_NORMAL_MODE_USE_INT8_QUANT=1`** environment variable — deprecated fallback, consulted only when `quant_mode=None` and no bool flags are set.
 4. **BF16** (default) — when none of the above are set.
 
@@ -268,7 +268,7 @@ dispatch(
 | **allocate_on_comm_stream** | `bool` | ❌ | `False` | 当前未使用。 |
 | **dispatch_wait_recv_cost_stats** | `torch.Tensor` (`int64`) | ❌ | `None` | Shape为 `[num_ranks]`，记录当前 rank 从每个 rank 收到全部 token 所耗时间（统计信息）。 |
 | **quant_mode** | `Optional[str]` | ❌ | `None` | 显式量化模式（最高优先级）。支持：`None`（BF16）、`"int8"`、`"pertoken_fp8_e4m3"`（A5）、`"mx_fp8_e4m3"`（A5）、`"mx_fp4_e2m1"`（A5）。设置后忽略下方布尔标志。 |
-| **use_fp8** | `bool` | ❌ | `False` | 启用 FP8 系列量化。A5 → `pertoken_fp8_e4m3`；A2/A3 → `int8`（带 warning）。 |
+| **use_fp8** | `bool` | ❌ | `False` | 启用 FP8 系列量化。A5 → `pertoken_fp8_e4m3`；A2/A3 → `int8`。 |
 | **use_mxfp4** | `bool` | ❌ | `False` | 启用 MXFP4 per-block 量化 → `mx_fp4_e2m1`（仅 A5）。A2/A3 上抛 `NotImplementedError`。 |
 | **use_mxfp8** | `bool` | ❌ | `False` | 启用 MXFP8 per-block 量化 → `mx_fp8_e4m3`（仅 A5）。A2/A3 上抛 `NotImplementedError`。 |
 
@@ -317,7 +317,7 @@ dispatch(
 2. **`use_mxfp4` / `use_mxfp8` / `use_fp8` 布尔标志** —— 仅当 `quant_mode=None` 时生效。设备架构在 `Buffer` 初始化时通过 `acl.rt.get_device_info(0, 601)` 自动检测：
    - `use_mxfp4=True` → A5：`"mx_fp4_e2m1"`；A2/A3：抛 `NotImplementedError`。
    - `use_mxfp8=True` → A5：`"mx_fp8_e4m3"`；A2/A3：抛 `NotImplementedError`。
-   - `use_fp8=True` → A5：`"pertoken_fp8_e4m3"`；A2/A3：`"int8"`（带 warning 日志）。
+   - `use_fp8=True` → A5：`"pertoken_fp8_e4m3"`；A2/A3：`"int8"`。
 3. **`DEEP_NORMAL_MODE_USE_INT8_QUANT=1`** 环境变量 —— 已弃用回退，仅当 `quant_mode=None` 且无布尔标志时生效。
 4. **BF16**（默认）—— 以上均未设置时。
 

--- a/python/deep_ep/doc/NORMAL_API.md
+++ b/python/deep_ep/doc/NORMAL_API.md
@@ -41,6 +41,10 @@ dispatch(
     async_finish: bool = False,
     allocate_on_comm_stream: bool = False,
     dispatch_wait_recv_cost_stats: Optional[torch.Tensor] = None,
+    quant_mode: Optional[str] = None,
+    use_fp8: bool = False,
+    use_mxfp4: bool = False,
+    use_mxfp8: bool = False,
 ) -> Tuple[
     Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor],
     Optional[torch.Tensor],
@@ -55,7 +59,7 @@ dispatch(
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| **x** | `torch.Tensor` or `(torch.Tensor, torch.Tensor)` | Yes | – | Shape `[num_tokens, hidden]`, dtype=`torch.bfloat16` for BF16 mode. For MXFP8/MXFP4 per-block quantization (A5 only), pass a tuple `(data_tensor, scale_tensor)`: see [Quantization Constraints](#constraints) for supported dtypes/shapes. |
+| **x** | `torch.Tensor` (`bfloat16`) | Yes | – | Shape `[num_tokens, hidden]`. The dtype of `x` is **no longer used** for quantization-mode detection; use `quant_mode` or the `use_fp8` / `use_mxfp4` / `use_mxfp8` bool flags instead. |
 | **handle** | `Optional[Tuple]` | No | `None` | Pre-created communication handle (currently only supports `None`). |
 | **num_tokens_per_rank** | `torch.Tensor` (`int32`) | Yes (intranode) | `None` | Shape `[num_ranks]`, number of tokens each rank will receive. |
 | **num_tokens_per_rdma_rank** | `torch.Tensor` | Yes (internode) | `None` | Shape `[num_rdma_ranks]`, number of tokens each remote rank receives in cross-node (RDMA) mode. |
@@ -70,6 +74,10 @@ dispatch(
 | **async_finish** | `bool` | No | `False` | If `True`, the current stream will not block until communication completes; the returned `event` can be used for subsequent synchronization. |
 | **allocate_on_comm_stream** | `bool` | No | `False` | Currently unused. |
 | **dispatch_wait_recv_cost_stats** | `torch.Tensor` (`int64`) | No | `None` | Shape `[num_ranks]`, recording the time cost for the current rank to receive all tokens from each rank (statistics). |
+| **quant_mode** | `Optional[str]` | No | `None` | Explicit quantization mode (highest priority). Supported: `None` (BF16), `"int8"`, `"pertoken_fp8_e4m3"` (A5), `"mx_fp8_e4m3"` (A5), `"mx_fp4_e2m1"` (A5). When set, the bool flags below are ignored. |
+| **use_fp8** | `bool` | No | `False` | Enable FP8-family quantization. On A5 → `pertoken_fp8_e4m3`; on A2/A3 → `int8` (with warning). |
+| **use_mxfp4** | `bool` | No | `False` | Enable MXFP4 per-block quantization → `mx_fp4_e2m1` (A5 only). Raises `NotImplementedError` on A2/A3. |
+| **use_mxfp8** | `bool` | No | `False` | Enable MXFP8 per-block quantization → `mx_fp8_e4m3` (A5 only). Raises `NotImplementedError` on A2/A3. |
 
 > **Internal Logic**
 >
@@ -80,7 +88,7 @@ dispatch(
 
 | Return Value | Type | Description |
 |--------------|------|-------------|
-| **recv_x** | `torch.Tensor` or `(torch.Tensor, torch.Tensor)` | Received tokens. Format depends on quantization mode:<br>- **BF16** (default): single `bfloat16` tensor `[recv_token_cnt, hidden]`.<br>- **INT8** (`DEEP_NORMAL_MODE_USE_INT8_QUANT=1`, deprecated): tuple `(int8_tensor, float32_scales)`. Data `[recv_token_cnt, hidden]` (`torch.int8`), scales `[recv_token_cnt]` (`torch.float32`).<br>- **MXFP8 per-block** (A5, tuple input): tuple `(float8_e4m3fn_or_e5m2_data, float8_e8m0fnu_scales)`. Data `[recv_token_cnt, hidden]`, scales `[recv_token_cnt * hidden / 32]` (one scale per 32-element block).<br>- **MXFP4 per-block** (A5, tuple input): tuple `(float4_e2m1fn_x2_data, float8_e8m0fnu_scales)`. Data `[recv_token_cnt, hidden / 2]`, scales `[recv_token_cnt * hidden / 32]`. |
+| **recv_x** | `torch.Tensor` or `(torch.Tensor, torch.Tensor)` | Received tokens. Format depends on quantization mode:<br>- **BF16** (default): single `bfloat16` tensor `[recv_token_cnt, hidden]`.<br>- **INT8** (`quant_mode="int8"`): tuple `(int8_tensor, float32_scales)`. Data `[recv_token_cnt, hidden]` (`torch.int8`), scales `[recv_token_cnt]` (`torch.float32`).<br>- **PerToken FP8** (A5, `quant_mode="pertoken_fp8_e4m3"`): tuple `(float8_e4m3fn_data, float32_scales)`. Data `[recv_token_cnt, hidden]`, scales `[recv_token_cnt]`.<br>- **MXFP8 per-block** (A5, `quant_mode="mx_fp8_e4m3"`): tuple `(float8_e4m3fn_data, float8_e8m0fnu_scales)`. Data `[recv_token_cnt, hidden]`, scales `[recv_token_cnt * hidden / 32]` (one scale per 32-element block).<br>- **MXFP4 per-block** (A5, `quant_mode="mx_fp4_e2m1"`): tuple `(float4_e2m1fn_x2_data, float8_e8m0fnu_scales)`. Data `[recv_token_cnt, hidden / 2]`, scales `[recv_token_cnt * hidden / 32]`. |
 | **recv_topk_idx** | `Optional[torch.Tensor]` (`int64`) | Received top‑k expert indices, shape `[recv_token_cnt, num_topk]`. `None` if top‑k is not used. |
 | **recv_topk_weights** | `Optional[torch.Tensor]` (`float`) | Corresponding top‑k weights, same shape as above. |
 | **num_recv_tokens_per_expert_list** | `List[int]` | Number of tokens actually received per **local expert** (aligned). Empty list if `num_worst_tokens>0` (no synchronization). |
@@ -103,27 +111,33 @@ dispatch(
 - HCCL_BUFFSIZE: Check the HCCL_BUFFSIZE environment variable before calling the API. It represents the memory size (MB) occupied by a single communication domain, default 200MB. Minimum required size (non-layered): `(bs × ep_world_size × min(num_local_experts, topk) × hidden × 2B + 2MB) × 2`. For layered (A2 dual-node): `num_experts × bs × (hidden × 2B + 4 × topk × 4B) + 4MB + 800MB`. A5 subtracts 1MB state zone from the configured value.
 - HCCL_INTRA_PCIE_ENABLE and HCCL_INTRA_ROCE_ENABLE:
     - A2 series internode scenario: set `HCCL_INTRA_PCIE_ENABLE=1` and `HCCL_INTRA_ROCE_ENABLE=0`;
-- Quantization: Setting `DEEP_NORMAL_MODE_USE_INT8_QUANT=1` quantizes `x` to INT8 and returns `(tensor, scales)`.
-- MXFP8 / MXFP4 quantization (A5 only, **intranode only**): Triggered by passing `x` as a tuple `(data_tensor, scale_tensor)` on the intranode dispatch path. The internode path does NOT support tuple input / MXFP8 / MXFP4.
-    - MXFP8 per-block: `data_tensor` dtype `float8_e4m3fn` or `float8_e5m2`, `scale_tensor` dtype `float8_e8m0fnu`, shape `[num_tokens, hidden / 32]`.
-    - MXFP4 per-block: `data_tensor` dtype `float4_e2m1fn_x2`, shape `[num_tokens, hidden / 2]`; `scale_tensor` dtype `float8_e8m0fnu`, shape `[num_tokens, hidden / 32]`.
+- Quantization: Use the `quant_mode` parameter or `use_fp8` / `use_mxfp4` / `use_mxfp8` bool flags. The `DEEP_NORMAL_MODE_USE_INT8_QUANT=1` env var is deprecated but still works as a fallback. The dtype of `x` is no longer inspected for quantization mode selection.
+- MXFP8 / MXFP4 / PerToken-FP8 quantization (A5 only, **intranode only**): Triggered via `use_mxfp8=True`, `use_mxfp4=True`, or `use_fp8=True` (or `quant_mode="mx_fp8_e4m3"` / `"mx_fp4_e2m1"` / `"pertoken_fp8_e4m3"`). The internode and alltoall paths do NOT support these modes.
 
 <a id="quantization-selection-priority"></a>
 
 ### Quantization Selection Priority
 
-The quantization mode for `dispatch` is determined with the following priority (intranode path):
+The quantization mode for `dispatch` is resolved in `Buffer._resolve_normal_quant_mode()` with the following priority:
 
-1. **`quant_mode` parameter** (explicit) — highest priority. When passed (not `None`), it is the single source of truth; the env var below is **not** consulted.
-2. **`DEEP_NORMAL_MODE_USE_INT8_QUANT=1`** environment variable — consulted **only** when `quant_mode=None` (omitted). Enables INT8 as a backward-compatible fallback.
-3. **BF16** (default) — when neither is set.
+1. **`quant_mode` parameter** (explicit) — highest priority. When passed (not `None`), it is the single source of truth; the bool flags and env var below are **not** consulted.
+2. **`use_mxfp4` / `use_mxfp8` / `use_fp8` bool flags** — consulted only when `quant_mode=None`. The device architecture is auto-detected at `Buffer` initialization time via `acl.rt.get_device_info(0, 601)`:
+   - `use_mxfp4=True` → A5: `"mx_fp4_e2m1"`; A2/A3: `NotImplementedError`.
+   - `use_mxfp8=True` → A5: `"mx_fp8_e4m3"`; A2/A3: `NotImplementedError`.
+   - `use_fp8=True` → A5: `"pertoken_fp8_e4m3"`; A2/A3: `"int8"` (with warning log).
+3. **`DEEP_NORMAL_MODE_USE_INT8_QUANT=1`** environment variable — deprecated fallback, consulted only when `quant_mode=None` and no bool flags are set.
+4. **BF16** (default) — when none of the above are set.
 
 > **Per-path differences:**
-> - **intranode**: `quant_mode` > env var > BF16 (the priority order above).
-> - **internode**: `quant_mode` is currently **not forwarded** to the underlying dispatch (a known gap from the strategy refactor). The env var and tuple-`x` dtype detection are always used. Setting `quant_mode` on the internode path has no effect.
-> - **alltoall** (`DEEP_USE_MODE=alltoall`): `dispatch()` does **not** accept `quant_mode` at all; INT8 is controlled solely by the env var.
+> - **intranode** (default strategy): full priority order above. FP8/FP4 modes supported on A5.
+> - **internode** (default strategy): only `"bf16"` and `"int8"` are supported. Other quant_mode values raise `NotImplementedError`.
+> - **alltoall** strategy (`DEEP_USE_MODE=alltoall`): only `"bf16"` and `"int8"` are supported. FP8/FP4 modes require the default strategy.
 >
-> **Platform support:** INT8 (`DYNAMIC_SCALES`) is supported on **all** platforms (A2/A3/A5). FP8/FP4 modes (`mx_fp8_*`, `pertoken_fp8_e4m3`, `mx_fp4_e2m1`) are **A5-only**.
+> **Platform support:** INT8 is supported on **all** platforms (A2/A3/A5). FP8/FP4 modes (`pertoken_fp8_e4m3`, `mx_fp8_e4m3`, `mx_fp4_e2m1`) are **A5-only**.
+>
+> **Device version codes** (first return value of `acl.rt.get_device_info(0, 601)`):
+> - A5: `9301`, `9201`, `3510`
+> - A2/A3: `2201`, `1001`, `2002`, `3002`
 
 ---
 
@@ -220,6 +234,10 @@ dispatch(
     async_finish: bool = False,
     allocate_on_comm_stream: bool = False,
     dispatch_wait_recv_cost_stats: Optional[torch.Tensor] = None,
+    quant_mode: Optional[str] = None,
+    use_fp8: bool = False,
+    use_mxfp4: bool = False,
+    use_mxfp8: bool = False,
 ) -> Tuple[
     Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor],
     Optional[torch.Tensor],
@@ -234,7 +252,7 @@ dispatch(
 
 | 参数 | 类型 | 必要 | 默认 | 说明 |
 |------|------|------|------|------|
-| **x** | `torch.Tensor` 或 `(torch.Tensor, torch.Tensor)` | ✅ | – | Shape为 `[num_tokens, hidden]`，BF16 模式下 dtype=`torch.bfloat16`。MXFP8/MXFP4 per-block 量化（仅 A5）需传入 tuple `(data_tensor, scale_tensor)`，支持的 dtype/shape 见 [量化约束](#约束说明)。|
+| **x** | `torch.Tensor` (`bfloat16`) | ✅ | – | Shape为 `[num_tokens, hidden]`。`x` 的 dtype **不再用于**量化模式检测，请使用 `quant_mode` 或 `use_fp8` / `use_mxfp4` / `use_mxfp8` 布尔标志。|
 | **handle** | `Optional[Tuple]` | ❌ | `None` | 预先创建的通信句柄（目前仅支持 `None`）。|
 | **num_tokens_per_rank** | `torch.Tensor` (`int32`) | ✅（intranode） | `None` | Shape为 `[num_ranks]`，每个 rank 将接收的 token 数。 |
 | **num_tokens_per_rdma_rank** | `torch.Tensor` | ✅（internode） | `None` | Shape为 `[num_rdma_ranks]`，跨节点（RDMA）时每个 remote rank 接收的 token 数。 |
@@ -249,6 +267,10 @@ dispatch(
 | **async_finish** | `bool` | ❌ | `False` | 若 `True`，当前 stream 不会阻塞等待通信完成，返回的 `event` 可用于后续同步。 |
 | **allocate_on_comm_stream** | `bool` | ❌ | `False` | 当前未使用。 |
 | **dispatch_wait_recv_cost_stats** | `torch.Tensor` (`int64`) | ❌ | `None` | Shape为 `[num_ranks]`，记录当前 rank 从每个 rank 收到全部 token 所耗时间（统计信息）。 |
+| **quant_mode** | `Optional[str]` | ❌ | `None` | 显式量化模式（最高优先级）。支持：`None`（BF16）、`"int8"`、`"pertoken_fp8_e4m3"`（A5）、`"mx_fp8_e4m3"`（A5）、`"mx_fp4_e2m1"`（A5）。设置后忽略下方布尔标志。 |
+| **use_fp8** | `bool` | ❌ | `False` | 启用 FP8 系列量化。A5 → `pertoken_fp8_e4m3`；A2/A3 → `int8`（带 warning）。 |
+| **use_mxfp4** | `bool` | ❌ | `False` | 启用 MXFP4 per-block 量化 → `mx_fp4_e2m1`（仅 A5）。A2/A3 上抛 `NotImplementedError`。 |
+| **use_mxfp8** | `bool` | ❌ | `False` | 启用 MXFP8 per-block 量化 → `mx_fp8_e4m3`（仅 A5）。A2/A3 上抛 `NotImplementedError`。 |
 
 > **内部逻辑**
 >
@@ -259,7 +281,7 @@ dispatch(
 
 | 返回值 | 类型 | 说明 |
 |--------|------|------|
-| **recv_x** | `torch.Tensor` 或 `(torch.Tensor, torch.Tensor)` | 接收到的 token。格式取决于量化模式：<br>- **BF16**（默认）：单个 `bfloat16` tensor `[recv_token_cnt, hidden]`。<br>- **INT8**（`DEEP_NORMAL_MODE_USE_INT8_QUANT=1`，已弃用）：tuple `(int8_tensor, float32_scales)`。数据 `[recv_token_cnt, hidden]`（`torch.int8`），scales `[recv_token_cnt]`（`torch.float32`）。<br>- **MXFP8 per-block**（A5，tuple 输入）：tuple `(float8_e4m3fn_或_e5m2_数据, float8_e8m0fnu_scales)`。数据 `[recv_token_cnt, hidden]`，scales `[recv_token_cnt * hidden / 32]`（每 32 个元素一个 scale）。<br>- **MXFP4 per-block**（A5，tuple 输入）：tuple `(float4_e2m1fn_x2_数据, float8_e8m0fnu_scales)`。数据 `[recv_token_cnt, hidden / 2]`，scales `[recv_token_cnt * hidden / 32]`。 |
+| **recv_x** | `torch.Tensor` 或 `(torch.Tensor, torch.Tensor)` | 接收到的 token。格式取决于量化模式：<br>- **BF16**（默认）：单个 `bfloat16` tensor `[recv_token_cnt, hidden]`。<br>- **INT8**（`quant_mode="int8"`）：tuple `(int8_tensor, float32_scales)`。数据 `[recv_token_cnt, hidden]`（`torch.int8`），scales `[recv_token_cnt]`（`torch.float32`）。<br>- **PerToken FP8**（A5，`quant_mode="pertoken_fp8_e4m3"`）：tuple `(float8_e4m3fn_数据, float32_scales)`。数据 `[recv_token_cnt, hidden]`，scales `[recv_token_cnt]`。<br>- **MXFP8 per-block**（A5，`quant_mode="mx_fp8_e4m3"`）：tuple `(float8_e4m3fn_数据, float8_e8m0fnu_scales)`。数据 `[recv_token_cnt, hidden]`，scales `[recv_token_cnt * hidden / 32]`（每 32 个元素一个 scale）。<br>- **MXFP4 per-block**（A5，`quant_mode="mx_fp4_e2m1"`）：tuple `(float4_e2m1fn_x2_数据, float8_e8m0fnu_scales)`。数据 `[recv_token_cnt, hidden / 2]`，scales `[recv_token_cnt * hidden / 32]`。 |
 | **recv_topk_idx** | `Optional[torch.Tensor]` (`int64`) | 接收到的 top‑k expert 索引（形状 `[recv_token_cnt, num_topk]`），若未使用 top‑k 则为 `None`。 |
 | **recv_topk_weights** | `Optional[torch.Tensor]` (`float`) | 对应的 top‑k 权重，形状同上。 |
 | **num_recv_tokens_per_expert_list** | `List[int]` | 每个 **本地 expert** 实际收到的 token 数（已对齐）。<br>若 `num_worst_tokens>0`，列表为空（因为不做同步）。 |
@@ -282,27 +304,33 @@ dispatch(
 - HCCL_BUFFSIZE: 调用接口前需检查HCCL_BUFFSIZE环境变量取值是否合理，该环境变量表示单个通信域占用内存大小，单位MB，不配置时默认为200MB。非分层最小需求：`(bs × ep_world_size × min(num_local_experts, topk) × hidden × 2B + 2MB) × 2`；分层（A2双机）：`num_experts × bs × (hidden × 2B + 4 × topk × 4B) + 4MB + 800MB`。A5 从配置值中扣除 1MB 状态区。
 - HCCL_INTRA_PCIE_ENABLE和HCCL_INTRA_ROCE_ENABLE：
     - A2系列双机场景需要配置，`HCCL_INTRA_PCIE_ENABLE=1` 和 `HCCL_INTRA_ROCE_ENABLE=0`；
-- 量化：设置环境变量 `DEEP_NORMAL_MODE_USE_INT8_QUANT=1` 时，会把 `x` 量化为 `int8` 并返回 `(tensor, scales)`。
-- MXFP8 / MXFP4 量化（仅 A5，**仅 intranode**）：在 intranode dispatch 路径上传入 `x` 为 tuple `(data_tensor, scale_tensor)` 时触发。internode 路径**不支持** tuple 输入 / MXFP8 / MXFP4。
-    - MXFP8 per-block：`data_tensor` dtype 为 `float8_e4m3fn` 或 `float8_e5m2`，`scale_tensor` dtype 为 `float8_e8m0fnu`，shape 为 `[num_tokens, hidden / 32]`。
-    - MXFP4 per-block：`data_tensor` dtype 为 `float4_e2m1fn_x2`，shape 为 `[num_tokens, hidden / 2]`；`scale_tensor` dtype 为 `float8_e8m0fnu`，shape 为 `[num_tokens, hidden / 32]`。
+- 量化：使用 `quant_mode` 参数或 `use_fp8` / `use_mxfp4` / `use_mxfp8` 布尔标志。`DEEP_NORMAL_MODE_USE_INT8_QUANT=1` 环境变量已弃用，但仍作为回退生效。`x` 的 dtype 不再用于量化模式选择。
+- MXFP8 / MXFP4 / PerToken-FP8 量化（仅 A5，**仅 intranode**）：通过 `use_mxfp8=True`、`use_mxfp4=True` 或 `use_fp8=True`（或 `quant_mode="mx_fp8_e4m3"` / `"mx_fp4_e2m1"` / `"pertoken_fp8_e4m3"`）触发。internode 和 alltoall 路径**不支持**这些模式。
 
 <a id="量化模式选择优先级"></a>
 
 ### 量化模式选择优先级
 
-`dispatch` 的量化模式按以下优先级确定（intranode 路径）：
+`dispatch` 的量化模式在 `Buffer._resolve_normal_quant_mode()` 中按以下优先级解析：
 
-1. **`quant_mode` 参数**（显式传入）—— 最高优先级。传入非 `None` 值时为唯一来源，下方环境变量**不读取**。
-2. **`DEEP_NORMAL_MODE_USE_INT8_QUANT=1`** 环境变量 —— 仅当 `quant_mode=None`（未传）时生效，作向后兼容回退开启 INT8。
-3. **BF16**（默认）—— 两者均未设时。
+1. **`quant_mode` 参数**（显式传入）—— 最高优先级。传入非 `None` 值时为唯一来源，下方布尔标志和环境变量**不读取**。
+2. **`use_mxfp4` / `use_mxfp8` / `use_fp8` 布尔标志** —— 仅当 `quant_mode=None` 时生效。设备架构在 `Buffer` 初始化时通过 `acl.rt.get_device_info(0, 601)` 自动检测：
+   - `use_mxfp4=True` → A5：`"mx_fp4_e2m1"`；A2/A3：抛 `NotImplementedError`。
+   - `use_mxfp8=True` → A5：`"mx_fp8_e4m3"`；A2/A3：抛 `NotImplementedError`。
+   - `use_fp8=True` → A5：`"pertoken_fp8_e4m3"`；A2/A3：`"int8"`（带 warning 日志）。
+3. **`DEEP_NORMAL_MODE_USE_INT8_QUANT=1`** 环境变量 —— 已弃用回退，仅当 `quant_mode=None` 且无布尔标志时生效。
+4. **BF16**（默认）—— 以上均未设置时。
 
 > **各路径差异：**
-> - **intranode**：`quant_mode` > 环境变量 > BF16（即上述优先级顺序）。
-> - **internode**：当前**不会透传** `quant_mode` 到底层 dispatch（策略重构遗留的已知缺口），始终读取环境变量与 tuple-`x` dtype 检测；在 internode 路径上设置 `quant_mode` 无效。
-> - **alltoall**（`DEEP_USE_MODE=alltoall`）：`dispatch()` **不接收** `quant_mode`，INT8 仅由环境变量控制。
+> - **intranode**（default 策略）：完整优先级顺序。FP8/FP4 模式仅 A5 支持。
+> - **internode**（default 策略）：仅支持 `"bf16"` 和 `"int8"`。其他 quant_mode 值抛 `NotImplementedError`。
+> - **alltoall** 策略（`DEEP_USE_MODE=alltoall`）：仅支持 `"bf16"` 和 `"int8"`。FP8/FP4 模式需使用 default 策略。
 >
-> **平台支持：** INT8（`DYNAMIC_SCALES`）**全平台**（A2/A3/A5）支持。FP8/FP4 模式（`mx_fp8_*`、`pertoken_fp8_e4m3`、`mx_fp4_e2m1`）**仅 A5**。
+> **平台支持：** INT8 **全平台**（A2/A3/A5）支持。FP8/FP4 模式（`pertoken_fp8_e4m3`、`mx_fp8_e4m3`、`mx_fp4_e2m1`）**仅 A5**。
+>
+> **设备版本号**（`acl.rt.get_device_info(0, 601)` 第一个返回值）：
+> - A5：`9301`、`9201`、`3510`
+> - A2/A3：`2201`、`1001`、`2002`、`3002`
 
 ---
 

--- a/python/deep_ep/doc/NORMAL_API.md
+++ b/python/deep_ep/doc/NORMAL_API.md
@@ -135,9 +135,6 @@ The quantization mode for `dispatch` is resolved in `Buffer._resolve_normal_quan
 > **Device version codes** (first return value of `acl.rt.get_device_info(0, 601)`):
 > - A5: `9301`, `9201`, `3510`
 > - A2/A3: `2201`
-> - V100: `1001`
-> - V200: `2002`
-> - V300: `3002`
 
 ---
 
@@ -328,9 +325,6 @@ dispatch(
 > **设备版本号**（`acl.rt.get_device_info(0, 601)` 第一个返回值）：
 > - A5：`9301`、`9201`、`3510`
 > - A2/A3：`2201`
-> - V100：`1001`
-> - V200：`2002`
-> - V300：`3002`
 
 ---
 

--- a/python/deep_ep/doc/NORMAL_API.md
+++ b/python/deep_ep/doc/NORMAL_API.md
@@ -41,7 +41,6 @@ dispatch(
     async_finish: bool = False,
     allocate_on_comm_stream: bool = False,
     dispatch_wait_recv_cost_stats: Optional[torch.Tensor] = None,
-    quant_mode: Optional[str] = None,
     use_fp8: bool = False,
     use_mxfp4: bool = False,
     use_mxfp8: bool = False,
@@ -59,7 +58,7 @@ dispatch(
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| **x** | `torch.Tensor` (`bfloat16`) | Yes | – | Shape `[num_tokens, hidden]`. The dtype of `x` is **no longer used** for quantization-mode detection; use `quant_mode` or the `use_fp8` / `use_mxfp4` / `use_mxfp8` bool flags instead. |
+| **x** | `torch.Tensor` (`bfloat16`) | Yes | – | Shape `[num_tokens, hidden]`. The dtype of `x` is **no longer used** for quantization-mode detection; use the `use_fp8` / `use_mxfp4` / `use_mxfp8` bool flags instead. |
 | **handle** | `Optional[Tuple]` | No | `None` | Pre-created communication handle (currently only supports `None`). |
 | **num_tokens_per_rank** | `torch.Tensor` (`int32`) | Yes (intranode) | `None` | Shape `[num_ranks]`, number of tokens each rank will receive. |
 | **num_tokens_per_rdma_rank** | `torch.Tensor` | Yes (internode) | `None` | Shape `[num_rdma_ranks]`, number of tokens each remote rank receives in cross-node (RDMA) mode. |
@@ -74,7 +73,6 @@ dispatch(
 | **async_finish** | `bool` | No | `False` | If `True`, the current stream will not block until communication completes; the returned `event` can be used for subsequent synchronization. |
 | **allocate_on_comm_stream** | `bool` | No | `False` | Currently unused. |
 | **dispatch_wait_recv_cost_stats** | `torch.Tensor` (`int64`) | No | `None` | Shape `[num_ranks]`, recording the time cost for the current rank to receive all tokens from each rank (statistics). |
-| **quant_mode** | `Optional[str]` | No | `None` | Explicit quantization mode (highest priority). Supported: `None` (BF16), `"int8"`, `"pertoken_fp8_e4m3"` (A5), `"mx_fp8_e4m3"` (A5), `"mx_fp4_e2m1"` (A5). When set, the bool flags below are ignored. |
 | **use_fp8** | `bool` | No | `False` | Enable FP8-family quantization. On A5 → `pertoken_fp8_e4m3`; on A2/A3 → `int8`. |
 | **use_mxfp4** | `bool` | No | `False` | Enable MXFP4 per-block quantization → `mx_fp4_e2m1` (A5 only). Raises `NotImplementedError` on A2/A3. |
 | **use_mxfp8** | `bool` | No | `False` | Enable MXFP8 per-block quantization → `mx_fp8_e4m3` (A5 only). Raises `NotImplementedError` on A2/A3. |
@@ -120,13 +118,12 @@ dispatch(
 
 The quantization mode for `dispatch` is resolved in `Buffer._resolve_normal_quant_mode()` with the following priority:
 
-1. **`quant_mode` parameter** (explicit) — highest priority. When passed (not `None`), it is the single source of truth; the bool flags and env var below are **not** consulted.
-2. **`use_mxfp4` / `use_mxfp8` / `use_fp8` bool flags** — consulted only when `quant_mode=None`. The device architecture is auto-detected at `Buffer` initialization time via `acl.rt.get_device_info(0, 601)`:
+1. **`use_mxfp4` / `use_mxfp8` / `use_fp8` bool flags** — combined with the detected device architecture:
    - `use_mxfp4=True` → A5: `"mx_fp4_e2m1"`; A2/A3: `NotImplementedError`.
    - `use_mxfp8=True` → A5: `"mx_fp8_e4m3"`; A2/A3: `NotImplementedError`.
    - `use_fp8=True` → A5: `"pertoken_fp8_e4m3"`; A2/A3: `"int8"`.
-3. **`DEEP_NORMAL_MODE_USE_INT8_QUANT=1`** environment variable — deprecated fallback, consulted only when `quant_mode=None` and no bool flags are set.
-4. **BF16** (default) — when none of the above are set.
+2. **`DEEP_NORMAL_MODE_USE_INT8_QUANT=1`** environment variable — deprecated fallback, consulted only when no bool flags are set.
+3. **BF16** (default) — when none of the above are set.
 
 > **Per-path differences:**
 > - **intranode** (default strategy): full priority order above. FP8/FP4 modes supported on A5.
@@ -137,7 +134,10 @@ The quantization mode for `dispatch` is resolved in `Buffer._resolve_normal_quan
 >
 > **Device version codes** (first return value of `acl.rt.get_device_info(0, 601)`):
 > - A5: `9301`, `9201`, `3510`
-> - A2/A3: `2201`, `1001`, `2002`, `3002`
+> - A2/A3: `2201`
+> - V100: `1001`
+> - V200: `2002`
+> - V300: `3002`
 
 ---
 
@@ -234,7 +234,6 @@ dispatch(
     async_finish: bool = False,
     allocate_on_comm_stream: bool = False,
     dispatch_wait_recv_cost_stats: Optional[torch.Tensor] = None,
-    quant_mode: Optional[str] = None,
     use_fp8: bool = False,
     use_mxfp4: bool = False,
     use_mxfp8: bool = False,
@@ -252,7 +251,7 @@ dispatch(
 
 | 参数 | 类型 | 必要 | 默认 | 说明 |
 |------|------|------|------|------|
-| **x** | `torch.Tensor` (`bfloat16`) | ✅ | – | Shape为 `[num_tokens, hidden]`。`x` 的 dtype **不再用于**量化模式检测，请使用 `quant_mode` 或 `use_fp8` / `use_mxfp4` / `use_mxfp8` 布尔标志。|
+| **x** | `torch.Tensor` (`bfloat16`) | ✅ | – | Shape为 `[num_tokens, hidden]`。`x` 的 dtype **不再用于**量化模式检测，请使用 `use_fp8` / `use_mxfp4` / `use_mxfp8` 布尔标志。|
 | **handle** | `Optional[Tuple]` | ❌ | `None` | 预先创建的通信句柄（目前仅支持 `None`）。|
 | **num_tokens_per_rank** | `torch.Tensor` (`int32`) | ✅（intranode） | `None` | Shape为 `[num_ranks]`，每个 rank 将接收的 token 数。 |
 | **num_tokens_per_rdma_rank** | `torch.Tensor` | ✅（internode） | `None` | Shape为 `[num_rdma_ranks]`，跨节点（RDMA）时每个 remote rank 接收的 token 数。 |
@@ -267,7 +266,6 @@ dispatch(
 | **async_finish** | `bool` | ❌ | `False` | 若 `True`，当前 stream 不会阻塞等待通信完成，返回的 `event` 可用于后续同步。 |
 | **allocate_on_comm_stream** | `bool` | ❌ | `False` | 当前未使用。 |
 | **dispatch_wait_recv_cost_stats** | `torch.Tensor` (`int64`) | ❌ | `None` | Shape为 `[num_ranks]`，记录当前 rank 从每个 rank 收到全部 token 所耗时间（统计信息）。 |
-| **quant_mode** | `Optional[str]` | ❌ | `None` | 显式量化模式（最高优先级）。支持：`None`（BF16）、`"int8"`、`"pertoken_fp8_e4m3"`（A5）、`"mx_fp8_e4m3"`（A5）、`"mx_fp4_e2m1"`（A5）。设置后忽略下方布尔标志。 |
 | **use_fp8** | `bool` | ❌ | `False` | 启用 FP8 系列量化。A5 → `pertoken_fp8_e4m3`；A2/A3 → `int8`。 |
 | **use_mxfp4** | `bool` | ❌ | `False` | 启用 MXFP4 per-block 量化 → `mx_fp4_e2m1`（仅 A5）。A2/A3 上抛 `NotImplementedError`。 |
 | **use_mxfp8** | `bool` | ❌ | `False` | 启用 MXFP8 per-block 量化 → `mx_fp8_e4m3`（仅 A5）。A2/A3 上抛 `NotImplementedError`。 |
@@ -313,13 +311,12 @@ dispatch(
 
 `dispatch` 的量化模式在 `Buffer._resolve_normal_quant_mode()` 中按以下优先级解析：
 
-1. **`quant_mode` 参数**（显式传入）—— 最高优先级。传入非 `None` 值时为唯一来源，下方布尔标志和环境变量**不读取**。
-2. **`use_mxfp4` / `use_mxfp8` / `use_fp8` 布尔标志** —— 仅当 `quant_mode=None` 时生效。设备架构在 `Buffer` 初始化时通过 `acl.rt.get_device_info(0, 601)` 自动检测：
+1. **`use_mxfp4` / `use_mxfp8` / `use_fp8` 布尔标志** —— 与检测到的设备架构结合：
    - `use_mxfp4=True` → A5：`"mx_fp4_e2m1"`；A2/A3：抛 `NotImplementedError`。
    - `use_mxfp8=True` → A5：`"mx_fp8_e4m3"`；A2/A3：抛 `NotImplementedError`。
    - `use_fp8=True` → A5：`"pertoken_fp8_e4m3"`；A2/A3：`"int8"`。
-3. **`DEEP_NORMAL_MODE_USE_INT8_QUANT=1`** 环境变量 —— 已弃用回退，仅当 `quant_mode=None` 且无布尔标志时生效。
-4. **BF16**（默认）—— 以上均未设置时。
+2. **`DEEP_NORMAL_MODE_USE_INT8_QUANT=1`** 环境变量 —— 已弃用回退，仅当无布尔标志时生效。
+3. **BF16**（默认）—— 以上均未设置时。
 
 > **各路径差异：**
 > - **intranode**（default 策略）：完整优先级顺序。FP8/FP4 模式仅 A5 支持。
@@ -330,7 +327,10 @@ dispatch(
 >
 > **设备版本号**（`acl.rt.get_device_info(0, 601)` 第一个返回值）：
 > - A5：`9301`、`9201`、`3510`
-> - A2/A3：`2201`、`1001`、`2002`、`3002`
+> - A2/A3：`2201`
+> - V100：`1001`
+> - V200：`2002`
+> - V300：`3002`
 
 ---
 

--- a/tests/python/deepep/test_intranode.py
+++ b/tests/python/deepep/test_intranode.py
@@ -54,24 +54,11 @@ def test_main(
         device_arch = get_device_arch()
         is_a5 = device_arch == "A5"
         if args.use_mxfp4:
-            if not is_a5:
-                raise NotImplementedError(
-                    "use_mxfp4 is not supported on A2/A3 devices."
-                )
             dispatch_quant_mode = "mx_fp4_e2m1"
         elif args.use_mxfp8:
-            if not is_a5:
-                raise NotImplementedError(
-                    "use_mxfp8 is not supported on A2/A3 devices."
-                )
             dispatch_quant_mode = "mx_fp8_e4m3"
         elif args.use_fp8:
             dispatch_quant_mode = "pertoken_fp8_e4m3" if is_a5 else "int8"
-            if not is_a5:
-                print(
-                    "[WARNING] use_fp8 is converted to int8 on A2/A3 devices.",
-                    flush=True,
-                )
         else:
             dispatch_quant_mode = None
         quant_dispatch_kwargs = {

--- a/tests/python/deepep/test_intranode.py
+++ b/tests/python/deepep/test_intranode.py
@@ -4,12 +4,12 @@ import random
 import time
 from typing import Optional
 
-# noinspection PyUnresolvedReferences
 import deep_ep
 import numpy as np
 import torch
 import torch.distributed as dist
 import torch_npu
+from deep_ep.device_info import get_device_arch
 from utils import (
     bench,
     calc_diff,
@@ -37,7 +37,52 @@ def test_main(
     enable_diagnose = args.enable_diagnose
     enable_dynamic_tokens = args.enable_dynamic_tokens
     quant_type = args.quant_type
-    dispatch_quant_mode = quant_type
+
+    # Validate mutual exclusion: --quant-type vs --use-fp8/--use-mxfp4/--use-mxfp8
+    use_bool_flags = args.use_fp8 or args.use_mxfp4 or args.use_mxfp8
+    if quant_type is not None and use_bool_flags:
+        raise ValueError(
+            "--quant-type and --use-fp8/--use-mxfp4/--use-mxfp8 are mutually exclusive."
+        )
+
+    # Compute the expected resolved quant_mode (for bandwidth calc, threshold, display)
+    # and build the quant kwargs that will be passed to buffer.dispatch().
+    if quant_type is not None:
+        dispatch_quant_mode = quant_type
+        quant_dispatch_kwargs = {"quant_mode": dispatch_quant_mode}
+    elif use_bool_flags:
+        device_arch = get_device_arch()
+        is_a5 = device_arch == "A5"
+        if args.use_mxfp4:
+            if not is_a5:
+                raise NotImplementedError(
+                    "use_mxfp4 is not supported on A2/A3 devices."
+                )
+            dispatch_quant_mode = "mx_fp4_e2m1"
+        elif args.use_mxfp8:
+            if not is_a5:
+                raise NotImplementedError(
+                    "use_mxfp8 is not supported on A2/A3 devices."
+                )
+            dispatch_quant_mode = "mx_fp8_e4m3"
+        elif args.use_fp8:
+            dispatch_quant_mode = "pertoken_fp8_e4m3" if is_a5 else "int8"
+            if not is_a5:
+                print(
+                    "[WARNING] use_fp8 is converted to int8 on A2/A3 devices.",
+                    flush=True,
+                )
+        else:
+            dispatch_quant_mode = None
+        quant_dispatch_kwargs = {
+            "quant_mode": None,
+            "use_fp8": args.use_fp8,
+            "use_mxfp4": args.use_mxfp4,
+            "use_mxfp8": args.use_mxfp8,
+        }
+    else:
+        dispatch_quant_mode = quant_type
+        quant_dispatch_kwargs = {"quant_mode": dispatch_quant_mode}
     num_servers = num_ranks // num_local_ranks
     expert_token_nums_type = int(os.getenv("MOE_EXPERT_TOKEN_NUMS_TYPE", 1))
 
@@ -294,7 +339,7 @@ def test_main(
                 "topk_idx": topk_idx,
                 "topk_weights": topk_weights_pure_rand,
                 "dispatch_wait_recv_cost_stats": dispatch_wait_recv_cost_stats,
-                "quant_mode": dispatch_quant_mode,
+                **quant_dispatch_kwargs,
             }
             if dispatch_wait_recv_cost_stats is not None:
                 bench(lambda: buffer.dispatch(**dispatch_args), num_warmups=0)
@@ -363,6 +408,10 @@ def test_main(
                 f'[testing] Running with {"FP8" if use_fp8 else iter_quant.upper()}, with top-k {num_topk} ...',
                 flush=True,
             )
+        if current_x is x_pure_rand:
+            quant_kwargs = quant_dispatch_kwargs
+        else:
+            quant_kwargs = {"quant_mode": "bf16"}
         dispatch_args = {
             "x": current_x,
             "num_tokens_per_rank": ref_num_tokens_per_rank,
@@ -373,7 +422,7 @@ def test_main(
             "topk_weights": (
                 topk_weights_pure_rand if current_x is x_pure_rand else topk_weights
             ),
-            "quant_mode": dispatch_quant_mode if current_x is x_pure_rand else "bf16",
+            **quant_kwargs,
         }
 
         (
@@ -501,7 +550,7 @@ def test_main(
             "num_tokens_per_expert": ref_num_tokens_per_expert,
             "topk_idx": topk_idx,
             "topk_weights": topk_weights,
-            "quant_mode": dispatch_quant_mode,
+            **quant_dispatch_kwargs,
         }
         t = bench(lambda: buffer.dispatch(**tune_args_quant))[0]
         if local_rank == 0:
@@ -519,7 +568,7 @@ def test_main(
         "config": config,
         "topk_idx": topk_idx,
         "topk_weights": topk_weights,
-        "quant_mode": dispatch_quant_mode,
+        **quant_dispatch_kwargs,
     }
     recv_x, _, _, _, handle, _ = buffer.dispatch(**dispatch_args)
     recv_x = per_token_cast_back(*recv_x) if isinstance(recv_x, tuple) else recv_x
@@ -633,6 +682,30 @@ if __name__ == "__main__":
         default=None,
         help="quant type: None (use DEEP_NORMAL_MODE_USE_INT8_QUANT env var), bf16, int8, "
         "mx_fp8_e4m3, mx_fp8_e5m2, pertoken_fp8_e4m3, mx_fp4_e2m1",
+    )
+    parser.add_argument(
+        "--use-fp8",
+        dest="use_fp8",
+        action="store_true",
+        help="Use use_fp8=True bool flag for normal dispatch. Architecture-aware: "
+        "A5 -> pertoken_fp8_e4m3, A2/A3 -> int8 (with warning). "
+        "Mutually exclusive with --quant-type.",
+    )
+    parser.add_argument(
+        "--use-mxfp4",
+        dest="use_mxfp4",
+        action="store_true",
+        help="Use use_mxfp4=True bool flag for normal dispatch. "
+        "A5 -> mx_fp4_e2m1, A2/A3 -> not supported. "
+        "Mutually exclusive with --quant-type.",
+    )
+    parser.add_argument(
+        "--use-mxfp8",
+        dest="use_mxfp8",
+        action="store_true",
+        help="Use use_mxfp8=True bool flag for normal dispatch. "
+        "A5 -> mx_fp8_e4m3, A2/A3 -> not supported. "
+        "Mutually exclusive with --quant-type.",
     )
     args = parser.parse_args()
 

--- a/tests/python/deepep/test_intranode.py
+++ b/tests/python/deepep/test_intranode.py
@@ -5,7 +5,6 @@ import time
 from typing import Optional
 
 import deep_ep
-import numpy as np
 import torch
 import torch.distributed as dist
 import torch_npu

--- a/tests/python/deepep/test_intranode.py
+++ b/tests/python/deepep/test_intranode.py
@@ -9,7 +9,6 @@ import numpy as np
 import torch
 import torch.distributed as dist
 import torch_npu
-from deep_ep.device_info import get_device_arch
 from utils import (
     bench,
     calc_diff,
@@ -36,40 +35,22 @@ def test_main(
     num_topk, num_experts = args.num_topk, args.num_experts
     enable_diagnose = args.enable_diagnose
     enable_dynamic_tokens = args.enable_dynamic_tokens
-    quant_type = args.quant_type
 
-    # Validate mutual exclusion: --quant-type vs --use-fp8/--use-mxfp4/--use-mxfp8
-    use_bool_flags = args.use_fp8 or args.use_mxfp4 or args.use_mxfp8
-    if quant_type is not None and use_bool_flags:
-        raise ValueError(
-            "--quant-type and --use-fp8/--use-mxfp4/--use-mxfp8 are mutually exclusive."
-        )
-
-    # Compute the expected resolved quant_mode (for bandwidth calc, threshold, display)
-    # and build the quant kwargs that will be passed to buffer.dispatch().
-    if quant_type is not None:
-        dispatch_quant_mode = quant_type
-        quant_dispatch_kwargs = {"quant_mode": dispatch_quant_mode}
-    elif use_bool_flags:
-        device_arch = get_device_arch()
-        is_a5 = device_arch == "A5"
-        if args.use_mxfp4:
-            dispatch_quant_mode = "mx_fp4_e2m1"
-        elif args.use_mxfp8:
-            dispatch_quant_mode = "mx_fp8_e4m3"
-        elif args.use_fp8:
-            dispatch_quant_mode = "pertoken_fp8_e4m3" if is_a5 else "int8"
-        else:
-            dispatch_quant_mode = None
-        quant_dispatch_kwargs = {
-            "quant_mode": None,
-            "use_fp8": args.use_fp8,
-            "use_mxfp4": args.use_mxfp4,
-            "use_mxfp8": args.use_mxfp8,
-        }
+    # dispatch_quant_mode is for bandwidth calc / display only.
+    # The actual resolution (architecture-aware) happens inside buffer.dispatch().
+    if args.use_mxfp4:
+        dispatch_quant_mode = "mx_fp4_e2m1"
+    elif args.use_mxfp8:
+        dispatch_quant_mode = "mx_fp8_e4m3"
+    elif args.use_fp8:
+        dispatch_quant_mode = "pertoken_fp8_e4m3"
     else:
-        dispatch_quant_mode = quant_type
-        quant_dispatch_kwargs = {"quant_mode": dispatch_quant_mode}
+        dispatch_quant_mode = None
+    quant_dispatch_kwargs = {
+        "use_fp8": args.use_fp8,
+        "use_mxfp4": args.use_mxfp4,
+        "use_mxfp8": args.use_mxfp8,
+    }
     num_servers = num_ranks // num_local_ranks
     expert_token_nums_type = int(os.getenv("MOE_EXPERT_TOKEN_NUMS_TYPE", 1))
 
@@ -398,7 +379,7 @@ def test_main(
         if current_x is x_pure_rand:
             quant_kwargs = quant_dispatch_kwargs
         else:
-            quant_kwargs = {"quant_mode": "bf16"}
+            quant_kwargs = {}
         dispatch_args = {
             "x": current_x,
             "num_tokens_per_rank": ref_num_tokens_per_rank,
@@ -500,7 +481,6 @@ def test_main(
         "num_tokens_per_expert": ref_num_tokens_per_expert,
         "topk_idx": topk_idx,
         "topk_weights": topk_weights,
-        "quant_mode": "bf16",
     }
     t = bench(lambda: buffer.dispatch(**tune_args_bf16))[0]
     if local_rank == 0:
@@ -661,14 +641,6 @@ if __name__ == "__main__":
         "--enable-dynamic-tokens",
         action="store_true",
         help="Whether to enable dynamic tokens for testing",
-    )
-    parser.add_argument(
-        "--quant-type",
-        dest="quant_type",
-        type=str,
-        default=None,
-        help="quant type: None (use DEEP_NORMAL_MODE_USE_INT8_QUANT env var), bf16, int8, "
-        "mx_fp8_e4m3, mx_fp8_e5m2, pertoken_fp8_e4m3, mx_fp4_e2m1",
     )
     parser.add_argument(
         "--use-fp8",

--- a/tests/python/deepep/test_mixed_dc_vs_alltoall.py
+++ b/tests/python/deepep/test_mixed_dc_vs_alltoall.py
@@ -52,7 +52,7 @@ def run_normal(buffer, x, topk_idx, topk_weights, num_experts, config, quant_typ
         config=config,
         topk_idx=topk_idx,
         topk_weights=topk_weights,
-        quant_mode=None if quant_type == "bf16" else quant_type,
+        use_fp8=(quant_type != "bf16"),
     )
     recv_x = per_token_cast_back(*recv_x) if isinstance(recv_x, tuple) else recv_x
 

--- a/tests/python/deepep/test_normal_alltoall.py
+++ b/tests/python/deepep/test_normal_alltoall.py
@@ -205,7 +205,7 @@ def test_main(
             "topk_weights": (
                 topk_weights_pure_rand if current_x is x_pure_rand else topk_weights
             ),
-            "quant_mode": dispatch_quant_mode if current_x is x_pure_rand else "bf16",
+            "use_fp8": (quant_type != "bf16") if current_x is x_pure_rand else False,
         }
 
         (
@@ -295,7 +295,6 @@ def test_main(
         "num_tokens_per_expert": ref_num_tokens_per_expert,
         "topk_idx": topk_idx,
         "topk_weights": topk_weights,
-        "quant_mode": "bf16",
     }
     t = bench(lambda: buffer.dispatch(**tune_args_bf16))[0]
     if local_rank == 0:
@@ -324,7 +323,7 @@ def test_main(
             "num_tokens_per_expert": ref_num_tokens_per_expert,
             "topk_idx": topk_idx,
             "topk_weights": topk_weights,
-            "quant_mode": dispatch_quant_mode,
+            "use_fp8": (quant_type != "bf16"),
         }
         t = bench(lambda: buffer.dispatch(**tune_args_quant))[0]
         if local_rank == 0:
@@ -342,7 +341,7 @@ def test_main(
         "config": config,
         "topk_idx": topk_idx,
         "topk_weights": topk_weights,
-        "quant_mode": dispatch_quant_mode,
+        "use_fp8": (quant_type != "bf16"),
     }
     recv_x, _, _, _, handle, _ = buffer.dispatch(**dispatch_args)
     recv_x = per_token_cast_back(*recv_x) if isinstance(recv_x, tuple) else recv_x

--- a/tests/python/deepep/test_normal_dc_vs_alltoall.py
+++ b/tests/python/deepep/test_normal_dc_vs_alltoall.py
@@ -49,7 +49,7 @@ def run_with_buffer(buffer, x, topk_idx, topk_weights, num_experts, config, quan
         config=config,
         topk_idx=topk_idx,
         topk_weights=topk_weights,
-        quant_mode=None if quant_type == "bf16" else quant_type,
+        use_fp8=(quant_type != "bf16"),
     )
     recv_x = per_token_cast_back(*recv_x) if isinstance(recv_x, tuple) else recv_x
 


### PR DESCRIPTION
## Motivation

Normal dispatch: architecture-aware quant mode via use_fp8/use_mxfp4/use_mxfp8 bool flags

## Modifications

Adding an Environment Detection Method
Modifying the quantization mode parameter configuration and using a Boolean parameter.
The test script is modified to verify the new features.

## Testing

python3 tests/python/deepep/test_intranode.py --num-processes 2 --use-fp8

[tuning] Dispatch (BF16, raw_bytes=0.470GB) raw_bw=54.19 GB/s, equiv_bw=54.19 GB/s (HCCS), avg_t: 8676.73 us
[tuning] Dispatch (pertoken_fp8_e4m3, raw_bytes=0.235GB) raw_bw=46.07 GB/s, equiv_bw=92.10 GB/s (HCCS), avg_t: 5105.19 us
[tuning] Combine 64.02 GB/s (HCCS), avg_t: 7344.49 us

## Checklist

- [x] Format your code.
- [x] Add unit tests.
- [x] Update documentation.
- [x] Provide accuracy and speed benchmark results.