### PR TITLE
[fix] Solving the Problem that DeepEP Is Suspended in A3 Hybrid Deployment Scenario Using SGLang

### DIFF
--- a/csrc/deepep/ops/op_host/cam_moe_combine_normal_tiling.cc
+++ b/csrc/deepep/ops/op_host/cam_moe_combine_normal_tiling.cc
@@ -565,17 +565,16 @@ static ge::graphStatus CamMoeCombineNormalA3TilingFuncImpl(gert::TilingContext *
     // combine数据区 token首地址对齐512
     uint64_t tokenNeedSizeCombine = ((h * MAX_OUT_DTYPE_SIZE + WIN_ADDR_ALIGN - 1UL) / WIN_ADDR_ALIGN) * WIN_ADDR_ALIGN;
     tokenNeedSizeCombine = maxRound > 1 ? tokenNeedSizeCombine * 2 : tokenNeedSizeCombine;
-    uint64_t actualSize = (realBs * k * tokenNeedSizeCombine + COMBINE_STATE_WIN_OFFSET + NOTIFY_DISPATCH_WIN_OFFSET) *
-                          DOUBLE_DATA_BUFFER;
+    uint64_t perHalfDataSize = realBs * k * tokenNeedSizeCombine;
+    uint64_t actualSize = (perHalfDataSize + Moe::A3WindowLayout::kPerHalfReservedSize) * DOUBLE_DATA_BUFFER;
     OP_TILING_CHECK(
         (actualSize > maxWindowSize),
         OP_LOGE(nodeName,
                 "HCCL_BUFFSIZE is too SMALL, realBs = %lu, h = %lu, epWorldSize = %lu, localMoeExpertNum = %u,"
-                " tokenNeedSizeCombine = %lu, k = %lu, NEEDED_HCCL_BUFFSIZE("
-                "((realBs * k * tokenNeedSizeCombine * 2)) + 4MB + 204MB) * 2) = %luMB, "
-                "HCCL_BUFFSIZE=%luMB.",
-                realBs, h, epWorldSize, localMoeExpertNum, tokenNeedSizeCombine, k, actualSize / MB_SIZE + 1UL,
-                maxWindowSize / MB_SIZE),
+                " tokenNeedSizeCombine = %lu, k = %lu, perHalfDataSize=%lu, perHalfReservedSize=%lu, "
+                "NEEDED_HCCL_BUFFSIZE((perHalfDataSize + perHalfReservedSize) * 2) = %luMB, HCCL_BUFFSIZE=%luMB.",
+                realBs, h, epWorldSize, localMoeExpertNum, tokenNeedSizeCombine, k, perHalfDataSize,
+                Moe::A3WindowLayout::kPerHalfReservedSize, actualSize / MB_SIZE + 1UL, maxWindowSize / MB_SIZE),
         return ge::GRAPH_FAILED);
     tilingData->camMoeCombineNormalInfo.totalWinSize = maxWindowSize;
 

--- a/csrc/deepep/ops/op_host/cam_moe_combine_normal_tiling.cc
+++ b/csrc/deepep/ops/op_host/cam_moe_combine_normal_tiling.cc
@@ -563,6 +563,17 @@ static ge::graphStatus CamMoeCombineNormalA3TilingFuncImpl(gert::TilingContext *
     uint64_t realMaxBs = tilingData->camMoeCombineNormalInfo.realMaxBs;
     uint64_t realBs = std::min(perRoundTokens, realMaxBs);
     uint32_t maxRound = tilingData->camMoeCombineNormalInfo.maxRound;
+    if (tilingData->camMoeCombineNormalInfo.isHybridDeployment) {
+        uint64_t normalStateSize = realBs * k * Moe::A3WindowLayout::kNormalCombineStateEntrySize;
+        uint64_t normalStateCapacity = maxRound > 1 ? Moe::A3WindowLayout::kNormalCombineStateHalfSize
+                                                    : Moe::A3WindowLayout::kNormalCombineStateSize;
+        OP_TILING_CHECK(normalStateSize > normalStateCapacity,
+                        OP_LOGE(nodeName,
+                                "normal combine token state exceeds the hybrid slot, needed=%lu, slot=%lu, "
+                                "realBs=%lu, k=%lu, maxRound=%u.",
+                                normalStateSize, normalStateCapacity, realBs, k, maxRound),
+                        return ge::GRAPH_FAILED);
+    }
     // combine数据区 token首地址对齐512
     uint64_t tokenNeedSizeCombine = ((h * MAX_OUT_DTYPE_SIZE + WIN_ADDR_ALIGN - 1UL) / WIN_ADDR_ALIGN) * WIN_ADDR_ALIGN;
     tokenNeedSizeCombine = maxRound > 1 ? tokenNeedSizeCombine * 2 : tokenNeedSizeCombine;

--- a/csrc/deepep/ops/op_host/cam_moe_combine_normal_tiling.cc
+++ b/csrc/deepep/ops/op_host/cam_moe_combine_normal_tiling.cc
@@ -539,6 +539,7 @@ static ge::graphStatus CamMoeCombineNormalA3TilingFuncImpl(gert::TilingContext *
     auto sendCostStatsStorageShape = context->GetOutputShape(OUTPUT_SEND_COST_INDEX);
     bool isEnableDiagnose = (sendCostStatsStorageShape != nullptr);
     tilingData->camMoeCombineNormalInfo.isEnableDiagnose = isEnableDiagnose;
+    tilingData->camMoeCombineNormalInfo.isHybridDeployment = Mc2TilingUtils::IsHybridDeployment();
     // 检查输入输出的dim、format、dataType
     OP_TILING_CHECK(TilingCheckCamMoeCombineNormal(context, nodeName, isEnableDiagnose) != ge::GRAPH_SUCCESS,
                     OP_LOGE(nodeName, "Tiling check params failed"), return ge::GRAPH_FAILED);
@@ -566,15 +567,20 @@ static ge::graphStatus CamMoeCombineNormalA3TilingFuncImpl(gert::TilingContext *
     uint64_t tokenNeedSizeCombine = ((h * MAX_OUT_DTYPE_SIZE + WIN_ADDR_ALIGN - 1UL) / WIN_ADDR_ALIGN) * WIN_ADDR_ALIGN;
     tokenNeedSizeCombine = maxRound > 1 ? tokenNeedSizeCombine * 2 : tokenNeedSizeCombine;
     uint64_t perHalfDataSize = realBs * k * tokenNeedSizeCombine;
-    uint64_t actualSize = (perHalfDataSize + Moe::A3WindowLayout::kPerHalfReservedSize) * DOUBLE_DATA_BUFFER;
+    uint64_t reservedSize = tilingData->camMoeCombineNormalInfo.isHybridDeployment
+                                ? Moe::A3WindowLayout::kPerHalfReservedSize
+                                : Moe::A3WindowLayout::kLegacyNormalDataOffset;
+    uint64_t actualSize = (perHalfDataSize + reservedSize) * DOUBLE_DATA_BUFFER;
     OP_TILING_CHECK(
         (actualSize > maxWindowSize),
-        OP_LOGE(nodeName,
-                "HCCL_BUFFSIZE is too SMALL, realBs = %lu, h = %lu, epWorldSize = %lu, localMoeExpertNum = %u,"
-                " tokenNeedSizeCombine = %lu, k = %lu, perHalfDataSize=%lu, perHalfReservedSize=%lu, "
-                "NEEDED_HCCL_BUFFSIZE((perHalfDataSize + perHalfReservedSize) * 2) = %luMB, HCCL_BUFFSIZE=%luMB.",
-                realBs, h, epWorldSize, localMoeExpertNum, tokenNeedSizeCombine, k, perHalfDataSize,
-                Moe::A3WindowLayout::kPerHalfReservedSize, actualSize / MB_SIZE + 1UL, maxWindowSize / MB_SIZE),
+        OP_LOGE(
+            nodeName,
+            "HCCL_BUFFSIZE is too SMALL, realBs = %lu, h = %lu, epWorldSize = %lu, localMoeExpertNum = %u,"
+            " tokenNeedSizeCombine = %lu, k = %lu, hybridDeployment=%d, perHalfDataSize=%lu, perHalfReservedSize=%lu, "
+            "NEEDED_HCCL_BUFFSIZE((perHalfDataSize + perHalfReservedSize) * 2) = %luMB, HCCL_BUFFSIZE=%luMB.",
+            realBs, h, epWorldSize, localMoeExpertNum, tokenNeedSizeCombine, k,
+            tilingData->camMoeCombineNormalInfo.isHybridDeployment, perHalfDataSize, reservedSize,
+            actualSize / MB_SIZE + 1UL, maxWindowSize / MB_SIZE),
         return ge::GRAPH_FAILED);
     tilingData->camMoeCombineNormalInfo.totalWinSize = maxWindowSize;
 

--- a/csrc/deepep/ops/op_host/cam_moe_dispatch_normal_tiling.cc
+++ b/csrc/deepep/ops/op_host/cam_moe_dispatch_normal_tiling.cc
@@ -647,17 +647,18 @@ static ge::graphStatus CamMoeDispatchNormalA3TilingFuncImpl(gert::TilingContext 
     tokenNeedSizeCombine =
         round > 1 ? tokenNeedSizeCombine * 2 : tokenNeedSizeCombine;  // round > 1 combine要使用double buffer
     // 未考虑双流时大小
-    uint64_t actualSize = (maxBs * k * (tokenNeedSizeCombine + tokenNeedSizeDispatch) + COMBINE_STATE_WIN_OFFSET +
-                           NOTIFY_DISPATCH_WIN_OFFSET) *
-                          DOUBLE_DATA_BUFFER;
+    uint64_t perHalfDataSize = maxBs * k * (tokenNeedSizeCombine + tokenNeedSizeDispatch);
+    uint64_t actualSize = (perHalfDataSize + Moe::A3WindowLayout::kPerHalfReservedSize) * DOUBLE_DATA_BUFFER;
     OP_TILING_CHECK((actualSize > maxWindowSize),
                     OP_LOGE(nodeName,
                             "HCCL_BUFFSIZE is too SMALL, maxBs = %lu, h = %lu, epWorldSize = %lu,"
                             " localMoeExpertNum = %u, tokenNeedSizeDispatch = %lu, tokenNeedSizeCombine = %lu,"
-                            " k = %lu, NEEDED_HCCL_BUFFSIZE((maxBs * k * (tokenNeedSizeDispatch"
-                            " + tokenNeedSizeCombine) + 4MB + 204MB) * 2) = %luMB, HCCL_BUFFSIZE=%luMB.",
+                            " k = %lu, perHalfDataSize=%lu, perHalfReservedSize=%lu, "
+                            "NEEDED_HCCL_BUFFSIZE((perHalfDataSize + perHalfReservedSize) * 2) = %luMB, "
+                            "HCCL_BUFFSIZE=%luMB.",
                             maxBs, h, epWorldSize, localMoeExpertNum, tokenNeedSizeDispatch, tokenNeedSizeCombine, k,
-                            actualSize / MB_SIZE + 1UL, maxWindowSize / MB_SIZE),
+                            perHalfDataSize, Moe::A3WindowLayout::kPerHalfReservedSize, actualSize / MB_SIZE + 1UL,
+                            maxWindowSize / MB_SIZE),
                     return ge::GRAPH_FAILED);
     tilingData->camMoeDispatchNormalInfo.totalWinSize = maxWindowSize;
     OP_LOGD(nodeName, "windowSize = %lu", maxWindowSize);

--- a/csrc/deepep/ops/op_host/cam_moe_dispatch_normal_tiling.cc
+++ b/csrc/deepep/ops/op_host/cam_moe_dispatch_normal_tiling.cc
@@ -615,6 +615,7 @@ static ge::graphStatus CamMoeDispatchNormalA3TilingFuncImpl(gert::TilingContext 
     auto waitRecvcostStatsStorageShape = context->GetOutputShape(OUTPUT_WAIT_RECV_COST_INDEX);
     bool isEnableDiagnose = (waitRecvcostStatsStorageShape != nullptr);
     tilingData->camMoeDispatchNormalInfo.isEnableDiagnose = isEnableDiagnose;
+    tilingData->camMoeDispatchNormalInfo.isHybridDeployment = Mc2TilingUtils::IsHybridDeployment();
 
     // 检查输入输出的dim、format、dataType
     OP_TILING_CHECK(
@@ -648,17 +649,20 @@ static ge::graphStatus CamMoeDispatchNormalA3TilingFuncImpl(gert::TilingContext 
         round > 1 ? tokenNeedSizeCombine * 2 : tokenNeedSizeCombine;  // round > 1 combine要使用double buffer
     // 未考虑双流时大小
     uint64_t perHalfDataSize = maxBs * k * (tokenNeedSizeCombine + tokenNeedSizeDispatch);
-    uint64_t actualSize = (perHalfDataSize + Moe::A3WindowLayout::kPerHalfReservedSize) * DOUBLE_DATA_BUFFER;
+    uint64_t reservedSize = tilingData->camMoeDispatchNormalInfo.isHybridDeployment
+                                ? Moe::A3WindowLayout::kPerHalfReservedSize
+                                : Moe::A3WindowLayout::kLegacyNormalDataOffset;
+    uint64_t actualSize = (perHalfDataSize + reservedSize) * DOUBLE_DATA_BUFFER;
     OP_TILING_CHECK((actualSize > maxWindowSize),
                     OP_LOGE(nodeName,
                             "HCCL_BUFFSIZE is too SMALL, maxBs = %lu, h = %lu, epWorldSize = %lu,"
                             " localMoeExpertNum = %u, tokenNeedSizeDispatch = %lu, tokenNeedSizeCombine = %lu,"
-                            " k = %lu, perHalfDataSize=%lu, perHalfReservedSize=%lu, "
+                            " k = %lu, hybridDeployment=%d, perHalfDataSize=%lu, perHalfReservedSize=%lu, "
                             "NEEDED_HCCL_BUFFSIZE((perHalfDataSize + perHalfReservedSize) * 2) = %luMB, "
                             "HCCL_BUFFSIZE=%luMB.",
                             maxBs, h, epWorldSize, localMoeExpertNum, tokenNeedSizeDispatch, tokenNeedSizeCombine, k,
-                            perHalfDataSize, Moe::A3WindowLayout::kPerHalfReservedSize, actualSize / MB_SIZE + 1UL,
-                            maxWindowSize / MB_SIZE),
+                            tilingData->camMoeDispatchNormalInfo.isHybridDeployment, perHalfDataSize, reservedSize,
+                            actualSize / MB_SIZE + 1UL, maxWindowSize / MB_SIZE),
                     return ge::GRAPH_FAILED);
     tilingData->camMoeDispatchNormalInfo.totalWinSize = maxWindowSize;
     OP_LOGD(nodeName, "windowSize = %lu", maxWindowSize);

--- a/csrc/deepep/ops/op_host/mc2_tiling_utils.h
+++ b/csrc/deepep/ops/op_host/mc2_tiling_utils.h
@@ -2,6 +2,7 @@
 #define __MC2_TILING_UTILS_H__
 
 #include <cstdint>
+#include <cstdlib>
 #include <map>
 #include <string>
 
@@ -19,6 +20,11 @@
 class Mc2TilingUtils
 {
 public:
+    static bool IsHybridDeployment()
+    {
+        return getenv("DEEPEP_HYBRID_DEPLOYMENT") != nullptr;
+    }
+
     static uint64_t GetMaxWindowSize()
     {
         uint16_t defaultWindowSize = 200;

--- a/csrc/deepep/ops/op_host/moe_distribute_combine_v2_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_combine_v2_tiling.cpp
@@ -18,6 +18,7 @@
 #include "register/op_def_registry.h"
 #include "../op_kernel/moe_distribute_combine_tiling.h"
 #include "../op_kernel/moe_distribute_combine_v2_tiling.h"
+#include "tiling_args.h"
 #include "platform/platform_infos_def.h"
 #include "moe_distribute_combine_v2_ccu_tiling.h"
 
@@ -1198,26 +1199,38 @@ static ge::graphStatus MoeDistributeCombineA3TilingFuncImpl(gert::TilingContext 
     uint64_t epWorldSize = static_cast<uint64_t>(tilingData->moeDistributeCombineV2Info.epWorldSize);
     uint64_t k = static_cast<uint64_t>(tilingData->moeDistributeCombineV2Info.k);
     uint64_t maxBs = static_cast<uint64_t>(tilingData->moeDistributeCombineV2Info.globalBs) / epWorldSize;
+    OP_TILING_CHECK(maxBs > Moe::A3WindowLayout::kV2MaxBs,
+                    OP_LOGE(nodeName, "maxBs exceeds the A3 window layout limit, maxBs=%lu, limit=%lu.", maxBs,
+                            Moe::A3WindowLayout::kV2MaxBs),
+                    return ge::GRAPH_FAILED);
     // combine数据区 token首地址对齐512
     uint64_t tokenNeedSizeCombine = ((h * MAX_OUT_DTYPE_SIZE + WIN_ADDR_ALIGN - 1UL) / WIN_ADDR_ALIGN) * WIN_ADDR_ALIGN;
     // dispatch数据区 token首对齐512，有效token长度h_align_32b + scale(32b) + 三元组(3*4b)
     uint64_t tokenActualLen =
         ((h * MAX_OUT_DTYPE_SIZE + UB_ALIGN - 1UL) / UB_ALIGN) * UB_ALIGN + SCALE_EXPAND_IDX_BUFFER;
     uint64_t tokenNeedSizeDispatch = ((tokenActualLen + WIN_ADDR_ALIGN - 1UL) / WIN_ADDR_ALIGN) * WIN_ADDR_ALIGN;
-    uint64_t actualSize = ((maxBs * tokenNeedSizeDispatch * epWorldSize * static_cast<uint64_t>(localMoeExpertNum)) +
-                           (maxBs * tokenNeedSizeCombine * (k + static_cast<uint64_t>(sharedExpertNum)))) *
-                          DOUBLE_DATA_BUFFER;
+    uint64_t perHalfDataSize =
+        (maxBs * tokenNeedSizeDispatch * epWorldSize * static_cast<uint64_t>(localMoeExpertNum)) +
+        (maxBs * tokenNeedSizeCombine * (k + static_cast<uint64_t>(sharedExpertNum)));
+    uint64_t combineStateSize =
+        maxBs * (k + static_cast<uint64_t>(sharedExpertNum)) * Moe::A3WindowLayout::kV2StateEntrySize;
+    OP_TILING_CHECK(combineStateSize > Moe::A3WindowLayout::kV2StateSize,
+                    OP_LOGE(nodeName, "V2 combine state exceeds its slot, needed=%lu, slot=%lu.", combineStateSize,
+                            Moe::A3WindowLayout::kV2StateSize),
+                    return ge::GRAPH_FAILED);
+    uint64_t actualSize = (perHalfDataSize + Moe::A3WindowLayout::kPerHalfReservedSize) * DOUBLE_DATA_BUFFER;
     OP_TILING_CHECK(
         (actualSize > maxWindowSize),
         OP_LOGE(
             nodeName,
             "HCCL_BUFFSIZE is too SMALL, maxBs = %lu, h = %lu, epWorldSize = %lu,"
             " localMoeExpertNum = %u, sharedExpertNum = %u, tokenNeedSizeDispatch = %lu, tokenNeedSizeCombine = %lu,"
-            " k = %lu, NEEDED_HCCL_BUFFSIZE(((maxBs * tokenNeedSizeDispatch * ep_worldsize * localMoeExpertNum) +"
-            " (maxBs * tokenNeedSizeCombine * (k + sharedExpertNum))) * 2) = %luMB,"
+            " k = %lu, perHalfDataSize=%lu, perHalfReservedSize=%lu, "
+            "NEEDED_HCCL_BUFFSIZE((perHalfDataSize + perHalfReservedSize) * 2) = %luMB,"
             " HCCL_BUFFSIZE=%luMB.",
             maxBs, h, epWorldSize, localMoeExpertNum, sharedExpertNum, tokenNeedSizeDispatch, tokenNeedSizeCombine, k,
-            actualSize / MB_SIZE + 1UL, maxWindowSize / MB_SIZE),
+            perHalfDataSize, Moe::A3WindowLayout::kPerHalfReservedSize, actualSize / MB_SIZE + 1UL,
+            maxWindowSize / MB_SIZE),
         return ge::GRAPH_FAILED);
     tilingData->moeDistributeCombineV2Info.totalWinSize = maxWindowSize;
 

--- a/csrc/deepep/ops/op_host/moe_distribute_combine_v2_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_combine_v2_tiling.cpp
@@ -1215,9 +1215,9 @@ static ge::graphStatus MoeDistributeCombineA3TilingFuncImpl(gert::TilingContext 
         (maxBs * tokenNeedSizeCombine * (k + static_cast<uint64_t>(sharedExpertNum)));
     uint64_t combineStateSize =
         maxBs * (k + static_cast<uint64_t>(sharedExpertNum)) * Moe::A3WindowLayout::kLlStateEntrySize;
-    OP_TILING_CHECK(combineStateSize > Moe::A3WindowLayout::kLlStateSize,
-                    OP_LOGE(nodeName, "V2 combine state exceeds its slot, needed=%lu, slot=%lu.", combineStateSize,
-                            Moe::A3WindowLayout::kLlStateSize),
+    OP_TILING_CHECK(combineStateSize > Moe::A3WindowLayout::kLlStateTimeoutOffset,
+                    OP_LOGE(nodeName, "V2 combine state overlaps timeout probe, needed=%lu, capacity=%lu.",
+                            combineStateSize, Moe::A3WindowLayout::kLlStateTimeoutOffset),
                     return ge::GRAPH_FAILED);
     uint64_t reservedSize =
         tilingData->moeDistributeCombineV2Info.isHybridDeployment ? Moe::A3WindowLayout::kPerHalfReservedSize : 0UL;
@@ -1228,12 +1228,16 @@ static ge::graphStatus MoeDistributeCombineA3TilingFuncImpl(gert::TilingContext 
             nodeName,
             "HCCL_BUFFSIZE is too SMALL, maxBs = %lu, h = %lu, epWorldSize = %lu,"
             " localMoeExpertNum = %u, sharedExpertNum = %u, tokenNeedSizeDispatch = %lu, tokenNeedSizeCombine = %lu,"
-            " k = %lu, hybridDeployment=%d, perHalfDataSize=%lu, perHalfReservedSize=%lu, "
+            " k = %lu, hybridDeployment=%d, combineStateSize=%lu, timeoutProbeOffset=%lu, "
+            "perHalfDataSize=%lu, perHalfReservedSize=%lu, "
             "NEEDED_HCCL_BUFFSIZE((perHalfDataSize + perHalfReservedSize) * 2) = %luMB,"
             " HCCL_BUFFSIZE=%luMB.",
             maxBs, h, epWorldSize, localMoeExpertNum, sharedExpertNum, tokenNeedSizeDispatch, tokenNeedSizeCombine, k,
-            tilingData->moeDistributeCombineV2Info.isHybridDeployment, perHalfDataSize, reservedSize,
-            actualSize / MB_SIZE + 1UL, maxWindowSize / MB_SIZE),
+            tilingData->moeDistributeCombineV2Info.isHybridDeployment, combineStateSize,
+            tilingData->moeDistributeCombineV2Info.isHybridDeployment
+                ? Moe::A3WindowLayout::kLlStateTimeoutOffset
+                : Moe::A3WindowLayout::kLegacyLlStateTimeoutOffset,
+            perHalfDataSize, reservedSize, actualSize / MB_SIZE + 1UL, maxWindowSize / MB_SIZE),
         return ge::GRAPH_FAILED);
     tilingData->moeDistributeCombineV2Info.totalWinSize = maxWindowSize;
 

--- a/csrc/deepep/ops/op_host/moe_distribute_combine_v2_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_combine_v2_tiling.cpp
@@ -1200,9 +1200,9 @@ static ge::graphStatus MoeDistributeCombineA3TilingFuncImpl(gert::TilingContext 
     uint64_t epWorldSize = static_cast<uint64_t>(tilingData->moeDistributeCombineV2Info.epWorldSize);
     uint64_t k = static_cast<uint64_t>(tilingData->moeDistributeCombineV2Info.k);
     uint64_t maxBs = static_cast<uint64_t>(tilingData->moeDistributeCombineV2Info.globalBs) / epWorldSize;
-    OP_TILING_CHECK(maxBs > Moe::A3WindowLayout::kV2MaxBs,
+    OP_TILING_CHECK(maxBs > Moe::A3WindowLayout::kLlMaxBs,
                     OP_LOGE(nodeName, "maxBs exceeds the A3 window layout limit, maxBs=%lu, limit=%lu.", maxBs,
-                            Moe::A3WindowLayout::kV2MaxBs),
+                            Moe::A3WindowLayout::kLlMaxBs),
                     return ge::GRAPH_FAILED);
     // combine数据区 token首地址对齐512
     uint64_t tokenNeedSizeCombine = ((h * MAX_OUT_DTYPE_SIZE + WIN_ADDR_ALIGN - 1UL) / WIN_ADDR_ALIGN) * WIN_ADDR_ALIGN;
@@ -1214,10 +1214,10 @@ static ge::graphStatus MoeDistributeCombineA3TilingFuncImpl(gert::TilingContext 
         (maxBs * tokenNeedSizeDispatch * epWorldSize * static_cast<uint64_t>(localMoeExpertNum)) +
         (maxBs * tokenNeedSizeCombine * (k + static_cast<uint64_t>(sharedExpertNum)));
     uint64_t combineStateSize =
-        maxBs * (k + static_cast<uint64_t>(sharedExpertNum)) * Moe::A3WindowLayout::kV2StateEntrySize;
-    OP_TILING_CHECK(combineStateSize > Moe::A3WindowLayout::kV2StateSize,
+        maxBs * (k + static_cast<uint64_t>(sharedExpertNum)) * Moe::A3WindowLayout::kLlStateEntrySize;
+    OP_TILING_CHECK(combineStateSize > Moe::A3WindowLayout::kLlStateSize,
                     OP_LOGE(nodeName, "V2 combine state exceeds its slot, needed=%lu, slot=%lu.", combineStateSize,
-                            Moe::A3WindowLayout::kV2StateSize),
+                            Moe::A3WindowLayout::kLlStateSize),
                     return ge::GRAPH_FAILED);
     uint64_t reservedSize =
         tilingData->moeDistributeCombineV2Info.isHybridDeployment ? Moe::A3WindowLayout::kPerHalfReservedSize : 0UL;

--- a/csrc/deepep/ops/op_host/moe_distribute_combine_v2_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_combine_v2_tiling.cpp
@@ -1195,6 +1195,7 @@ static ge::graphStatus MoeDistributeCombineA3TilingFuncImpl(gert::TilingContext 
 
     // 校验win区大小
     uint64_t maxWindowSize = Mc2TilingUtils::GetMaxWindowSize();
+    tilingData->moeDistributeCombineV2Info.isHybridDeployment = Mc2TilingUtils::IsHybridDeployment();
     uint64_t h = static_cast<uint64_t>(tilingData->moeDistributeCombineV2Info.h);
     uint64_t epWorldSize = static_cast<uint64_t>(tilingData->moeDistributeCombineV2Info.epWorldSize);
     uint64_t k = static_cast<uint64_t>(tilingData->moeDistributeCombineV2Info.k);
@@ -1218,19 +1219,21 @@ static ge::graphStatus MoeDistributeCombineA3TilingFuncImpl(gert::TilingContext 
                     OP_LOGE(nodeName, "V2 combine state exceeds its slot, needed=%lu, slot=%lu.", combineStateSize,
                             Moe::A3WindowLayout::kV2StateSize),
                     return ge::GRAPH_FAILED);
-    uint64_t actualSize = (perHalfDataSize + Moe::A3WindowLayout::kPerHalfReservedSize) * DOUBLE_DATA_BUFFER;
+    uint64_t reservedSize =
+        tilingData->moeDistributeCombineV2Info.isHybridDeployment ? Moe::A3WindowLayout::kPerHalfReservedSize : 0UL;
+    uint64_t actualSize = (perHalfDataSize + reservedSize) * DOUBLE_DATA_BUFFER;
     OP_TILING_CHECK(
         (actualSize > maxWindowSize),
         OP_LOGE(
             nodeName,
             "HCCL_BUFFSIZE is too SMALL, maxBs = %lu, h = %lu, epWorldSize = %lu,"
             " localMoeExpertNum = %u, sharedExpertNum = %u, tokenNeedSizeDispatch = %lu, tokenNeedSizeCombine = %lu,"
-            " k = %lu, perHalfDataSize=%lu, perHalfReservedSize=%lu, "
+            " k = %lu, hybridDeployment=%d, perHalfDataSize=%lu, perHalfReservedSize=%lu, "
             "NEEDED_HCCL_BUFFSIZE((perHalfDataSize + perHalfReservedSize) * 2) = %luMB,"
             " HCCL_BUFFSIZE=%luMB.",
             maxBs, h, epWorldSize, localMoeExpertNum, sharedExpertNum, tokenNeedSizeDispatch, tokenNeedSizeCombine, k,
-            perHalfDataSize, Moe::A3WindowLayout::kPerHalfReservedSize, actualSize / MB_SIZE + 1UL,
-            maxWindowSize / MB_SIZE),
+            tilingData->moeDistributeCombineV2Info.isHybridDeployment, perHalfDataSize, reservedSize,
+            actualSize / MB_SIZE + 1UL, maxWindowSize / MB_SIZE),
         return ge::GRAPH_FAILED);
     tilingData->moeDistributeCombineV2Info.totalWinSize = maxWindowSize;
 

--- a/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
@@ -20,6 +20,7 @@
 #include "register/op_def_registry.h"
 #include "../op_kernel/moe_distribute_dispatch_tiling.h"
 #include "../op_kernel/moe_distribute_dispatch_v2_tiling.h"
+#include "tiling_args.h"
 #include "moe_distribute_dispatch_v2_ccu_tiling.h"
 #include "platform/platform_infos_def.h"
 
@@ -1215,6 +1216,10 @@ static ge::graphStatus CheckWinSize(const gert::TilingContext *context, MoeDistr
     uint64_t k = static_cast<uint64_t>(tilingData.moeDistributeDispatchV2Info.k);
     uint64_t epWorldSize = static_cast<uint64_t>(tilingData.moeDistributeDispatchV2Info.epWorldSize);
     uint64_t maxBs = static_cast<uint64_t>(tilingData.moeDistributeDispatchV2Info.globalBs) / epWorldSize;
+    OP_TILING_CHECK(maxBs > Moe::A3WindowLayout::kV2MaxBs,
+                    OP_LOGE(nodeName, "maxBs exceeds the A3 window layout limit, maxBs=%lu, limit=%lu.", maxBs,
+                            Moe::A3WindowLayout::kV2MaxBs),
+                    return ge::GRAPH_FAILED);
     // combine数据区 token首地址对齐512
     uint64_t tokenNeedSizeCombine = ((h * MAX_OUT_DTYPE_SIZE + WIN_ADDR_ALIGN - 1UL) / WIN_ADDR_ALIGN) * WIN_ADDR_ALIGN;
     auto expandXDesc = context->GetOutputDesc(OUTPUT_EXPAND_X_INDEX);
@@ -1233,20 +1238,28 @@ static ge::graphStatus CheckWinSize(const gert::TilingContext *context, MoeDistr
     } else {
         tokenNeedSizeDispatch = ((tokenActualLen + WIN_ADDR_ALIGN - 1UL) / WIN_ADDR_ALIGN) * WIN_ADDR_ALIGN;
     }
-    uint64_t actualSize = ((maxBs * tokenNeedSizeDispatch * epWorldSize * static_cast<uint64_t>(localMoeExpertNum)) +
-                           (maxBs * tokenNeedSizeCombine * (k + static_cast<uint64_t>(sharedExpertNum)))) *
-                          DOUBLE_DATA_BUFFER;
+    uint64_t perHalfDataSize =
+        (maxBs * tokenNeedSizeDispatch * epWorldSize * static_cast<uint64_t>(localMoeExpertNum)) +
+        (maxBs * tokenNeedSizeCombine * (k + static_cast<uint64_t>(sharedExpertNum)));
+    uint64_t dispatchStateSize = static_cast<uint64_t>(tilingData.moeDistributeDispatchV2Info.moeExpertNum) *
+                                 Moe::A3WindowLayout::kV2StateEntrySize;
+    OP_TILING_CHECK(dispatchStateSize > Moe::A3WindowLayout::kV2StateSize,
+                    OP_LOGE(nodeName, "V2 dispatch state exceeds its slot, needed=%lu, slot=%lu.", dispatchStateSize,
+                            Moe::A3WindowLayout::kV2StateSize),
+                    return ge::GRAPH_FAILED);
+    uint64_t actualSize = (perHalfDataSize + Moe::A3WindowLayout::kPerHalfReservedSize) * DOUBLE_DATA_BUFFER;
     OP_TILING_CHECK(
         (actualSize > maxWindowSize),
         OP_LOGE(
             nodeName,
             "HCCL_BUFFSIZE is too SMALL, maxBs = %lu, h = %lu, epWorldSize = %lu,"
             " localMoeExpertNum = %u, sharedExpertNum = %u, tokenNeedSizeDispatch = %lu, tokenNeedSizeCombine = %lu,"
-            " k = %lu, NEEDED_HCCL_BUFFSIZE(((maxBs * tokenNeedSizeDispatch * ep_worldsize * localMoeExpertNum) +"
-            " (maxBs * tokenNeedSizeCombine * (k + sharedExpertNum))) * 2) = %luMB,"
+            " k = %lu, perHalfDataSize=%lu, perHalfReservedSize=%lu, "
+            "NEEDED_HCCL_BUFFSIZE((perHalfDataSize + perHalfReservedSize) * 2) = %luMB,"
             " HCCL_BUFFSIZE=%luMB.",
             maxBs, h, epWorldSize, localMoeExpertNum, sharedExpertNum, tokenNeedSizeDispatch, tokenNeedSizeCombine, k,
-            actualSize / MB_SIZE + 1UL, maxWindowSize / MB_SIZE),
+            perHalfDataSize, Moe::A3WindowLayout::kPerHalfReservedSize, actualSize / MB_SIZE + 1UL,
+            maxWindowSize / MB_SIZE),
         return ge::GRAPH_FAILED);
     tilingData.moeDistributeDispatchV2Info.totalWinSize = maxWindowSize;
     OP_LOGD(nodeName, "windowSize = %lu", maxWindowSize);

--- a/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
@@ -1211,6 +1211,7 @@ static ge::graphStatus CheckWinSize(const gert::TilingContext *context, MoeDistr
                                     const char *nodeName, const bool isSetCommAlg, uint32_t &localMoeExpertNum)
 {
     uint64_t maxWindowSize = Mc2TilingUtils::GetMaxWindowSize();
+    tilingData.moeDistributeDispatchV2Info.isHybridDeployment = Mc2TilingUtils::IsHybridDeployment();
     uint32_t sharedExpertNum = tilingData.moeDistributeDispatchV2Info.sharedExpertNum;
     uint64_t h = static_cast<uint64_t>(tilingData.moeDistributeDispatchV2Info.h);
     uint64_t k = static_cast<uint64_t>(tilingData.moeDistributeDispatchV2Info.k);
@@ -1247,19 +1248,21 @@ static ge::graphStatus CheckWinSize(const gert::TilingContext *context, MoeDistr
                     OP_LOGE(nodeName, "V2 dispatch state exceeds its slot, needed=%lu, slot=%lu.", dispatchStateSize,
                             Moe::A3WindowLayout::kV2StateSize),
                     return ge::GRAPH_FAILED);
-    uint64_t actualSize = (perHalfDataSize + Moe::A3WindowLayout::kPerHalfReservedSize) * DOUBLE_DATA_BUFFER;
+    uint64_t reservedSize =
+        tilingData.moeDistributeDispatchV2Info.isHybridDeployment ? Moe::A3WindowLayout::kPerHalfReservedSize : 0UL;
+    uint64_t actualSize = (perHalfDataSize + reservedSize) * DOUBLE_DATA_BUFFER;
     OP_TILING_CHECK(
         (actualSize > maxWindowSize),
         OP_LOGE(
             nodeName,
             "HCCL_BUFFSIZE is too SMALL, maxBs = %lu, h = %lu, epWorldSize = %lu,"
             " localMoeExpertNum = %u, sharedExpertNum = %u, tokenNeedSizeDispatch = %lu, tokenNeedSizeCombine = %lu,"
-            " k = %lu, perHalfDataSize=%lu, perHalfReservedSize=%lu, "
+            " k = %lu, hybridDeployment=%d, perHalfDataSize=%lu, perHalfReservedSize=%lu, "
             "NEEDED_HCCL_BUFFSIZE((perHalfDataSize + perHalfReservedSize) * 2) = %luMB,"
             " HCCL_BUFFSIZE=%luMB.",
             maxBs, h, epWorldSize, localMoeExpertNum, sharedExpertNum, tokenNeedSizeDispatch, tokenNeedSizeCombine, k,
-            perHalfDataSize, Moe::A3WindowLayout::kPerHalfReservedSize, actualSize / MB_SIZE + 1UL,
-            maxWindowSize / MB_SIZE),
+            tilingData.moeDistributeDispatchV2Info.isHybridDeployment, perHalfDataSize, reservedSize,
+            actualSize / MB_SIZE + 1UL, maxWindowSize / MB_SIZE),
         return ge::GRAPH_FAILED);
     tilingData.moeDistributeDispatchV2Info.totalWinSize = maxWindowSize;
     OP_LOGD(nodeName, "windowSize = %lu", maxWindowSize);

--- a/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
@@ -1217,9 +1217,9 @@ static ge::graphStatus CheckWinSize(const gert::TilingContext *context, MoeDistr
     uint64_t k = static_cast<uint64_t>(tilingData.moeDistributeDispatchV2Info.k);
     uint64_t epWorldSize = static_cast<uint64_t>(tilingData.moeDistributeDispatchV2Info.epWorldSize);
     uint64_t maxBs = static_cast<uint64_t>(tilingData.moeDistributeDispatchV2Info.globalBs) / epWorldSize;
-    OP_TILING_CHECK(maxBs > Moe::A3WindowLayout::kV2MaxBs,
+    OP_TILING_CHECK(maxBs > Moe::A3WindowLayout::kLlMaxBs,
                     OP_LOGE(nodeName, "maxBs exceeds the A3 window layout limit, maxBs=%lu, limit=%lu.", maxBs,
-                            Moe::A3WindowLayout::kV2MaxBs),
+                            Moe::A3WindowLayout::kLlMaxBs),
                     return ge::GRAPH_FAILED);
     // combine数据区 token首地址对齐512
     uint64_t tokenNeedSizeCombine = ((h * MAX_OUT_DTYPE_SIZE + WIN_ADDR_ALIGN - 1UL) / WIN_ADDR_ALIGN) * WIN_ADDR_ALIGN;
@@ -1243,10 +1243,10 @@ static ge::graphStatus CheckWinSize(const gert::TilingContext *context, MoeDistr
         (maxBs * tokenNeedSizeDispatch * epWorldSize * static_cast<uint64_t>(localMoeExpertNum)) +
         (maxBs * tokenNeedSizeCombine * (k + static_cast<uint64_t>(sharedExpertNum)));
     uint64_t dispatchStateSize = static_cast<uint64_t>(tilingData.moeDistributeDispatchV2Info.moeExpertNum) *
-                                 Moe::A3WindowLayout::kV2StateEntrySize;
-    OP_TILING_CHECK(dispatchStateSize > Moe::A3WindowLayout::kV2StateSize,
+                                 Moe::A3WindowLayout::kLlStateEntrySize;
+    OP_TILING_CHECK(dispatchStateSize > Moe::A3WindowLayout::kLlStateSize,
                     OP_LOGE(nodeName, "V2 dispatch state exceeds its slot, needed=%lu, slot=%lu.", dispatchStateSize,
-                            Moe::A3WindowLayout::kV2StateSize),
+                            Moe::A3WindowLayout::kLlStateSize),
                     return ge::GRAPH_FAILED);
     uint64_t reservedSize =
         tilingData.moeDistributeDispatchV2Info.isHybridDeployment ? Moe::A3WindowLayout::kPerHalfReservedSize : 0UL;

--- a/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
+++ b/csrc/deepep/ops/op_host/moe_distribute_dispatch_v2_tiling.cpp
@@ -1244,9 +1244,9 @@ static ge::graphStatus CheckWinSize(const gert::TilingContext *context, MoeDistr
         (maxBs * tokenNeedSizeCombine * (k + static_cast<uint64_t>(sharedExpertNum)));
     uint64_t dispatchStateSize = static_cast<uint64_t>(tilingData.moeDistributeDispatchV2Info.moeExpertNum) *
                                  Moe::A3WindowLayout::kLlStateEntrySize;
-    OP_TILING_CHECK(dispatchStateSize > Moe::A3WindowLayout::kLlStateSize,
-                    OP_LOGE(nodeName, "V2 dispatch state exceeds its slot, needed=%lu, slot=%lu.", dispatchStateSize,
-                            Moe::A3WindowLayout::kLlStateSize),
+    OP_TILING_CHECK(dispatchStateSize > Moe::A3WindowLayout::kLlStateTimeoutOffset,
+                    OP_LOGE(nodeName, "V2 dispatch state overlaps timeout probe, needed=%lu, capacity=%lu.",
+                            dispatchStateSize, Moe::A3WindowLayout::kLlStateTimeoutOffset),
                     return ge::GRAPH_FAILED);
     uint64_t reservedSize =
         tilingData.moeDistributeDispatchV2Info.isHybridDeployment ? Moe::A3WindowLayout::kPerHalfReservedSize : 0UL;
@@ -1257,12 +1257,16 @@ static ge::graphStatus CheckWinSize(const gert::TilingContext *context, MoeDistr
             nodeName,
             "HCCL_BUFFSIZE is too SMALL, maxBs = %lu, h = %lu, epWorldSize = %lu,"
             " localMoeExpertNum = %u, sharedExpertNum = %u, tokenNeedSizeDispatch = %lu, tokenNeedSizeCombine = %lu,"
-            " k = %lu, hybridDeployment=%d, perHalfDataSize=%lu, perHalfReservedSize=%lu, "
+            " k = %lu, hybridDeployment=%d, dispatchStateSize=%lu, timeoutProbeOffset=%lu, "
+            "perHalfDataSize=%lu, perHalfReservedSize=%lu, "
             "NEEDED_HCCL_BUFFSIZE((perHalfDataSize + perHalfReservedSize) * 2) = %luMB,"
             " HCCL_BUFFSIZE=%luMB.",
             maxBs, h, epWorldSize, localMoeExpertNum, sharedExpertNum, tokenNeedSizeDispatch, tokenNeedSizeCombine, k,
-            tilingData.moeDistributeDispatchV2Info.isHybridDeployment, perHalfDataSize, reservedSize,
-            actualSize / MB_SIZE + 1UL, maxWindowSize / MB_SIZE),
+            tilingData.moeDistributeDispatchV2Info.isHybridDeployment, dispatchStateSize,
+            tilingData.moeDistributeDispatchV2Info.isHybridDeployment
+                ? Moe::A3WindowLayout::kLlStateTimeoutOffset
+                : Moe::A3WindowLayout::kLegacyLlStateTimeoutOffset,
+            perHalfDataSize, reservedSize, actualSize / MB_SIZE + 1UL, maxWindowSize / MB_SIZE),
         return ge::GRAPH_FAILED);
     tilingData.moeDistributeDispatchV2Info.totalWinSize = maxWindowSize;
     OP_LOGD(nodeName, "windowSize = %lu", maxWindowSize);

--- a/csrc/deepep/ops/op_host/notify_dispatch_tiling.cc
+++ b/csrc/deepep/ops/op_host/notify_dispatch_tiling.cc
@@ -16,6 +16,7 @@
 #include "register/op_def_registry.h"
 #include "mc2_tiling_utils.h"
 #include "../op_kernel/notify_dispatch_tiling.h"
+#include "tiling_args.h"
 #include "tiling/platform/platform_ascendc.h"
 #include "tiling/hccl/hccl_tiling.h"
 #include "platform/platform_infos_def.h"
@@ -274,8 +275,13 @@ static bool CheckTensorDataType(gert::TilingContext *context, const char *nodeNa
     NotifyDispatchTilingData *tilingData = context->GetTilingData<NotifyDispatchTilingData>();
     uint64_t maxWindowSize = Mc2TilingUtils::GetMaxWindowSize();
     uint64_t actualSize = dataSize * tilingData->notifyDispatchInfo.sendCount + 2 * 1024 * 1024;  // 2MB flag位
+    if (actualSize > Moe::A3WindowLayout::kNotifyDispatchSize) {
+        OP_LOGE(nodeName, "notify payload exceeds its fixed 102MB window region, needed=%luMB.",
+                actualSize / MB_SIZE + 1UL);
+        return false;
+    }
     if (actualSize > maxWindowSize) {
-        OP_LOGE(nodeName, "HCCL_BUFFSIZE is too SMALL, should larger than %luMB.", actualSize / MB_SIZE);
+        OP_LOGE(nodeName, "HCCL_BUFFSIZE is too SMALL, should be at least %luMB.", actualSize / MB_SIZE + 1UL);
         return false;
     }
     tilingData->notifyDispatchInfo.totalWinSize = maxWindowSize;

--- a/csrc/deepep/ops/op_host/tiling_args.h
+++ b/csrc/deepep/ops/op_host/tiling_args.h
@@ -18,10 +18,10 @@ constexpr uint64_t MB = 1024UL * KB;
 //   | [0, 102MB)                | notify-dispatch state/payload               |
 //   | [102MB, 106MB)            | normal combine token-state                  |
 //   | [106MB, 106MB + 24KB)     | ll dispatch selector metadata (48 * 512B)   |
-//   | [106MB + 24KB, 107MB+24KB)| ll dispatch working state                   |
-//   | [107MB + 24KB, 107MB+48KB)| ll combine selector metadata (48 * 512B)    |
-//   | [107MB + 48KB, 108MB+48KB)| ll combine working state                    |
-//   | [108MB + 48KB, halfSize)  | unified data area for normal and ll         |
+//   | [106MB + 24KB, 106MB + 536KB)    | ll dispatch working state              |
+//   | [106MB + 536KB, 106MB + 560KB)   | ll combine selector metadata (48*512B)|
+//   | [106MB + 560KB, 107MB + 48KB)    | ll combine working state               |
+//   | [107MB + 48KB, halfSize)         | unified data area for normal and ll    |
 //   +---------------------------+---------------------------------------------+
 
 constexpr uint64_t kNotifyDispatchSize = 102UL * MB;
@@ -31,9 +31,11 @@ constexpr uint64_t kNormalCombineStateEntrySize = 32UL;
 constexpr uint64_t kAivCount = 48UL;
 constexpr uint64_t kAivMetadataStride = 512UL;
 constexpr uint64_t kLlSelectorMetadataSize = kAivCount * kAivMetadataStride;
-constexpr uint64_t kLlStateSize = 1UL * MB;
-constexpr uint64_t kLlStateTimeoutOffset = 1000UL * KB;
 constexpr uint64_t kLlStateTimeoutBytes = 8UL * sizeof(float);
+constexpr uint64_t kLlStateSize = 512UL * KB;
+// Hybrid timeout probes occupy the final 32 bytes of their owning state slot.
+// Legacy keeps its original +1000KB probe address in the V2 kernels.
+constexpr uint64_t kLlStateTimeoutOffset = kLlStateSize - kLlStateTimeoutBytes;
 constexpr uint64_t kLlStateEntrySize = 32UL;
 constexpr uint64_t kLlMaxBs = 512UL;
 constexpr uint64_t kLlMaxTopK = 16UL;
@@ -56,6 +58,7 @@ constexpr uint64_t kLegacyV2StateHalfSize = 500UL * KB;
 constexpr uint64_t kLegacyV2CombineStateOffset = 64UL * KB;
 constexpr uint64_t kLegacyV2DispatchSelectorOffset = 950UL * KB;
 constexpr uint64_t kLegacyV2CombineSelectorOffset = 975UL * KB;
+constexpr uint64_t kLegacyLlStateTimeoutOffset = 1000UL * KB;
 
 constexpr uint64_t kLlDispatchSelectorOffset = kNotifyDispatchSize + kNormalCombineStateSize;
 constexpr uint64_t kLlDispatchStateOffset = kLlDispatchSelectorOffset + kLlSelectorMetadataSize;
@@ -66,10 +69,8 @@ constexpr uint64_t kPerHalfReservedSize = kDataOffset;
 
 static_assert(kLlStateTimeoutOffset + kLlStateTimeoutBytes <= kLlStateSize,
               "V2 timeout probe must remain inside its state slot");
-static_assert(kLlMaxBs * (kLlMaxTopK + kLlMaxSharedExpertNum) * kLlStateEntrySize <= kLlStateSize,
-              "V2 combine state must remain inside its state slot");
 static_assert(kLlMaxBs * (kLlMaxTopK + kLlMaxSharedExpertNum) * kLlStateEntrySize <= kLlStateTimeoutOffset,
-              "V2 combine state must not overlap the timeout probe");
+              "V2 combine state must remain inside its state slot");
 }  // namespace A3WindowLayout
 }  // namespace Moe
 

--- a/csrc/deepep/ops/op_host/tiling_args.h
+++ b/csrc/deepep/ops/op_host/tiling_args.h
@@ -9,38 +9,66 @@ namespace A3WindowLayout {
 constexpr uint64_t KB = 1024UL;
 constexpr uint64_t MB = 1024UL * KB;
 
+// A3 windowsIn layout for one ping-pong half:
+//
+//   windowsIn + dataState * (totalWinSize / 2)
+//   +---------------------------+---------------------------------------------+
+//   | byte range                | owner / purpose                             |
+//   +---------------------------+---------------------------------------------+
+//   | [0, 102MB)                | notify-dispatch state/payload               |
+//   | [102MB, 106MB)            | normal combine token-state                  |
+//   | [106MB, 106MB + 24KB)     | ll dispatch selector metadata (48 * 512B)   |
+//   | [106MB + 24KB, 107MB+24KB)| ll dispatch working state                   |
+//   | [107MB + 24KB, 107MB+48KB)| ll combine selector metadata (48 * 512B)    |
+//   | [107MB + 48KB, 108MB+48KB)| ll combine working state                    |
+//   | [108MB + 48KB, halfSize)  | unified data area for normal and ll         |
+//   +---------------------------+---------------------------------------------+
+
 constexpr uint64_t kNotifyDispatchSize = 102UL * MB;
 constexpr uint64_t kNormalCombineStateSize = 4UL * MB;
+constexpr uint64_t kNormalCombineStateHalfSize = kNormalCombineStateSize / 2UL;
+constexpr uint64_t kNormalCombineStateEntrySize = 32UL;
 constexpr uint64_t kAivCount = 48UL;
 constexpr uint64_t kAivMetadataStride = 512UL;
-constexpr uint64_t kV2SelectorMetadataSize = kAivCount * kAivMetadataStride;
-constexpr uint64_t kV2StateSize = 1UL * MB;
-constexpr uint64_t kV2StateTimeoutOffset = 1000UL * KB;
-constexpr uint64_t kV2StateTimeoutBytes = 8UL * sizeof(float);
-constexpr uint64_t kV2StateEntrySize = 32UL;
-constexpr uint64_t kV2MaxBs = 512UL;
-constexpr uint64_t kV2MaxTopK = 16UL;
-constexpr uint64_t kV2MaxSharedExpertNum = 4UL;
+constexpr uint64_t kLlSelectorMetadataSize = kAivCount * kAivMetadataStride;
+constexpr uint64_t kLlStateSize = 1UL * MB;
+constexpr uint64_t kLlStateTimeoutOffset = 1000UL * KB;
+constexpr uint64_t kLlStateTimeoutBytes = 8UL * sizeof(float);
+constexpr uint64_t kLlStateEntrySize = 32UL;
+constexpr uint64_t kLlMaxBs = 512UL;
+constexpr uint64_t kLlMaxTopK = 16UL;
+constexpr uint64_t kLlMaxSharedExpertNum = 4UL;
 
-// Keep these legacy values synchronized with op_kernel/window_layout.h.
+// Keep these legacy values and this layout description synchronized with
+// op_kernel/window_layout.h. Legacy windowsIn, per ping-pong half:
+//
+//   [0, 102MB)        notify-dispatch payload/state
+//   [102MB, 106MB)    normal combine token-state
+//   [106MB, halfSize) normal dispatch/combine payload
+//   [0, halfSize)     V2 dispatch/combine payload (overlaps normal layout)
+//
+// Legacy windowsExp holds shared V2 control addresses. Dispatch state starts
+// at +0KB/+500KB for dataState 0/1; combine starts at +64KB/+564KB. Selector
+// metadata starts at +950KB for dispatch and +975KB for combine (48 * 512B).
+// These state regions are reused by sequential V2 phases, not isolated slots.
 constexpr uint64_t kLegacyNormalDataOffset = kNotifyDispatchSize + kNormalCombineStateSize;
 constexpr uint64_t kLegacyV2StateHalfSize = 500UL * KB;
 constexpr uint64_t kLegacyV2CombineStateOffset = 64UL * KB;
 constexpr uint64_t kLegacyV2DispatchSelectorOffset = 950UL * KB;
 constexpr uint64_t kLegacyV2CombineSelectorOffset = 975UL * KB;
 
-constexpr uint64_t kV2DispatchSelectorOffset = kNotifyDispatchSize + kNormalCombineStateSize;
-constexpr uint64_t kV2DispatchStateOffset = kV2DispatchSelectorOffset + kV2SelectorMetadataSize;
-constexpr uint64_t kV2CombineSelectorOffset = kV2DispatchStateOffset + kV2StateSize;
-constexpr uint64_t kV2CombineStateOffset = kV2CombineSelectorOffset + kV2SelectorMetadataSize;
-constexpr uint64_t kDataOffset = kV2CombineStateOffset + kV2StateSize;
+constexpr uint64_t kLlDispatchSelectorOffset = kNotifyDispatchSize + kNormalCombineStateSize;
+constexpr uint64_t kLlDispatchStateOffset = kLlDispatchSelectorOffset + kLlSelectorMetadataSize;
+constexpr uint64_t kLlCombineSelectorOffset = kLlDispatchStateOffset + kLlStateSize;
+constexpr uint64_t kLlCombineStateOffset = kLlCombineSelectorOffset + kLlSelectorMetadataSize;
+constexpr uint64_t kDataOffset = kLlCombineStateOffset + kLlStateSize;
 constexpr uint64_t kPerHalfReservedSize = kDataOffset;
 
-static_assert(kV2StateTimeoutOffset + kV2StateTimeoutBytes <= kV2StateSize,
+static_assert(kLlStateTimeoutOffset + kLlStateTimeoutBytes <= kLlStateSize,
               "V2 timeout probe must remain inside its state slot");
-static_assert(kV2MaxBs * (kV2MaxTopK + kV2MaxSharedExpertNum) * kV2StateEntrySize <= kV2StateSize,
+static_assert(kLlMaxBs * (kLlMaxTopK + kLlMaxSharedExpertNum) * kLlStateEntrySize <= kLlStateSize,
               "V2 combine state must remain inside its state slot");
-static_assert(kV2MaxBs * (kV2MaxTopK + kV2MaxSharedExpertNum) * kV2StateEntrySize <= kV2StateTimeoutOffset,
+static_assert(kLlMaxBs * (kLlMaxTopK + kLlMaxSharedExpertNum) * kLlStateEntrySize <= kLlStateTimeoutOffset,
               "V2 combine state must not overlap the timeout probe");
 }  // namespace A3WindowLayout
 }  // namespace Moe

--- a/csrc/deepep/ops/op_host/tiling_args.h
+++ b/csrc/deepep/ops/op_host/tiling_args.h
@@ -22,6 +22,13 @@ constexpr uint64_t kV2MaxBs = 512UL;
 constexpr uint64_t kV2MaxTopK = 16UL;
 constexpr uint64_t kV2MaxSharedExpertNum = 4UL;
 
+// Keep these legacy values synchronized with op_kernel/window_layout.h.
+constexpr uint64_t kLegacyNormalDataOffset = kNotifyDispatchSize + kNormalCombineStateSize;
+constexpr uint64_t kLegacyV2StateHalfSize = 500UL * KB;
+constexpr uint64_t kLegacyV2CombineStateOffset = 64UL * KB;
+constexpr uint64_t kLegacyV2DispatchSelectorOffset = 950UL * KB;
+constexpr uint64_t kLegacyV2CombineSelectorOffset = 975UL * KB;
+
 constexpr uint64_t kV2DispatchSelectorOffset = kNotifyDispatchSize + kNormalCombineStateSize;
 constexpr uint64_t kV2DispatchStateOffset = kV2DispatchSelectorOffset + kV2SelectorMetadataSize;
 constexpr uint64_t kV2CombineSelectorOffset = kV2DispatchStateOffset + kV2StateSize;

--- a/csrc/deepep/ops/op_host/tiling_args.h
+++ b/csrc/deepep/ops/op_host/tiling_args.h
@@ -18,7 +18,7 @@ constexpr uint64_t kV2StateSize = 1UL * MB;
 constexpr uint64_t kV2StateTimeoutOffset = 1000UL * KB;
 constexpr uint64_t kV2StateTimeoutBytes = 8UL * sizeof(float);
 constexpr uint64_t kV2StateEntrySize = 32UL;
-constexpr uint64_t kV2MaxBs = 256UL;
+constexpr uint64_t kV2MaxBs = 512UL;
 constexpr uint64_t kV2MaxTopK = 16UL;
 constexpr uint64_t kV2MaxSharedExpertNum = 4UL;
 
@@ -31,6 +31,10 @@ constexpr uint64_t kPerHalfReservedSize = kDataOffset;
 
 static_assert(kV2StateTimeoutOffset + kV2StateTimeoutBytes <= kV2StateSize,
               "V2 timeout probe must remain inside its state slot");
+static_assert(kV2MaxBs * (kV2MaxTopK + kV2MaxSharedExpertNum) * kV2StateEntrySize <= kV2StateSize,
+              "V2 combine state must remain inside its state slot");
+static_assert(kV2MaxBs * (kV2MaxTopK + kV2MaxSharedExpertNum) * kV2StateEntrySize <= kV2StateTimeoutOffset,
+              "V2 combine state must not overlap the timeout probe");
 }  // namespace A3WindowLayout
 }  // namespace Moe
 

--- a/csrc/deepep/ops/op_kernel/cam_moe_combine_normal.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_combine_normal.h
@@ -11,7 +11,6 @@ namespace CamMoeCombineNormalImpl {
 constexpr uint32_t RANK_ID_OFFSET_IN_SRC_INFO = 0U;
 constexpr uint32_t TOKEN_IDX_OFFSET_IN_SRC_INFO = 1U;
 constexpr uint32_t TOPK_IDX_OFFSET_IN_SRC_INFO = 2U;
-constexpr uint64_t COMBINE_STATE_WIN_OFFSET = 4UL * 1024UL * 1024UL;
 constexpr uint64_t MAGIC_WIN_OFFSET = 975UL * 1024UL;
 constexpr uint32_t TOKEN_SRC_INFO_LEN = 3U;
 constexpr uint32_t UB_32_ALIGN = 32U;
@@ -71,7 +70,9 @@ private:
 
     __aicore__ GM_ADDR GetBufferAddrByRankId(const int32_t rankId)
     {
-        return GetStateAddrByRankId(rankId) + COMBINE_STATE_WIN_OFFSET;
+        return GetStateAddrByRankId(rankId) + Moe::A3WindowLayout::kNormalCombineStateSize +
+               Moe::A3WindowLayout::kV2SelectorMetadataSize + Moe::A3WindowLayout::kV2StateSize +
+               Moe::A3WindowLayout::kV2SelectorMetadataSize + Moe::A3WindowLayout::kV2StateSize;
     }
 
     __aicore__ inline void SplitCoreCal(uint32_t totalNum, uint32_t &perCoreNum, uint32_t &startIdx, uint32_t &endIdx)

--- a/csrc/deepep/ops/op_kernel/cam_moe_combine_normal.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_combine_normal.h
@@ -70,9 +70,11 @@ private:
 
     __aicore__ GM_ADDR GetBufferAddrByRankId(const int32_t rankId)
     {
-        return GetStateAddrByRankId(rankId) + Moe::A3WindowLayout::kNormalCombineStateSize +
-               Moe::A3WindowLayout::kV2SelectorMetadataSize + Moe::A3WindowLayout::kV2StateSize +
-               Moe::A3WindowLayout::kV2SelectorMetadataSize + Moe::A3WindowLayout::kV2StateSize;
+        uint64_t dataOffset = Moe::A3WindowLayout::kNormalCombineStateSize;
+        if (isHybridDeployment_) {
+            dataOffset = Moe::A3WindowLayout::kDataOffset - Moe::A3WindowLayout::kNotifyDispatchSize;
+        }
+        return GetStateAddrByRankId(rankId) + dataOffset;
     }
 
     __aicore__ inline void SplitCoreCal(uint32_t totalNum, uint32_t &perCoreNum, uint32_t &startIdx, uint32_t &endIdx)
@@ -113,6 +115,7 @@ private:
     uint32_t sendCostStatsBufSize_{0};
 
     bool isEnableDiagnose_{false};
+    bool isHybridDeployment_{false};
 
     TPipe *tpipe_{nullptr};
     TQue<QuePosition::VECIN, 1> weightedSumQueue_;
@@ -185,6 +188,7 @@ CamMoeCombineNormal<TemplateMC2TypeFunc>::InitTilingData(const CamMoeCombineNorm
     epWorldSize_ = tilingData->camMoeCombineNormalInfo.epWorldSize;
     epRankId_ = tilingData->camMoeCombineNormalInfo.epRankId;
     isEnableDiagnose_ = tilingData->camMoeCombineNormalInfo.isEnableDiagnose;
+    isHybridDeployment_ = tilingData->camMoeCombineNormalInfo.isHybridDeployment;
 }
 
 template <TemplateMC2TypeClass>

--- a/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_multi_round.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_multi_round.h
@@ -11,7 +11,7 @@ namespace CamMoeCombineNormalMultiRoundImpl {
 constexpr uint32_t RANK_ID_OFFSET_IN_SRC_INFO = 0U;
 constexpr uint32_t TOKEN_IDX_OFFSET_IN_SRC_INFO = 1U;
 constexpr uint32_t TOPK_IDX_OFFSET_IN_SRC_INFO = 2U;
-constexpr uint64_t STATE_WIN_SIZE = 4UL * 1024UL * 1024UL;
+constexpr uint64_t STATE_WIN_SIZE = Moe::A3WindowLayout::kNormalCombineStateSize;
 constexpr uint64_t STATE_WIN_SIZE_HALF = STATE_WIN_SIZE / 2;
 #ifdef __DAV_C310__
 constexpr uint64_t MAGIC_WIN_OFFSET = 1100UL * 1024UL;
@@ -81,7 +81,9 @@ private:
 
     __aicore__ GM_ADDR GetBufferAddrByRankId(const int32_t rankId)
     {
-        return GetStateAddrByRankId(rankId) + STATE_WIN_SIZE + roundMagic_ * combineDataBuffSize_;
+        return GetStateAddrByRankId(rankId) + STATE_WIN_SIZE + roundMagic_ * combineDataBuffSize_ +
+               Moe::A3WindowLayout::kV2SelectorMetadataSize + Moe::A3WindowLayout::kV2StateSize +
+               Moe::A3WindowLayout::kV2SelectorMetadataSize + Moe::A3WindowLayout::kV2StateSize;
     }
 
     __aicore__ inline GM_ADDR GetRoundStateAddrByRankId(const int32_t rankId)

--- a/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_multi_round.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_multi_round.h
@@ -81,9 +81,12 @@ private:
 
     __aicore__ GM_ADDR GetBufferAddrByRankId(const int32_t rankId)
     {
-        return GetStateAddrByRankId(rankId) + STATE_WIN_SIZE + roundMagic_ * combineDataBuffSize_ +
-               Moe::A3WindowLayout::kV2SelectorMetadataSize + Moe::A3WindowLayout::kV2StateSize +
-               Moe::A3WindowLayout::kV2SelectorMetadataSize + Moe::A3WindowLayout::kV2StateSize;
+        uint64_t dataOffset = STATE_WIN_SIZE + roundMagic_ * combineDataBuffSize_;
+        if (isHybridDeployment_) {
+            dataOffset += Moe::A3WindowLayout::kV2SelectorMetadataSize + Moe::A3WindowLayout::kV2StateSize +
+                          Moe::A3WindowLayout::kV2SelectorMetadataSize + Moe::A3WindowLayout::kV2StateSize;
+        }
+        return GetStateAddrByRankId(rankId) + dataOffset;
     }
 
     __aicore__ inline GM_ADDR GetRoundStateAddrByRankId(const int32_t rankId)
@@ -154,6 +157,7 @@ private:
     uint32_t combineDataBuffSize_{0};
 
     bool isEnableDiagnose_{false};
+    bool isHybridDeployment_{false};
 
     TPipe *tpipe_{nullptr};
     TQue<QuePosition::VECIN, 1> weightedSumQueue_;
@@ -238,6 +242,7 @@ CamMoeCombineNormalMultiRound<TemplateMC2TypeFunc>::InitTilingData(const CamMoeC
     epWorldSize_ = tilingData->camMoeCombineNormalInfo.epWorldSize;
     epRankId_ = tilingData->camMoeCombineNormalInfo.epRankId;
     isEnableDiagnose_ = tilingData->camMoeCombineNormalInfo.isEnableDiagnose;
+    isHybridDeployment_ = tilingData->camMoeCombineNormalInfo.isHybridDeployment;
     realMaxBs_ = tilingData->camMoeCombineNormalInfo.realMaxBs;
     maxRound_ = tilingData->camMoeCombineNormalInfo.maxRound;
     perRoundTokens_ = tilingData->camMoeCombineNormalInfo.perRoundTokens;

--- a/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_multi_round.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_multi_round.h
@@ -83,8 +83,8 @@ private:
     {
         uint64_t dataOffset = STATE_WIN_SIZE + roundMagic_ * combineDataBuffSize_;
         if (isHybridDeployment_) {
-            dataOffset += Moe::A3WindowLayout::kV2SelectorMetadataSize + Moe::A3WindowLayout::kV2StateSize +
-                          Moe::A3WindowLayout::kV2SelectorMetadataSize + Moe::A3WindowLayout::kV2StateSize;
+            dataOffset += Moe::A3WindowLayout::kLlSelectorMetadataSize + Moe::A3WindowLayout::kLlStateSize +
+                          Moe::A3WindowLayout::kLlSelectorMetadataSize + Moe::A3WindowLayout::kLlStateSize;
         }
         return GetStateAddrByRankId(rankId) + dataOffset;
     }

--- a/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_tiling.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_combine_normal_tiling.h
@@ -24,6 +24,7 @@ struct CamMoeCombineNormalInfo {
     float armAvgFactor;
     float epsilon;
     bool isEnableDiagnose;
+    bool isHybridDeployment;
 };
 struct CamMoeCombineNormalTilingData {
     Mc2InitTiling mc2InitTiling;

--- a/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal.h
@@ -19,7 +19,6 @@ constexpr uint64_t WIN_STATE_OFFSET = 500UL * 1024UL;
 constexpr uint64_t STATE_WIN_OFFSET = 950UL * 1024UL;
 constexpr uint64_t WIN_ADDR_ALIGN = 512UL;
 constexpr uint32_t EXPAND_IDX_INFO = 3U;
-constexpr uint64_t COMBINE_STATE_WIN_OFFSET = 4UL * 1024UL * 1024UL;
 constexpr int64_t CYCLE_TO_TIME = 50;  // cycle num is converted into a fixed base unit of time, set at 50
 constexpr uint64_t ROUND_STATE_OFFSET = Moe::BASE_ROUND_STATE_OFFSET;
 constexpr uint32_t FLOAT_NUM_PER_ALIGN = 8U;
@@ -68,11 +67,11 @@ private:
     {
         uint32_t curRankId = ((ctxIdx == COMM_EP_IDX) ? epRankId : tpRankId);
         if (curRankId == rankId) {
-            return (GM_ADDR)(winContext_[ctxIdx]->localWindowsIn) + winDataSizeOffset + COMBINE_STATE_WIN_OFFSET +
-                   Moe::NOTIFY_DISPATCH_BUFF_OFFSET;
+            return (GM_ADDR)(winContext_[ctxIdx]->localWindowsIn) + winDataSizeOffset +
+                   Moe::A3WindowLayout::kDataOffset;
         }
         return (GM_ADDR)(((HcclRankRelationResV2 *)(winContext_[ctxIdx]->remoteRes[rankId].nextDevicePtr))->windowsIn) +
-               winDataSizeOffset + COMBINE_STATE_WIN_OFFSET + Moe::NOTIFY_DISPATCH_BUFF_OFFSET;
+               winDataSizeOffset + Moe::A3WindowLayout::kDataOffset;
     }
 
     __aicore__ inline GM_ADDR GetWindStateAddrByRankId(uint8_t ctxIdx, const int32_t rankId)

--- a/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal.h
@@ -66,12 +66,13 @@ private:
     __aicore__ inline GM_ADDR GetWindAddrByRankId(uint8_t ctxIdx, const int32_t rankId)
     {
         uint32_t curRankId = ((ctxIdx == COMM_EP_IDX) ? epRankId : tpRankId);
+        uint64_t dataOffset =
+            isHybridDeployment ? Moe::A3WindowLayout::kDataOffset : Moe::A3WindowLayout::kLegacyNormalDataOffset;
         if (curRankId == rankId) {
-            return (GM_ADDR)(winContext_[ctxIdx]->localWindowsIn) + winDataSizeOffset +
-                   Moe::A3WindowLayout::kDataOffset;
+            return (GM_ADDR)(winContext_[ctxIdx]->localWindowsIn) + winDataSizeOffset + dataOffset;
         }
         return (GM_ADDR)(((HcclRankRelationResV2 *)(winContext_[ctxIdx]->remoteRes[rankId].nextDevicePtr))->windowsIn) +
-               winDataSizeOffset + Moe::A3WindowLayout::kDataOffset;
+               winDataSizeOffset + dataOffset;
     }
 
     __aicore__ inline GM_ADDR GetWindStateAddrByRankId(uint8_t ctxIdx, const int32_t rankId)
@@ -166,6 +167,7 @@ private:
     uint32_t moeExpertNum{0};
     uint32_t moeExpertNumPerRank{0};
     bool isEnableDiagnose{false};
+    bool isHybridDeployment{false};
 
     uint32_t hUBAlignSize{0};
     uint32_t hOutGMAlignSize{0};
@@ -228,6 +230,7 @@ __aicore__ inline void CamMoeDispatchNormal<CamTypeFunc>::Init(
     moeExpertNum = tilingData->camMoeDispatchNormalInfo.moeExpertNum;
     moeExpertNumPerRank = moeExpertNum / epRankSize;
     isEnableDiagnose = tilingData->camMoeDispatchNormalInfo.isEnableDiagnose;
+    isHybridDeployment = tilingData->camMoeDispatchNormalInfo.isHybridDeployment;
 
     xGT.SetGlobalBuffer((__gm__ XType *)x);
     expertIdsGT.SetGlobalBuffer((__gm__ int32_t *)expertIds);

--- a/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal_tiling.h
+++ b/csrc/deepep/ops/op_kernel/cam_moe_dispatch_normal_tiling.h
@@ -18,9 +18,9 @@ struct CamMoeDispatchNormalInfo {
     uint32_t aivNum;        // aivNum
     bool isQuant;           // whether quant or not
     bool isEnableDiagnose;  // whether enable diagnose or not
-    bool reserved2;         // reserved
-    bool reserved3;         // reserved
-    uint64_t totalUbSize;   // epWorldSize
+    bool isHybridDeployment;
+    bool reserved3;        // reserved
+    uint64_t totalUbSize;  // epWorldSize
     uint64_t totalWinSize;
 };
 

--- a/csrc/deepep/ops/op_kernel/comm_args.h
+++ b/csrc/deepep/ops/op_kernel/comm_args.h
@@ -2,13 +2,15 @@
 #define COMM_ARGS_H
 #include <cstdint>
 
+#include "window_layout.h"
+
 #define FORCE_INLINE_AICORE __attribute__((always_inline)) inline __aicore__
 #include "kernel_operator.h"
 
 namespace Moe {
 constexpr int CAM_MAX_RANK_SIZE = 384;  // Maximum number of NPU cards supported by the communication library
 
-constexpr uint64_t NOTIFY_DISPATCH_BUFF_OFFSET = 102UL * 1024UL * 1024UL;
+constexpr uint64_t NOTIFY_DISPATCH_BUFF_OFFSET = A3WindowLayout::kNotifyDispatchSize;
 constexpr int64_t IPC_BUFF_MAX_SIZE = 100 * 1024 * 1024;
 constexpr int64_t IPC_DATA_OFFSET = 2 * 1024 * 1024;  // First 2MB as flag, then 100MB as data storage
 constexpr int64_t PING_PONG_SIZE = 2;

--- a/csrc/deepep/ops/op_kernel/moe_distribute_combine_v2.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_combine_v2.h
@@ -7,12 +7,12 @@
 #include "moe_distribute_v2_base.h"
 #include "moe_distribute_combine_v2_tiling.h"
 #include "check_winsize.h"
+#include "window_layout.h"
 namespace MoeDistributeCombineV2Impl {
 using namespace MoeDistributeV2Base;
-constexpr uint8_t BUFFER_NUM = 2;                       // 多buf
-constexpr uint32_t STATE_OFFSET = 32U;                  // 状态空间偏移地址
-constexpr uint32_t STATE_SIZE = 1024UL * 1024UL;        // 1M
-constexpr uint32_t COMBINE_STATE_OFFSET = 64U * 1024U;  // 本卡状态空间偏移地址，前面的地址给dispatch用
+constexpr uint8_t BUFFER_NUM = 2;                 // 多buf
+constexpr uint32_t STATE_OFFSET = 32U;            // 状态空间偏移地址
+constexpr uint32_t STATE_SIZE = 1024UL * 1024UL;  // 1M
 constexpr uint8_t EP_DOMAIN = 0;
 constexpr uint8_t TP_DOMAIN = 1;
 constexpr uint32_t FLOAT_PER_UB_ALIGN = 8U;
@@ -90,18 +90,21 @@ private:
     __aicore__ GM_ADDR GetWinAddrByRankId(const int32_t rankId, const uint8_t domain)
     {
         if (domain == EP_DOMAIN) {
-            return GetBaseWindAddrByRankId(epWinContext_, rankId, epRankIdOriginal_) + winDataSizeOffset_;
-        } else {
-            return GetBaseWindAddrByRankId(tpWinContext_, rankId, tpRankId_) + winDataSizeOffset_;
+            return GetBaseWindAddrByRankId(epWinContext_, rankId, epRankIdOriginal_) + winDataSizeOffset_ +
+                   Moe::A3WindowLayout::kDataOffset;
         }
+        return GetBaseWindAddrByRankId(tpWinContext_, rankId, tpRankId_) + winDataSizeOffset_ +
+               Moe::A3WindowLayout::kDataOffset;
     }
 
     __aicore__ GM_ADDR GetWinStateAddrByRankId(const int32_t rankId, const uint8_t domain)
     {
         if (domain == EP_DOMAIN) {
-            return GetBaseWindStateAddrByRankId(epWinContext_, rankId, epRankIdOriginal_) + winStatusOffset_;
+            return GetBaseWindAddrByRankId(epWinContext_, rankId, epRankIdOriginal_) +
+                   dataState_ * (totalWinSize_ / 2UL) + Moe::A3WindowLayout::kV2CombineStateOffset;
         } else {
-            return GetBaseWindStateAddrByRankId(tpWinContext_, rankId, tpRankId_) + winStatusOffset_;
+            return GetBaseWindAddrByRankId(tpWinContext_, rankId, tpRankId_) + dataState_ * (totalWinSize_ / 2UL) +
+                   Moe::A3WindowLayout::kV2CombineStateOffset;
         }
     }
 
@@ -179,7 +182,6 @@ private:
     uint32_t stateOffset_{0};
     uint64_t activeMaskBsCnt_{0};
     uint64_t winDataSizeOffset_{0};
-    uint64_t winStatusOffset_{0};
     uint64_t totalWinSize_{0};
     uint32_t selfSendCnt_{0};
     uint32_t tpRemoteSendCnt_{0};
@@ -385,9 +387,10 @@ MoeDistributeCombineV2<TemplateMC2TypeFunc>::InitAttrs(const MoeDistributeCombin
     uint32_t sharedExpertRankNum = tilingData->moeDistributeCombineV2Info.sharedExpertRankNum;
     auto contextGM0 = AscendC::GetHcclContext<HCCL_GROUP_ID_0>();
     epWinContext_ = (__gm__ HcclOpParam *)contextGM0;
-    statusDataSpaceGm_ = GetStatusDataSpaceGm(epWinContext_);
+    statusDataSpaceGm_ = GetBaseWindAddrByRankId(epWinContext_, epRankIdOriginal_, epRankIdOriginal_) +
+                         Moe::A3WindowLayout::kV2CombineSelectorOffset;
     selfDataStatusGMTensor_.SetGlobalBuffer(
-        (__gm__ uint32_t *)(statusDataSpaceGm_ + STATE_WIN_OFFSET + coreIdx_ * WIN_ADDR_ALIGN));
+        (__gm__ uint32_t *)(statusDataSpaceGm_ + coreIdx_ * Moe::A3WindowLayout::kAivMetadataStride));
     TBuf<> dataStateBuf;
     tpipe_->InitBuffer(dataStateBuf, UB_ALIGN);
     dataState_ = InitWinState(selfDataStatusGMTensor_, epWinContext_, epRankIdOriginal_, moeExpertNum_,
@@ -454,12 +457,13 @@ __aicore__ inline void MoeDistributeCombineV2<TemplateMC2TypeFunc>::Init(
     // 当前win区划分为前后两半区，连续两次dispatch，切换半区
     winDataSizeOffset_ =
         static_cast<uint64_t>(dataState_) * (tilingData->moeDistributeCombineV2Info.totalWinSize / 2UL);
-    winStatusOffset_ = COMBINE_STATE_OFFSET + dataState_ * WIN_STATE_OFFSET;  // 前面的预留给dispatch使用
     epWindowGM_ = GetWinAddrByRankId(epRankIdOriginal_, EP_DOMAIN);
 #if defined(ASCENDC_OOM) && ASCENDC_OOM == 1
     for (int tempepRankId = 0; tempepRankId < epWorldSize_; tempepRankId++) {
-        OOMCheckAddrRange<XType>((__gm__ XType *)(GetWinAddrByRankId(tempepRankId, EP_DOMAIN)), totalWinSize_);
-        OOMCheckAddrRange<float>((__gm__ float *)(GetWinStateAddrByRankId(tempepRankId, EP_DOMAIN)), STATE_SIZE);
+        OOMCheckAddrRange<XType>((__gm__ XType *)(GetWinAddrByRankId(tempepRankId, EP_DOMAIN)),
+                                 totalWinSize_ / 2UL - Moe::A3WindowLayout::kDataOffset);
+        OOMCheckAddrRange<float>((__gm__ float *)(GetWinStateAddrByRankId(tempepRankId, EP_DOMAIN)),
+                                 Moe::A3WindowLayout::kV2StateSize);
     }
 #endif
     if (isShareExpertRankFlag_) {
@@ -481,9 +485,10 @@ __aicore__ inline void MoeDistributeCombineV2<TemplateMC2TypeFunc>::Init(
         tpWindowGM_ = GetWinAddrByRankId(tpRankId_, TP_DOMAIN);
 #if defined(ASCENDC_OOM) && ASCENDC_OOM == 1
         for (int temptpRankId = 0; temptpRankId < tpWorldSize_; temptpRankId++) {
-            OOMCheckAddrRange<XType>((__gm__ XType *)(GetWinAddrByRankId(temptpRankId, TP_DOMAIN)), totalWinSize_);
+            OOMCheckAddrRange<XType>((__gm__ XType *)(GetWinAddrByRankId(temptpRankId, TP_DOMAIN)),
+                                     totalWinSize_ / 2UL - Moe::A3WindowLayout::kDataOffset);
             OOMCheckAddrRange<int32_t>((__gm__ int32_t *)(GetWinStateAddrByRankId(temptpRankId, TP_DOMAIN)),
-                                       STATE_SIZE);
+                                       Moe::A3WindowLayout::kV2StateSize);
         }
 #endif
         tpStateOffsetOnWin_ = tpRankId_ * WIN_ADDR_ALIGN;

--- a/csrc/deepep/ops/op_kernel/moe_distribute_combine_v2.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_combine_v2.h
@@ -110,10 +110,10 @@ private:
         }
         if (domain == EP_DOMAIN) {
             return GetBaseWindAddrByRankId(epWinContext_, rankId, epRankIdOriginal_) +
-                   dataState_ * (totalWinSize_ / 2UL) + Moe::A3WindowLayout::kV2CombineStateOffset;
+                   dataState_ * (totalWinSize_ / 2UL) + Moe::A3WindowLayout::kLlCombineStateOffset;
         } else {
             return GetBaseWindAddrByRankId(tpWinContext_, rankId, tpRankId_) + dataState_ * (totalWinSize_ / 2UL) +
-                   Moe::A3WindowLayout::kV2CombineStateOffset;
+                   Moe::A3WindowLayout::kLlCombineStateOffset;
         }
     }
 
@@ -405,7 +405,7 @@ MoeDistributeCombineV2<TemplateMC2TypeFunc>::InitAttrs(const MoeDistributeCombin
     epWinContext_ = (__gm__ HcclOpParam *)contextGM0;
     statusDataSpaceGm_ =
         isHybridDeployment_ ? GetBaseWindAddrByRankId(epWinContext_, epRankIdOriginal_, epRankIdOriginal_) +
-                                  Moe::A3WindowLayout::kV2CombineSelectorOffset
+                                  Moe::A3WindowLayout::kLlCombineSelectorOffset
                             : GetStatusDataSpaceGm(epWinContext_) + Moe::A3WindowLayout::kLegacyV2CombineSelectorOffset;
     selfDataStatusGMTensor_.SetGlobalBuffer((__gm__ uint32_t *)(statusDataSpaceGm_ + coreIdx_ * WIN_ADDR_ALIGN));
     TBuf<> dataStateBuf;
@@ -479,7 +479,7 @@ __aicore__ inline void MoeDistributeCombineV2<TemplateMC2TypeFunc>::Init(
     for (int tempepRankId = 0; tempepRankId < epWorldSize_; tempepRankId++) {
         OOMCheckAddrRange<XType>((__gm__ XType *)(GetWinAddrByRankId(tempepRankId, EP_DOMAIN)), GetDataWindowSize());
         OOMCheckAddrRange<float>((__gm__ float *)(GetWinStateAddrByRankId(tempepRankId, EP_DOMAIN)),
-                                 Moe::A3WindowLayout::kV2StateSize);
+                                 Moe::A3WindowLayout::kLlStateSize);
     }
 #endif
     if (isShareExpertRankFlag_) {
@@ -504,7 +504,7 @@ __aicore__ inline void MoeDistributeCombineV2<TemplateMC2TypeFunc>::Init(
             OOMCheckAddrRange<XType>((__gm__ XType *)(GetWinAddrByRankId(temptpRankId, TP_DOMAIN)),
                                      GetDataWindowSize());
             OOMCheckAddrRange<int32_t>((__gm__ int32_t *)(GetWinStateAddrByRankId(temptpRankId, TP_DOMAIN)),
-                                       Moe::A3WindowLayout::kV2StateSize);
+                                       Moe::A3WindowLayout::kLlStateSize);
         }
 #endif
         tpStateOffsetOnWin_ = tpRankId_ * WIN_ADDR_ALIGN;

--- a/csrc/deepep/ops/op_kernel/moe_distribute_combine_v2.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_combine_v2.h
@@ -89,16 +89,25 @@ private:
     __aicore__ inline void WaitDispatch(uint32_t tokenIndex);
     __aicore__ GM_ADDR GetWinAddrByRankId(const int32_t rankId, const uint8_t domain)
     {
+        uint64_t dataOffset = isHybridDeployment_ ? Moe::A3WindowLayout::kDataOffset : 0UL;
         if (domain == EP_DOMAIN) {
-            return GetBaseWindAddrByRankId(epWinContext_, rankId, epRankIdOriginal_) + winDataSizeOffset_ +
-                   Moe::A3WindowLayout::kDataOffset;
+            return GetBaseWindAddrByRankId(epWinContext_, rankId, epRankIdOriginal_) + winDataSizeOffset_ + dataOffset;
         }
-        return GetBaseWindAddrByRankId(tpWinContext_, rankId, tpRankId_) + winDataSizeOffset_ +
-               Moe::A3WindowLayout::kDataOffset;
+        return GetBaseWindAddrByRankId(tpWinContext_, rankId, tpRankId_) + winDataSizeOffset_ + dataOffset;
     }
 
     __aicore__ GM_ADDR GetWinStateAddrByRankId(const int32_t rankId, const uint8_t domain)
     {
+        if (!isHybridDeployment_) {
+            if (domain == EP_DOMAIN) {
+                return GetBaseWindStateAddrByRankId(epWinContext_, rankId, epRankIdOriginal_) +
+                       Moe::A3WindowLayout::kLegacyV2CombineStateOffset +
+                       dataState_ * Moe::A3WindowLayout::kLegacyV2StateHalfSize;
+            }
+            return GetBaseWindStateAddrByRankId(tpWinContext_, rankId, tpRankId_) +
+                   Moe::A3WindowLayout::kLegacyV2CombineStateOffset +
+                   dataState_ * Moe::A3WindowLayout::kLegacyV2StateHalfSize;
+        }
         if (domain == EP_DOMAIN) {
             return GetBaseWindAddrByRankId(epWinContext_, rankId, epRankIdOriginal_) +
                    dataState_ * (totalWinSize_ / 2UL) + Moe::A3WindowLayout::kV2CombineStateOffset;
@@ -106,6 +115,11 @@ private:
             return GetBaseWindAddrByRankId(tpWinContext_, rankId, tpRankId_) + dataState_ * (totalWinSize_ / 2UL) +
                    Moe::A3WindowLayout::kV2CombineStateOffset;
         }
+    }
+
+    __aicore__ inline uint64_t GetDataWindowSize()
+    {
+        return isHybridDeployment_ ? totalWinSize_ / 2UL - Moe::A3WindowLayout::kDataOffset : totalWinSize_ / 2UL;
     }
 
     __aicore__ inline uint32_t MIN(uint32_t x, uint32_t y)
@@ -226,6 +240,7 @@ private:
     bool isInputExpertMaskFlag_ = false;
     bool hasSharedExpertX_ = false;
     bool hasElasticInfoFlag_ = false;
+    bool isHybridDeployment_ = false;
     bool isScalingDownFlag_ = false;
     bool isShareExpertRankFlag_ = false;
     bool enableSpecialExpert_ = false;
@@ -361,6 +376,7 @@ MoeDistributeCombineV2<TemplateMC2TypeFunc>::InitTilingAttrs(const MoeDistribute
     ubSize_ = tilingData->moeDistributeCombineV2Info.totalUbSize;
     globalBS_ = tilingData->moeDistributeCombineV2Info.globalBs;
     hasElasticInfoFlag_ = tilingData->moeDistributeCombineV2Info.hasElasticInfo;
+    isHybridDeployment_ = tilingData->moeDistributeCombineV2Info.isHybridDeployment;
     epWorldSizeOriginal_ = tilingData->moeDistributeCombineV2Info.epWorldSize;
     epRankId_ = tilingData->moeDistributeCombineV2Info.epRankId;
     epRankIdOriginal_ = tilingData->moeDistributeCombineV2Info.epRankId;
@@ -387,10 +403,11 @@ MoeDistributeCombineV2<TemplateMC2TypeFunc>::InitAttrs(const MoeDistributeCombin
     uint32_t sharedExpertRankNum = tilingData->moeDistributeCombineV2Info.sharedExpertRankNum;
     auto contextGM0 = AscendC::GetHcclContext<HCCL_GROUP_ID_0>();
     epWinContext_ = (__gm__ HcclOpParam *)contextGM0;
-    statusDataSpaceGm_ = GetBaseWindAddrByRankId(epWinContext_, epRankIdOriginal_, epRankIdOriginal_) +
-                         Moe::A3WindowLayout::kV2CombineSelectorOffset;
-    selfDataStatusGMTensor_.SetGlobalBuffer(
-        (__gm__ uint32_t *)(statusDataSpaceGm_ + coreIdx_ * Moe::A3WindowLayout::kAivMetadataStride));
+    statusDataSpaceGm_ =
+        isHybridDeployment_ ? GetBaseWindAddrByRankId(epWinContext_, epRankIdOriginal_, epRankIdOriginal_) +
+                                  Moe::A3WindowLayout::kV2CombineSelectorOffset
+                            : GetStatusDataSpaceGm(epWinContext_) + Moe::A3WindowLayout::kLegacyV2CombineSelectorOffset;
+    selfDataStatusGMTensor_.SetGlobalBuffer((__gm__ uint32_t *)(statusDataSpaceGm_ + coreIdx_ * WIN_ADDR_ALIGN));
     TBuf<> dataStateBuf;
     tpipe_->InitBuffer(dataStateBuf, UB_ALIGN);
     dataState_ = InitWinState(selfDataStatusGMTensor_, epWinContext_, epRankIdOriginal_, moeExpertNum_,
@@ -460,8 +477,7 @@ __aicore__ inline void MoeDistributeCombineV2<TemplateMC2TypeFunc>::Init(
     epWindowGM_ = GetWinAddrByRankId(epRankIdOriginal_, EP_DOMAIN);
 #if defined(ASCENDC_OOM) && ASCENDC_OOM == 1
     for (int tempepRankId = 0; tempepRankId < epWorldSize_; tempepRankId++) {
-        OOMCheckAddrRange<XType>((__gm__ XType *)(GetWinAddrByRankId(tempepRankId, EP_DOMAIN)),
-                                 totalWinSize_ / 2UL - Moe::A3WindowLayout::kDataOffset);
+        OOMCheckAddrRange<XType>((__gm__ XType *)(GetWinAddrByRankId(tempepRankId, EP_DOMAIN)), GetDataWindowSize());
         OOMCheckAddrRange<float>((__gm__ float *)(GetWinStateAddrByRankId(tempepRankId, EP_DOMAIN)),
                                  Moe::A3WindowLayout::kV2StateSize);
     }
@@ -486,7 +502,7 @@ __aicore__ inline void MoeDistributeCombineV2<TemplateMC2TypeFunc>::Init(
 #if defined(ASCENDC_OOM) && ASCENDC_OOM == 1
         for (int temptpRankId = 0; temptpRankId < tpWorldSize_; temptpRankId++) {
             OOMCheckAddrRange<XType>((__gm__ XType *)(GetWinAddrByRankId(temptpRankId, TP_DOMAIN)),
-                                     totalWinSize_ / 2UL - Moe::A3WindowLayout::kDataOffset);
+                                     GetDataWindowSize());
             OOMCheckAddrRange<int32_t>((__gm__ int32_t *)(GetWinStateAddrByRankId(temptpRankId, TP_DOMAIN)),
                                        Moe::A3WindowLayout::kV2StateSize);
         }

--- a/csrc/deepep/ops/op_kernel/moe_distribute_combine_v2.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_combine_v2.h
@@ -19,7 +19,6 @@ constexpr uint32_t FLOAT_PER_UB_ALIGN = 8U;
 constexpr uint64_t WIN_STATE_OFFSET = 500UL * 1024UL;
 constexpr uint64_t STATE_WIN_OFFSET = 975UL * 1024UL;  // 预留48*512内存
 constexpr uint64_t STATE_HCCL_OFFSET = 32UL;
-constexpr uint64_t STATE_CHECK_OFFSET = 1000UL * 1024UL;
 constexpr uint64_t TIMEOUT_DETECTION_THRESHOLD = 50000UL;
 constexpr uint64_t CYCLES_PER_US = 50UL;
 constexpr uint64_t TIMEOUT_DETECTION_TX_UNITS = 8UL;
@@ -115,6 +114,12 @@ private:
             return GetBaseWindAddrByRankId(tpWinContext_, rankId, tpRankId_) + dataState_ * (totalWinSize_ / 2UL) +
                    Moe::A3WindowLayout::kLlCombineStateOffset;
         }
+    }
+
+    __aicore__ inline uint64_t GetTimeoutProbeOffset()
+    {
+        return isHybridDeployment_ ? Moe::A3WindowLayout::kLlStateTimeoutOffset
+                                   : Moe::A3WindowLayout::kLegacyLlStateTimeoutOffset;
     }
 
     __aicore__ inline uint64_t GetDataWindowSize()
@@ -1013,7 +1018,7 @@ __aicore__ inline void MoeDistributeCombineV2<TemplateMC2TypeFunc>::WaitDispatch
                     toRankId = index;
                 }
                 GM_ADDR timeoutCheckGM =
-                    (__gm__ uint8_t *)(GetWinStateAddrByRankId(toRankId, EP_DOMAIN) + STATE_CHECK_OFFSET);
+                    (__gm__ uint8_t *)(GetWinStateAddrByRankId(toRankId, EP_DOMAIN) + GetTimeoutProbeOffset());
                 timeoutCheckGMTensor.SetGlobalBuffer((__gm__ float *)(timeoutCheckGM));
                 DataCopy<float>(timeoutCheckGMTensor, stateTensor, TIMEOUT_DETECTION_TX_UNITS);
             }

--- a/csrc/deepep/ops/op_kernel/moe_distribute_combine_v2_tiling.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_combine_v2_tiling.h
@@ -27,6 +27,7 @@ struct MoeDistributeCombineV2Info {
     bool isExpertMask;      // input active mask 2dims or not
     bool hasSharedExpertX;  // input shared expert x or not
     bool hasElasticInfo;    // has elasticinfo or not
+    bool isHybridDeployment;
     uint64_t totalUbSize;
     uint64_t totalWinSize;
     float armAvgFactor;

--- a/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2.h
@@ -7,6 +7,7 @@
 #include "moe_distribute_v2_base.h"
 #include "moe_distribute_dispatch_v2_tiling.h"
 #include "check_winsize.h"
+#include "comm_args.h"
 
 namespace MoeDistributeDispatchV2Impl {
 constexpr uint8_t BUFFER_NUM = 2;  // 多buf
@@ -90,14 +91,16 @@ private:
                                          LocalTensor<float> &statusSumOutTensor);
     __aicore__ inline GM_ADDR GetWindAddrByRankId(uint8_t ctxIdx, const int32_t rankId)
     {
-        uint32_t curRankId = ((ctxIdx == COMM_EP_IDX) ? epRankIdOriginal_ : tpRankId_);
-        return GetBaseWindAddrByRankId(winContext_[ctxIdx], rankId, curRankId) + winDataSizeOffset_;
+        uint32_t curRankId = ctxIdx == COMM_EP_IDX ? epRankIdOriginal_ : tpRankId_;
+        return GetBaseWindAddrByRankId(winContext_[ctxIdx], rankId, curRankId) + winDataSizeOffset_ +
+               Moe::A3WindowLayout::kDataOffset;
     }
 
     __aicore__ inline GM_ADDR GetWindStateAddrByRankId(uint8_t ctxIdx, const int32_t rankId)
     {
         uint32_t curRankId = ctxIdx == COMM_EP_IDX ? epRankIdOriginal_ : tpRankId_;
-        return GetBaseWindStateAddrByRankId(winContext_[ctxIdx], rankId, curRankId) + dataState_ * WIN_STATE_OFFSET;
+        return GetBaseWindAddrByRankId(winContext_[ctxIdx], rankId, curRankId) + dataState_ * (totalWinSize_ / 2UL) +
+               Moe::A3WindowLayout::kV2DispatchStateOffset;
     }
 
     __aicore__ inline uint32_t MIN(uint32_t x, uint32_t y)
@@ -309,9 +312,10 @@ __aicore__ inline void MoeDistributeDispatchV2<TemplateMC2TypeFunc>::Init(
     sharedExpertRankNum_ = tilingData->moeDistributeDispatchV2Info.sharedExpertRankNum;
     moeExpertNum_ = tilingData->moeDistributeDispatchV2Info.moeExpertNum;
     globalBS_ = tilingData->moeDistributeDispatchV2Info.globalBs;
-    statusDataSpaceGm_ = GetStatusDataSpaceGm(winContext_[0]);
+    statusDataSpaceGm_ = GetBaseWindAddrByRankId(winContext_[COMM_EP_IDX], epRankIdOriginal_, epRankIdOriginal_) +
+                         Moe::A3WindowLayout::kV2DispatchSelectorOffset;
     selfDataStatusGMTensor_.SetGlobalBuffer(
-        (__gm__ uint32_t *)(statusDataSpaceGm_ + STATE_WIN_OFFSET + aivId_ * WIN_ADDR_ALIGN));
+        (__gm__ uint32_t *)(statusDataSpaceGm_ + aivId_ * Moe::A3WindowLayout::kAivMetadataStride));
     TBuf<> dataStateBuf;
     tpipe_->InitBuffer(dataStateBuf, UB_ALIGN);
     dataState_ = InitWinState(selfDataStatusGMTensor_, winContext_[0], epRankIdOriginal_, moeExpertNum_,
@@ -399,8 +403,9 @@ __aicore__ inline void MoeDistributeDispatchV2<TemplateMC2TypeFunc>::Init(
 #if defined(ASCENDC_OOM) && ASCENDC_OOM == 1
     for (int tempepRankId = 0; tempepRankId < epWorldSize_; tempepRankId++) {
         OOMCheckAddrRange<ExpandXOutType>((__gm__ ExpandXOutType *)(GetWindAddrByRankId(COMM_EP_IDX, tempepRankId)),
-                                          totalWinSize_);
-        OOMCheckAddrRange<float>((__gm__ float *)(GetWindStateAddrByRankId(COMM_EP_IDX, tempepRankId)), STATE_SIZE);
+                                          totalWinSize_ / 2UL - Moe::A3WindowLayout::kDataOffset);
+        OOMCheckAddrRange<float>((__gm__ float *)(GetWindStateAddrByRankId(COMM_EP_IDX, tempepRankId)),
+                                 Moe::A3WindowLayout::kV2StateSize);
     }
 #endif
     sumTarget_ = static_cast<float>(1.0);
@@ -418,15 +423,16 @@ __aicore__ inline void MoeDistributeDispatchV2<TemplateMC2TypeFunc>::Init(
     GlobalTensor<ExpandXOutType> winDouble;
     winDouble.SetL2CacheHint(CacheMode::CACHE_MODE_DISABLE);
     winDouble.SetGlobalBuffer((__gm__ ExpandXOutType *)(windowGM_));
-    OOMCheckAddrRange<ExpandXOutType>((__gm__ ExpandXOutType *)(winDouble.GetPhyAddr()), totalWinSize_);
+    OOMCheckAddrRange<ExpandXOutType>((__gm__ ExpandXOutType *)(winDouble.GetPhyAddr()),
+                                      totalWinSize_ / 2UL - Moe::A3WindowLayout::kDataOffset);
 #endif
     if constexpr (IsNeedAllgather) {
 #if defined(ASCENDC_OOM) && ASCENDC_OOM == 1
         for (int temptpRankId = 0; temptpRankId < tpWorldSize_; temptpRankId++) {
             OOMCheckAddrRange<ExpandXOutType>((__gm__ ExpandXOutType *)(GetWindAddrByRankId(COMM_TP_IDX, temptpRankId)),
-                                              totalWinSize_);
+                                              totalWinSize_ / 2UL - Moe::A3WindowLayout::kDataOffset);
             OOMCheckAddrRange<int32_t>((__gm__ int32_t *)(GetWindStateAddrByRankId(COMM_TP_IDX, temptpRankId)),
-                                       STATE_SIZE);
+                                       Moe::A3WindowLayout::kV2StateSize);
         }
 #endif
         tpLocalWindowGM_ = GetWindAddrByRankId(COMM_TP_IDX, tpRankId_);

--- a/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2.h
@@ -104,7 +104,7 @@ private:
                    dataState_ * Moe::A3WindowLayout::kLegacyV2StateHalfSize;
         }
         return GetBaseWindAddrByRankId(winContext_[ctxIdx], rankId, curRankId) + dataState_ * (totalWinSize_ / 2UL) +
-               Moe::A3WindowLayout::kV2DispatchStateOffset;
+               Moe::A3WindowLayout::kLlDispatchStateOffset;
     }
 
     __aicore__ inline uint64_t GetDataWindowSize()
@@ -326,7 +326,7 @@ __aicore__ inline void MoeDistributeDispatchV2<TemplateMC2TypeFunc>::Init(
     statusDataSpaceGm_ =
         isHybridDeployment_
             ? GetBaseWindAddrByRankId(winContext_[COMM_EP_IDX], epRankIdOriginal_, epRankIdOriginal_) +
-                  Moe::A3WindowLayout::kV2DispatchSelectorOffset
+                  Moe::A3WindowLayout::kLlDispatchSelectorOffset
             : GetStatusDataSpaceGm(winContext_[COMM_EP_IDX]) + Moe::A3WindowLayout::kLegacyV2DispatchSelectorOffset;
     selfDataStatusGMTensor_.SetGlobalBuffer((__gm__ uint32_t *)(statusDataSpaceGm_ + aivId_ * WIN_ADDR_ALIGN));
     TBuf<> dataStateBuf;
@@ -418,7 +418,7 @@ __aicore__ inline void MoeDistributeDispatchV2<TemplateMC2TypeFunc>::Init(
         OOMCheckAddrRange<ExpandXOutType>((__gm__ ExpandXOutType *)(GetWindAddrByRankId(COMM_EP_IDX, tempepRankId)),
                                           GetDataWindowSize());
         OOMCheckAddrRange<float>((__gm__ float *)(GetWindStateAddrByRankId(COMM_EP_IDX, tempepRankId)),
-                                 Moe::A3WindowLayout::kV2StateSize);
+                                 Moe::A3WindowLayout::kLlStateSize);
     }
 #endif
     sumTarget_ = static_cast<float>(1.0);
@@ -444,7 +444,7 @@ __aicore__ inline void MoeDistributeDispatchV2<TemplateMC2TypeFunc>::Init(
             OOMCheckAddrRange<ExpandXOutType>((__gm__ ExpandXOutType *)(GetWindAddrByRankId(COMM_TP_IDX, temptpRankId)),
                                               GetDataWindowSize());
             OOMCheckAddrRange<int32_t>((__gm__ int32_t *)(GetWindStateAddrByRankId(COMM_TP_IDX, temptpRankId)),
-                                       Moe::A3WindowLayout::kV2StateSize);
+                                       Moe::A3WindowLayout::kLlStateSize);
         }
 #endif
         tpLocalWindowGM_ = GetWindAddrByRankId(COMM_TP_IDX, tpRankId_);

--- a/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2.h
@@ -92,15 +92,24 @@ private:
     __aicore__ inline GM_ADDR GetWindAddrByRankId(uint8_t ctxIdx, const int32_t rankId)
     {
         uint32_t curRankId = ctxIdx == COMM_EP_IDX ? epRankIdOriginal_ : tpRankId_;
-        return GetBaseWindAddrByRankId(winContext_[ctxIdx], rankId, curRankId) + winDataSizeOffset_ +
-               Moe::A3WindowLayout::kDataOffset;
+        uint64_t dataOffset = isHybridDeployment_ ? Moe::A3WindowLayout::kDataOffset : 0UL;
+        return GetBaseWindAddrByRankId(winContext_[ctxIdx], rankId, curRankId) + winDataSizeOffset_ + dataOffset;
     }
 
     __aicore__ inline GM_ADDR GetWindStateAddrByRankId(uint8_t ctxIdx, const int32_t rankId)
     {
         uint32_t curRankId = ctxIdx == COMM_EP_IDX ? epRankIdOriginal_ : tpRankId_;
+        if (!isHybridDeployment_) {
+            return GetBaseWindStateAddrByRankId(winContext_[ctxIdx], rankId, curRankId) +
+                   dataState_ * Moe::A3WindowLayout::kLegacyV2StateHalfSize;
+        }
         return GetBaseWindAddrByRankId(winContext_[ctxIdx], rankId, curRankId) + dataState_ * (totalWinSize_ / 2UL) +
                Moe::A3WindowLayout::kV2DispatchStateOffset;
+    }
+
+    __aicore__ inline uint64_t GetDataWindowSize()
+    {
+        return isHybridDeployment_ ? totalWinSize_ / 2UL - Moe::A3WindowLayout::kDataOffset : totalWinSize_ / 2UL;
     }
 
     __aicore__ inline uint32_t MIN(uint32_t x, uint32_t y)
@@ -234,6 +243,7 @@ private:
     bool isTokenMaskFlag_ = false;
     bool isExpertMaskFlag_ = false;
     bool hasElasticInfoFlag_ = false;
+    bool isHybridDeployment_ = false;
     bool isScalingDownFlag_ = false;
     bool isShareExpertRankFlag_ = false;
     float sumTarget_;
@@ -312,10 +322,13 @@ __aicore__ inline void MoeDistributeDispatchV2<TemplateMC2TypeFunc>::Init(
     sharedExpertRankNum_ = tilingData->moeDistributeDispatchV2Info.sharedExpertRankNum;
     moeExpertNum_ = tilingData->moeDistributeDispatchV2Info.moeExpertNum;
     globalBS_ = tilingData->moeDistributeDispatchV2Info.globalBs;
-    statusDataSpaceGm_ = GetBaseWindAddrByRankId(winContext_[COMM_EP_IDX], epRankIdOriginal_, epRankIdOriginal_) +
-                         Moe::A3WindowLayout::kV2DispatchSelectorOffset;
-    selfDataStatusGMTensor_.SetGlobalBuffer(
-        (__gm__ uint32_t *)(statusDataSpaceGm_ + aivId_ * Moe::A3WindowLayout::kAivMetadataStride));
+    isHybridDeployment_ = tilingData->moeDistributeDispatchV2Info.isHybridDeployment;
+    statusDataSpaceGm_ =
+        isHybridDeployment_
+            ? GetBaseWindAddrByRankId(winContext_[COMM_EP_IDX], epRankIdOriginal_, epRankIdOriginal_) +
+                  Moe::A3WindowLayout::kV2DispatchSelectorOffset
+            : GetStatusDataSpaceGm(winContext_[COMM_EP_IDX]) + Moe::A3WindowLayout::kLegacyV2DispatchSelectorOffset;
+    selfDataStatusGMTensor_.SetGlobalBuffer((__gm__ uint32_t *)(statusDataSpaceGm_ + aivId_ * WIN_ADDR_ALIGN));
     TBuf<> dataStateBuf;
     tpipe_->InitBuffer(dataStateBuf, UB_ALIGN);
     dataState_ = InitWinState(selfDataStatusGMTensor_, winContext_[0], epRankIdOriginal_, moeExpertNum_,
@@ -403,7 +416,7 @@ __aicore__ inline void MoeDistributeDispatchV2<TemplateMC2TypeFunc>::Init(
 #if defined(ASCENDC_OOM) && ASCENDC_OOM == 1
     for (int tempepRankId = 0; tempepRankId < epWorldSize_; tempepRankId++) {
         OOMCheckAddrRange<ExpandXOutType>((__gm__ ExpandXOutType *)(GetWindAddrByRankId(COMM_EP_IDX, tempepRankId)),
-                                          totalWinSize_ / 2UL - Moe::A3WindowLayout::kDataOffset);
+                                          GetDataWindowSize());
         OOMCheckAddrRange<float>((__gm__ float *)(GetWindStateAddrByRankId(COMM_EP_IDX, tempepRankId)),
                                  Moe::A3WindowLayout::kV2StateSize);
     }
@@ -423,14 +436,13 @@ __aicore__ inline void MoeDistributeDispatchV2<TemplateMC2TypeFunc>::Init(
     GlobalTensor<ExpandXOutType> winDouble;
     winDouble.SetL2CacheHint(CacheMode::CACHE_MODE_DISABLE);
     winDouble.SetGlobalBuffer((__gm__ ExpandXOutType *)(windowGM_));
-    OOMCheckAddrRange<ExpandXOutType>((__gm__ ExpandXOutType *)(winDouble.GetPhyAddr()),
-                                      totalWinSize_ / 2UL - Moe::A3WindowLayout::kDataOffset);
+    OOMCheckAddrRange<ExpandXOutType>((__gm__ ExpandXOutType *)(winDouble.GetPhyAddr()), GetDataWindowSize());
 #endif
     if constexpr (IsNeedAllgather) {
 #if defined(ASCENDC_OOM) && ASCENDC_OOM == 1
         for (int temptpRankId = 0; temptpRankId < tpWorldSize_; temptpRankId++) {
             OOMCheckAddrRange<ExpandXOutType>((__gm__ ExpandXOutType *)(GetWindAddrByRankId(COMM_TP_IDX, temptpRankId)),
-                                              totalWinSize_ / 2UL - Moe::A3WindowLayout::kDataOffset);
+                                              GetDataWindowSize());
             OOMCheckAddrRange<int32_t>((__gm__ int32_t *)(GetWindStateAddrByRankId(COMM_TP_IDX, temptpRankId)),
                                        Moe::A3WindowLayout::kV2StateSize);
         }

--- a/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2.h
@@ -21,7 +21,6 @@ constexpr uint8_t COMM_TP_IDX = 1;
 constexpr uint64_t WIN_STATE_OFFSET = 500UL * 1024UL;
 constexpr uint64_t STATE_WIN_OFFSET = 950UL * 1024UL;
 constexpr uint64_t STATE_HCCL_OFFSET = 32UL;
-constexpr uint64_t STATE_CHECK_OFFSET = 1000UL * 1024UL;
 constexpr uint64_t TIMEOUT_DETECTION_THRESHOLD = 50000UL;
 constexpr uint64_t CYCLES_PER_US = 50UL;
 constexpr uint64_t TIMEOUT_DETECTION_TX_UNITS = 8UL;
@@ -105,6 +104,12 @@ private:
         }
         return GetBaseWindAddrByRankId(winContext_[ctxIdx], rankId, curRankId) + dataState_ * (totalWinSize_ / 2UL) +
                Moe::A3WindowLayout::kLlDispatchStateOffset;
+    }
+
+    __aicore__ inline uint64_t GetTimeoutProbeOffset()
+    {
+        return isHybridDeployment_ ? Moe::A3WindowLayout::kLlStateTimeoutOffset
+                                   : Moe::A3WindowLayout::kLegacyLlStateTimeoutOffset;
     }
 
     __aicore__ inline uint64_t GetDataWindowSize()
@@ -1127,7 +1132,7 @@ __aicore__ inline void MoeDistributeDispatchV2<TemplateMC2TypeFunc>::TimeOutDete
             toRankId = index % epWorldSize_;
         }
         GM_ADDR timeoutCheckGM =
-            (__gm__ uint8_t *)(GetWindStateAddrByRankId(COMM_EP_IDX, toRankId) + STATE_CHECK_OFFSET);
+            (__gm__ uint8_t *)(GetWindStateAddrByRankId(COMM_EP_IDX, toRankId) + GetTimeoutProbeOffset());
         timeoutCheckGMTensor.SetGlobalBuffer((__gm__ float *)(timeoutCheckGM));
         DataCopy<float>(timeoutCheckGMTensor, statusFp32Tensor_, TIMEOUT_DETECTION_TX_UNITS);
     }

--- a/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2_tiling.h
+++ b/csrc/deepep/ops/op_kernel/moe_distribute_dispatch_v2_tiling.h
@@ -19,8 +19,8 @@ struct MoeDistributeDispatchV2Info {
     bool isTokenMask;              // input active mask 1dims or not
     bool isExpertMask;             // input active mask 2dims or not
     bool hasElasticInfo;           // has elasticinfo or not
-    bool reserved3;                // reserved
-    uint64_t totalUbSize;          // epWorldSize
+    bool isHybridDeployment;
+    uint64_t totalUbSize;  // epWorldSize
     uint64_t totalWinSize;
     uint32_t expertTokenNumsType;  // expert token nums type, support 0: cumsum mode, 1: count mode
     int32_t zeroComputeExpertNum;  // sum of zero、copy and const expert nums

--- a/csrc/deepep/ops/op_kernel/window_layout.h
+++ b/csrc/deepep/ops/op_kernel/window_layout.h
@@ -1,11 +1,10 @@
-#ifndef TILING_ARGS_H
-#define TILING_ARGS_H
+#ifndef WINDOW_LAYOUT_H
+#define WINDOW_LAYOUT_H
 
 #include <cstdint>
 
 namespace Moe {
 namespace A3WindowLayout {
-// Keep these host-side layout values synchronized with op_kernel/window_layout.h.
 constexpr uint64_t KB = 1024UL;
 constexpr uint64_t MB = 1024UL * KB;
 
@@ -34,4 +33,4 @@ static_assert(kV2StateTimeoutOffset + kV2StateTimeoutBytes <= kV2StateSize,
 }  // namespace A3WindowLayout
 }  // namespace Moe
 
-#endif  // TILING_ARGS_H
+#endif  // WINDOW_LAYOUT_H

--- a/csrc/deepep/ops/op_kernel/window_layout.h
+++ b/csrc/deepep/ops/op_kernel/window_layout.h
@@ -29,37 +29,59 @@ constexpr uint64_t MB = 1024UL * KB;
 // ping-pong halves; dataState selects the active half.
 constexpr uint64_t kNotifyDispatchSize = 102UL * MB;
 constexpr uint64_t kNormalCombineStateSize = 4UL * MB;
+constexpr uint64_t kNormalCombineStateHalfSize = kNormalCombineStateSize / 2UL;
+constexpr uint64_t kNormalCombineStateEntrySize = 32UL;
 constexpr uint64_t kAivCount = 48UL;
 constexpr uint64_t kAivMetadataStride = 512UL;
-constexpr uint64_t kV2SelectorMetadataSize = kAivCount * kAivMetadataStride;
-constexpr uint64_t kV2StateSize = 1UL * MB;
-constexpr uint64_t kV2StateTimeoutOffset = 1000UL * KB;
-constexpr uint64_t kV2StateTimeoutBytes = 8UL * sizeof(float);
-constexpr uint64_t kV2StateEntrySize = 32UL;
-constexpr uint64_t kV2MaxBs = 512UL;
-constexpr uint64_t kV2MaxTopK = 16UL;
-constexpr uint64_t kV2MaxSharedExpertNum = 4UL;
+constexpr uint64_t kLlSelectorMetadataSize = kAivCount * kAivMetadataStride;
+constexpr uint64_t kLlStateSize = 1UL * MB;
+constexpr uint64_t kLlStateTimeoutOffset = 1000UL * KB;
+constexpr uint64_t kLlStateTimeoutBytes = 8UL * sizeof(float);
+constexpr uint64_t kLlStateEntrySize = 32UL;
+constexpr uint64_t kLlMaxBs = 512UL;
+constexpr uint64_t kLlMaxTopK = 16UL;
+constexpr uint64_t kLlMaxSharedExpertNum = 4UL;
 
 // Legacy layout is safe only when normal and V2 low-latency operators are
-// never deployed against the same HCCL window.
+// never deployed against the same HCCL window. It intentionally reuses the
+// following areas instead of isolating the two operator families:
+//
+//   windowsIn, per ping-pong half:
+//   +---------------------------+---------------------------------------------+
+//   | byte range                | legacy user / purpose                       |
+//   +---------------------------+---------------------------------------------+
+//   | [0, 102MB)                | notify-dispatch payload/state               |
+//   | [102MB, 106MB)            | normal combine token-state                  |
+//   | [106MB, halfSize)         | normal dispatch/combine payload             |
+//   | [0, halfSize)             | ll dispatch/combine payload (overlaps above)|
+//   +---------------------------+---------------------------------------------+
+//
+//   windowsExp, V2 logical control addresses (shared between V2 phases):
+//   dispatch state: dataState 0 at +0KB,   dataState 1 at +500KB
+//   combine  state: dataState 0 at +64KB,  dataState 1 at +564KB
+//   dispatch selector metadata: +950KB (48 * 512B)
+//   combine  selector metadata: +975KB (48 * 512B)
+//
+// The V2 state ranges are deliberately reused by sequential dispatch/combine.
+// They must not be considered independent state slots.
 constexpr uint64_t kLegacyNormalDataOffset = kNotifyDispatchSize + kNormalCombineStateSize;
 constexpr uint64_t kLegacyV2StateHalfSize = 500UL * KB;
 constexpr uint64_t kLegacyV2CombineStateOffset = 64UL * KB;
 constexpr uint64_t kLegacyV2DispatchSelectorOffset = 950UL * KB;
 constexpr uint64_t kLegacyV2CombineSelectorOffset = 975UL * KB;
 
-constexpr uint64_t kV2DispatchSelectorOffset = kNotifyDispatchSize + kNormalCombineStateSize;
-constexpr uint64_t kV2DispatchStateOffset = kV2DispatchSelectorOffset + kV2SelectorMetadataSize;
-constexpr uint64_t kV2CombineSelectorOffset = kV2DispatchStateOffset + kV2StateSize;
-constexpr uint64_t kV2CombineStateOffset = kV2CombineSelectorOffset + kV2SelectorMetadataSize;
-constexpr uint64_t kDataOffset = kV2CombineStateOffset + kV2StateSize;
+constexpr uint64_t kLlDispatchSelectorOffset = kNotifyDispatchSize + kNormalCombineStateSize;
+constexpr uint64_t kLlDispatchStateOffset = kLlDispatchSelectorOffset + kLlSelectorMetadataSize;
+constexpr uint64_t kLlCombineSelectorOffset = kLlDispatchStateOffset + kLlStateSize;
+constexpr uint64_t kLlCombineStateOffset = kLlCombineSelectorOffset + kLlSelectorMetadataSize;
+constexpr uint64_t kDataOffset = kLlCombineStateOffset + kLlStateSize;
 constexpr uint64_t kPerHalfReservedSize = kDataOffset;
 
-static_assert(kV2StateTimeoutOffset + kV2StateTimeoutBytes <= kV2StateSize,
+static_assert(kLlStateTimeoutOffset + kLlStateTimeoutBytes <= kLlStateSize,
               "V2 timeout probe must remain inside its state slot");
-static_assert(kV2MaxBs * (kV2MaxTopK + kV2MaxSharedExpertNum) * kV2StateEntrySize <= kV2StateSize,
+static_assert(kLlMaxBs * (kLlMaxTopK + kLlMaxSharedExpertNum) * kLlStateEntrySize <= kLlStateSize,
               "V2 combine state must remain inside its state slot");
-static_assert(kV2MaxBs * (kV2MaxTopK + kV2MaxSharedExpertNum) * kV2StateEntrySize <= kV2StateTimeoutOffset,
+static_assert(kLlMaxBs * (kLlMaxTopK + kLlMaxSharedExpertNum) * kLlStateEntrySize <= kLlStateTimeoutOffset,
               "V2 combine state must not overlap the timeout probe");
 }  // namespace A3WindowLayout
 }  // namespace Moe

--- a/csrc/deepep/ops/op_kernel/window_layout.h
+++ b/csrc/deepep/ops/op_kernel/window_layout.h
@@ -17,10 +17,10 @@ constexpr uint64_t MB = 1024UL * KB;
 //   | [0, 102MB)                | notify-dispatch state/payload               |
 //   | [102MB, 106MB)            | normal combine token-state                  |
 //   | [106MB, 106MB + 24KB)     | ll dispatch selector metadata (48 * 512B)   |
-//   | [106MB + 24KB, 107MB+24KB)| ll dispatch working state                   |
-//   | [107MB + 24KB, 107MB+48KB)| ll combine selector metadata (48 * 512B)    |
-//   | [107MB + 48KB, 108MB+48KB)| ll combine working state                    |
-//   | [108MB + 48KB, halfSize)  | unified data area for normal and ll         |
+//   | [106MB + 24KB, 106MB + 536KB)    | ll dispatch working state              |
+//   | [106MB + 536KB, 106MB + 560KB)   | ll combine selector metadata (48*512B)|
+//   | [106MB + 560KB, 107MB + 48KB)    | ll combine working state               |
+//   | [107MB + 48KB, halfSize)         | unified data area for normal and ll    |
 //   +---------------------------+---------------------------------------------+
 //
 // The state areas above are private to their owners. Normal/ll payload data
@@ -34,9 +34,11 @@ constexpr uint64_t kNormalCombineStateEntrySize = 32UL;
 constexpr uint64_t kAivCount = 48UL;
 constexpr uint64_t kAivMetadataStride = 512UL;
 constexpr uint64_t kLlSelectorMetadataSize = kAivCount * kAivMetadataStride;
-constexpr uint64_t kLlStateSize = 1UL * MB;
-constexpr uint64_t kLlStateTimeoutOffset = 1000UL * KB;
 constexpr uint64_t kLlStateTimeoutBytes = 8UL * sizeof(float);
+constexpr uint64_t kLlStateSize = 512UL * KB;
+// Hybrid timeout probes occupy the final 32 bytes of their owning state slot.
+// Legacy keeps its original +1000KB probe address in the V2 kernels.
+constexpr uint64_t kLlStateTimeoutOffset = kLlStateSize - kLlStateTimeoutBytes;
 constexpr uint64_t kLlStateEntrySize = 32UL;
 constexpr uint64_t kLlMaxBs = 512UL;
 constexpr uint64_t kLlMaxTopK = 16UL;
@@ -69,6 +71,7 @@ constexpr uint64_t kLegacyV2StateHalfSize = 500UL * KB;
 constexpr uint64_t kLegacyV2CombineStateOffset = 64UL * KB;
 constexpr uint64_t kLegacyV2DispatchSelectorOffset = 950UL * KB;
 constexpr uint64_t kLegacyV2CombineSelectorOffset = 975UL * KB;
+constexpr uint64_t kLegacyLlStateTimeoutOffset = 1000UL * KB;
 
 constexpr uint64_t kLlDispatchSelectorOffset = kNotifyDispatchSize + kNormalCombineStateSize;
 constexpr uint64_t kLlDispatchStateOffset = kLlDispatchSelectorOffset + kLlSelectorMetadataSize;
@@ -79,10 +82,8 @@ constexpr uint64_t kPerHalfReservedSize = kDataOffset;
 
 static_assert(kLlStateTimeoutOffset + kLlStateTimeoutBytes <= kLlStateSize,
               "V2 timeout probe must remain inside its state slot");
-static_assert(kLlMaxBs * (kLlMaxTopK + kLlMaxSharedExpertNum) * kLlStateEntrySize <= kLlStateSize,
-              "V2 combine state must remain inside its state slot");
 static_assert(kLlMaxBs * (kLlMaxTopK + kLlMaxSharedExpertNum) * kLlStateEntrySize <= kLlStateTimeoutOffset,
-              "V2 combine state must not overlap the timeout probe");
+              "V2 combine state must remain inside its state slot");
 }  // namespace A3WindowLayout
 }  // namespace Moe
 

--- a/csrc/deepep/ops/op_kernel/window_layout.h
+++ b/csrc/deepep/ops/op_kernel/window_layout.h
@@ -40,6 +40,14 @@ constexpr uint64_t kV2MaxBs = 512UL;
 constexpr uint64_t kV2MaxTopK = 16UL;
 constexpr uint64_t kV2MaxSharedExpertNum = 4UL;
 
+// Legacy layout is safe only when normal and V2 low-latency operators are
+// never deployed against the same HCCL window.
+constexpr uint64_t kLegacyNormalDataOffset = kNotifyDispatchSize + kNormalCombineStateSize;
+constexpr uint64_t kLegacyV2StateHalfSize = 500UL * KB;
+constexpr uint64_t kLegacyV2CombineStateOffset = 64UL * KB;
+constexpr uint64_t kLegacyV2DispatchSelectorOffset = 950UL * KB;
+constexpr uint64_t kLegacyV2CombineSelectorOffset = 975UL * KB;
+
 constexpr uint64_t kV2DispatchSelectorOffset = kNotifyDispatchSize + kNormalCombineStateSize;
 constexpr uint64_t kV2DispatchStateOffset = kV2DispatchSelectorOffset + kV2SelectorMetadataSize;
 constexpr uint64_t kV2CombineSelectorOffset = kV2DispatchStateOffset + kV2StateSize;

--- a/csrc/deepep/ops/op_kernel/window_layout.h
+++ b/csrc/deepep/ops/op_kernel/window_layout.h
@@ -8,6 +8,25 @@ namespace A3WindowLayout {
 constexpr uint64_t KB = 1024UL;
 constexpr uint64_t MB = 1024UL * KB;
 
+// A3 windowsIn layout for one ping-pong half:
+//
+//   windowsIn + dataState * (totalWinSize / 2)
+//   +---------------------------+---------------------------------------------+
+//   | byte range                | owner / purpose                             |
+//   +---------------------------+---------------------------------------------+
+//   | [0, 102MB)                | notify-dispatch state/payload               |
+//   | [102MB, 106MB)            | normal combine token-state                  |
+//   | [106MB, 106MB + 24KB)     | ll dispatch selector metadata (48 * 512B)   |
+//   | [106MB + 24KB, 107MB+24KB)| ll dispatch working state                   |
+//   | [107MB + 24KB, 107MB+48KB)| ll combine selector metadata (48 * 512B)    |
+//   | [107MB + 48KB, 108MB+48KB)| ll combine working state                    |
+//   | [108MB + 48KB, halfSize)  | unified data area for normal and ll         |
+//   +---------------------------+---------------------------------------------+
+//
+// The state areas above are private to their owners. Normal/ll payload data
+// must start at kDataOffset, so neither may overwrite low-latency notify or
+// normal/ll synchronization state. The same layout is repeated in both
+// ping-pong halves; dataState selects the active half.
 constexpr uint64_t kNotifyDispatchSize = 102UL * MB;
 constexpr uint64_t kNormalCombineStateSize = 4UL * MB;
 constexpr uint64_t kAivCount = 48UL;
@@ -17,7 +36,7 @@ constexpr uint64_t kV2StateSize = 1UL * MB;
 constexpr uint64_t kV2StateTimeoutOffset = 1000UL * KB;
 constexpr uint64_t kV2StateTimeoutBytes = 8UL * sizeof(float);
 constexpr uint64_t kV2StateEntrySize = 32UL;
-constexpr uint64_t kV2MaxBs = 256UL;
+constexpr uint64_t kV2MaxBs = 512UL;
 constexpr uint64_t kV2MaxTopK = 16UL;
 constexpr uint64_t kV2MaxSharedExpertNum = 4UL;
 
@@ -30,6 +49,10 @@ constexpr uint64_t kPerHalfReservedSize = kDataOffset;
 
 static_assert(kV2StateTimeoutOffset + kV2StateTimeoutBytes <= kV2StateSize,
               "V2 timeout probe must remain inside its state slot");
+static_assert(kV2MaxBs * (kV2MaxTopK + kV2MaxSharedExpertNum) * kV2StateEntrySize <= kV2StateSize,
+              "V2 combine state must remain inside its state slot");
+static_assert(kV2MaxBs * (kV2MaxTopK + kV2MaxSharedExpertNum) * kV2StateEntrySize <= kV2StateTimeoutOffset,
+              "V2 combine state must not overlap the timeout probe");
 }  // namespace A3WindowLayout
 }  // namespace Moe
 

--- a/python/deep_ep/README.md
+++ b/python/deep_ep/README.md
@@ -221,6 +221,7 @@ See [Fused Deep MoE API](doc/FUSED_DEEP_MOE.md) for details.
 | `MOE_ENABLE_CCU` | `0` | Set to `1` to use `comm_alg="ccu"` in default low-latency strategy. |
 | `HCCL_BUFFSIZE` | `200` (MB) | HCCL buffer size in MB. **Must be set** when using DeepEP on A2. Minimum required size (non-layered): `(bs × ep_world_size × min(num_local_experts, topk) × hidden × 2B + 2MB) × 2`. For layered (dual-node): `num_experts × bs × (hidden × 2B + 4 × topk × 4B) + 4MB + 800MB`. A5 subtracts 1MB state zone from the configured value. |
 | `DEEPEP_HCCL_BUFFSIZE` | — | Reserved. Takes priority over `HCCL_BUFFSIZE` if set. DeepEP reads this for preliminary validation only; actual HCCL buffer must be configured by the framework (e.g., SGLang). |
+| `DEEPEP_HYBRID_DEPLOYMENT` | — | Set this when one process uses both Normal and Low-Latency APIs against the same EP group. Its presence enables an isolated hybrid window layout for the two modes. Set it before every rank process starts and keep it identical on all ranks in the EP group. Leave it unset when the process uses only one mode. |
 | `DEEPEP_NORMAL_LONG_SEQ_ROUND` | `1` | "Ant moving home" feature: number of dispatch rounds per rank. Range [1, 256]. Must be set together with `DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS`. |
 | `DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS` | `8192` | "Ant moving home" feature: tokens per round per rank. Range [32, 8192]. Product with `ROUND` must be ≤ 131072. |
 | `DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ` | `0` | Set to `1` to enable "ant moving home" in the combine phase. |
@@ -251,6 +252,13 @@ For detailed A2 usage, see [A2_DEEPEP](doc/A2_DEEPEP.md).
 
 - Pure HCCS communication for both intranode and internode. No hierarchical implementation needed.
 - Supports `ops` strategy with multiple `comm_alg` options for low-latency mode.
+- When the same process invokes both Normal and Low-Latency APIs for one EP group, enable the hybrid window layout before launching every rank:
+
+```bash
+export DEEPEP_HYBRID_DEPLOYMENT=1
+```
+
+  All ranks in the EP group must use the same setting. There is no need to set this variable for a process that uses only Normal APIs or only Low-Latency APIs.
 
 #### A5
 
@@ -488,6 +496,7 @@ low_latency_dispatch 量化模式。`quant_mode` 字符串参数仅对 `default`
 | `MOE_ENABLE_CCU` | `0` | 设为 `1` 时 default low-latency 策略使用 `comm_alg="ccu"`。 |
 | `HCCL_BUFFSIZE` | `200`（MB） | HCCL 缓冲区大小（MB）。A2 使用 DeepEP 时**必须设置**。非分层最小需求：`(bs × ep_world_size × min(num_local_experts, topk) × hidden × 2B + 2MB) × 2`；分层（双机）：`num_experts × bs × (hidden × 2B + 4 × topk × 4B) + 4MB + 800MB`。A5 从配置值中扣除 1MB 状态区。 |
 | `DEEPEP_HCCL_BUFFSIZE` | — | 预留字段，优先级高于 `HCCL_BUFFSIZE`。DeepEP 仅用于初步校验，实际 HCCL 缓冲需由框架（如 SGLang）配置。 |
+| `DEEPEP_HYBRID_DEPLOYMENT` | — | 同一进程在同一 EP group 上同时使用 Normal 和 Low-Latency 接口时设置。变量存在即启用两种模式隔离的 hybrid window 布局。必须在各 rank 进程启动前设置，且同一 EP group 的所有 rank 必须保持一致。进程仅使用一种模式时无需设置。 |
 | `DEEPEP_NORMAL_LONG_SEQ_ROUND` | `1` | 蚂蚁搬家特性：每 rank 发送轮数。范围 [1, 256]。需与 `DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS` 同时设置。 |
 | `DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS` | `8192` | 蚂蚁搬家特性：每轮每 rank 发送 token 数。范围 [32, 8192]。与 `ROUND` 的乘积需 ≤ 131072。 |
 | `DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ` | `0` | 设为 `1` 在 combine 阶段启用蚂蚁搬家。 |
@@ -518,6 +527,13 @@ low_latency_dispatch 量化模式。`quant_mode` 字符串参数仅对 `default`
 
 - 纯 HCCS 通信（节点内和节点间）。无需分层实现。
 - Low-latency 模式支持 `ops` 策略及多种 `comm_alg` 选项。
+- 同一进程在一个 EP group 上同时调用 Normal 和 Low-Latency 接口时，需在每个 rank 进程启动前启用 hybrid window 布局：
+
+```bash
+export DEEPEP_HYBRID_DEPLOYMENT=1
+```
+
+  同一 EP group 的所有 rank 必须使用相同配置。进程仅调用 Normal 接口或仅调用 Low-Latency 接口时，无需设置该变量。
 
 #### A5
 


### PR DESCRIPTION
## Motivation

Solving the Problem that DeepEP Is Suspended in A3 Hybrid Deployment Scenario Using SGLang

fixed issue: https://github.com/sgl-project/sgl-kernel-npu/issues/786

## Modifications

DeepEP adding external environment variables "DEEPEP_HYBRID_DEPLOYMENT", when one process uses both Normal and Low-Latency APIs against the same EP group. Its presence enables an isolated hybrid window layout for the two modes.

Hybrid window is as follows:
```bash
+---------------------------+---------------------------------------------+
| byte range                | owner / purpose                             |
+---------------------------+---------------------------------------------+
| [0, 102MB)                | notify-dispatch state/payload               |
| [102MB, 106MB)            | normal combine token-state                  |
| [106MB, 106MB + 24KB)     | ll dispatch selector metadata (48 * 512B)   |
| [106MB + 24KB, 107MB+24KB)| ll dispatch working state                   |
| [107MB + 24KB, 107MB+48KB)| ll combine selector metadata (48 * 512B)    |
| [107MB + 48KB, 108MB+48KB)| ll combine working state                    |
| [108MB + 48KB, halfSize)  | unified data area for normal and ll         |
+---------------------------+---------------------------------------------+
```

## Testing

```bash
Evaluating[gpqa_diamond]: 100%|████████████████████████████████████████████| 198/198 [1:57:47<00:00, 35.70s/it]
gpqa_diamond report table:
┌─────────┬──────────────┬────────────┬──────────┬───────┬─────────┐
│ Model   │ Dataset      │ Metric     │ Subset   │   Num │ Score   │
├─────────┼──────────────┼────────────┼──────────┼───────┼─────────┤
│ glm-5   │ GPQA-Diamond │ Accuracy ↑ │ default  │   198 │ 90.4%   │
└─────────┴──────────────┴────────────┴──────────┴───────┴─────────┘
```

## Benchmarking and Profiling

NA

## Checklist

- [x] Format your code.
- [ ] Add unit tests.
- [x] Update documentation.
- [ ] Provide accuracy and speed benchmark results.