### PR TITLE
ci: re-enable test_mamba_state_update.py in mamba group

### DIFF
--- a/scripts/run_kernel_tests.sh
+++ b/scripts/run_kernel_tests.sh
@@ -77,7 +77,7 @@ MAMBA_TESTS=(
     test_conv1d_prefill.py
     test_conv1d_update.py
     test_mamba_conv.py
-    # test_mamba_state_update.py  # FAILING: move_intermediate_cache strided-dst exact mismatch
+    test_mamba_state_update.py  # fixed in #748: physical-order mover semantics + conv_state_rollback in-place update
 )
 
 FLA_TESTS=(


### PR DESCRIPTION
## Problem
`test_mamba_state_update.py` is still commented out in `run_kernel_tests.sh`, so the mamba CI job has **never** exercised it — including the fixes merged in #748 (physical-order mover semantics + `conv_state_rollback` in-place update of non-contiguous views). #748's green CI only ran the other mamba tests, so the fix is unverified.

## Change
Re-enable `test_mamba_state_update.py` in the mamba test group so the fixed cases actually run on CI:
- `test_move_intermediate_cache_mask_and_physical_layout` (was `..._mask_and_destination_strides`)
- `test_conv_state_rollback_updates_noncontiguous_view_in_place`

## Expected
mamba job runs the full file (pytest) and passes. If the physical-layout semantics don't match the merged fix, this PR will surface it. Pure test-runner change; no kernel/test code modified.
