### PR TITLE
[DeepEP] Add test cases for the 950‑environment pipeline and update the runner tag

### DIFF
--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -841,32 +841,32 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=4 --num-tokens=256 --num-experts=32 --use-mxfp4
 
-      - name: Run low‑latency mode use-mxfp8 quantization
+      - name: Run low‑latency mode mx_fp8_e4m3 quantization
         env:
           HCCL_BUFFSIZE: 10000
         timeout-minutes: 10
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --use-mxfp8 --num-processes=4
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --use-mxfp8 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=256 --hidden=8192
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --use-mxfp8 --num-processes=4 --num-topk=6 --num-tokens=512 --num-experts=256 --hidden=7168
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --use-mxfp8 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=520 --hidden=8192
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=256 --hidden=8192
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4 --num-topk=6 --num-tokens=512 --num-experts=256 --hidden=7168
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type mx_fp8_e4m3 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=520 --hidden=8192
 
-      - name: Run low‑latency mode use-mxfp4 quantization
+      - name: Run low‑latency mode mx_fp4_e2m1 quantization
         env:
           HCCL_BUFFSIZE: 2500
         timeout-minutes: 10
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=8 --num-experts=256 --hidden=7168 --num-tokens=256 --use-mxfp4
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=12 --num-experts=512 --hidden=8192 --num-tokens=128 --use-mxfp4 --enable-dynamic-tokens
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=8 --num-experts=256 --hidden=7168 --num-tokens=256 --quant-type=mx_fp4_e2m1
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=12 --num-experts=512 --hidden=8192 --num-tokens=128 --quant-type=mx_fp4_e2m1 --enable-dynamic-tokens
 
-      - name: Run low‑latency mode use-fp8 quantization
+      - name: Run low‑latency mode pertoken_fp8_e4m3 quantization
         env:
           HCCL_BUFFSIZE: 2500
         timeout-minutes: 10
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 256 --hidden 7168 --num-topk 8 --num-experts 256 --use-mxfp8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-mxfp8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --use-mxfp8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 256 --hidden 7168 --num-topk 8 --num-experts 256 --quant-type pertoken_fp8_e4m3
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --quant-type pertoken_fp8_e4m3
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --quant-type pertoken_fp8_e4m3
 
       - name: Run alltoall normal
         timeout-minutes: 10

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -887,7 +887,7 @@ jobs:
         timeout-minutes: 10
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
-          --use-mxfp8 \
+          --quant fp8_e4m3 \
           --num-processes 4 \
           --hidden 7168 \
           --moe-intermediate-size 3072 \
@@ -901,7 +901,7 @@ jobs:
         timeout-minutes: 10
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
-          --use-mxfp8 \
+          --quant fp8_e4m3 \
           --num-processes 4 \
           --hidden 7168 \
           --moe-intermediate-size 3072 \
@@ -915,7 +915,7 @@ jobs:
         timeout-minutes: 10
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
-          --use-mxfp8 \
+          --quant fp8_e4m3 \
           --num-processes 4 \
           --hidden 7168 \
           --moe-intermediate-size 3072 \

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -60,7 +60,7 @@ jobs:
         github.event.pull_request.draft == false &&
         (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
       )
-    runs-on: linux-aarch64-a3-16
+    runs-on: linux-aarch64-a3-800t-16
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
     env:
@@ -290,7 +290,7 @@ jobs:
         github.event.pull_request.draft == false &&
         (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
       )
-    runs-on: ["linux-aarch64-a3-16", "a3-752t"]
+    runs-on: linux-aarch64-a3-800t-16
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
     env:
@@ -749,12 +749,191 @@ jobs:
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --num-processes=8
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --test-type="low_latency" --num-processes=8
 
+  test-deepep-a5:
+    needs: get-changed-files
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call' || (
+        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
+        github.event.pull_request.draft == false &&
+        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
+      )
+    runs-on: linux-amd64-a5-4
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-950-ubuntu22.04-py3.12
+    env:
+      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+    strategy:
+      matrix:
+        cann_version: [9.1.0]
+    steps:
+      - name: Clean git config
+        run: |
+          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
+          git config --global --unset "$CONFIG_KEY" || true
+      - name: Clean workspace
+        run: |
+          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          clean: true
+          submodules: recursive
+      - name: Get build hash
+        id: get_build_hash
+        run: |
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
+            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+      - name: Restore build cache
+        id: cache-build
+        uses: runs-on/cache@v4
+        with:
+          path: output
+          key: sgl-kernel-npu-build-v4-${{ runner.os }}-a5-cann${{ matrix.cann_version }}-py3.12-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+      - name: Install dependencies
+        run: |
+          # speed up by using infra cache services
+          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+          pip config set global.trusted-host ${CACHING_URL}
+          pip install uv
+          bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
+      - name: Prepare Deepep
+        # - cache hit: install cached wheel only (skip build via -s flag)
+        # - cache miss: clear stale wheels + build + install
+        run: |
+          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+            echo "Cache hit, installing cached wheel only"
+            bash scripts/prepare_deepep_in_container.sh -s
+          else
+            echo "Cache miss, building and installing"
+            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+            bash scripts/prepare_deepep_in_container.sh -a deepep Ascend950
+          fi
+      - name: Run normal mode pertoken_fp8_e4m3 quantization
+        env:
+          HCCL_BUFFSIZE: 500
+        timeout-minutes: 20
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 512 --hidden 7168 --num-topk 8 --num-experts 256 --quant-type pertoken_fp8_e4m3
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --quant-type pertoken_fp8_e4m3
+
+      - name: Run normal mode mx_fp8_e4m3 quantization
+        env:
+          HCCL_BUFFSIZE: 500
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=4 --num-tokens=256 --num-experts=32 --quant-type=mx_fp8_e4m3
+
+      - name: Run normal mode mx_fp4_e2m1 quantization
+        env:
+          HCCL_BUFFSIZE: 500
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=4 --num-tokens=256 --num-experts=32 --quant-type=mx_fp4_e2m1
+
+      - name: Run low‑latency mode mx_fp8_e4m3 quantization
+        env:
+          HCCL_BUFFSIZE: 10000
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=256 --hidden=8192
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4 --num-topk=6 --num-tokens=512 --num-experts=256 --hidden=7168
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type mx_fp8_e4m3 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=520 --hidden=8192
+
+      - name: Run low‑latency mode mx_fp4_e2m1 quantization
+        env:
+          HCCL_BUFFSIZE: 2500
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=8 --num-experts=256 --hidden=7168 --num-tokens=256 --quant-type=mx_fp4_e2m1
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=12 --num-experts=512 --hidden=8192 --num-tokens=128 --quant-type=mx_fp4_e2m1 --enable-dynamic-tokens
+
+      - name: Run low‑latency mode pertoken_fp8_e4m3 quantization
+        env:
+          HCCL_BUFFSIZE: 2500
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 256 --hidden 7168 --num-topk 8 --num-experts 256 --quant-type pertoken_fp8_e4m3
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --quant-type pertoken_fp8_e4m3
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --quant-type pertoken_fp8_e4m3
+
+      - name: Run alltoall normal
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --num-processes 4
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --num-processes 4 --quant-type int8
+
+      - name: Run alltoall low-latency
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --num-processes 4
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --num-processes 4 --quant-type int8
+
+      - name: Run fusion operator
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py --num-processes 4 --num-warmups 3  --num-tests 10
+
+      - name: Run single bs scenario
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
+          --quant fp8_e4m3 \
+          --num-processes 4 \
+          --hidden 7168 \
+          --moe-intermediate-size 3072 \
+          --num-topk 8 \
+          --num-experts 32 \
+          --num-warmups 3 \
+          --num-tests 10 \
+          --single-active-rank 1
+
+      - name: Run bs uneven scenario
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
+          --quant fp8_e4m3 \
+          --num-processes 4 \
+          --hidden 7168 \
+          --moe-intermediate-size 3072 \
+          --num-topk 8 \
+          --num-experts 32 \
+          --num-warmups 3 \
+          --num-tests 10 \
+          --num-token-jitter 5
+
+      - name: Run nz format weights
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
+          --quant fp8_e4m3 \
+          --num-processes 4 \
+          --hidden 7168 \
+          --moe-intermediate-size 3072 \
+          --num-topk 8 \
+          --num-experts 32 \
+          --num-warmups 3 \
+          --num-tests 10 \
+          --weight-format NZ
+
   finish:
     if: always()
     needs:
       - test-all-build-core
-      - test-all-build-moe
-      - test-build-deepep-a2
+#      - test-all-build-moe
+#      - test-build-deepep-a2
+#      - test-deepep-a5
     runs-on: ubuntu-latest
     steps:
       - name: Check all dependent job statuses
@@ -768,4 +947,3 @@ jobs:
           done
           echo "All jobs completed successfully"
           exit 0
-

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -51,703 +51,703 @@ jobs:
               - scripts/**
               - .github/workflows/pr-test-deepep-npu.yml
 
-#  test-all-build-core:
-#    needs: get-changed-files
-#    if: |
-#      github.event_name == 'workflow_dispatch' ||
-#      github.event_name == 'workflow_call' || (
-#        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
-#        github.event.pull_request.draft == false &&
-#        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
-#      )
-#    runs-on: linux-aarch64-a3-800t-16
-#    container:
-#      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
-#    env:
-#      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
-#      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
-#      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
-#      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-#    strategy:
-#      matrix:
-#        cann_version: [9.0.0, 9.1.0]
-#    steps:
-#      - name: Clean git config
-#        run: |
-#          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
-#          git config --global --unset "$CONFIG_KEY" || true
-#      - name: Clean workspace
-#        run: |
-#          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
-#      - name: Checkout code
-#        uses: actions/checkout@v4
-#        with:
-#          clean: true
-#          submodules: recursive
-#      - name: Get build hash
-#        id: get_build_hash
-#        run: |
-#          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
-#            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
-#          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
-#          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
-#          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
-#          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
-#          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
-#      - name: Restore build cache
-#        id: cache-build
-#        uses: runs-on/cache@v4
-#        with:
-#          path: output
-#          key: sgl-kernel-npu-build-v4-${{ runner.os }}-a3-cann${{ matrix.cann_version }}-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
-#      - name: Install dependencies
-#        run: |
-#          # speed up by using infra cache services
-#          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
-#          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
-#          pip config set global.index-url http://${CACHING_URL}/pypi/simple
-#          pip config set global.trusted-host ${CACHING_URL}
-#          pip install uv
-#          bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
-#      - name: Prepare Deepep
-#        # - cache hit: install cached wheel only (skip build via -s flag)
-#        # - cache miss: clear stale wheels + build + install
-#        run: |
-#          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
-#            echo "Cache hit, installing cached wheel only"
-#            bash scripts/prepare_deepep_in_container.sh -s
-#          else
-#            echo "Cache miss, building and installing"
-#            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
-#            bash scripts/prepare_deepep_in_container.sh
-#          fi
-#      - name: Run test intranode
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
-#      - name: Run test intranode for little bs
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 4065
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=4
-#      - name: Run test intranode for big bs
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 4065
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=8192
-#      - name: Run test multi-round intranode
-#        timeout-minutes: 10
-#        env:
-#          DEEPEP_NORMAL_LONG_SEQ_ROUND: 5
-#          DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS: 512
-#          HCCL_BUFFSIZE: 1000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2122
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2048
-#      - name: Run test little processes intranode
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2241
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2
-#      - name: Run test hidden intranode
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=2048
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=4096
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=6144
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=7168
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=8192
-#      - name: Run test topk num intranode
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 4065
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=1
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=16
-#      - name: Run test experts num intranode
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2 --num-topk=1 --num-experts=2
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=512 --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=1024 --num-processes=16
-#      - name: Run test intranode for active ranks
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --active-ranks="0,1,3"
-#      - name: Run test intranode for DeepXtrace
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-diagnose
-#      - name: Run test intranode for use-fp8 quant
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --use-fp8
-#
-#      - name: Run test intranode for output parameters of different types
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#          MOE_EXPERT_TOKEN_NUMS_TYPE: 0
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
-#      - name: Run test intranode for dynamic tokens
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-dynamic-tokens
-#      - name: Run test low latency
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1913
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=1
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=2
-#      - name: Run test low latency for big bs
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3825
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=512
-#      - name: Run test low latency for little num processes
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1913
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2
-#      - name: Run test low latency for hidden
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2200
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=2048
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=4096
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=6144
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=7168
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=8192
-#      - name: Run test low latency for topk
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1969
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=4
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=16
-#      - name: Run test low latency for experts
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 7481
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-experts=1024
-#      - name: Run test low latency for drop percent
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1913
-#          MOE_ENABLE_TOPK_NEG_ONE: 1
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --drop-percent=0.3
-#      - name: Run test low latency for dynamic tokens
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --enable-dynamic-tokens
-#      - name: Run test generalization of fused deep moe
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2048
-#        run: bash scripts/generalization_test_fused_deep_moe.sh
-#      - name: Run test combine only
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3900
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --test-type="low_latency"
-#
-#  test-all-build-moe:
-#    needs: get-changed-files
-#    if: |
-#      github.event_name == 'workflow_dispatch' ||
-#      github.event_name == 'workflow_call' || (
-#        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
-#        github.event.pull_request.draft == false &&
-#        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
-#      )
-#    runs-on: linux-aarch64-a3-800t-16
-#    container:
-#      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
-#    env:
-#      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
-#      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
-#      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
-#      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-#    strategy:
-#      matrix:
-#        cann_version: [9.0.0, 9.1.0]
-#    steps:
-#      - name: Clean git config
-#        run: |
-#          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
-#          git config --global --unset "$CONFIG_KEY" || true
-#      - name: Clean workspace
-#        run: |
-#          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
-#      - name: Checkout code
-#        uses: actions/checkout@v4
-#        with:
-#          clean: true
-#          submodules: recursive
-#      - name: Get build hash
-#        id: get_build_hash
-#        run: |
-#          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
-#            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
-#          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
-#          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
-#          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
-#          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
-#          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
-#      - name: Restore build cache
-#        id: cache-build
-#        uses: runs-on/cache@v4
-#        with:
-#          path: output
-#          key: sgl-kernel-npu-build-v4-${{ runner.os }}-a3-cann${{ matrix.cann_version }}-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
-#      - name: Install dependencies
-#        run: |
-#          # speed up by using infra cache services
-#          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
-#          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
-#          pip config set global.index-url http://${CACHING_URL}/pypi/simple
-#          pip config set global.trusted-host ${CACHING_URL}
-#          pip install uv
-#          bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
-#      - name: Prepare Deepep
-#        # - cache hit: install cached wheel only (skip build via -s flag)
-#        # - cache miss: clear stale wheels + build + install
-#        run: |
-#          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
-#            echo "Cache hit, installing cached wheel only"
-#            bash scripts/prepare_deepep_in_container.sh -s
-#          else
-#            echo "Cache miss, building and installing"
-#            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
-#            bash scripts/prepare_deepep_in_container.sh
-#          fi
-#      - name: Run test base fused deep moe
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 256
-#      - name: Run test muti-model for fused deep moe
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256 --hidden 6144 --moe-intermediate-size 2048
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128 --hidden 6144 --moe-intermediate-size 2048
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256 --hidden 4096 --moe-intermediate-size 1536
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 256 --hidden 4096 --moe-intermediate-size 1536
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128 --hidden 4096 --moe-intermediate-size 1536
-#      - name: Run test fused deepep moe eplb
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --topk-drop-col 3
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --topk-drop-prob 0.3
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 2
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 3 --num-experts 16
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 4 --topk-drop-col 1 --num-experts 32
-#      - name: Run test fused deepep moe for little processes
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-experts=24
-#      - name: Run test fused deepep moe for bs
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1913
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens=256
-#      - name: Run test fused deepep moe for hidden
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1913
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --hidden=2048
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --hidden=7168
-#      - name: Run test fused deepep moe for topk
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-topk=1
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-topk=12
-#      - name: Run test fused deepep moe for experts
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-topk=1 --num-experts=4
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-experts=384
-#      - name: Run test mixed running
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py
-#      - name: Run test mixed running for little processes
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2241
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --test-loop=100
-#      - name: Run test mixed running for bs
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 4065
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=1 --low-latency-num-tokens=1 --test-loop=100
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=8192 --low-latency-num-tokens=512 --test-loop=100
-#      - name: Run test mixed running for hidden
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=2048 --test-loop=100
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=4096 --test-loop=100
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=6144 --test-loop=100
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=7168 --test-loop=100
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=8192 --test-loop=100
-#      - name: Run test mixed running for experts
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 7500
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2 --test-loop=100
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=512 --test-loop=100 --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=1024 --test-loop=100 --num-processes=16
-#      - name: Run test mixed running for topk
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 4065
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=1 --test-loop=100
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=16 --test-loop=100
-#      - name: Run test mixed running for dynamic tokens
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3769
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --test-loop=100 --enable-dynamic-tokens
-#      - name: Run test fused deep moe for fuse_mode.DISPATCH_FFN_COMBINE
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2048
-#        run: python3 $GITHUB_WORKSPACE/tests/python/deepep/test_dispatch_ffn_combine.py
-#      - name: Run test alltoall mode for both normal and low_latency
-#        if: matrix.cann_version == '9.0.0'
-#        timeout-minutes: 10
-#        env:
-#          DEEP_MOE_MODE: alltoall
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type int8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type int8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type bf16
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type bf16
-#
-#  test-build-deepep-a2:
-#    needs: get-changed-files
-#    if: |
-#      github.event_name == 'workflow_dispatch' ||
-#      github.event_name == 'workflow_call' || (
-#        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
-#        github.event.pull_request.draft == false &&
-#        needs.get-changed-files.outputs.ops2_changed == 'true'
-#      )
-#    runs-on: linux-aarch64-a2-8
-#    container:
-#      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
-#    env:
-#      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
-#      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
-#      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
-#      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-#    strategy:
-#      matrix:
-#        cann_version: [9.0.0, 9.1.0]
-#    steps:
-#      - name: Clean git config
-#        run: |
-#          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
-#          git config --global --unset "$CONFIG_KEY" || true
-#      - name: Clean workspace
-#        run: |
-#          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
-#      - name: Checkout code
-#        uses: actions/checkout@v4
-#        with:
-#          clean: true
-#          submodules: recursive
-#      - name: Get build hash
-#        id: get_build_hash
-#        run: |
-#          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
-#            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
-#          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
-#          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
-#          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
-#          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
-#          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
-#      - name: Restore build cache
-#        id: cache-build
-#        uses: runs-on/cache@v4
-#        with:
-#          path: output
-#          key: sgl-kernel-npu-build-v4-${{ runner.os }}-a2-cann${{ matrix.cann_version }}-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
-#
-#      - name: Install dependencies
-#        run: |
-#          # speed up by using infra cache services
-#          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
-#          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
-#          pip config set global.index-url http://${CACHING_URL}/pypi/simple
-#          pip config set global.trusted-host ${CACHING_URL}
-#          pip install uv
-#          bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
-#      - name: Prepare Deepep
-#        # - cache hit: install cached wheel only (skip build via -s flag)
-#        # - cache miss: clear stale wheels + build (-a deepep2) + install
-#        run: |
-#          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
-#            echo "Cache hit, installing cached wheel only"
-#            bash scripts/prepare_deepep_in_container.sh -s
-#          else
-#            echo "Cache miss, building and installing"
-#            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
-#            bash scripts/prepare_deepep_in_container.sh -a deepep2
-#          fi
-#      - name: Run test intranode
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=8
-#      - name: Run test intranode for little bs
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=1 --num-processes=8
-#      - name: Run test intranode for big bs
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 4500
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=8000 --num-processes=8
-#      - name: Run test little processes intranode
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2
-#      - name: Run test hidden intranode
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=2048 --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=4096 --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=6144 --num-processes=8
-#      - name: Run test topk num intranode
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 4500
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=1 --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=16 --num-processes=8
-#      - name: Run test experts num intranode
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2 --num-topk=1 --num-experts=2
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=512 --num-processes=8
-#      - name: Run test intranode for active ranks
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=8 --active-ranks="0,1,3"
-#      - name: Run test intranode for DeepXtrace
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-diagnose --num-processes=8
-#      - name: Run test multi-round intranode
-#        timeout-minutes: 10
-#        env:
-#          DEEPEP_NORMAL_LONG_SEQ_ROUND: 5
-#          DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS: 512
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2122 --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2048 --num-processes=8
-#      - name: Run test intranode for use-fp8 quant
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=8 --use-fp8
-#
-#      - name: Run test intranode for output parameters of different types
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#          MOE_EXPERT_TOKEN_NUMS_TYPE: 0
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=8
-#      - name: Run test intranode for dynamic tokens
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-dynamic-tokens --num-processes=8
-#      - name: Run test low latency
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1913
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=1 --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=2 --num-processes=8
-#      - name: Run test low latency for big bs
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3825
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=8 --num-tokens=512
-#      - name: Run test low latency for little num processes
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1913
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2
-#      - name: Run test low latency for hidden
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1913
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=2048 --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=4096 --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=6144 --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=7168 --num-processes=8
-#      - name: Run test low latency for topk
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1969
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=4 --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=16 --num-processes=8
-#      - name: Run test low latency for experts
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 7481
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-experts=1024 --num-processes=8
-#      - name: Run test low latency for drop percent
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 1913
-#          MOE_ENABLE_TOPK_NEG_ONE: 1
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --drop-percent=0.3 --num-processes=8
-#      - name: Run test low latency for dynamic tokens
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 2300
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=8 --enable-dynamic-tokens
-#      - name: Run test mixed running
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=8
-#      - name: Run test mixed running for little processes
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --test-loop=100
-#      - name: Run test mixed running for bs
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 5000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=1 --low-latency-num-tokens=1 --test-loop=100 --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=8000 --low-latency-num-tokens=512 --test-loop=100 --num-processes=8
-#      - name: Run test mixed running for hidden
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=2048 --test-loop=100 --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=4096 --test-loop=100 --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=6144 --test-loop=100 --num-processes=8
-#      - name: Run test mixed running for topk
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 5000
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=1 --test-loop=100 --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=16 --test-loop=100 --num-processes=8
-#      - name: Run test mixed running for experts
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3769
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2 --test-loop=100
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=512 --test-loop=100 --num-processes=8
-#      - name: Run test mixed running for dynamic tokens
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3769
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --test-loop=100 --enable-dynamic-tokens --num-processes=8
-#      - name: Run test combine only
-#        timeout-minutes: 10
-#        env:
-#          HCCL_BUFFSIZE: 3900
-#        run: |
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --num-processes=8
-#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --test-type="low_latency" --num-processes=8
+  test-all-build-core:
+    needs: get-changed-files
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call' || (
+        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
+        github.event.pull_request.draft == false &&
+        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
+      )
+    runs-on: linux-aarch64-a3-800t-16
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
+    env:
+      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+    strategy:
+      matrix:
+        cann_version: [9.0.0, 9.1.0]
+    steps:
+      - name: Clean git config
+        run: |
+          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
+          git config --global --unset "$CONFIG_KEY" || true
+      - name: Clean workspace
+        run: |
+          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          clean: true
+          submodules: recursive
+      - name: Get build hash
+        id: get_build_hash
+        run: |
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
+            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+      - name: Restore build cache
+        id: cache-build
+        uses: runs-on/cache@v4
+        with:
+          path: output
+          key: sgl-kernel-npu-build-v4-${{ runner.os }}-a3-cann${{ matrix.cann_version }}-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+      - name: Install dependencies
+        run: |
+          # speed up by using infra cache services
+          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+          pip config set global.trusted-host ${CACHING_URL}
+          pip install uv
+          bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
+      - name: Prepare Deepep
+        # - cache hit: install cached wheel only (skip build via -s flag)
+        # - cache miss: clear stale wheels + build + install
+        run: |
+          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+            echo "Cache hit, installing cached wheel only"
+            bash scripts/prepare_deepep_in_container.sh -s
+          else
+            echo "Cache miss, building and installing"
+            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+            bash scripts/prepare_deepep_in_container.sh
+          fi
+      - name: Run test intranode
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
+      - name: Run test intranode for little bs
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 4065
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=4
+      - name: Run test intranode for big bs
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 4065
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=8192
+      - name: Run test multi-round intranode
+        timeout-minutes: 10
+        env:
+          DEEPEP_NORMAL_LONG_SEQ_ROUND: 5
+          DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS: 512
+          HCCL_BUFFSIZE: 1000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2122
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2048
+      - name: Run test little processes intranode
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2241
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2
+      - name: Run test hidden intranode
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=2048
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=4096
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=6144
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=7168
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=8192
+      - name: Run test topk num intranode
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 4065
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=1
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=16
+      - name: Run test experts num intranode
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2 --num-topk=1 --num-experts=2
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=512 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=1024 --num-processes=16
+      - name: Run test intranode for active ranks
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --active-ranks="0,1,3"
+      - name: Run test intranode for DeepXtrace
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-diagnose
+      - name: Run test intranode for use-fp8 quant
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --use-fp8
+
+      - name: Run test intranode for output parameters of different types
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+          MOE_EXPERT_TOKEN_NUMS_TYPE: 0
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
+      - name: Run test intranode for dynamic tokens
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-dynamic-tokens
+      - name: Run test low latency
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1913
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=1
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=2
+      - name: Run test low latency for big bs
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3825
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=512
+      - name: Run test low latency for little num processes
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1913
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2
+      - name: Run test low latency for hidden
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2200
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=2048
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=4096
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=6144
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=7168
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=8192
+      - name: Run test low latency for topk
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1969
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=4
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=16
+      - name: Run test low latency for experts
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 7481
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-experts=1024
+      - name: Run test low latency for drop percent
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1913
+          MOE_ENABLE_TOPK_NEG_ONE: 1
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --drop-percent=0.3
+      - name: Run test low latency for dynamic tokens
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --enable-dynamic-tokens
+      - name: Run test generalization of fused deep moe
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2048
+        run: bash scripts/generalization_test_fused_deep_moe.sh
+      - name: Run test combine only
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3900
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --test-type="low_latency"
+
+  test-all-build-moe:
+    needs: get-changed-files
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call' || (
+        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
+        github.event.pull_request.draft == false &&
+        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
+      )
+    runs-on: linux-aarch64-a3-800t-16
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
+    env:
+      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+    strategy:
+      matrix:
+        cann_version: [9.0.0, 9.1.0]
+    steps:
+      - name: Clean git config
+        run: |
+          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
+          git config --global --unset "$CONFIG_KEY" || true
+      - name: Clean workspace
+        run: |
+          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          clean: true
+          submodules: recursive
+      - name: Get build hash
+        id: get_build_hash
+        run: |
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
+            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+      - name: Restore build cache
+        id: cache-build
+        uses: runs-on/cache@v4
+        with:
+          path: output
+          key: sgl-kernel-npu-build-v4-${{ runner.os }}-a3-cann${{ matrix.cann_version }}-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+      - name: Install dependencies
+        run: |
+          # speed up by using infra cache services
+          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+          pip config set global.trusted-host ${CACHING_URL}
+          pip install uv
+          bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
+      - name: Prepare Deepep
+        # - cache hit: install cached wheel only (skip build via -s flag)
+        # - cache miss: clear stale wheels + build + install
+        run: |
+          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+            echo "Cache hit, installing cached wheel only"
+            bash scripts/prepare_deepep_in_container.sh -s
+          else
+            echo "Cache miss, building and installing"
+            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+            bash scripts/prepare_deepep_in_container.sh
+          fi
+      - name: Run test base fused deep moe
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 256
+      - name: Run test muti-model for fused deep moe
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256 --hidden 6144 --moe-intermediate-size 2048
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128 --hidden 6144 --moe-intermediate-size 2048
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256 --hidden 4096 --moe-intermediate-size 1536
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 256 --hidden 4096 --moe-intermediate-size 1536
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128 --hidden 4096 --moe-intermediate-size 1536
+      - name: Run test fused deepep moe eplb
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --topk-drop-col 3
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --topk-drop-prob 0.3
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 2
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 3 --num-experts 16
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 4 --topk-drop-col 1 --num-experts 32
+      - name: Run test fused deepep moe for little processes
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-experts=24
+      - name: Run test fused deepep moe for bs
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1913
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens=256
+      - name: Run test fused deepep moe for hidden
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1913
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --hidden=2048
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --hidden=7168
+      - name: Run test fused deepep moe for topk
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-topk=1
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-topk=12
+      - name: Run test fused deepep moe for experts
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-topk=1 --num-experts=4
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-experts=384
+      - name: Run test mixed running
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py
+      - name: Run test mixed running for little processes
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2241
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --test-loop=100
+      - name: Run test mixed running for bs
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 4065
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=1 --low-latency-num-tokens=1 --test-loop=100
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=8192 --low-latency-num-tokens=512 --test-loop=100
+      - name: Run test mixed running for hidden
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=2048 --test-loop=100
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=4096 --test-loop=100
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=6144 --test-loop=100
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=7168 --test-loop=100
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=8192 --test-loop=100
+      - name: Run test mixed running for experts
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 7500
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2 --test-loop=100
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=512 --test-loop=100 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=1024 --test-loop=100 --num-processes=16
+      - name: Run test mixed running for topk
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 4065
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=1 --test-loop=100
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=16 --test-loop=100
+      - name: Run test mixed running for dynamic tokens
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3769
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --test-loop=100 --enable-dynamic-tokens
+      - name: Run test fused deep moe for fuse_mode.DISPATCH_FFN_COMBINE
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2048
+        run: python3 $GITHUB_WORKSPACE/tests/python/deepep/test_dispatch_ffn_combine.py
+      - name: Run test alltoall mode for both normal and low_latency
+        if: matrix.cann_version == '9.0.0'
+        timeout-minutes: 10
+        env:
+          DEEP_MOE_MODE: alltoall
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type int8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type int8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type bf16
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type bf16
+
+  test-build-deepep-a2:
+    needs: get-changed-files
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call' || (
+        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
+        github.event.pull_request.draft == false &&
+        needs.get-changed-files.outputs.ops2_changed == 'true'
+      )
+    runs-on: linux-aarch64-a2-8
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
+    env:
+      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+    strategy:
+      matrix:
+        cann_version: [9.0.0, 9.1.0]
+    steps:
+      - name: Clean git config
+        run: |
+          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
+          git config --global --unset "$CONFIG_KEY" || true
+      - name: Clean workspace
+        run: |
+          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          clean: true
+          submodules: recursive
+      - name: Get build hash
+        id: get_build_hash
+        run: |
+          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
+            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+      - name: Restore build cache
+        id: cache-build
+        uses: runs-on/cache@v4
+        with:
+          path: output
+          key: sgl-kernel-npu-build-v4-${{ runner.os }}-a2-cann${{ matrix.cann_version }}-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+
+      - name: Install dependencies
+        run: |
+          # speed up by using infra cache services
+          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+          pip config set global.trusted-host ${CACHING_URL}
+          pip install uv
+          bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
+      - name: Prepare Deepep
+        # - cache hit: install cached wheel only (skip build via -s flag)
+        # - cache miss: clear stale wheels + build (-a deepep2) + install
+        run: |
+          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+            echo "Cache hit, installing cached wheel only"
+            bash scripts/prepare_deepep_in_container.sh -s
+          else
+            echo "Cache miss, building and installing"
+            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+            bash scripts/prepare_deepep_in_container.sh -a deepep2
+          fi
+      - name: Run test intranode
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=8
+      - name: Run test intranode for little bs
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=1 --num-processes=8
+      - name: Run test intranode for big bs
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 4500
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=8000 --num-processes=8
+      - name: Run test little processes intranode
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2
+      - name: Run test hidden intranode
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=2048 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=4096 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=6144 --num-processes=8
+      - name: Run test topk num intranode
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 4500
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=1 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=16 --num-processes=8
+      - name: Run test experts num intranode
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2 --num-topk=1 --num-experts=2
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=512 --num-processes=8
+      - name: Run test intranode for active ranks
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=8 --active-ranks="0,1,3"
+      - name: Run test intranode for DeepXtrace
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-diagnose --num-processes=8
+      - name: Run test multi-round intranode
+        timeout-minutes: 10
+        env:
+          DEEPEP_NORMAL_LONG_SEQ_ROUND: 5
+          DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS: 512
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2122 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2048 --num-processes=8
+      - name: Run test intranode for use-fp8 quant
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=8 --use-fp8
+
+      - name: Run test intranode for output parameters of different types
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+          MOE_EXPERT_TOKEN_NUMS_TYPE: 0
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=8
+      - name: Run test intranode for dynamic tokens
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-dynamic-tokens --num-processes=8
+      - name: Run test low latency
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1913
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=1 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=2 --num-processes=8
+      - name: Run test low latency for big bs
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3825
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=8 --num-tokens=512
+      - name: Run test low latency for little num processes
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1913
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2
+      - name: Run test low latency for hidden
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1913
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=2048 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=4096 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=6144 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=7168 --num-processes=8
+      - name: Run test low latency for topk
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1969
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=4 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=16 --num-processes=8
+      - name: Run test low latency for experts
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 7481
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-experts=1024 --num-processes=8
+      - name: Run test low latency for drop percent
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 1913
+          MOE_ENABLE_TOPK_NEG_ONE: 1
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --drop-percent=0.3 --num-processes=8
+      - name: Run test low latency for dynamic tokens
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 2300
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=8 --enable-dynamic-tokens
+      - name: Run test mixed running
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=8
+      - name: Run test mixed running for little processes
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --test-loop=100
+      - name: Run test mixed running for bs
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 5000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=1 --low-latency-num-tokens=1 --test-loop=100 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=8000 --low-latency-num-tokens=512 --test-loop=100 --num-processes=8
+      - name: Run test mixed running for hidden
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=2048 --test-loop=100 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=4096 --test-loop=100 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=6144 --test-loop=100 --num-processes=8
+      - name: Run test mixed running for topk
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 5000
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=1 --test-loop=100 --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=16 --test-loop=100 --num-processes=8
+      - name: Run test mixed running for experts
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3769
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2 --test-loop=100
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=512 --test-loop=100 --num-processes=8
+      - name: Run test mixed running for dynamic tokens
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3769
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --test-loop=100 --enable-dynamic-tokens --num-processes=8
+      - name: Run test combine only
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 3900
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --num-processes=8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --test-type="low_latency" --num-processes=8
 
   test-deepep-a5:
     needs: get-changed-files
@@ -928,9 +928,9 @@ jobs:
   finish:
     if: always()
     needs:
-#      - test-all-build-core
-#      - test-all-build-moe
-#      - test-build-deepep-a2
+      - test-all-build-core
+      - test-all-build-moe
+      - test-build-deepep-a2
       - test-deepep-a5
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -819,66 +819,64 @@ jobs:
             rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
             bash scripts/prepare_deepep_in_container.sh -a deepep Ascend950
           fi
-      - name: Run normal mode pertoken_fp8_e4m3 quantization
+      - name: Run normal mode use-fp8 quantization
         env:
           HCCL_BUFFSIZE: 500
         timeout-minutes: 20
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 512 --hidden 7168 --num-topk 8 --num-experts 256 --quant-type pertoken_fp8_e4m3
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --quant-type pertoken_fp8_e4m3
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 512 --hidden 7168 --num-topk 8 --num-experts 256 --use-fp8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --use-fp8
 
-      - name: Run normal mode mx_fp8_e4m3 quantization
+      - name: Run normal mode use-mxfp8 quantization
         env:
           HCCL_BUFFSIZE: 500
         timeout-minutes: 10
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=4 --num-tokens=256 --num-experts=32 --quant-type=mx_fp8_e4m3
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=4 --num-tokens=256 --num-experts=32 --use-mxfp8
 
-      - name: Run normal mode mx_fp4_e2m1 quantization
+      - name: Run normal mode use-mxfp4 quantization
         env:
           HCCL_BUFFSIZE: 500
         timeout-minutes: 10
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=4 --num-tokens=256 --num-experts=32 --quant-type=mx_fp4_e2m1
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=4 --num-tokens=256 --num-experts=32 --use-mxfp4
 
-      - name: Run low‑latency mode mx_fp8_e4m3 quantization
+      - name: Run low‑latency mode use-mxfp8 quantization
         env:
           HCCL_BUFFSIZE: 10000
         timeout-minutes: 10
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=256 --hidden=8192
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4 --num-topk=6 --num-tokens=512 --num-experts=256 --hidden=7168
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type mx_fp8_e4m3 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=520 --hidden=8192
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --use-mxfp8 --num-processes=4
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --use-mxfp8 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=256 --hidden=8192
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --use-mxfp8 --num-processes=4 --num-topk=6 --num-tokens=512 --num-experts=256 --hidden=7168
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --use-mxfp8 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=520 --hidden=8192
 
-      - name: Run low‑latency mode mx_fp4_e2m1 quantization
+      - name: Run low‑latency mode use-mxfp4 quantization
         env:
           HCCL_BUFFSIZE: 2500
         timeout-minutes: 10
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=8 --num-experts=256 --hidden=7168 --num-tokens=256 --quant-type=mx_fp4_e2m1
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=12 --num-experts=512 --hidden=8192 --num-tokens=128 --quant-type=mx_fp4_e2m1 --enable-dynamic-tokens
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=8 --num-experts=256 --hidden=7168 --num-tokens=256 --use-mxfp4
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=12 --num-experts=512 --hidden=8192 --num-tokens=128 --use-mxfp4 --enable-dynamic-tokens
 
-      - name: Run low‑latency mode pertoken_fp8_e4m3 quantization
+      - name: Run low‑latency mode use-fp8 quantization
         env:
           HCCL_BUFFSIZE: 2500
         timeout-minutes: 10
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 256 --hidden 7168 --num-topk 8 --num-experts 256 --quant-type pertoken_fp8_e4m3
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --quant-type pertoken_fp8_e4m3
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --quant-type pertoken_fp8_e4m3
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 256 --hidden 7168 --num-topk 8 --num-experts 256 --use-mxfp8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-mxfp8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --use-mxfp8
 
       - name: Run alltoall normal
         timeout-minutes: 10
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --num-processes 4
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --num-processes 4 --quant-type int8
 
       - name: Run alltoall low-latency
         timeout-minutes: 10
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --num-processes 4
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --num-processes 4 --quant-type int8
 
       - name: Run fusion operator
         timeout-minutes: 10
@@ -889,7 +887,7 @@ jobs:
         timeout-minutes: 10
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
-          --quant fp8_e4m3 \
+          --use-mxfp8 \
           --num-processes 4 \
           --hidden 7168 \
           --moe-intermediate-size 3072 \
@@ -903,7 +901,7 @@ jobs:
         timeout-minutes: 10
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
-          --quant fp8_e4m3 \
+          --use-mxfp8 \
           --num-processes 4 \
           --hidden 7168 \
           --moe-intermediate-size 3072 \
@@ -917,7 +915,7 @@ jobs:
         timeout-minutes: 10
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
-          --quant fp8_e4m3 \
+          --use-mxfp8 \
           --num-processes 4 \
           --hidden 7168 \
           --moe-intermediate-size 3072 \

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -51,703 +51,703 @@ jobs:
               - scripts/**
               - .github/workflows/pr-test-deepep-npu.yml
 
-  test-all-build-core:
-    needs: get-changed-files
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call' || (
-        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
-        github.event.pull_request.draft == false &&
-        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
-      )
-    runs-on: linux-aarch64-a3-800t-16
-    container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
-    env:
-      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
-      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
-      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
-      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-    strategy:
-      matrix:
-        cann_version: [9.0.0, 9.1.0]
-    steps:
-      - name: Clean git config
-        run: |
-          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
-          git config --global --unset "$CONFIG_KEY" || true
-      - name: Clean workspace
-        run: |
-          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          clean: true
-          submodules: recursive
-      - name: Get build hash
-        id: get_build_hash
-        run: |
-          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
-            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
-          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
-          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
-          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
-          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
-          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
-      - name: Restore build cache
-        id: cache-build
-        uses: runs-on/cache@v4
-        with:
-          path: output
-          key: sgl-kernel-npu-build-v4-${{ runner.os }}-a3-cann${{ matrix.cann_version }}-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
-      - name: Install dependencies
-        run: |
-          # speed up by using infra cache services
-          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
-          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
-          pip config set global.index-url http://${CACHING_URL}/pypi/simple
-          pip config set global.trusted-host ${CACHING_URL}
-          pip install uv
-          bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
-      - name: Prepare Deepep
-        # - cache hit: install cached wheel only (skip build via -s flag)
-        # - cache miss: clear stale wheels + build + install
-        run: |
-          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
-            echo "Cache hit, installing cached wheel only"
-            bash scripts/prepare_deepep_in_container.sh -s
-          else
-            echo "Cache miss, building and installing"
-            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
-            bash scripts/prepare_deepep_in_container.sh
-          fi
-      - name: Run test intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
-      - name: Run test intranode for little bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 4065
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=4
-      - name: Run test intranode for big bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 4065
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=8192
-      - name: Run test multi-round intranode
-        timeout-minutes: 10
-        env:
-          DEEPEP_NORMAL_LONG_SEQ_ROUND: 5
-          DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS: 512
-          HCCL_BUFFSIZE: 1000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2122
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2048
-      - name: Run test little processes intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2241
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2
-      - name: Run test hidden intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=2048
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=4096
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=6144
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=7168
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=8192
-      - name: Run test topk num intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 4065
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=1
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=16
-      - name: Run test experts num intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2 --num-topk=1 --num-experts=2
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=512 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=1024 --num-processes=16
-      - name: Run test intranode for active ranks
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --active-ranks="0,1,3"
-      - name: Run test intranode for DeepXtrace
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-diagnose
-      - name: Run test intranode for use-fp8 quant
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --use-fp8
-
-      - name: Run test intranode for output parameters of different types
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-          MOE_EXPERT_TOKEN_NUMS_TYPE: 0
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
-      - name: Run test intranode for dynamic tokens
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-dynamic-tokens
-      - name: Run test low latency
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1913
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=1
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=2
-      - name: Run test low latency for big bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3825
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=512
-      - name: Run test low latency for little num processes
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1913
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2
-      - name: Run test low latency for hidden
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2200
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=2048
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=4096
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=6144
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=7168
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=8192
-      - name: Run test low latency for topk
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1969
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=4
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=16
-      - name: Run test low latency for experts
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 7481
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-experts=1024
-      - name: Run test low latency for drop percent
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1913
-          MOE_ENABLE_TOPK_NEG_ONE: 1
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --drop-percent=0.3
-      - name: Run test low latency for dynamic tokens
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --enable-dynamic-tokens
-      - name: Run test generalization of fused deep moe
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2048
-        run: bash scripts/generalization_test_fused_deep_moe.sh
-      - name: Run test combine only
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3900
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --test-type="low_latency"
-
-  test-all-build-moe:
-    needs: get-changed-files
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call' || (
-        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
-        github.event.pull_request.draft == false &&
-        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
-      )
-    runs-on: linux-aarch64-a3-800t-16
-    container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
-    env:
-      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
-      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
-      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
-      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-    strategy:
-      matrix:
-        cann_version: [9.0.0, 9.1.0]
-    steps:
-      - name: Clean git config
-        run: |
-          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
-          git config --global --unset "$CONFIG_KEY" || true
-      - name: Clean workspace
-        run: |
-          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          clean: true
-          submodules: recursive
-      - name: Get build hash
-        id: get_build_hash
-        run: |
-          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
-            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
-          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
-          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
-          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
-          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
-          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
-      - name: Restore build cache
-        id: cache-build
-        uses: runs-on/cache@v4
-        with:
-          path: output
-          key: sgl-kernel-npu-build-v4-${{ runner.os }}-a3-cann${{ matrix.cann_version }}-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
-      - name: Install dependencies
-        run: |
-          # speed up by using infra cache services
-          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
-          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
-          pip config set global.index-url http://${CACHING_URL}/pypi/simple
-          pip config set global.trusted-host ${CACHING_URL}
-          pip install uv
-          bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
-      - name: Prepare Deepep
-        # - cache hit: install cached wheel only (skip build via -s flag)
-        # - cache miss: clear stale wheels + build + install
-        run: |
-          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
-            echo "Cache hit, installing cached wheel only"
-            bash scripts/prepare_deepep_in_container.sh -s
-          else
-            echo "Cache miss, building and installing"
-            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
-            bash scripts/prepare_deepep_in_container.sh
-          fi
-      - name: Run test base fused deep moe
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 256
-      - name: Run test muti-model for fused deep moe
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256 --hidden 6144 --moe-intermediate-size 2048
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128 --hidden 6144 --moe-intermediate-size 2048
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256 --hidden 4096 --moe-intermediate-size 1536
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 256 --hidden 4096 --moe-intermediate-size 1536
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128 --hidden 4096 --moe-intermediate-size 1536
-      - name: Run test fused deepep moe eplb
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --topk-drop-col 3
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --topk-drop-prob 0.3
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 2
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 3 --num-experts 16
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 4 --topk-drop-col 1 --num-experts 32
-      - name: Run test fused deepep moe for little processes
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-experts=24
-      - name: Run test fused deepep moe for bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1913
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens=256
-      - name: Run test fused deepep moe for hidden
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1913
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --hidden=2048
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --hidden=7168
-      - name: Run test fused deepep moe for topk
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-topk=1
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-topk=12
-      - name: Run test fused deepep moe for experts
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-topk=1 --num-experts=4
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-experts=384
-      - name: Run test mixed running
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py
-      - name: Run test mixed running for little processes
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2241
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --test-loop=100
-      - name: Run test mixed running for bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 4065
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=1 --low-latency-num-tokens=1 --test-loop=100
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=8192 --low-latency-num-tokens=512 --test-loop=100
-      - name: Run test mixed running for hidden
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=2048 --test-loop=100
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=4096 --test-loop=100
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=6144 --test-loop=100
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=7168 --test-loop=100
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=8192 --test-loop=100
-      - name: Run test mixed running for experts
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 7500
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2 --test-loop=100
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=512 --test-loop=100 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=1024 --test-loop=100 --num-processes=16
-      - name: Run test mixed running for topk
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 4065
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=1 --test-loop=100
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=16 --test-loop=100
-      - name: Run test mixed running for dynamic tokens
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3769
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --test-loop=100 --enable-dynamic-tokens
-      - name: Run test fused deep moe for fuse_mode.DISPATCH_FFN_COMBINE
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2048
-        run: python3 $GITHUB_WORKSPACE/tests/python/deepep/test_dispatch_ffn_combine.py
-      - name: Run test alltoall mode for both normal and low_latency
-        if: matrix.cann_version == '9.0.0'
-        timeout-minutes: 10
-        env:
-          DEEP_MOE_MODE: alltoall
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type int8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type int8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type bf16
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type bf16
-
-  test-build-deepep-a2:
-    needs: get-changed-files
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call' || (
-        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
-        github.event.pull_request.draft == false &&
-        needs.get-changed-files.outputs.ops2_changed == 'true'
-      )
-    runs-on: linux-aarch64-a2-8
-    container:
-      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
-    env:
-      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
-      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
-      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
-      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-    strategy:
-      matrix:
-        cann_version: [9.0.0, 9.1.0]
-    steps:
-      - name: Clean git config
-        run: |
-          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
-          git config --global --unset "$CONFIG_KEY" || true
-      - name: Clean workspace
-        run: |
-          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          clean: true
-          submodules: recursive
-      - name: Get build hash
-        id: get_build_hash
-        run: |
-          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
-            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
-          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
-          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
-          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
-          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
-          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
-      - name: Restore build cache
-        id: cache-build
-        uses: runs-on/cache@v4
-        with:
-          path: output
-          key: sgl-kernel-npu-build-v4-${{ runner.os }}-a2-cann${{ matrix.cann_version }}-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
-
-      - name: Install dependencies
-        run: |
-          # speed up by using infra cache services
-          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
-          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
-          pip config set global.index-url http://${CACHING_URL}/pypi/simple
-          pip config set global.trusted-host ${CACHING_URL}
-          pip install uv
-          bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
-      - name: Prepare Deepep
-        # - cache hit: install cached wheel only (skip build via -s flag)
-        # - cache miss: clear stale wheels + build (-a deepep2) + install
-        run: |
-          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
-            echo "Cache hit, installing cached wheel only"
-            bash scripts/prepare_deepep_in_container.sh -s
-          else
-            echo "Cache miss, building and installing"
-            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
-            bash scripts/prepare_deepep_in_container.sh -a deepep2
-          fi
-      - name: Run test intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=8
-      - name: Run test intranode for little bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=1 --num-processes=8
-      - name: Run test intranode for big bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 4500
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=8000 --num-processes=8
-      - name: Run test little processes intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2
-      - name: Run test hidden intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=2048 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=4096 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=6144 --num-processes=8
-      - name: Run test topk num intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 4500
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=1 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=16 --num-processes=8
-      - name: Run test experts num intranode
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2 --num-topk=1 --num-experts=2
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=512 --num-processes=8
-      - name: Run test intranode for active ranks
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=8 --active-ranks="0,1,3"
-      - name: Run test intranode for DeepXtrace
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-diagnose --num-processes=8
-      - name: Run test multi-round intranode
-        timeout-minutes: 10
-        env:
-          DEEPEP_NORMAL_LONG_SEQ_ROUND: 5
-          DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS: 512
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2122 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2048 --num-processes=8
-      - name: Run test intranode for use-fp8 quant
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=8 --use-fp8
-
-      - name: Run test intranode for output parameters of different types
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-          MOE_EXPERT_TOKEN_NUMS_TYPE: 0
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=8
-      - name: Run test intranode for dynamic tokens
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-dynamic-tokens --num-processes=8
-      - name: Run test low latency
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1913
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=1 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=2 --num-processes=8
-      - name: Run test low latency for big bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3825
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=8 --num-tokens=512
-      - name: Run test low latency for little num processes
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1913
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2
-      - name: Run test low latency for hidden
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1913
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=2048 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=4096 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=6144 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=7168 --num-processes=8
-      - name: Run test low latency for topk
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1969
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=4 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=16 --num-processes=8
-      - name: Run test low latency for experts
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 7481
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-experts=1024 --num-processes=8
-      - name: Run test low latency for drop percent
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 1913
-          MOE_ENABLE_TOPK_NEG_ONE: 1
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --drop-percent=0.3 --num-processes=8
-      - name: Run test low latency for dynamic tokens
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 2300
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=8 --enable-dynamic-tokens
-      - name: Run test mixed running
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=8
-      - name: Run test mixed running for little processes
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --test-loop=100
-      - name: Run test mixed running for bs
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 5000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=1 --low-latency-num-tokens=1 --test-loop=100 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=8000 --low-latency-num-tokens=512 --test-loop=100 --num-processes=8
-      - name: Run test mixed running for hidden
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=2048 --test-loop=100 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=4096 --test-loop=100 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=6144 --test-loop=100 --num-processes=8
-      - name: Run test mixed running for topk
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 5000
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=1 --test-loop=100 --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=16 --test-loop=100 --num-processes=8
-      - name: Run test mixed running for experts
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3769
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2 --test-loop=100
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=512 --test-loop=100 --num-processes=8
-      - name: Run test mixed running for dynamic tokens
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3769
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --test-loop=100 --enable-dynamic-tokens --num-processes=8
-      - name: Run test combine only
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 3900
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --num-processes=8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --test-type="low_latency" --num-processes=8
+#  test-all-build-core:
+#    needs: get-changed-files
+#    if: |
+#      github.event_name == 'workflow_dispatch' ||
+#      github.event_name == 'workflow_call' || (
+#        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
+#        github.event.pull_request.draft == false &&
+#        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
+#      )
+#    runs-on: linux-aarch64-a3-800t-16
+#    container:
+#      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
+#    env:
+#      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+#      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+#      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+#      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+#    strategy:
+#      matrix:
+#        cann_version: [9.0.0, 9.1.0]
+#    steps:
+#      - name: Clean git config
+#        run: |
+#          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
+#          git config --global --unset "$CONFIG_KEY" || true
+#      - name: Clean workspace
+#        run: |
+#          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
+#      - name: Checkout code
+#        uses: actions/checkout@v4
+#        with:
+#          clean: true
+#          submodules: recursive
+#      - name: Get build hash
+#        id: get_build_hash
+#        run: |
+#          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
+#            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+#          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+#          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+#          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+#          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+#          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+#      - name: Restore build cache
+#        id: cache-build
+#        uses: runs-on/cache@v4
+#        with:
+#          path: output
+#          key: sgl-kernel-npu-build-v4-${{ runner.os }}-a3-cann${{ matrix.cann_version }}-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+#      - name: Install dependencies
+#        run: |
+#          # speed up by using infra cache services
+#          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+#          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+#          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+#          pip config set global.trusted-host ${CACHING_URL}
+#          pip install uv
+#          bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
+#      - name: Prepare Deepep
+#        # - cache hit: install cached wheel only (skip build via -s flag)
+#        # - cache miss: clear stale wheels + build + install
+#        run: |
+#          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+#            echo "Cache hit, installing cached wheel only"
+#            bash scripts/prepare_deepep_in_container.sh -s
+#          else
+#            echo "Cache miss, building and installing"
+#            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+#            bash scripts/prepare_deepep_in_container.sh
+#          fi
+#      - name: Run test intranode
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
+#      - name: Run test intranode for little bs
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 4065
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=4
+#      - name: Run test intranode for big bs
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 4065
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=8192
+#      - name: Run test multi-round intranode
+#        timeout-minutes: 10
+#        env:
+#          DEEPEP_NORMAL_LONG_SEQ_ROUND: 5
+#          DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS: 512
+#          HCCL_BUFFSIZE: 1000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2122
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2048
+#      - name: Run test little processes intranode
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2241
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2
+#      - name: Run test hidden intranode
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=2048
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=4096
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=6144
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=7168
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=8192
+#      - name: Run test topk num intranode
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 4065
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=1
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=16
+#      - name: Run test experts num intranode
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2 --num-topk=1 --num-experts=2
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=512 --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=1024 --num-processes=16
+#      - name: Run test intranode for active ranks
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --active-ranks="0,1,3"
+#      - name: Run test intranode for DeepXtrace
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-diagnose
+#      - name: Run test intranode for use-fp8 quant
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --use-fp8
+#
+#      - name: Run test intranode for output parameters of different types
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#          MOE_EXPERT_TOKEN_NUMS_TYPE: 0
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py
+#      - name: Run test intranode for dynamic tokens
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-dynamic-tokens
+#      - name: Run test low latency
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1913
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=1
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=2
+#      - name: Run test low latency for big bs
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3825
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=512
+#      - name: Run test low latency for little num processes
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1913
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2
+#      - name: Run test low latency for hidden
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2200
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=2048
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=4096
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=6144
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=7168
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=8192
+#      - name: Run test low latency for topk
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1969
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=4
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=16
+#      - name: Run test low latency for experts
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 7481
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-experts=1024
+#      - name: Run test low latency for drop percent
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1913
+#          MOE_ENABLE_TOPK_NEG_ONE: 1
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --drop-percent=0.3
+#      - name: Run test low latency for dynamic tokens
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --enable-dynamic-tokens
+#      - name: Run test generalization of fused deep moe
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2048
+#        run: bash scripts/generalization_test_fused_deep_moe.sh
+#      - name: Run test combine only
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3900
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --test-type="low_latency"
+#
+#  test-all-build-moe:
+#    needs: get-changed-files
+#    if: |
+#      github.event_name == 'workflow_dispatch' ||
+#      github.event_name == 'workflow_call' || (
+#        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
+#        github.event.pull_request.draft == false &&
+#        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
+#      )
+#    runs-on: linux-aarch64-a3-800t-16
+#    container:
+#      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
+#    env:
+#      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+#      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+#      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+#      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+#    strategy:
+#      matrix:
+#        cann_version: [9.0.0, 9.1.0]
+#    steps:
+#      - name: Clean git config
+#        run: |
+#          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
+#          git config --global --unset "$CONFIG_KEY" || true
+#      - name: Clean workspace
+#        run: |
+#          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
+#      - name: Checkout code
+#        uses: actions/checkout@v4
+#        with:
+#          clean: true
+#          submodules: recursive
+#      - name: Get build hash
+#        id: get_build_hash
+#        run: |
+#          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
+#            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+#          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+#          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+#          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+#          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+#          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+#      - name: Restore build cache
+#        id: cache-build
+#        uses: runs-on/cache@v4
+#        with:
+#          path: output
+#          key: sgl-kernel-npu-build-v4-${{ runner.os }}-a3-cann${{ matrix.cann_version }}-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+#      - name: Install dependencies
+#        run: |
+#          # speed up by using infra cache services
+#          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+#          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+#          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+#          pip config set global.trusted-host ${CACHING_URL}
+#          pip install uv
+#          bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
+#      - name: Prepare Deepep
+#        # - cache hit: install cached wheel only (skip build via -s flag)
+#        # - cache miss: clear stale wheels + build + install
+#        run: |
+#          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+#            echo "Cache hit, installing cached wheel only"
+#            bash scripts/prepare_deepep_in_container.sh -s
+#          else
+#            echo "Cache miss, building and installing"
+#            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+#            bash scripts/prepare_deepep_in_container.sh
+#          fi
+#      - name: Run test base fused deep moe
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 256
+#      - name: Run test muti-model for fused deep moe
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256 --hidden 6144 --moe-intermediate-size 2048
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128 --hidden 6144 --moe-intermediate-size 2048
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --num-experts 256 --hidden 4096 --moe-intermediate-size 1536
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 256 --hidden 4096 --moe-intermediate-size 1536
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 48 --num-experts 128 --hidden 4096 --moe-intermediate-size 1536
+#      - name: Run test fused deepep moe eplb
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --topk-drop-col 3
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --topk-drop-prob 0.3
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 2
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 2 --topk-drop-col 3 --num-experts 16
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens 4 --topk-drop-col 1 --num-experts 32
+#      - name: Run test fused deepep moe for little processes
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-experts=24
+#      - name: Run test fused deepep moe for bs
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1913
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-tokens=256
+#      - name: Run test fused deepep moe for hidden
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1913
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --hidden=2048
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --hidden=7168
+#      - name: Run test fused deepep moe for topk
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-topk=1
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-topk=12
+#      - name: Run test fused deepep moe for experts
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-processes=2 --num-topk=1 --num-experts=4
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe.py --num-experts=384
+#      - name: Run test mixed running
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py
+#      - name: Run test mixed running for little processes
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2241
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --test-loop=100
+#      - name: Run test mixed running for bs
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 4065
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=1 --low-latency-num-tokens=1 --test-loop=100
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=8192 --low-latency-num-tokens=512 --test-loop=100
+#      - name: Run test mixed running for hidden
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=2048 --test-loop=100
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=4096 --test-loop=100
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=6144 --test-loop=100
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=7168 --test-loop=100
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=8192 --test-loop=100
+#      - name: Run test mixed running for experts
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 7500
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2 --test-loop=100
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=512 --test-loop=100 --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=1024 --test-loop=100 --num-processes=16
+#      - name: Run test mixed running for topk
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 4065
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=1 --test-loop=100
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=16 --test-loop=100
+#      - name: Run test mixed running for dynamic tokens
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3769
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --test-loop=100 --enable-dynamic-tokens
+#      - name: Run test fused deep moe for fuse_mode.DISPATCH_FFN_COMBINE
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2048
+#        run: python3 $GITHUB_WORKSPACE/tests/python/deepep/test_dispatch_ffn_combine.py
+#      - name: Run test alltoall mode for both normal and low_latency
+#        if: matrix.cann_version == '9.0.0'
+#        timeout-minutes: 10
+#        env:
+#          DEEP_MOE_MODE: alltoall
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type int8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type int8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --quant-type bf16
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --quant-type bf16
+#
+#  test-build-deepep-a2:
+#    needs: get-changed-files
+#    if: |
+#      github.event_name == 'workflow_dispatch' ||
+#      github.event_name == 'workflow_call' || (
+#        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
+#        github.event.pull_request.draft == false &&
+#        needs.get-changed-files.outputs.ops2_changed == 'true'
+#      )
+#    runs-on: linux-aarch64-a2-8
+#    container:
+#      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
+#    env:
+#      TORCH_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu"
+#      PYPI_CACHE_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+#      GITHUB_PROXY_URL: "https://gh-proxy.test.osinfra.cn/"
+#      UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+#    strategy:
+#      matrix:
+#        cann_version: [9.0.0, 9.1.0]
+#    steps:
+#      - name: Clean git config
+#        run: |
+#          CONFIG_KEY='http.https://gh-proxy.test.osinfra.cn/.extraheader'
+#          git config --global --unset "$CONFIG_KEY" || true
+#      - name: Clean workspace
+#        run: |
+#          sudo rm -rf --one-file-system "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.* 2>/dev/null || true
+#      - name: Checkout code
+#        uses: actions/checkout@v4
+#        with:
+#          clean: true
+#          submodules: recursive
+#      - name: Get build hash
+#        id: get_build_hash
+#        run: |
+#          BUILD_HASH=$(find ./csrc ./cmake ./python ./build.sh ./CMakeLists.txt ./scripts/prepare_deepep_in_container.sh ./scripts/npu_ci_install_dependency.sh \
+#            -type f -not -path '*/.*' 2>/dev/null | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+#          echo "BUILD_HASH=$BUILD_HASH" >> $GITHUB_OUTPUT
+#          CANN_RAW=$(cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || echo "unknown")
+#          CANN_VERSION=$(echo "$CANN_RAW" | tr -cd '[:alnum:].-' | head -c 32)
+#          [ -z "$CANN_VERSION" ] && CANN_VERSION="unknown"
+#          echo "CANN_VERSION=$CANN_VERSION" >> $GITHUB_OUTPUT
+#      - name: Restore build cache
+#        id: cache-build
+#        uses: runs-on/cache@v4
+#        with:
+#          path: output
+#          key: sgl-kernel-npu-build-v4-${{ runner.os }}-a2-cann${{ matrix.cann_version }}-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}-${{ steps.get_build_hash.outputs.BUILD_HASH }}
+#
+#      - name: Install dependencies
+#        run: |
+#          # speed up by using infra cache services
+#          CACHING_URL="cache-service.nginx-pypi-cache.svc.cluster.local"
+#          sed -Ei "s@(ports|archive).ubuntu.com@${CACHING_URL}:8081@g" /etc/apt/sources.list
+#          pip config set global.index-url http://${CACHING_URL}/pypi/simple
+#          pip config set global.trusted-host ${CACHING_URL}
+#          pip install uv
+#          bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
+#      - name: Prepare Deepep
+#        # - cache hit: install cached wheel only (skip build via -s flag)
+#        # - cache miss: clear stale wheels + build (-a deepep2) + install
+#        run: |
+#          if [ "${{ steps.cache-build.outputs.cache-hit }}" = "true" ]; then
+#            echo "Cache hit, installing cached wheel only"
+#            bash scripts/prepare_deepep_in_container.sh -s
+#          else
+#            echo "Cache miss, building and installing"
+#            rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
+#            bash scripts/prepare_deepep_in_container.sh -a deepep2
+#          fi
+#      - name: Run test intranode
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=8
+#      - name: Run test intranode for little bs
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=1 --num-processes=8
+#      - name: Run test intranode for big bs
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 4500
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=8000 --num-processes=8
+#      - name: Run test little processes intranode
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2
+#      - name: Run test hidden intranode
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=2048 --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=4096 --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --hidden=6144 --num-processes=8
+#      - name: Run test topk num intranode
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 4500
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=1 --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-topk=16 --num-processes=8
+#      - name: Run test experts num intranode
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=2 --num-topk=1 --num-experts=2
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-experts=512 --num-processes=8
+#      - name: Run test intranode for active ranks
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=8 --active-ranks="0,1,3"
+#      - name: Run test intranode for DeepXtrace
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-diagnose --num-processes=8
+#      - name: Run test multi-round intranode
+#        timeout-minutes: 10
+#        env:
+#          DEEPEP_NORMAL_LONG_SEQ_ROUND: 5
+#          DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS: 512
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2122 --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-tokens=2048 --num-processes=8
+#      - name: Run test intranode for use-fp8 quant
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=8 --use-fp8
+#
+#      - name: Run test intranode for output parameters of different types
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#          MOE_EXPERT_TOKEN_NUMS_TYPE: 0
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=8
+#      - name: Run test intranode for dynamic tokens
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --enable-dynamic-tokens --num-processes=8
+#      - name: Run test low latency
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1913
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=1 --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-tokens=2 --num-processes=8
+#      - name: Run test low latency for big bs
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3825
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=8 --num-tokens=512
+#      - name: Run test low latency for little num processes
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1913
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2
+#      - name: Run test low latency for hidden
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1913
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=2048 --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=4096 --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=6144 --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --hidden=7168 --num-processes=8
+#      - name: Run test low latency for topk
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1969
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=4 --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-topk=16 --num-processes=8
+#      - name: Run test low latency for experts
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 7481
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-experts=1024 --num-processes=8
+#      - name: Run test low latency for drop percent
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 1913
+#          MOE_ENABLE_TOPK_NEG_ONE: 1
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --drop-percent=0.3 --num-processes=8
+#      - name: Run test low latency for dynamic tokens
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 2300
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=8 --enable-dynamic-tokens
+#      - name: Run test mixed running
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=8
+#      - name: Run test mixed running for little processes
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --test-loop=100
+#      - name: Run test mixed running for bs
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 5000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=1 --low-latency-num-tokens=1 --test-loop=100 --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --normal-num-tokens=8000 --low-latency-num-tokens=512 --test-loop=100 --num-processes=8
+#      - name: Run test mixed running for hidden
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=2048 --test-loop=100 --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=4096 --test-loop=100 --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --hidden=6144 --test-loop=100 --num-processes=8
+#      - name: Run test mixed running for topk
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 5000
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=1 --test-loop=100 --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-topk=16 --test-loop=100 --num-processes=8
+#      - name: Run test mixed running for experts
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3769
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-processes=2 --num-topk=1 --num-experts=2 --test-loop=100
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --num-experts=512 --test-loop=100 --num-processes=8
+#      - name: Run test mixed running for dynamic tokens
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3769
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_and_low_latency.py --test-loop=100 --enable-dynamic-tokens --num-processes=8
+#      - name: Run test combine only
+#        timeout-minutes: 10
+#        env:
+#          HCCL_BUFFSIZE: 3900
+#        run: |
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --num-processes=8
+#          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_combine.py --test-type="low_latency" --num-processes=8
 
   test-deepep-a5:
     needs: get-changed-files
@@ -928,9 +928,9 @@ jobs:
   finish:
     if: always()
     needs:
-      - test-all-build-core
-      - test-all-build-moe
-      - test-build-deepep-a2
+#      - test-all-build-core
+#      - test-all-build-moe
+#      - test-build-deepep-a2
       - test-deepep-a5
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -768,3 +768,4 @@ jobs:
           done
           echo "All jobs completed successfully"
           exit 0
+

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -931,9 +931,9 @@ jobs:
     if: always()
     needs:
       - test-all-build-core
-#      - test-all-build-moe
-#      - test-build-deepep-a2
-#      - test-deepep-a5
+      - test-all-build-moe
+      - test-build-deepep-a2
+      - test-deepep-a5
     runs-on: ubuntu-latest
     steps:
       - name: Check all dependent job statuses

--- a/scripts/prepare_deepep_in_container.sh
+++ b/scripts/prepare_deepep_in_container.sh
@@ -1,6 +1,7 @@
 set -e
 
 BUILD_ARGS=""
+SOC_VERSION=""
 SKIP_BUILD=false
 
 while getopts ":a:s" opt; do
@@ -23,12 +24,17 @@ while getopts ":a:s" opt; do
 done
 
 shift $((OPTIND -1))
+SOC_VERSION="${1:-}"
 
 cd ${GITHUB_WORKSPACE}
 
 if [ "$SKIP_BUILD" = false ]; then
     if [ -n "$BUILD_ARGS" ]; then
-        bash build.sh -a "$BUILD_ARGS"
+        if [ -n "$SOC_VERSION" ]; then
+            bash build.sh -a "$BUILD_ARGS" "$SOC_VERSION"
+        else
+            bash build.sh -a "$BUILD_ARGS"
+        fi
     else
         bash build.sh
     fi


### PR DESCRIPTION
## Motivation

Add test cases for the 950‑environment pipeline and Update the runner tag.

## Modifications

- Updated the runner tag from `linux-aarch64-a3-16` (and `a3-752t`) to `linux-aarch64-a3-800t-16` for the `test-all-build-core` and `test-build-deepep-a2` jobs in `.github/workflows/pr-test-deepep-npu.yml`.
- Added a new `test-deepep-a5` job to the DeepEP PR test workflow, running on the 950 environment (`linux-amd64-a5-4` runner, CANN 9.1.0 `950-ubuntu22.04-py3.12` image) with build-cache support, covering:
  - Normal mode: `test_intranode.py` with `--use-fp8` (including dynamic tokens), `--use-mxfp8`, and `--use-mxfp4` quantization.
  - Low-latency mode: `test_low_latency.py` with `mx_fp8_e4m3`, `mx_fp4_e2m1`, and `pertoken_fp8_e4m3` quantization (including dynamic tokens).
  - Alltoall: `test_normal_alltoall.py` and `test_ll_alltoall.py`.
  - Fused MoE: `test_fused_deep_moe_a5.py` for the fusion operator, single-bs scenario (`--single-active-rank`), uneven-bs scenario (`--num-token-jitter`), and NZ-format weights (`--weight-format NZ`).
- Added `test-deepep-a5` to the `needs` list of the `finish` job so the final status check waits for the 950 pipeline.
- Add 950 compilation command, `scripts/prepare_deepep_in_container.sh`: accept an optional positional `SOC_VERSION` argument and forward it to `build.sh` when set (e.g., `bash build.sh -a deepep Ascend950`), keeping the original behavior when it is not provided.
