### PR TITLE
[DeepEP] Fix combine tuning timeout by adding rank synchronization in bench

### DIFF
--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -907,12 +907,19 @@ jobs:
       #     --num-tests 10 \
       #     --weight-format NZ
 
-      - name: Run combine timeout regression test
+      - name: Run combine timeout regression test (2 processes)
         timeout-minutes: 10
         env:
           HCCL_BUFFSIZE: 8192
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 2 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8
+
+      - name: Run combine timeout regression test (4 processes)
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 8192
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8
 
   finish:
     if: always()

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -912,14 +912,14 @@ jobs:
         env:
           HCCL_BUFFSIZE: 8192
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 2 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8 --sync-bench
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 2 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8
 
       - name: Run combine timeout regression test (4 processes)
         timeout-minutes: 10
         env:
           HCCL_BUFFSIZE: 8192
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8 --sync-bench
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8
 
   finish:
     if: always()

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -907,14 +907,28 @@ jobs:
       #     --num-tests 10 \
       #     --weight-format NZ
 
-      - name: Run combine timeout regression test (2 processes)
+      - name: Run combine timeout regression test (2 processes, bf16)
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 8192
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 2 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64
+
+      - name: Run combine timeout regression test (4 processes, bf16)
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 8192
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64
+
+      - name: Run combine timeout regression test (2 processes, fp8)
         timeout-minutes: 10
         env:
           HCCL_BUFFSIZE: 8192
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 2 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8
 
-      - name: Run combine timeout regression test (4 processes)
+      - name: Run combine timeout regression test (4 processes, fp8)
         timeout-minutes: 10
         env:
           HCCL_BUFFSIZE: 8192

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -801,111 +801,111 @@ jobs:
             rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
             bash scripts/prepare_deepep_in_container.sh -a deepep Ascend950
           fi
-      - name: Run normal mode use-fp8 quantization
-        env:
-          HCCL_BUFFSIZE: 500
-        timeout-minutes: 20
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 512 --hidden 7168 --num-topk 8 --num-experts 256 --use-fp8
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --use-fp8
+      # - name: Run normal mode use-fp8 quantization
+      #   env:
+      #     HCCL_BUFFSIZE: 500
+      #   timeout-minutes: 20
+      #   run: |
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 512 --hidden 7168 --num-topk 8 --num-experts 256 --use-fp8
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --use-fp8
 
-      - name: Run normal mode use-mxfp8 quantization
-        env:
-          HCCL_BUFFSIZE: 500
-        timeout-minutes: 10
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=4 --num-tokens=256 --num-experts=32 --use-mxfp8
+      # - name: Run normal mode use-mxfp8 quantization
+      #   env:
+      #     HCCL_BUFFSIZE: 500
+      #   timeout-minutes: 10
+      #   run: |
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=4 --num-tokens=256 --num-experts=32 --use-mxfp8
 
-      - name: Run normal mode use-mxfp4 quantization
-        env:
-          HCCL_BUFFSIZE: 500
-        timeout-minutes: 10
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=4 --num-tokens=256 --num-experts=32 --use-mxfp4
+      # - name: Run normal mode use-mxfp4 quantization
+      #   env:
+      #     HCCL_BUFFSIZE: 500
+      #   timeout-minutes: 10
+      #   run: |
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=4 --num-tokens=256 --num-experts=32 --use-mxfp4
 
-      - name: Run low‑latency mode mx_fp8_e4m3 quantization
-        env:
-          HCCL_BUFFSIZE: 10000
-        timeout-minutes: 10
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=256 --hidden=8192
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4 --num-topk=6 --num-tokens=512 --num-experts=256 --hidden=7168
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type mx_fp8_e4m3 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=520 --hidden=8192
+      # - name: Run low‑latency mode mx_fp8_e4m3 quantization
+      #   env:
+      #     HCCL_BUFFSIZE: 10000
+      #   timeout-minutes: 10
+      #   run: |
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=256 --hidden=8192
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4 --num-topk=6 --num-tokens=512 --num-experts=256 --hidden=7168
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type mx_fp8_e4m3 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=520 --hidden=8192
 
-      - name: Run low‑latency mode mx_fp4_e2m1 quantization
-        env:
-          HCCL_BUFFSIZE: 2500
-        timeout-minutes: 10
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=8 --num-experts=256 --hidden=7168 --num-tokens=256 --quant-type=mx_fp4_e2m1
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=12 --num-experts=512 --hidden=8192 --num-tokens=128 --quant-type=mx_fp4_e2m1 --enable-dynamic-tokens
+      # - name: Run low‑latency mode mx_fp4_e2m1 quantization
+      #   env:
+      #     HCCL_BUFFSIZE: 2500
+      #   timeout-minutes: 10
+      #   run: |
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=8 --num-experts=256 --hidden=7168 --num-tokens=256 --quant-type=mx_fp4_e2m1
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=12 --num-experts=512 --hidden=8192 --num-tokens=128 --quant-type=mx_fp4_e2m1 --enable-dynamic-tokens
 
-      - name: Run low‑latency mode pertoken_fp8_e4m3 quantization
-        env:
-          HCCL_BUFFSIZE: 2500
-        timeout-minutes: 10
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 256 --hidden 7168 --num-topk 8 --num-experts 256 --quant-type pertoken_fp8_e4m3
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --quant-type pertoken_fp8_e4m3
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --quant-type pertoken_fp8_e4m3
+      # - name: Run low‑latency mode pertoken_fp8_e4m3 quantization
+      #   env:
+      #     HCCL_BUFFSIZE: 2500
+      #   timeout-minutes: 10
+      #   run: |
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 256 --hidden 7168 --num-topk 8 --num-experts 256 --quant-type pertoken_fp8_e4m3
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --quant-type pertoken_fp8_e4m3
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --quant-type pertoken_fp8_e4m3
 
-      - name: Run alltoall normal
-        timeout-minutes: 10
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --num-processes 4
+      # - name: Run alltoall normal
+      #   timeout-minutes: 10
+      #   run: |
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --num-processes 4
 
-      - name: Run alltoall low-latency
-        timeout-minutes: 10
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --num-processes 4
+      # - name: Run alltoall low-latency
+      #   timeout-minutes: 10
+      #   run: |
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --num-processes 4
 
-      - name: Run fusion operator
-        timeout-minutes: 10
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py --num-processes 4 --num-warmups 3  --num-tests 10
+      # - name: Run fusion operator
+      #   timeout-minutes: 10
+      #   run: |
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py --num-processes 4 --num-warmups 3  --num-tests 10
 
-      - name: Run single bs scenario
-        timeout-minutes: 10
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
-          --quant fp8_e4m3 \
-          --num-processes 4 \
-          --hidden 7168 \
-          --moe-intermediate-size 3072 \
-          --num-topk 8 \
-          --num-experts 32 \
-          --num-warmups 3 \
-          --num-tests 10 \
-          --single-active-rank 1
+      # - name: Run single bs scenario
+      #   timeout-minutes: 10
+      #   run: |
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
+      #     --quant fp8_e4m3 \
+      #     --num-processes 4 \
+      #     --hidden 7168 \
+      #     --moe-intermediate-size 3072 \
+      #     --num-topk 8 \
+      #     --num-experts 32 \
+      #     --num-warmups 3 \
+      #     --num-tests 10 \
+      #     --single-active-rank 1
 
-      - name: Run bs uneven scenario
-        timeout-minutes: 10
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
-          --quant fp8_e4m3 \
-          --num-processes 4 \
-          --hidden 7168 \
-          --moe-intermediate-size 3072 \
-          --num-topk 8 \
-          --num-experts 32 \
-          --num-warmups 3 \
-          --num-tests 10 \
-          --num-token-jitter 5
+      # - name: Run bs uneven scenario
+      #   timeout-minutes: 10
+      #   run: |
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
+      #     --quant fp8_e4m3 \
+      #     --num-processes 4 \
+      #     --hidden 7168 \
+      #     --moe-intermediate-size 3072 \
+      #     --num-topk 8 \
+      #     --num-experts 32 \
+      #     --num-warmups 3 \
+      #     --num-tests 10 \
+      #     --num-token-jitter 5
 
-      - name: Run nz format weights
-        timeout-minutes: 10
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
-          --quant fp8_e4m3 \
-          --num-processes 4 \
-          --hidden 7168 \
-          --moe-intermediate-size 3072 \
-          --num-topk 8 \
-          --num-experts 32 \
-          --num-warmups 3 \
-          --num-tests 10 \
-          --weight-format NZ
+      # - name: Run nz format weights
+      #   timeout-minutes: 10
+      #   run: |
+      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
+      #     --quant fp8_e4m3 \
+      #     --num-processes 4 \
+      #     --hidden 7168 \
+      #     --moe-intermediate-size 3072 \
+      #     --num-topk 8 \
+      #     --num-experts 32 \
+      #     --num-warmups 3 \
+      #     --num-tests 10 \
+      #     --weight-format NZ
 
       - name: Run combine timeout regression test
         timeout-minutes: 10

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -846,27 +846,27 @@ jobs:
           HCCL_BUFFSIZE: 10000
         timeout-minutes: 10
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=256 --hidden=8192
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4 --num-topk=6 --num-tokens=512 --num-experts=256 --hidden=7168
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type mx_fp8_e4m3 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=520 --hidden=8192
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --use-mxfp8 --num-processes=4
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --use-mxfp8 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=256 --hidden=8192
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --use-mxfp8 --num-processes=4 --num-topk=6 --num-tokens=512 --num-experts=256 --hidden=7168
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --use-mxfp8 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=520 --hidden=8192
 
       - name: Run low‑latency mode mx_fp4_e2m1 quantization
         env:
           HCCL_BUFFSIZE: 2500
         timeout-minutes: 10
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=8 --num-experts=256 --hidden=7168 --num-tokens=256 --quant-type=mx_fp4_e2m1
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=12 --num-experts=512 --hidden=8192 --num-tokens=128 --quant-type=mx_fp4_e2m1 --enable-dynamic-tokens
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=8 --num-experts=256 --hidden=7168 --num-tokens=256 --use-mxfp4
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=12 --num-experts=512 --hidden=8192 --num-tokens=128 --use-mxfp4 --enable-dynamic-tokens
 
       - name: Run low‑latency mode pertoken_fp8_e4m3 quantization
         env:
           HCCL_BUFFSIZE: 2500
         timeout-minutes: 10
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 256 --hidden 7168 --num-topk 8 --num-experts 256 --quant-type pertoken_fp8_e4m3
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --quant-type pertoken_fp8_e4m3
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --quant-type pertoken_fp8_e4m3
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 256 --hidden 7168 --num-topk 8 --num-experts 256 --use-fp8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --use-fp8
 
       - name: Run alltoall normal
         timeout-minutes: 10

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -53,13 +53,7 @@ jobs:
 
   test-all-build-core:
     needs: get-changed-files
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call' || (
-        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
-        github.event.pull_request.draft == false &&
-        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
-      )
+    if: false  # temporarily disabled, only running A5 tests
     runs-on: linux-aarch64-a3-800t-16
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
@@ -283,13 +277,7 @@ jobs:
 
   test-all-build-moe:
     needs: get-changed-files
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call' || (
-        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
-        github.event.pull_request.draft == false &&
-        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
-      )
+    if: false  # temporarily disabled, only running A5 tests
     runs-on: linux-aarch64-a3-800t-16
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
@@ -482,13 +470,7 @@ jobs:
 
   test-build-deepep-a2:
     needs: get-changed-files
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'workflow_call' || (
-        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
-        github.event.pull_request.draft == false &&
-        needs.get-changed-files.outputs.ops2_changed == 'true'
-      )
+    if: false  # temporarily disabled, only running A5 tests
     runs-on: linux-aarch64-a2-8
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
@@ -925,12 +907,16 @@ jobs:
           --num-tests 10 \
           --weight-format NZ
 
+      - name: Run combine timeout regression test
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 8192
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 2 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8
+
   finish:
     if: always()
     needs:
-      - test-all-build-core
-      - test-all-build-moe
-      - test-build-deepep-a2
       - test-deepep-a5
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -912,14 +912,14 @@ jobs:
         env:
           HCCL_BUFFSIZE: 8192
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 2 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 2 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8 --sync-bench
 
       - name: Run combine timeout regression test (4 processes)
         timeout-minutes: 10
         env:
           HCCL_BUFFSIZE: 8192
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8 --sync-bench
 
   finish:
     if: always()

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -826,6 +826,7 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 512 --hidden 7168 --num-topk 8 --num-experts 256 --use-fp8
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --use-fp8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8
 
       - name: Run normal mode use-mxfp8 quantization
         env:

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -53,7 +53,13 @@ jobs:
 
   test-all-build-core:
     needs: get-changed-files
-    if: false  # temporarily disabled, only running A5 tests
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call' || (
+        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
+        github.event.pull_request.draft == false &&
+        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
+      )
     runs-on: linux-aarch64-a3-800t-16
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
@@ -277,7 +283,13 @@ jobs:
 
   test-all-build-moe:
     needs: get-changed-files
-    if: false  # temporarily disabled, only running A5 tests
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call' || (
+        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
+        github.event.pull_request.draft == false &&
+        (needs.get-changed-files.outputs.ops_changed == 'true' || needs.get-changed-files.outputs.common_changed == 'true')
+      )
     runs-on: linux-aarch64-a3-800t-16
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-a3-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
@@ -470,7 +482,13 @@ jobs:
 
   test-build-deepep-a2:
     needs: get-changed-files
-    if: false  # temporarily disabled, only running A5 tests
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call' || (
+        (github.repository == 'sgl-project/sgl-kernel-npu' || github.event_name == 'pull_request') &&
+        github.event.pull_request.draft == false &&
+        needs.get-changed-files.outputs.ops2_changed == 'true'
+      )
     runs-on: linux-aarch64-a2-8
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.cann_version }}-910b-ubuntu22.04-py${{ matrix.cann_version == '9.1.0' && '3.12' || '3.11' }}
@@ -801,143 +819,118 @@ jobs:
             rm -f ${GITHUB_WORKSPACE}/output/deep_ep*.whl
             bash scripts/prepare_deepep_in_container.sh -a deepep Ascend950
           fi
-      # - name: Run normal mode use-fp8 quantization
-      #   env:
-      #     HCCL_BUFFSIZE: 500
-      #   timeout-minutes: 20
-      #   run: |
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 512 --hidden 7168 --num-topk 8 --num-experts 256 --use-fp8
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --use-fp8
-
-      # - name: Run normal mode use-mxfp8 quantization
-      #   env:
-      #     HCCL_BUFFSIZE: 500
-      #   timeout-minutes: 10
-      #   run: |
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=4 --num-tokens=256 --num-experts=32 --use-mxfp8
-
-      # - name: Run normal mode use-mxfp4 quantization
-      #   env:
-      #     HCCL_BUFFSIZE: 500
-      #   timeout-minutes: 10
-      #   run: |
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=4 --num-tokens=256 --num-experts=32 --use-mxfp4
-
-      # - name: Run low‑latency mode mx_fp8_e4m3 quantization
-      #   env:
-      #     HCCL_BUFFSIZE: 10000
-      #   timeout-minutes: 10
-      #   run: |
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=256 --hidden=8192
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4 --num-topk=6 --num-tokens=512 --num-experts=256 --hidden=7168
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type mx_fp8_e4m3 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=520 --hidden=8192
-
-      # - name: Run low‑latency mode mx_fp4_e2m1 quantization
-      #   env:
-      #     HCCL_BUFFSIZE: 2500
-      #   timeout-minutes: 10
-      #   run: |
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=8 --num-experts=256 --hidden=7168 --num-tokens=256 --quant-type=mx_fp4_e2m1
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=12 --num-experts=512 --hidden=8192 --num-tokens=128 --quant-type=mx_fp4_e2m1 --enable-dynamic-tokens
-
-      # - name: Run low‑latency mode pertoken_fp8_e4m3 quantization
-      #   env:
-      #     HCCL_BUFFSIZE: 2500
-      #   timeout-minutes: 10
-      #   run: |
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 256 --hidden 7168 --num-topk 8 --num-experts 256 --quant-type pertoken_fp8_e4m3
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --quant-type pertoken_fp8_e4m3
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --quant-type pertoken_fp8_e4m3
-
-      # - name: Run alltoall normal
-      #   timeout-minutes: 10
-      #   run: |
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --num-processes 4
-
-      # - name: Run alltoall low-latency
-      #   timeout-minutes: 10
-      #   run: |
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --num-processes 4
-
-      # - name: Run fusion operator
-      #   timeout-minutes: 10
-      #   run: |
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py --num-processes 4 --num-warmups 3  --num-tests 10
-
-      # - name: Run single bs scenario
-      #   timeout-minutes: 10
-      #   run: |
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
-      #     --quant fp8_e4m3 \
-      #     --num-processes 4 \
-      #     --hidden 7168 \
-      #     --moe-intermediate-size 3072 \
-      #     --num-topk 8 \
-      #     --num-experts 32 \
-      #     --num-warmups 3 \
-      #     --num-tests 10 \
-      #     --single-active-rank 1
-
-      # - name: Run bs uneven scenario
-      #   timeout-minutes: 10
-      #   run: |
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
-      #     --quant fp8_e4m3 \
-      #     --num-processes 4 \
-      #     --hidden 7168 \
-      #     --moe-intermediate-size 3072 \
-      #     --num-topk 8 \
-      #     --num-experts 32 \
-      #     --num-warmups 3 \
-      #     --num-tests 10 \
-      #     --num-token-jitter 5
-
-      # - name: Run nz format weights
-      #   timeout-minutes: 10
-      #   run: |
-      #     python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
-      #     --quant fp8_e4m3 \
-      #     --num-processes 4 \
-      #     --hidden 7168 \
-      #     --moe-intermediate-size 3072 \
-      #     --num-topk 8 \
-      #     --num-experts 32 \
-      #     --num-warmups 3 \
-      #     --num-tests 10 \
-      #     --weight-format NZ
-
-      - name: Run combine timeout regression test (2 processes, bf16)
-        timeout-minutes: 10
+      - name: Run normal mode use-fp8 quantization
         env:
-          HCCL_BUFFSIZE: 8192
+          HCCL_BUFFSIZE: 500
+        timeout-minutes: 20
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 2 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 512 --hidden 7168 --num-topk 8 --num-experts 256 --use-fp8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --use-fp8
 
-      - name: Run combine timeout regression test (4 processes, bf16)
-        timeout-minutes: 10
+      - name: Run normal mode use-mxfp8 quantization
         env:
-          HCCL_BUFFSIZE: 8192
+          HCCL_BUFFSIZE: 500
+        timeout-minutes: 10
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=4 --num-tokens=256 --num-experts=32 --use-mxfp8
 
-      - name: Run combine timeout regression test (2 processes, fp8)
-        timeout-minutes: 10
+      - name: Run normal mode use-mxfp4 quantization
         env:
-          HCCL_BUFFSIZE: 8192
+          HCCL_BUFFSIZE: 500
+        timeout-minutes: 10
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 2 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes=4 --num-tokens=256 --num-experts=32 --use-mxfp4
 
-      - name: Run combine timeout regression test (4 processes, fp8)
-        timeout-minutes: 10
+      - name: Run low‑latency mode mx_fp8_e4m3 quantization
         env:
-          HCCL_BUFFSIZE: 8192
+          HCCL_BUFFSIZE: 10000
+        timeout-minutes: 10
         run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=256 --hidden=8192
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type=mx_fp8_e4m3 --num-processes=4 --num-topk=6 --num-tokens=512 --num-experts=256 --hidden=7168
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --quant-type mx_fp8_e4m3 --num-processes=4 --num-topk=12 --num-tokens=512 --num-experts=520 --hidden=8192
+
+      - name: Run low‑latency mode mx_fp4_e2m1 quantization
+        env:
+          HCCL_BUFFSIZE: 2500
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=8 --num-experts=256 --hidden=7168 --num-tokens=256 --quant-type=mx_fp4_e2m1
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes=4 --num-topk=12 --num-experts=512 --hidden=8192 --num-tokens=128 --quant-type=mx_fp4_e2m1 --enable-dynamic-tokens
+
+      - name: Run low‑latency mode pertoken_fp8_e4m3 quantization
+        env:
+          HCCL_BUFFSIZE: 2500
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 256 --hidden 7168 --num-topk 8 --num-experts 256 --quant-type pertoken_fp8_e4m3
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --quant-type pertoken_fp8_e4m3
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_low_latency.py --num-processes 4 --num-tokens 257 --hidden 7168 --num-topk 2 --num-experts 128 --enable-dynamic-tokens --quant-type pertoken_fp8_e4m3
+
+      - name: Run alltoall normal
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_normal_alltoall.py --num-processes 4
+
+      - name: Run alltoall low-latency
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_ll_alltoall.py --num-processes 4
+
+      - name: Run fusion operator
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py --num-processes 4 --num-warmups 3  --num-tests 10
+
+      - name: Run single bs scenario
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
+          --quant fp8_e4m3 \
+          --num-processes 4 \
+          --hidden 7168 \
+          --moe-intermediate-size 3072 \
+          --num-topk 8 \
+          --num-experts 32 \
+          --num-warmups 3 \
+          --num-tests 10 \
+          --single-active-rank 1
+
+      - name: Run bs uneven scenario
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
+          --quant fp8_e4m3 \
+          --num-processes 4 \
+          --hidden 7168 \
+          --moe-intermediate-size 3072 \
+          --num-topk 8 \
+          --num-experts 32 \
+          --num-warmups 3 \
+          --num-tests 10 \
+          --num-token-jitter 5
+
+      - name: Run nz format weights
+        timeout-minutes: 10
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_fused_deep_moe_a5.py \
+          --quant fp8_e4m3 \
+          --num-processes 4 \
+          --hidden 7168 \
+          --moe-intermediate-size 3072 \
+          --num-topk 8 \
+          --num-experts 32 \
+          --num-warmups 3 \
+          --num-tests 10 \
+          --weight-format NZ
 
   finish:
     if: always()
     needs:
+      - test-all-build-core
+      - test-all-build-moe
+      - test-build-deepep-a2
       - test-deepep-a5
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -921,6 +921,13 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8
 
+      - name: Run combine timeout regression test (8 processes)
+        timeout-minutes: 10
+        env:
+          HCCL_BUFFSIZE: 8192
+        run: |
+          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 8 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8
+
   finish:
     if: always()
     needs:

--- a/.github/workflows/pr-test-deepep-npu.yml
+++ b/.github/workflows/pr-test-deepep-npu.yml
@@ -921,13 +921,6 @@ jobs:
         run: |
           python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 4 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8
 
-      - name: Run combine timeout regression test (8 processes)
-        timeout-minutes: 10
-        env:
-          HCCL_BUFFSIZE: 8192
-        run: |
-          python3 $GITHUB_WORKSPACE/tests/python/deepep/test_intranode.py --num-processes 8 --num-tokens 1 --hidden 7168 --num-topk 1 --num-experts 64 --use-fp8
-
   finish:
     if: always()
     needs:

--- a/csrc/deepep/ops/op_host/dispatch_ffn_combine_tiling.cpp
+++ b/csrc/deepep/ops/op_host/dispatch_ffn_combine_tiling.cpp
@@ -137,7 +137,6 @@ static ge::graphStatus DispatchFFNCombineCheckShapeAndSetTiling(gert::TilingCont
     info.expertPerRank = expertPerRank;
     info.topK = topK;
     info.listLen = listLen;
-    OP_TILING_CHECK(info.M == 0, OP_LOGE(nodeName, "M must not be 0."), return ge::GRAPH_FAILED);
     OP_TILING_CHECK(info.K == 0, OP_LOGE(nodeName, "K must not be 0."), return ge::GRAPH_FAILED);
     OP_TILING_CHECK(info.topK == 0, OP_LOGE(nodeName, "topK must not be 0."), return ge::GRAPH_FAILED);
     OP_LOGD(K_INNER_DEBUG, "M=%d ", info.M);

--- a/tests/python/deepep/test_intranode.py
+++ b/tests/python/deepep/test_intranode.py
@@ -4,9 +4,7 @@ import random
 import time
 from typing import Optional
 
-# noinspection PyUnresolvedReferences
 import deep_ep
-import numpy as np
 import torch
 import torch.distributed as dist
 import torch_npu
@@ -36,8 +34,22 @@ def test_main(
     num_topk, num_experts = args.num_topk, args.num_experts
     enable_diagnose = args.enable_diagnose
     enable_dynamic_tokens = args.enable_dynamic_tokens
-    quant_type = args.quant_type
-    dispatch_quant_mode = quant_type
+
+    # dispatch_quant_mode is for bandwidth calc / display only.
+    # The actual resolution (architecture-aware) happens inside buffer.dispatch().
+    if args.use_mxfp4:
+        dispatch_quant_mode = "mx_fp4_e2m1"
+    elif args.use_mxfp8:
+        dispatch_quant_mode = "mx_fp8_e4m3"
+    elif args.use_fp8:
+        dispatch_quant_mode = "pertoken_fp8_e4m3"
+    else:
+        dispatch_quant_mode = None
+    quant_dispatch_kwargs = {
+        "use_fp8": args.use_fp8,
+        "use_mxfp4": args.use_mxfp4,
+        "use_mxfp8": args.use_mxfp8,
+    }
     num_servers = num_ranks // num_local_ranks
     expert_token_nums_type = int(os.getenv("MOE_EXPERT_TOKEN_NUMS_TYPE", 1))
 
@@ -294,7 +306,7 @@ def test_main(
                 "topk_idx": topk_idx,
                 "topk_weights": topk_weights_pure_rand,
                 "dispatch_wait_recv_cost_stats": dispatch_wait_recv_cost_stats,
-                "quant_mode": dispatch_quant_mode,
+                **quant_dispatch_kwargs,
             }
             if dispatch_wait_recv_cost_stats is not None:
                 bench(lambda: buffer.dispatch(**dispatch_args), num_warmups=0)
@@ -351,11 +363,22 @@ def test_main(
             dispatch_quant_mode not in ("bf16", "int8", None)
             and current_x is x_pure_rand
         )
+        iter_quant = dispatch_quant_mode if current_x is x_pure_rand else "bf16"
+        if iter_quant is None:
+            iter_quant = (
+                "int8"
+                if os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT") == "1"
+                else "bf16"
+            )
         if local_rank == 0:
             print(
-                f'[testing] Running with {"FP8" if use_fp8 else "BF16"}, with top-k {num_topk} ...',
+                f'[testing] Running with {"FP8" if use_fp8 else iter_quant.upper()}, with top-k {num_topk} ...',
                 flush=True,
             )
+        if current_x is x_pure_rand:
+            quant_kwargs = quant_dispatch_kwargs
+        else:
+            quant_kwargs = {}
         dispatch_args = {
             "x": current_x,
             "num_tokens_per_rank": ref_num_tokens_per_rank,
@@ -366,7 +389,7 @@ def test_main(
             "topk_weights": (
                 topk_weights_pure_rand if current_x is x_pure_rand else topk_weights
             ),
-            "quant_mode": dispatch_quant_mode if current_x is x_pure_rand else "bf16",
+            **quant_kwargs,
         }
 
         (
@@ -433,7 +456,7 @@ def test_main(
         max_diff = torch.max(torch.abs(check_x - golden) / golden_nozero).item()
         avg_diff = torch.mean(torch.abs(check_x - golden) / golden_nozero).item()
         print(f"{rank=}, {avg_diff=:.8f}, {max_diff=:.8f}, cosine_diff={diff:.8f}")
-        diff_threshold = get_diff_threshold(quant_type)
+        diff_threshold = get_diff_threshold(iter_quant)
         assert diff < diff_threshold, f"Error: {diff=}, {diff_threshold=}"
 
         # For later tuning
@@ -461,14 +484,17 @@ def test_main(
     t = bench(lambda: buffer.dispatch(**tune_args_bf16))[0]
     if local_rank == 0:
         print(
-            f"[tuning] Dispatch (BF16) {dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
+            f"[tuning] Dispatch (BF16, raw_bytes={dispatch_bf16_recv_bytes/1e9:.3f}GB) "
+            f"raw_bw={dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s, equiv_bw={dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
             flush=True,
         )
 
-    # FP8 dispatch tuning (if quantized)
-    if dispatch_quant_mode not in ("bf16", "int8", None):
+    # Quantized dispatch tuning (int8/fp8/fp4)
+    if dispatch_quant_mode not in ("bf16", None):
         num_recv_tokens = dispatch_bf16_recv_bytes // (hidden * 2)
-        if dispatch_quant_mode.startswith("pertoken_fp8"):
+        if dispatch_quant_mode == "int8" or dispatch_quant_mode.startswith(
+            "pertoken_fp8"
+        ):
             quant_data_bytes = num_recv_tokens * hidden
             quant_scale_bytes = num_recv_tokens * 4
         elif dispatch_quant_mode.startswith("mx_fp8"):
@@ -478,10 +504,11 @@ def test_main(
             quant_data_bytes = num_recv_tokens * hidden // 2
             quant_scale_bytes = num_recv_tokens * hidden // 32
         else:
-            quant_data_bytes = num_recv_tokens * hidden
-            quant_scale_bytes = 0
-        fp8_recv_bytes = quant_data_bytes + quant_scale_bytes
-        tune_args_fp8 = {
+            raise ValueError(
+                f"Unsupported quant_mode for bandwidth calculation: {dispatch_quant_mode}"
+            )
+        quant_recv_bytes = quant_data_bytes + quant_scale_bytes
+        tune_args_quant = {
             "x": x,
             "config": config,
             "num_tokens_per_rank": ref_num_tokens_per_rank,
@@ -489,13 +516,13 @@ def test_main(
             "num_tokens_per_expert": ref_num_tokens_per_expert,
             "topk_idx": topk_idx,
             "topk_weights": topk_weights,
-            "quant_mode": dispatch_quant_mode,
+            **quant_dispatch_kwargs,
         }
-        t = bench(lambda: buffer.dispatch(**tune_args_fp8))[0]
+        t = bench(lambda: buffer.dispatch(**tune_args_quant))[0]
         if local_rank == 0:
             print(
-                f"[tuning] Dispatch ({dispatch_quant_mode}, raw_bytes={fp8_recv_bytes/1e9:.3f}GB) "
-                f"{dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
+                f"[tuning] Dispatch ({dispatch_quant_mode}, raw_bytes={quant_recv_bytes/1e9:.3f}GB) "
+                f"raw_bw={quant_recv_bytes / 1e9 / t:.2f} GB/s, equiv_bw={dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
                 flush=True,
             )
 
@@ -507,7 +534,7 @@ def test_main(
         "config": config,
         "topk_idx": topk_idx,
         "topk_weights": topk_weights,
-        "quant_mode": dispatch_quant_mode,
+        **quant_dispatch_kwargs,
     }
     recv_x, _, _, _, handle, _ = buffer.dispatch(**dispatch_args)
     recv_x = per_token_cast_back(*recv_x) if isinstance(recv_x, tuple) else recv_x
@@ -519,8 +546,7 @@ def test_main(
         "async_finish": False,
         "topk_weights": handle[7],
     }
-    if args.sync_bench:
-        dist.barrier()
+    dist.barrier()
     t = bench(lambda: buffer.combine(**tune_args))[0]
     if local_rank == 0:
         print(
@@ -617,18 +643,28 @@ if __name__ == "__main__":
         help="Whether to enable dynamic tokens for testing",
     )
     parser.add_argument(
-        "--quant-type",
-        dest="quant_type",
-        type=str,
-        default="bf16",
-        help="quant type: bf16, int8, mx_fp8_e4m3, mx_fp8_e5m2, pertoken_fp8_e4m3, mx_fp4_e2m1",
+        "--use-fp8",
+        dest="use_fp8",
+        action="store_true",
+        help="Use use_fp8=True bool flag for normal dispatch. Architecture-aware: "
+        "A5 -> pertoken_fp8_e4m3, A2/A3 -> int8 (with warning). "
+        "Mutually exclusive with --quant-type.",
     )
     parser.add_argument(
-        "--sync-bench",
-        dest="sync_bench",
+        "--use-mxfp4",
+        dest="use_mxfp4",
         action="store_true",
-        help="Enable rank synchronization (dist.barrier) before combine bench. "
-        "Prevents timeout with tiny token counts.",
+        help="Use use_mxfp4=True bool flag for normal dispatch. "
+        "A5 -> mx_fp4_e2m1, A2/A3 -> not supported. "
+        "Mutually exclusive with --quant-type.",
+    )
+    parser.add_argument(
+        "--use-mxfp8",
+        dest="use_mxfp8",
+        action="store_true",
+        help="Use use_mxfp8=True bool flag for normal dispatch. "
+        "A5 -> mx_fp8_e4m3, A2/A3 -> not supported. "
+        "Mutually exclusive with --quant-type.",
     )
     args = parser.parse_args()
 

--- a/tests/python/deepep/test_intranode.py
+++ b/tests/python/deepep/test_intranode.py
@@ -546,8 +546,7 @@ def test_main(
         "async_finish": False,
         "topk_weights": handle[7],
     }
-    dist.barrier()
-    t = bench(lambda: buffer.combine(**tune_args))[0]
+    t = bench(lambda: buffer.combine(**tune_args), sync_fn=dist.barrier)[0]
     if local_rank == 0:
         print(
             f"[tuning] Combine {combine_bf16_send_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",

--- a/tests/python/deepep/test_intranode.py
+++ b/tests/python/deepep/test_intranode.py
@@ -546,7 +546,6 @@ def test_main(
         "async_finish": False,
         "topk_weights": handle[7],
     }
-    dist.barrier()
     t = bench(lambda: buffer.combine(**tune_args), sync_fn=dist.barrier)[0]
     if local_rank == 0:
         print(

--- a/tests/python/deepep/test_intranode.py
+++ b/tests/python/deepep/test_intranode.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import random
+import threading
 import time
 from typing import Optional
 
@@ -441,7 +442,17 @@ def test_main(
             "async_finish": False,
             "topk_weights": handle[7],
         }
+        _timer = threading.Timer(
+            30,
+            lambda: (
+                print("[TIMEOUT] combine test: timed out after 30s", flush=True),
+                os._exit(1),
+            ),
+        )
+        _timer.start()
+        dist.barrier()
         combined_x, combined_topk_weights, event = buffer.combine(**combine_args)
+        _timer.cancel()
         check_x = combined_x.float()
 
         ref_x = x_pure_rand if current_x is x_pure_rand else x
@@ -546,7 +557,17 @@ def test_main(
         "async_finish": False,
         "topk_weights": handle[7],
     }
-    t = bench(lambda: buffer.combine(**tune_args))[0]
+    _timer = threading.Timer(
+        30,
+        lambda: (
+            print("[tuning] Combine TIMEOUT: timed out after 30s", flush=True),
+            os._exit(1),
+        ),
+    )
+    _timer.start()
+    _sync_fn = dist.barrier if args.sync_bench else None
+    t = bench(lambda: buffer.combine(**tune_args), sync_fn=_sync_fn)[0]
+    _timer.cancel()
     if local_rank == 0:
         print(
             f"[tuning] Combine {combine_bf16_send_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
@@ -664,6 +685,13 @@ if __name__ == "__main__":
         help="Use use_mxfp8=True bool flag for normal dispatch. "
         "A5 -> mx_fp8_e4m3, A2/A3 -> not supported. "
         "Mutually exclusive with --quant-type.",
+    )
+    parser.add_argument(
+        "--sync-bench",
+        dest="sync_bench",
+        action="store_true",
+        help="Enable rank synchronization (dist.barrier) during combine bench. "
+        "Prevents timeout with tiny token counts.",
     )
     args = parser.parse_args()
 

--- a/tests/python/deepep/test_intranode.py
+++ b/tests/python/deepep/test_intranode.py
@@ -1,11 +1,12 @@
 import argparse
 import os
 import random
-import threading
 import time
 from typing import Optional
 
+# noinspection PyUnresolvedReferences
 import deep_ep
+import numpy as np
 import torch
 import torch.distributed as dist
 import torch_npu
@@ -35,22 +36,8 @@ def test_main(
     num_topk, num_experts = args.num_topk, args.num_experts
     enable_diagnose = args.enable_diagnose
     enable_dynamic_tokens = args.enable_dynamic_tokens
-
-    # dispatch_quant_mode is for bandwidth calc / display only.
-    # The actual resolution (architecture-aware) happens inside buffer.dispatch().
-    if args.use_mxfp4:
-        dispatch_quant_mode = "mx_fp4_e2m1"
-    elif args.use_mxfp8:
-        dispatch_quant_mode = "mx_fp8_e4m3"
-    elif args.use_fp8:
-        dispatch_quant_mode = "pertoken_fp8_e4m3"
-    else:
-        dispatch_quant_mode = None
-    quant_dispatch_kwargs = {
-        "use_fp8": args.use_fp8,
-        "use_mxfp4": args.use_mxfp4,
-        "use_mxfp8": args.use_mxfp8,
-    }
+    quant_type = args.quant_type
+    dispatch_quant_mode = quant_type
     num_servers = num_ranks // num_local_ranks
     expert_token_nums_type = int(os.getenv("MOE_EXPERT_TOKEN_NUMS_TYPE", 1))
 
@@ -307,7 +294,7 @@ def test_main(
                 "topk_idx": topk_idx,
                 "topk_weights": topk_weights_pure_rand,
                 "dispatch_wait_recv_cost_stats": dispatch_wait_recv_cost_stats,
-                **quant_dispatch_kwargs,
+                "quant_mode": dispatch_quant_mode,
             }
             if dispatch_wait_recv_cost_stats is not None:
                 bench(lambda: buffer.dispatch(**dispatch_args), num_warmups=0)
@@ -364,22 +351,11 @@ def test_main(
             dispatch_quant_mode not in ("bf16", "int8", None)
             and current_x is x_pure_rand
         )
-        iter_quant = dispatch_quant_mode if current_x is x_pure_rand else "bf16"
-        if iter_quant is None:
-            iter_quant = (
-                "int8"
-                if os.getenv("DEEP_NORMAL_MODE_USE_INT8_QUANT") == "1"
-                else "bf16"
-            )
         if local_rank == 0:
             print(
-                f'[testing] Running with {"FP8" if use_fp8 else iter_quant.upper()}, with top-k {num_topk} ...',
+                f'[testing] Running with {"FP8" if use_fp8 else "BF16"}, with top-k {num_topk} ...',
                 flush=True,
             )
-        if current_x is x_pure_rand:
-            quant_kwargs = quant_dispatch_kwargs
-        else:
-            quant_kwargs = {}
         dispatch_args = {
             "x": current_x,
             "num_tokens_per_rank": ref_num_tokens_per_rank,
@@ -390,7 +366,7 @@ def test_main(
             "topk_weights": (
                 topk_weights_pure_rand if current_x is x_pure_rand else topk_weights
             ),
-            **quant_kwargs,
+            "quant_mode": dispatch_quant_mode if current_x is x_pure_rand else "bf16",
         }
 
         (
@@ -442,17 +418,7 @@ def test_main(
             "async_finish": False,
             "topk_weights": handle[7],
         }
-        _timer = threading.Timer(
-            30,
-            lambda: (
-                print("[TIMEOUT] combine test: timed out after 30s", flush=True),
-                os._exit(1),
-            ),
-        )
-        _timer.start()
-        dist.barrier()
         combined_x, combined_topk_weights, event = buffer.combine(**combine_args)
-        _timer.cancel()
         check_x = combined_x.float()
 
         ref_x = x_pure_rand if current_x is x_pure_rand else x
@@ -467,7 +433,7 @@ def test_main(
         max_diff = torch.max(torch.abs(check_x - golden) / golden_nozero).item()
         avg_diff = torch.mean(torch.abs(check_x - golden) / golden_nozero).item()
         print(f"{rank=}, {avg_diff=:.8f}, {max_diff=:.8f}, cosine_diff={diff:.8f}")
-        diff_threshold = get_diff_threshold(iter_quant)
+        diff_threshold = get_diff_threshold(quant_type)
         assert diff < diff_threshold, f"Error: {diff=}, {diff_threshold=}"
 
         # For later tuning
@@ -495,17 +461,14 @@ def test_main(
     t = bench(lambda: buffer.dispatch(**tune_args_bf16))[0]
     if local_rank == 0:
         print(
-            f"[tuning] Dispatch (BF16, raw_bytes={dispatch_bf16_recv_bytes/1e9:.3f}GB) "
-            f"raw_bw={dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s, equiv_bw={dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
+            f"[tuning] Dispatch (BF16) {dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
             flush=True,
         )
 
-    # Quantized dispatch tuning (int8/fp8/fp4)
-    if dispatch_quant_mode not in ("bf16", None):
+    # FP8 dispatch tuning (if quantized)
+    if dispatch_quant_mode not in ("bf16", "int8", None):
         num_recv_tokens = dispatch_bf16_recv_bytes // (hidden * 2)
-        if dispatch_quant_mode == "int8" or dispatch_quant_mode.startswith(
-            "pertoken_fp8"
-        ):
+        if dispatch_quant_mode.startswith("pertoken_fp8"):
             quant_data_bytes = num_recv_tokens * hidden
             quant_scale_bytes = num_recv_tokens * 4
         elif dispatch_quant_mode.startswith("mx_fp8"):
@@ -515,11 +478,10 @@ def test_main(
             quant_data_bytes = num_recv_tokens * hidden // 2
             quant_scale_bytes = num_recv_tokens * hidden // 32
         else:
-            raise ValueError(
-                f"Unsupported quant_mode for bandwidth calculation: {dispatch_quant_mode}"
-            )
-        quant_recv_bytes = quant_data_bytes + quant_scale_bytes
-        tune_args_quant = {
+            quant_data_bytes = num_recv_tokens * hidden
+            quant_scale_bytes = 0
+        fp8_recv_bytes = quant_data_bytes + quant_scale_bytes
+        tune_args_fp8 = {
             "x": x,
             "config": config,
             "num_tokens_per_rank": ref_num_tokens_per_rank,
@@ -527,13 +489,13 @@ def test_main(
             "num_tokens_per_expert": ref_num_tokens_per_expert,
             "topk_idx": topk_idx,
             "topk_weights": topk_weights,
-            **quant_dispatch_kwargs,
+            "quant_mode": dispatch_quant_mode,
         }
-        t = bench(lambda: buffer.dispatch(**tune_args_quant))[0]
+        t = bench(lambda: buffer.dispatch(**tune_args_fp8))[0]
         if local_rank == 0:
             print(
-                f"[tuning] Dispatch ({dispatch_quant_mode}, raw_bytes={quant_recv_bytes/1e9:.3f}GB) "
-                f"raw_bw={quant_recv_bytes / 1e9 / t:.2f} GB/s, equiv_bw={dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
+                f"[tuning] Dispatch ({dispatch_quant_mode}, raw_bytes={fp8_recv_bytes/1e9:.3f}GB) "
+                f"{dispatch_bf16_recv_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
                 flush=True,
             )
 
@@ -545,7 +507,7 @@ def test_main(
         "config": config,
         "topk_idx": topk_idx,
         "topk_weights": topk_weights,
-        **quant_dispatch_kwargs,
+        "quant_mode": dispatch_quant_mode,
     }
     recv_x, _, _, _, handle, _ = buffer.dispatch(**dispatch_args)
     recv_x = per_token_cast_back(*recv_x) if isinstance(recv_x, tuple) else recv_x
@@ -557,17 +519,9 @@ def test_main(
         "async_finish": False,
         "topk_weights": handle[7],
     }
-    _timer = threading.Timer(
-        30,
-        lambda: (
-            print("[tuning] Combine TIMEOUT: timed out after 30s", flush=True),
-            os._exit(1),
-        ),
-    )
-    _timer.start()
-    _sync_fn = dist.barrier if args.sync_bench else None
-    t = bench(lambda: buffer.combine(**tune_args), sync_fn=_sync_fn)[0]
-    _timer.cancel()
+    if args.sync_bench:
+        dist.barrier()
+    t = bench(lambda: buffer.combine(**tune_args))[0]
     if local_rank == 0:
         print(
             f"[tuning] Combine {combine_bf16_send_bytes / 1e9 / t:.2f} GB/s (HCCS), avg_t: {t * 1e6:.2f} us",
@@ -663,35 +617,11 @@ if __name__ == "__main__":
         help="Whether to enable dynamic tokens for testing",
     )
     parser.add_argument(
-        "--use-fp8",
-        dest="use_fp8",
-        action="store_true",
-        help="Use use_fp8=True bool flag for normal dispatch. Architecture-aware: "
-        "A5 -> pertoken_fp8_e4m3, A2/A3 -> int8 (with warning). "
-        "Mutually exclusive with --quant-type.",
-    )
-    parser.add_argument(
-        "--use-mxfp4",
-        dest="use_mxfp4",
-        action="store_true",
-        help="Use use_mxfp4=True bool flag for normal dispatch. "
-        "A5 -> mx_fp4_e2m1, A2/A3 -> not supported. "
-        "Mutually exclusive with --quant-type.",
-    )
-    parser.add_argument(
-        "--use-mxfp8",
-        dest="use_mxfp8",
-        action="store_true",
-        help="Use use_mxfp8=True bool flag for normal dispatch. "
-        "A5 -> mx_fp8_e4m3, A2/A3 -> not supported. "
-        "Mutually exclusive with --quant-type.",
-    )
-    parser.add_argument(
-        "--sync-bench",
-        dest="sync_bench",
-        action="store_true",
-        help="Enable rank synchronization (dist.barrier) during combine bench. "
-        "Prevents timeout with tiny token counts.",
+        "--quant-type",
+        dest="quant_type",
+        type=str,
+        default="bf16",
+        help="quant type: bf16, int8, mx_fp8_e4m3, mx_fp8_e5m2, pertoken_fp8_e4m3, mx_fp4_e2m1",
     )
     args = parser.parse_args()
 

--- a/tests/python/deepep/test_intranode.py
+++ b/tests/python/deepep/test_intranode.py
@@ -623,6 +623,13 @@ if __name__ == "__main__":
         default="bf16",
         help="quant type: bf16, int8, mx_fp8_e4m3, mx_fp8_e5m2, pertoken_fp8_e4m3, mx_fp4_e2m1",
     )
+    parser.add_argument(
+        "--sync-bench",
+        dest="sync_bench",
+        action="store_true",
+        help="Enable rank synchronization (dist.barrier) before combine bench. "
+        "Prevents timeout with tiny token counts.",
+    )
     args = parser.parse_args()
 
     num_processes = args.num_processes

--- a/tests/python/deepep/test_intranode.py
+++ b/tests/python/deepep/test_intranode.py
@@ -546,6 +546,7 @@ def test_main(
         "async_finish": False,
         "topk_weights": handle[7],
     }
+    dist.barrier()
     t = bench(lambda: buffer.combine(**tune_args), sync_fn=dist.barrier)[0]
     if local_rank == 0:
         print(

--- a/tests/python/deepep/utils.py
+++ b/tests/python/deepep/utils.py
@@ -55,7 +55,7 @@ def inplace_unique(x: torch.Tensor, num_slots: int):
     x[:, :valid_len] = sorted_bin_idx[:, :valid_len]
 
 
-def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None, sync_fn=None):
+def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None):
     device = torch.device("npu")
     torch.npu.synchronize()
 
@@ -65,9 +65,6 @@ def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None, sync_fn=
     # Warmup
     for _ in range(num_warmups):
         fn()
-        # torch.npu.synchronize()
-        if sync_fn is not None:
-            sync_fn()
 
     # Flush L2 cache
     cache.zero_()
@@ -77,8 +74,6 @@ def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None, sync_fn=
     times = []
     for _ in range(num_tests):
         torch.npu.synchronize()
-        if sync_fn is not None:
-            sync_fn()
         start = torch.npu.Event(enable_timing=True)
         end = torch.npu.Event(enable_timing=True)
 

--- a/tests/python/deepep/utils.py
+++ b/tests/python/deepep/utils.py
@@ -65,8 +65,8 @@ def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None, sync_fn=
     # Warmup
     for _ in range(num_warmups):
         fn()
-        # if sync_fn is not None:
-        #     sync_fn()
+        if sync_fn is not None:
+            sync_fn()
 
     # Flush L2 cache
     cache.zero_()
@@ -76,8 +76,8 @@ def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None, sync_fn=
     times = []
     for _ in range(num_tests):
         torch.npu.synchronize()
-        # if sync_fn is not None:
-        #     sync_fn()
+        if sync_fn is not None:
+            sync_fn()
         start = torch.npu.Event(enable_timing=True)
         end = torch.npu.Event(enable_timing=True)
 

--- a/tests/python/deepep/utils.py
+++ b/tests/python/deepep/utils.py
@@ -55,7 +55,7 @@ def inplace_unique(x: torch.Tensor, num_slots: int):
     x[:, :valid_len] = sorted_bin_idx[:, :valid_len]
 
 
-def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None):
+def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None, sync_fn=None):
     device = torch.device("npu")
     torch.npu.synchronize()
 
@@ -66,6 +66,8 @@ def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None):
     for _ in range(num_warmups):
         fn()
         torch.npu.synchronize()
+        if sync_fn is not None:
+            sync_fn()
 
     # Flush L2 cache
     cache.zero_()
@@ -75,6 +77,8 @@ def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None):
     times = []
     for _ in range(num_tests):
         torch.npu.synchronize()
+        if sync_fn is not None:
+            sync_fn()
         start = torch.npu.Event(enable_timing=True)
         end = torch.npu.Event(enable_timing=True)
 

--- a/tests/python/deepep/utils.py
+++ b/tests/python/deepep/utils.py
@@ -65,6 +65,7 @@ def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None):
     # Warmup
     for _ in range(num_warmups):
         fn()
+        torch.npu.synchronize()
 
     # Flush L2 cache
     cache.zero_()

--- a/tests/python/deepep/utils.py
+++ b/tests/python/deepep/utils.py
@@ -65,8 +65,8 @@ def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None, sync_fn=
     # Warmup
     for _ in range(num_warmups):
         fn()
-        if sync_fn is not None:
-            sync_fn()
+        # if sync_fn is not None:
+        #     sync_fn()
 
     # Flush L2 cache
     cache.zero_()
@@ -76,8 +76,8 @@ def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None, sync_fn=
     times = []
     for _ in range(num_tests):
         torch.npu.synchronize()
-        if sync_fn is not None:
-            sync_fn()
+        # if sync_fn is not None:
+        #     sync_fn()
         start = torch.npu.Event(enable_timing=True)
         end = torch.npu.Event(enable_timing=True)
 

--- a/tests/python/deepep/utils.py
+++ b/tests/python/deepep/utils.py
@@ -55,7 +55,7 @@ def inplace_unique(x: torch.Tensor, num_slots: int):
     x[:, :valid_len] = sorted_bin_idx[:, :valid_len]
 
 
-def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None):
+def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None, sync_fn=None):
     device = torch.device("npu")
     torch.npu.synchronize()
 
@@ -65,6 +65,8 @@ def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None):
     # Warmup
     for _ in range(num_warmups):
         fn()
+        if sync_fn is not None:
+            sync_fn()
 
     # Flush L2 cache
     cache.zero_()
@@ -74,6 +76,8 @@ def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None):
     times = []
     for _ in range(num_tests):
         torch.npu.synchronize()
+        if sync_fn is not None:
+            sync_fn()
         start = torch.npu.Event(enable_timing=True)
         end = torch.npu.Event(enable_timing=True)
 

--- a/tests/python/deepep/utils.py
+++ b/tests/python/deepep/utils.py
@@ -65,7 +65,7 @@ def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None, sync_fn=
     # Warmup
     for _ in range(num_warmups):
         fn()
-        torch.npu.synchronize()
+        # torch.npu.synchronize()
         if sync_fn is not None:
             sync_fn()
 


### PR DESCRIPTION
## Motivation

Fix combine tuning timeout by adding rank synchronization in bench

## Modifications

Fix combine tuning timeout by adding rank synchronization in bench
Fixed a parameter validation issue.

## Testing

The CI file is modified. If the CI is passed, it indicates that the test is passed.

## Benchmarking and Profiling

Since the synchronization operation is performed outside of the timing measurement and is an optional operation, it does not affect performance.

## Checklist

- [x] Format your code.
- [x] Add unit tests.
- [x] Update documentation.
- [x] Provide accuracy and speed benchmark results.