### PR TITLE
build kernels with Ascend950PR_9599 config for 950

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -55,11 +55,20 @@ jobs:
         run: |
           bash scripts/npu_ci_install_dependency.sh --cann-version ${{ matrix.cann_version }}
 
-      - name: Build SGL-Kernel-NPU
+      - name: Build SGL-Kernel-NPU for 910b/a3
+        if: matrix.npu_hardware != '950'
         run: |
           env -i PATH=${PATH} bash --login -c "
             export LD_LIBRARY_PATH=${ASCEND_HOME_PATH}/runtime/lib64/stub:${LD_LIBRARY_PATH} && \
             ./build.sh -a kernels
+          "
+
+      - name: Build SGL-Kernel-NPU for 950
+        if: matrix.npu_hardware == '950'
+        run: |
+          env -i PATH=${PATH} bash --login -c "
+            export LD_LIBRARY_PATH=${ASCEND_HOME_PATH}/runtime/lib64/stub:${LD_LIBRARY_PATH} && \
+            ./build.sh -a kernels Ascend950PR_9599
           "
 
       - name: Build Attentions


### PR DESCRIPTION
Split the "Build SGL-Kernel-NPU" step by NPU hardware so that the 950
builds compile kernels with the `Ascend950PR_9599` configuration, while
910b and a3 keep using the original command.

## Changes

- `Build SGL-Kernel-NPU` is now split into two steps:
  - **910b / a3** (`matrix.npu_hardware != '950'`): behavior unchanged,
    runs `./build.sh -a kernels`.
  - **950** (`matrix.npu_hardware == '950'`): runs
    `./build.sh -a kernels Ascend950PR_9599`.

No other steps (attentions, memory-saver, DeepEP, ops-transformer,
cann-custom ops) are affected.

## Motivation

The 950 kernels need to be built against the `Ascend950PR_9599`
profile; the previous single command did not pass this argument. Keeping
910b and a3 on the original command preserves their existing build
behavior and avoids unintended changes to their artifacts.

## Testing

- The pull_request matrix in this workflow exercises all
  `npu_hardware` (910b, a3, 950) x `arch` (x86_64, aarch64)
  combinations.
- Verified that each matrix leg selects the intended build command via
  the step-level `if` conditions.
- Full release packaging was not run; it will be exercised on the next
  published release.