### PR TITLE
[FIX] UB rewrite in LoRA on rank = 8

### DIFF
--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -203,7 +203,7 @@ private:
             pipe_barrier(PIPE_V);
         }
 
-        //TODO: can be vectorized
+        // TODO: can be vectorized
         for (int32_t i = maxLoRARank_; i < NUM_ELEMENTS_PER_REPEAT; i += maxLoRARank_) {
             for (int32_t j = 0; j < maxLoRARank_; j++) {
                 float entry = xDup.GetValue(j);
@@ -322,7 +322,7 @@ private:
 
         pipe_barrier(PIPE_V);
 
-        //TODO: can be vectorized
+        // TODO: can be vectorized
         for (int32_t row = 0; row < rows; ++row) {
             const int32_t base = row * rank;
             float sum = 0.0f;

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -203,7 +203,7 @@ private:
             pipe_barrier(PIPE_V);
         }
 
-       for (int32_t i = maxLoRARank_; i < NUM_ELEMENTS_PER_REPEAT; i += maxLoRARank_) {
+        for (int32_t i = maxLoRARank_; i < NUM_ELEMENTS_PER_REPEAT; i += maxLoRARank_) {
             for (int32_t j = 0; j < maxLoRARank_; j++) {
                 float entry = xDup.GetValue(j);
                 xDup.SetValue(i + j, entry);

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -214,61 +214,20 @@ private:
         inQueueX_.FreeTensor(xLocal);
     }
 
-    __aicore__ inline void CopyInY(int32_t progress, int32_t numElements)
+     __aicore__ inline void CopyInY(int32_t progress, int32_t numElements = Y_OUT_TILE_NUM_ELEMENTS)
     {
-        AscendC::LocalTensor<Y_T> yLocal = inQueueY_.AllocTensor<Y_T>();
-        const uint64_t offset = yOffset_ + static_cast<uint64_t>(progress) * Y_OUT_TILE_NUM_ELEMENTS;
-
-        if (numElements == Y_OUT_TILE_NUM_ELEMENTS) {
-            DataCopy(yLocal, yInGm_[offset], numElements);
-
-        } else {
-            const uint32_t bytes = static_cast<uint32_t>(numElements * sizeof(Y_T));
-            const uint32_t paddedBytes = ((bytes + DATA_VECTOR_BLOCK - 1) / DATA_VECTOR_BLOCK) * DATA_VECTOR_BLOCK;
-            const uint32_t paddingBytes = paddedBytes - bytes;
-            const uint32_t paddingElements = paddingBytes / sizeof(Y_T);
-            AscendC::DataCopyExtParams copyParams{1, bytes, 0, 0, 0};
-            AscendC::DataCopyPadExtParams<Y_T> padParams{true, 0, static_cast<uint8_t>(paddingElements),
-                                                         static_cast<Y_T>(0)};
-
-            DataCopyPad(yLocal, yInGm_[offset], copyParams, padParams);
-        }
-
-        inQueueY_.EnQue(yLocal);
+        AscendC::LocalTensor<Y_T> yInLocal = inQueueY_.AllocTensor<Y_T>();
+        DataCopy(yInLocal, yInGm_[yOffset_ + progress * Y_OUT_TILE_NUM_ELEMENTS], numElements);
+        inQueueY_.EnQue(yInLocal);
     }
 
-    __aicore__ inline void CopyInW(int32_t progress, int32_t numElements)
+    __aicore__ inline void CopyInW(int32_t progress, int32_t numElements = W_IN_TILE_NUM_ELEMENTS)
     {
         AscendC::LocalTensor<W_T> wLocal = inQueueW_.AllocTensor<W_T>();
-        const int32_t rows = (numElements + reqLoRARank_ - 1) / reqLoRARank_;
-        const int32_t actualElements = rows * reqLoRARank_;
-        const uint32_t rowBytes = static_cast<uint32_t>(reqLoRARank_ * sizeof(W_T));
-        const uint32_t rowStrideBytes = static_cast<uint32_t>(maxLoRARank_ * sizeof(W_T));
-        const uint64_t offset =
-            reqLoRAWeightOffset_ + static_cast<uint64_t>(progress) * static_cast<uint64_t>(maxLoRARank_);
-
-        if (actualElements <= 0) {
-            inQueueW_.FreeTensor(wLocal);
-            return;
-        }
-
-        const uint32_t paddedRowBytes = ((rowBytes + DATA_VECTOR_BLOCK - 1) / DATA_VECTOR_BLOCK) * DATA_VECTOR_BLOCK;
-        const uint32_t paddedRowElements = paddedRowBytes / sizeof(W_T);
-        const int32_t physicalElements = rows * paddedRowElements;
-        AscendC::DataCopyExtParams copyParams{static_cast<uint16_t>(rows), rowBytes, rowStrideBytes - rowBytes, 0, 0};
-        const uint32_t rightPaddingBytes = paddedRowBytes - rowBytes;
-        const uint32_t rightPaddingElements = rightPaddingBytes / sizeof(W_T);
-        AscendC::DataCopyPadExtParams<W_T> padParams{true, 0, static_cast<uint8_t>(rightPaddingElements),
-                                                     static_cast<W_T>(0)};
-
-        DataCopyPad(wLocal, wGm_[offset], copyParams, padParams);
-
-        if (physicalElements < W_IN_TILE_STORAGE_ELEMENTS) {
-            AscendC::LocalTensor<W_T> tail = wLocal[physicalElements];
-            Duplicate(tail, static_cast<W_T>(0), W_IN_TILE_STORAGE_ELEMENTS - physicalElements);
-            pipe_barrier(PIPE_V);
-        }
-
+        DataCopy(wLocal, wGm_[reqLoRAWeightOffset_ + progress * (W_IN_TILE_NUM_ELEMENTS / reqLoRARank_) * maxLoRARank_],
+                 {static_cast<uint16_t>(numElements / reqLoRARank_),
+                  static_cast<uint16_t>((reqLoRARank_ * sizeof(W_T) + DATA_VECTOR_BLOCK - 1) / DATA_VECTOR_BLOCK),
+                  static_cast<uint16_t>((maxLoRARank_ - reqLoRARank_) * sizeof(W_T) / DATA_VECTOR_BLOCK), 0});
         inQueueW_.EnQue(wLocal);
     }
 

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -214,7 +214,7 @@ private:
         inQueueX_.FreeTensor(xLocal);
     }
 
-     __aicore__ inline void CopyInY(int32_t progress, int32_t numElements = Y_OUT_TILE_NUM_ELEMENTS)
+    __aicore__ inline void CopyInY(int32_t progress, int32_t numElements = Y_OUT_TILE_NUM_ELEMENTS)
     {
         AscendC::LocalTensor<Y_T> yInLocal = inQueueY_.AllocTensor<Y_T>();
         DataCopy(yInLocal, yInGm_[yOffset_ + progress * Y_OUT_TILE_NUM_ELEMENTS], numElements);

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -30,31 +30,31 @@ public:
     using W_T = scalar_t;
     using Y_T = scalar_t;
 
-    static constexpr uint64_t LORA_RANK_8 = 8;
-    static constexpr uint64_t LORA_RANK_16 = 16;
-    static constexpr uint64_t LORA_RANK_32 = 32;
-    static constexpr uint64_t LORA_RANK_64 = 64;
-    static constexpr uint64_t SUPPORTED_RANKS[] = {LORA_RANK_8, LORA_RANK_16, LORA_RANK_32, LORA_RANK_64};
-    static constexpr int32_t BUFFER_NUM = 2;
-    static constexpr int32_t DATA_VECTOR_BLOCK = 32;
+    static constexpr int32_t LORA_RANK_8 = 8;
+    static constexpr int32_t LORA_RANK_16 = 16;
+    static constexpr int32_t LORA_RANK_32 = 32;
+    static constexpr int32_t LORA_RANK_64 = 64;
 
-    // The vector unit reads 8 blocks (32 bytes each and 256 bytes in total) of contiguous data each time.
+    static constexpr int32_t BUFFER_NUM = 2;
+
+    static constexpr int32_t DATA_VECTOR_BLOCK = 32;
     static constexpr int32_t NUM_BYTES_PER_REPEAT = 256;
     static constexpr int32_t NUM_BLOCKS_PER_REPEAT = 8;
-    // The maximum number of elements in a single iteration is 256 / sizeof(intermediate data type).
+
     static constexpr int32_t NUM_ELEMENTS_PER_REPEAT = NUM_BYTES_PER_REPEAT / sizeof(float);
-    // Mask is used to control the elements that participate in computation in each iteration.
+
     static constexpr int32_t MASK_COUNT = NUM_BYTES_PER_REPEAT / sizeof(float);
-    // Refer to numOutputElementsPerInputTile_ initialization for the constraints on the following constants.
-    static constexpr int32_t W_IN_TILE_NUM_ELEMENTS = 8192;
-    static constexpr int32_t Y_OUT_TILE_NUM_ELEMENTS = 4096;
+    static constexpr int32_t W_IN_TILE_NUM_ELEMENTS = 4096;
+
+    static constexpr int32_t W_IN_TILE_STORAGE_ELEMENTS = 8192;
+
+    static constexpr int32_t Y_OUT_TILE_NUM_ELEMENTS = 512;
+
     static constexpr int32_t BLOCK_REDUCE_NUM_REPEATS = W_IN_TILE_NUM_ELEMENTS / NUM_ELEMENTS_PER_REPEAT;
-    // BlockReduceSum would generate(BLOCK_REDUCE_NUM_REPEATS * NUM_BLOCKS_PER_REPEAT)floats.
-    // So need to read them all and apply PairReduceSum
+
     static constexpr int32_t PAIR_REDUCE_NUM_REPEATS_16 =
         (BLOCK_REDUCE_NUM_REPEATS * NUM_BLOCKS_PER_REPEAT + NUM_ELEMENTS_PER_REPEAT - 1) / NUM_ELEMENTS_PER_REPEAT;
-    // The second PairReduceSum for rank=32, needs half of the repetition that happened for rank=16.
-    // Same for rank=64, we do not support ranks greater than 64.
+
     static constexpr int32_t PAIR_REDUCE_NUM_REPEATS_32 = (PAIR_REDUCE_NUM_REPEATS_16 + 1) / 2;
 
 public:
@@ -69,9 +69,15 @@ public:
         batchSize_ = batchSize;
         numTokensPerCore_ = numTokensPerCore;
         maxLoRARank_ = maxLoRARank;
-        sliceCount_ = sliceOffsetsSize - 1;
         outputFullDim_ = outputFullDim;
-        singleLoRAWeightLen_ = maxLoRARank_ * outputFullDim_;
+
+        if (sliceOffsetsSize >= 2) {
+            sliceCount_ = sliceOffsetsSize - 1;
+        } else {
+            sliceCount_ = 0;
+        }
+
+        singleLoRAWeightLen_ = static_cast<uint64_t>(maxLoRARank_) * static_cast<uint64_t>(outputFullDim_);
 
         xGm_.SetGlobalBuffer(reinterpret_cast<__gm__ X_T *>(x));
         wGm_.SetGlobalBuffer(reinterpret_cast<__gm__ W_T *>(weight));
@@ -82,12 +88,11 @@ public:
         loraRanksGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(loraRanks), loraRanksSize);
         sliceOffsetsGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(sliceOffsets), sliceOffsetsSize);
 
-        pipe_->InitBuffer(inQueueX_, 1, NUM_ELEMENTS_PER_REPEAT * sizeof(X_T));
-        pipe_->InitBuffer(inQueueW_, BUFFER_NUM, W_IN_TILE_NUM_ELEMENTS * sizeof(W_T));
+        pipe_->InitBuffer(inQueueX_, 1, NUM_ELEMENTS_PER_REPEAT * sizeof(float));
+        pipe_->InitBuffer(inQueueW_, BUFFER_NUM, W_IN_TILE_STORAGE_ELEMENTS * sizeof(W_T));
         pipe_->InitBuffer(inQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(Y_T));
         pipe_->InitBuffer(outQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(Y_T));
-
-        pipe_->InitBuffer(dupBufferX_, NUM_ELEMENTS_PER_REPEAT * sizeof(float));
+        pipe_->InitBuffer(dupBufferX_, W_IN_TILE_NUM_ELEMENTS * sizeof(float));
         pipe_->InitBuffer(tmpBufferW_, W_IN_TILE_NUM_ELEMENTS * sizeof(float));
         pipe_->InitBuffer(inBufferY_, Y_OUT_TILE_NUM_ELEMENTS * sizeof(float));
         pipe_->InitBuffer(tmpBufferY_, Y_OUT_TILE_NUM_ELEMENTS * sizeof(float));
@@ -95,266 +100,343 @@ public:
 
     __aicore__ inline void Process()
     {
-        int64_t blockIdx_Slice = AscendC::GetBlockIdx();
-        int64_t blockIdx = blockIdx_Slice / sliceCount_;
-        int64_t startIdx = blockIdx * numTokensPerCore_;
-        int64_t endIdx = startIdx + numTokensPerCore_;
-        reqSlice_ = blockIdx_Slice % sliceCount_;
-
-        sliceOffset_ = sliceOffsetsGm_.GetValue(reqSlice_);
-        outputHiddenDim_ = sliceOffsetsGm_.GetValue(reqSlice_ + 1) - sliceOffset_;
-
-        if (endIdx > batchSize_) {
-            endIdx = batchSize_;
+        if (sliceCount_ == 0) {
+            return;
         }
 
-        int64_t requestBlock = 0;
-        lora_common::BlockIterator blockIterator(seqLenGm_);
-        for (int64_t idx = startIdx; idx < endIdx; idx++) {
-            yOffset_ = outputFullDim_ * idx + sliceOffset_;
+        const int64_t blockIdxSlice = static_cast<int64_t>(AscendC::GetBlockIdx());
+        const int64_t blockIdx = blockIdxSlice / static_cast<int64_t>(sliceCount_);
+        const int64_t startIdx = blockIdx * static_cast<int64_t>(numTokensPerCore_);
+        int64_t endIdx = startIdx + static_cast<int64_t>(numTokensPerCore_);
+        if (endIdx > static_cast<int64_t>(batchSize_)) {
+            endIdx = static_cast<int64_t>(batchSize_);
+        }
 
-            requestBlock = blockIterator.GetBlockIdx(idx);
+        reqSlice_ = static_cast<int32_t>(blockIdxSlice % static_cast<int64_t>(sliceCount_));
+
+        sliceOffset_ = static_cast<uint32_t>(sliceOffsetsGm_.GetValue(reqSlice_));
+        outputHiddenDim_ = static_cast<uint32_t>(sliceOffsetsGm_.GetValue(reqSlice_ + 1)) - sliceOffset_;
+
+        lora_common::BlockIterator blockIterator(seqLenGm_);
+        for (int64_t idx = startIdx; idx < endIdx; ++idx) {
+            yOffset_ = static_cast<uint64_t>(outputFullDim_) * static_cast<uint64_t>(idx) +
+                       static_cast<uint64_t>(sliceOffset_);
+
+            const int64_t requestBlock = blockIterator.GetBlockIdx(idx);
+
             if (requestBlock < 0) {
                 continue;
             }
 
-            // Set up LoRA index
             reqLoRAIndex_ = loraIndicesGm_.GetValue(requestBlock);
+
             if (reqLoRAIndex_ < 0) {
                 continue;
             }
 
             reqLoRARank_ = loraRanksGm_.GetValue(reqLoRAIndex_);
-            if (reqLoRARank_ == 0) {
+
+            if (!IsSupportedRank(reqLoRARank_)) {
                 continue;
             }
-
-            reqLoRAWeightOffset_ = reqLoRAIndex_ * singleLoRAWeightLen_ + sliceOffset_ * maxLoRARank_;
-
-            // Each compute iteration would generate not one, but several output elements.
-            // Therefore, the following variable would determine how many output elements are calculated in each
-            // iteration.
+            reqLoRAWeightOffset_ = static_cast<uint64_t>(reqLoRAIndex_) * singleLoRAWeightLen_ +
+                                   static_cast<uint64_t>(sliceOffset_) * static_cast<uint64_t>(maxLoRARank_);
             numOutputElementsPerInputTile_ = BLOCK_REDUCE_NUM_REPEATS * (NUM_ELEMENTS_PER_REPEAT / reqLoRARank_);
-            numStreamInPerOutputTile_ = Y_OUT_TILE_NUM_ELEMENTS / numOutputElementsPerInputTile_;
+            numStreamInPerOutputTile_ =
+                (Y_OUT_TILE_NUM_ELEMENTS + numOutputElementsPerInputTile_ - 1) / numOutputElementsPerInputTile_;
 
             CopyInX(idx);
-            int32_t numStreamOut = outputHiddenDim_ / Y_OUT_TILE_NUM_ELEMENTS;
-            for (int32_t i = 0; i < numStreamOut; i++) {
-                CopyInY(i);
-                for (int32_t j = 0; j < numStreamInPerOutputTile_; j++) {
-                    CopyInW(i * numStreamInPerOutputTile_ + j);
+            const int32_t numFullYTiles = outputHiddenDim_ / Y_OUT_TILE_NUM_ELEMENTS;
+            for (int32_t i = 0; i < numFullYTiles; ++i) {
+                CopyInY(i, Y_OUT_TILE_NUM_ELEMENTS);
+                ClearAccumulator();
+                for (int32_t j = 0; j < numStreamInPerOutputTile_; ++j) {
+                    CopyInW(i * numStreamInPerOutputTile_ + j, W_IN_TILE_NUM_ELEMENTS);
                     Compute(j * numOutputElementsPerInputTile_);
                 }
-                ScaleOutput();
-                CopyOut(i);
+                ScaleOutput(Y_OUT_TILE_NUM_ELEMENTS);
+                CopyOut(i, Y_OUT_TILE_NUM_ELEMENTS);
             }
+
             ComputeLastIteration();
         }
     }
 
 private:
+    __aicore__ inline bool IsSupportedRank(int32_t rank)
+    {
+        return rank == LORA_RANK_8 || rank == LORA_RANK_16 || rank == LORA_RANK_32 || rank == LORA_RANK_64;
+    }
+
+    __aicore__ inline void CopyInX(int64_t idx)
+    {
+        AscendC::LocalTensor<X_T> xLocal = inQueueX_.AllocTensor<X_T>();
+
+        const uint64_t xOffset =
+            static_cast<uint64_t>(sliceCount_) * static_cast<uint64_t>(maxLoRARank_) * static_cast<uint64_t>(idx) +
+            static_cast<uint64_t>(reqSlice_) * static_cast<uint64_t>(maxLoRARank_);
+
+        if constexpr (std::is_same_v<X_T, float>) {
+            DataCopy(xLocal, xGm_[xOffset], reqLoRARank_);
+
+        } else {
+            AscendC::DataCopyExtParams copyParams{1, static_cast<uint32_t>(reqLoRARank_ * sizeof(X_T)), 0, 0, 0};
+            const uint32_t paddedElements = ((reqLoRARank_ * sizeof(X_T) + DATA_VECTOR_BLOCK - 1) / DATA_VECTOR_BLOCK) *
+                                            DATA_VECTOR_BLOCK / sizeof(X_T);
+            const uint32_t rightPadding = paddedElements - reqLoRARank_;
+            AscendC::DataCopyPadExtParams<X_T> padParams{true, 0, static_cast<uint8_t>(rightPadding),
+                                                         static_cast<X_T>(0)};
+            DataCopyPad(xLocal, xGm_[xOffset], copyParams, padParams);
+        }
+
+        inQueueX_.EnQue(xLocal);
+        xLocal = inQueueX_.DeQue<X_T>();
+        AscendC::LocalTensor<float> xDup = dupBufferX_.Get<float>();
+
+        if constexpr (std::is_same_v<X_T, float>) {
+            for (int32_t j = 0; j < reqLoRARank_; ++j) {
+                xDup.SetValue(j, xLocal.GetValue(j));
+            }
+
+        } else {
+            Cast(xDup, xLocal, AscendC::RoundMode::CAST_NONE, reqLoRARank_);
+            pipe_barrier(PIPE_V);
+        }
+
+        for (int32_t i = reqLoRARank_; i < NUM_ELEMENTS_PER_REPEAT; i += reqLoRARank_) {
+            for (int32_t j = 0; j < reqLoRARank_; ++j) {
+                xDup.SetValue(i + j, xDup.GetValue(j));
+            }
+        }
+
+        inQueueX_.FreeTensor(xLocal);
+    }
+
+    __aicore__ inline void CopyInY(int32_t progress, int32_t numElements)
+    {
+        AscendC::LocalTensor<Y_T> yLocal = inQueueY_.AllocTensor<Y_T>();
+        const uint64_t offset = yOffset_ + static_cast<uint64_t>(progress) * Y_OUT_TILE_NUM_ELEMENTS;
+
+        if (numElements == Y_OUT_TILE_NUM_ELEMENTS) {
+            DataCopy(yLocal, yInGm_[offset], numElements);
+
+        } else {
+            const uint32_t bytes = static_cast<uint32_t>(numElements * sizeof(Y_T));
+            const uint32_t paddedBytes = ((bytes + DATA_VECTOR_BLOCK - 1) / DATA_VECTOR_BLOCK) * DATA_VECTOR_BLOCK;
+            const uint32_t paddingBytes = paddedBytes - bytes;
+            const uint32_t paddingElements = paddingBytes / sizeof(Y_T);
+            AscendC::DataCopyExtParams copyParams{1, bytes, 0, 0, 0};
+            AscendC::DataCopyPadExtParams<Y_T> padParams{true, 0, static_cast<uint8_t>(paddingElements),
+                                                         static_cast<Y_T>(0)};
+
+            DataCopyPad(yLocal, yInGm_[offset], copyParams, padParams);
+        }
+
+        inQueueY_.EnQue(yLocal);
+    }
+
+    __aicore__ inline void CopyInW(int32_t progress, int32_t numElements)
+    {
+        AscendC::LocalTensor<W_T> wLocal = inQueueW_.AllocTensor<W_T>();
+        const int32_t rows = (numElements + reqLoRARank_ - 1) / reqLoRARank_;
+        const int32_t actualElements = rows * reqLoRARank_;
+        const uint32_t rowBytes = static_cast<uint32_t>(reqLoRARank_ * sizeof(W_T));
+        const uint32_t rowStrideBytes = static_cast<uint32_t>(maxLoRARank_ * sizeof(W_T));
+        const uint64_t offset =
+            reqLoRAWeightOffset_ + static_cast<uint64_t>(progress) * static_cast<uint64_t>(maxLoRARank_);
+
+        if (actualElements <= 0) {
+            inQueueW_.FreeTensor(wLocal);
+            return;
+        }
+
+        const uint32_t paddedRowBytes = ((rowBytes + DATA_VECTOR_BLOCK - 1) / DATA_VECTOR_BLOCK) * DATA_VECTOR_BLOCK;
+        const uint32_t paddedRowElements = paddedRowBytes / sizeof(W_T);
+        const int32_t physicalElements = rows * paddedRowElements;
+        AscendC::DataCopyExtParams copyParams{static_cast<uint16_t>(rows), rowBytes, rowStrideBytes - rowBytes, 0, 0};
+        const uint32_t rightPaddingBytes = paddedRowBytes - rowBytes;
+        const uint32_t rightPaddingElements = rightPaddingBytes / sizeof(W_T);
+        AscendC::DataCopyPadExtParams<W_T> padParams{true, 0, static_cast<uint8_t>(rightPaddingElements),
+                                                     static_cast<W_T>(0)};
+
+        DataCopyPad(wLocal, wGm_[offset], copyParams, padParams);
+
+        if (physicalElements < W_IN_TILE_STORAGE_ELEMENTS) {
+            AscendC::LocalTensor<W_T> tail = wLocal[physicalElements];
+            Duplicate(tail, static_cast<W_T>(0), W_IN_TILE_STORAGE_ELEMENTS - physicalElements);
+            pipe_barrier(PIPE_V);
+        }
+
+        inQueueW_.EnQue(wLocal);
+    }
+
+    __aicore__ inline void ClearAccumulator()
+    {
+        AscendC::LocalTensor<float> yLocal = tmpBufferY_.Get<float>();
+        Duplicate(yLocal, 0.0f, Y_OUT_TILE_NUM_ELEMENTS);
+        pipe_barrier(PIPE_V);
+    }
+
+    __aicore__ inline void Compute(int32_t progress, int32_t blockReduceRepeatCount = BLOCK_REDUCE_NUM_REPEATS, int32_t /*pairReduceRepeat16*/ = 0, int32_t /*pairReduceRepeat32*/ = 0)
+    {
+        if (blockReduceRepeatCount <= 0) {
+            return;
+        }
+
+        AscendC::LocalTensor<float> yLocal = tmpBufferY_.Get<float>();
+        AscendC::LocalTensor<float> xDup = dupBufferX_.Get<float>();
+        AscendC::LocalTensor<W_T> wLocal = inQueueW_.DeQue<W_T>();
+        AscendC::LocalTensor<float> wTmp = tmpBufferW_.Get<float>();
+        
+        const int32_t rank = reqLoRARank_;
+        const int32_t rows = (blockReduceRepeatCount * NUM_ELEMENTS_PER_REPEAT) / rank;
+        const int32_t logicalElements = rows * rank;
+
+        const uint32_t paddedRowBytes =
+            ((static_cast<uint32_t>(rank) * sizeof(W_T) + DATA_VECTOR_BLOCK - 1) / DATA_VECTOR_BLOCK) * DATA_VECTOR_BLOCK;
+        const int32_t paddedRowElements = static_cast<int32_t>(paddedRowBytes / sizeof(W_T));
+
+        for (int32_t row = 0; row < rows; ++row) {
+            AscendC::LocalTensor<W_T> src = wLocal[row * paddedRowElements];
+
+            AscendC::LocalTensor<float> dst = wTmp[row * rank];
+
+            Cast(dst, src, AscendC::RoundMode::CAST_NONE, rank);
+        }
+
+        if (logicalElements < W_IN_TILE_NUM_ELEMENTS) {
+            Duplicate(wTmp[logicalElements], 0.0f, W_IN_TILE_NUM_ELEMENTS - logicalElements);
+
+            pipe_barrier(PIPE_V);
+        }
+
+        pipe_barrier(PIPE_V);
+
+        inQueueW_.FreeTensor(wLocal);
+
+        Mul(wTmp, wTmp, xDup, MASK_COUNT, blockReduceRepeatCount, dotProductParams_);
+
+        pipe_barrier(PIPE_V);
+
+        for (int32_t row = 0; row < rows; ++row) {
+            const int32_t base = row * rank;
+            float sum = 0.0f;
+
+            for (int32_t k = 0; k < rank; ++k) {
+                sum += wTmp.GetValue(base + k);
+            }
+
+            yLocal.SetValue(progress + row, sum);
+        }
+
+        pipe_barrier(PIPE_V);
+    }
+
+    __aicore__ inline void ScaleOutput(int32_t numElements)
+    {
+        AscendC::LocalTensor<float> yLocal = tmpBufferY_.Get<float>();
+        AscendC::LocalTensor<Y_T> yInLocal = inQueueY_.DeQue<Y_T>();
+        AscendC::LocalTensor<float> yInLocalFP32 = inBufferY_.Get<float>();
+        Cast(yInLocalFP32, yInLocal, AscendC::RoundMode::CAST_NONE, numElements);
+        pipe_barrier(PIPE_V);
+        inQueueY_.FreeTensor(yInLocal);
+        Add(yLocal, yLocal, yInLocalFP32, numElements);
+        pipe_barrier(PIPE_V);
+        AscendC::LocalTensor<Y_T> yOutLocal = outQueueY_.AllocTensor<Y_T>();
+        Cast(yOutLocal, yLocal, AscendC::RoundMode::CAST_RINT, numElements);
+        pipe_barrier(PIPE_V);
+        outQueueY_.EnQue(yOutLocal);
+    }
+
     __aicore__ inline void ComputeLastIteration()
     {
-        int32_t remainingY = outputHiddenDim_ % Y_OUT_TILE_NUM_ELEMENTS;
+        const int32_t remainingY = outputHiddenDim_ % Y_OUT_TILE_NUM_ELEMENTS;
         if (remainingY == 0) {
             return;
         }
-        int32_t numStreamOut = outputHiddenDim_ / Y_OUT_TILE_NUM_ELEMENTS;
-        int32_t remainingW = remainingY * reqLoRARank_;
-        int32_t numCompleteWTileInForLastIteration = remainingW / W_IN_TILE_NUM_ELEMENTS;
-        int32_t remainingWForLastRepeat = remainingW % W_IN_TILE_NUM_ELEMENTS;
 
+        const int32_t numStreamOut = outputHiddenDim_ / Y_OUT_TILE_NUM_ELEMENTS;
+        const int32_t remainingW = remainingY * reqLoRARank_;
+        const int32_t fullWTiles = remainingW / W_IN_TILE_NUM_ELEMENTS;
+        const int32_t remainingWElements = remainingW % W_IN_TILE_NUM_ELEMENTS;
         CopyInY(numStreamOut, remainingY);
-
-        int32_t outputIdx = 0;
-        for (outputIdx = 0; outputIdx < numCompleteWTileInForLastIteration; outputIdx++) {
-            CopyInW(numStreamOut * numStreamInPerOutputTile_ + outputIdx);
-            Compute(outputIdx * numOutputElementsPerInputTile_);
+        ClearAccumulator();
+        for (int32_t i = 0; i < fullWTiles; ++i) {
+            CopyInW(numStreamOut * numStreamInPerOutputTile_ + i, W_IN_TILE_NUM_ELEMENTS);
+            Compute(i * numOutputElementsPerInputTile_);
         }
 
-        if (remainingWForLastRepeat != 0) {
-            CopyInW(numStreamOut * numStreamInPerOutputTile_ + numCompleteWTileInForLastIteration,
-                    remainingWForLastRepeat);
-            int32_t lastRepeatCount = remainingWForLastRepeat / NUM_ELEMENTS_PER_REPEAT;
-            int32_t pairReduceRepeat16 =
+        if (remainingWElements > 0) {
+            const int32_t progress = numStreamOut * numStreamInPerOutputTile_ + fullWTiles;
+            CopyInW(progress, remainingWElements);
+            const int32_t lastRepeatCount =
+                (remainingWElements + NUM_ELEMENTS_PER_REPEAT - 1) / NUM_ELEMENTS_PER_REPEAT;
+            const int32_t pairReduceRepeat16 =
                 (lastRepeatCount * NUM_BLOCKS_PER_REPEAT + NUM_ELEMENTS_PER_REPEAT - 1) / NUM_ELEMENTS_PER_REPEAT;
-            int32_t pairReduceRepeat32 = (pairReduceRepeat16 + 1) / 2;
-            int32_t lastComputeOutputElement = outputIdx * numOutputElementsPerInputTile_;
-            Compute(lastComputeOutputElement, lastRepeatCount, pairReduceRepeat16, pairReduceRepeat32);
+            const int32_t pairReduceRepeat32 = (pairReduceRepeat16 + 1) / 2;
+            const int32_t outputProgress = fullWTiles * numOutputElementsPerInputTile_;
+            Compute(outputProgress, lastRepeatCount, pairReduceRepeat16, pairReduceRepeat32);
         }
 
         ScaleOutput(remainingY);
         CopyOut(numStreamOut, remainingY);
     }
 
-    __aicore__ inline void CopyInX(const int64_t idx)
-    {
-        AscendC::LocalTensor<X_T> xLocal = inQueueX_.AllocTensor<X_T>();
-        if constexpr (std::is_same_v<X_T, float>) {
-            DataCopy(xLocal, xGm_[sliceCount_ * maxLoRARank_ * idx + reqLoRARank_ * reqSlice_], reqLoRARank_);
-        } else {
-            uint16_t blockLen = static_cast<uint16_t>(reqLoRARank_ * sizeof(X_T));
-            DataCopyPad(xLocal, xGm_[sliceCount_ * maxLoRARank_ * idx + reqLoRARank_ * reqSlice_], {1, blockLen, 0, 0},
-                        {});
-        }
-        inQueueX_.EnQue(xLocal);
-        xLocal = inQueueX_.DeQue<X_T>();
-        AscendC::LocalTensor<float> xDup = dupBufferX_.Get<float>();
-
-        // As we are generating multiple output elements with one API invocation,
-        // we need to duplicate the X vector multiple times to fill one NUM_BYTES_PER_REPEAT
-        if constexpr (std::is_same_v<X_T, float>) {
-            for (int32_t i = 0; i < NUM_ELEMENTS_PER_REPEAT; i += reqLoRARank_) {
-                for (int32_t j = 0; j < reqLoRARank_; j++) {
-                    float entry = xLocal.GetValue(j);
-                    xDup.SetValue(i + j, entry);
-                }
-            }
-        } else {
-            Cast(xDup, xLocal, AscendC::RoundMode::CAST_NONE, reqLoRARank_);
-            AscendC::PipeBarrier<PIPE_V>();
-
-            for (int32_t i = reqLoRARank_; i < NUM_ELEMENTS_PER_REPEAT; i += reqLoRARank_) {
-                for (int32_t j = 0; j < reqLoRARank_; j++) {
-                    float entry = xDup.GetValue(j);
-                    xDup.SetValue(i + j, entry);
-                }
-            }
-        }
-        inQueueX_.FreeTensor(xLocal);
-    }
-
-    __aicore__ inline void CopyInY(int32_t progress, int32_t numElements = Y_OUT_TILE_NUM_ELEMENTS)
-    {
-        AscendC::LocalTensor<Y_T> yInLocal = inQueueY_.AllocTensor<Y_T>();
-        DataCopy(yInLocal, yInGm_[yOffset_ + progress * Y_OUT_TILE_NUM_ELEMENTS], numElements);
-        inQueueY_.EnQue(yInLocal);
-    }
-
-    __aicore__ inline void CopyInW(int32_t progress, int32_t numElements = W_IN_TILE_NUM_ELEMENTS)
-    {
-        AscendC::LocalTensor<W_T> wLocal = inQueueW_.AllocTensor<W_T>();
-        DataCopy(wLocal, wGm_[reqLoRAWeightOffset_ + progress * (W_IN_TILE_NUM_ELEMENTS / reqLoRARank_) * maxLoRARank_],
-                 {static_cast<uint16_t>(numElements / reqLoRARank_),
-                  static_cast<uint16_t>((reqLoRARank_ * sizeof(W_T) + DATA_VECTOR_BLOCK - 1) / DATA_VECTOR_BLOCK),
-                  static_cast<uint16_t>((maxLoRARank_ - reqLoRARank_) * sizeof(W_T) / DATA_VECTOR_BLOCK), 0});
-        inQueueW_.EnQue(wLocal);
-    }
-
-    __aicore__ inline void ScaleOutput(int32_t numElements = Y_OUT_TILE_NUM_ELEMENTS)
-    {
-        AscendC::LocalTensor<float> yLocal = tmpBufferY_.Get<float>();
-        AscendC::LocalTensor<Y_T> yInLocal = inQueueY_.DeQue<Y_T>();
-        AscendC::LocalTensor<float> yInLocalFP32 = inBufferY_.Get<float>();
-        Cast(yInLocalFP32, yInLocal, AscendC::RoundMode::CAST_NONE, numElements);
-        AscendC::PipeBarrier<PIPE_V>();
-        inQueueY_.FreeTensor(yInLocal);
-
-        Add(yLocal, yLocal, yInLocalFP32, numElements);
-        AscendC::PipeBarrier<PIPE_V>();
-
-        AscendC::LocalTensor<Y_T> yOutLocal = outQueueY_.AllocTensor<Y_T>();
-        Cast(yOutLocal, yLocal, AscendC::RoundMode::CAST_RINT, numElements);
-        AscendC::PipeBarrier<PIPE_V>();
-
-        outQueueY_.EnQue<Y_T>(yOutLocal);
-    }
-
-    __aicore__ inline void Compute(int32_t progress, int32_t blockReduceRepeatCount = BLOCK_REDUCE_NUM_REPEATS,
-                                   int32_t pairReduceRepeat16 = PAIR_REDUCE_NUM_REPEATS_16,
-                                   int32_t pairReduceRepeat32 = PAIR_REDUCE_NUM_REPEATS_32)
-    {
-        AscendC::LocalTensor<float> yLocal = tmpBufferY_.Get<float>();
-        AscendC::LocalTensor<float> xDup = dupBufferX_.Get<float>();
-        AscendC::LocalTensor<W_T> wLocal = inQueueW_.DeQue<W_T>();
-        AscendC::LocalTensor<float> wTmpTensor = tmpBufferW_.Get<float>();
-
-        Cast(wTmpTensor, wLocal, AscendC::RoundMode::CAST_NONE, MASK_COUNT, blockReduceRepeatCount, castParams_);
-        AscendC::PipeBarrier<PIPE_V>();
-        inQueueW_.FreeTensor(wLocal);
-
-        Mul(wTmpTensor, xDup, wTmpTensor, MASK_COUNT, blockReduceRepeatCount, dotProductParams_);
-        AscendC::PipeBarrier<PIPE_V>();
-
-        if (reqLoRARank_ == LORA_RANK_8) {
-            BlockReduceSum(yLocal[progress], wTmpTensor, blockReduceRepeatCount, MASK_COUNT,
-                           reduceSumParams_.dstRepStride, reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
-            AscendC::PipeBarrier<PIPE_V>();
-        } else if (reqLoRARank_ == LORA_RANK_16) {
-            BlockReduceSum(wTmpTensor, wTmpTensor, blockReduceRepeatCount, MASK_COUNT, reduceSumParams_.dstRepStride,
-                           reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
-            AscendC::PipeBarrier<PIPE_V>();
-            PairReduceSum(yLocal[progress], wTmpTensor, pairReduceRepeat16, MASK_COUNT, reduceSumParams_.dstRepStride,
-                          reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
-            AscendC::PipeBarrier<PIPE_V>();
-        } else if (reqLoRARank_ == LORA_RANK_32) {
-            BlockReduceSum(wTmpTensor, wTmpTensor, blockReduceRepeatCount, MASK_COUNT, reduceSumParams_.dstRepStride,
-                           reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
-            AscendC::PipeBarrier<PIPE_V>();
-            PairReduceSum(wTmpTensor, wTmpTensor, pairReduceRepeat16, MASK_COUNT, reduceSumParams_.dstRepStride,
-                          reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
-            AscendC::PipeBarrier<PIPE_V>();
-            PairReduceSum(yLocal[progress], wTmpTensor, pairReduceRepeat32, MASK_COUNT, reduceSumParams_.dstRepStride,
-                          reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
-            AscendC::PipeBarrier<PIPE_V>();
-        } else if (reqLoRARank_ == LORA_RANK_64) {
-            BlockReduceSum(wTmpTensor, wTmpTensor, blockReduceRepeatCount, MASK_COUNT, reduceSumParams_.dstRepStride,
-                           reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
-            AscendC::PipeBarrier<PIPE_V>();
-            BlockReduceSum(yLocal[progress], wTmpTensor, pairReduceRepeat16, MASK_COUNT, reduceSumParams_.dstRepStride,
-                           reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
-            AscendC::PipeBarrier<PIPE_V>();
-        }
-    }
-
-    __aicore__ inline void CopyOut(int32_t progress, int32_t numElements = Y_OUT_TILE_NUM_ELEMENTS)
+    __aicore__ inline void CopyOut(int32_t progress, int32_t numElements)
     {
         AscendC::LocalTensor<Y_T> yOutLocal = outQueueY_.DeQue<Y_T>();
-        DataCopy(yOutGm_[yOffset_ + progress * Y_OUT_TILE_NUM_ELEMENTS], yOutLocal, numElements);
+        const uint64_t offset = yOffset_ + static_cast<uint64_t>(progress) * Y_OUT_TILE_NUM_ELEMENTS;
+
+        if (numElements == Y_OUT_TILE_NUM_ELEMENTS) {
+            DataCopy(yOutGm_[offset], yOutLocal, numElements);
+
+        } else {
+            AscendC::DataCopyExtParams copyParams{1, static_cast<uint32_t>(numElements * sizeof(Y_T)), 0, 0, 0};
+
+            DataCopyPad(yOutGm_[offset], yOutLocal, copyParams);
+        }
+
         outQueueY_.FreeTensor(yOutLocal);
     }
 
 private:
     AscendC::TPipe *pipe_;
-    AscendC::TQue<AscendC::QuePosition::VECIN, BUFFER_NUM> inQueueY_, inQueueW_;
+    AscendC::TQue<AscendC::QuePosition::VECIN, BUFFER_NUM> inQueueY_;
+    AscendC::TQue<AscendC::QuePosition::VECIN, 8 * BUFFER_NUM> inQueueW_;
     AscendC::TQue<AscendC::QuePosition::VECIN, 1> inQueueX_;
     AscendC::TQue<AscendC::QuePosition::VECOUT, BUFFER_NUM> outQueueY_;
-    AscendC::TBuf<AscendC::QuePosition::VECCALC> tmpBufferW_, dupBufferX_, inBufferY_, tmpBufferY_;
+    AscendC::TBuf<AscendC::QuePosition::VECCALC> tmpBufferW_;
+    AscendC::TBuf<AscendC::QuePosition::VECCALC> dupBufferX_;
+    AscendC::TBuf<AscendC::QuePosition::VECCALC> inBufferY_;
+    AscendC::TBuf<AscendC::QuePosition::VECCALC> tmpBufferY_;
+
     AscendC::GlobalTensor<X_T> xGm_;
     AscendC::GlobalTensor<W_T> wGm_;
     AscendC::GlobalTensor<Y_T> yInGm_;
     AscendC::GlobalTensor<Y_T> yOutGm_;
+
     AscendC::GlobalTensor<int32_t> loraIndicesGm_;
     AscendC::GlobalTensor<int32_t> seqLenGm_;
     AscendC::GlobalTensor<int32_t> loraRanksGm_;
     AscendC::GlobalTensor<int32_t> sliceOffsetsGm_;
-    uint32_t batchSize_;
-    uint32_t sliceCount_;
-    uint32_t numTokensPerCore_;
-    uint32_t maxLoRARank_;
-    uint32_t outputHiddenDim_;
-    uint32_t sliceOffset_;
-    uint32_t outputFullDim_;
-    uint32_t singleLoRAWeightLen_;
-    int64_t reqLoRAIndex_;
-    int32_t reqLoRARank_;
-    uint64_t reqLoRAWeightOffset_;
-    int32_t reqSlice_;
-    uint32_t numOutputElementsPerInputTile_;
-    uint32_t numStreamInPerOutputTile_;
-    uint64_t yOffset_;
 
-    // The block stride is set to 1, and 8 blocks in the same repeat are processed continuously.
-    // The repeat stride is 8, so the vector unit reads 8 consecutive blocks in the first repeat,
-    // reads next 8 consecutive blocks in the second repeat.
+    uint32_t batchSize_ = 0;
+    uint32_t sliceCount_ = 0;
+    uint32_t numTokensPerCore_ = 0;
+    uint32_t maxLoRARank_ = 0;
+    uint32_t outputHiddenDim_ = 0;
+    uint32_t sliceOffset_ = 0;
+    uint32_t outputFullDim_ = 0;
+    uint64_t singleLoRAWeightLen_ = 0;
+    int64_t reqLoRAIndex_ = -1;
+    int32_t reqLoRARank_ = 0;
+    uint64_t reqLoRAWeightOffset_ = 0;
+    int32_t reqSlice_ = 0;
+    uint32_t numOutputElementsPerInputTile_ = 0;
+    uint32_t numStreamInPerOutputTile_ = 0;
+    uint64_t yOffset_ = 0;
+
     AscendC::UnaryRepeatParams castParams_ = {1, 1, 8, 4};
-
-    // For each repeat in BlockReduceSum and PairReduceSum we should move forward only one block,
-    // so we set dstRepStride = 1
-    AscendC::UnaryRepeatParams reduceSumParams_ = {1, 1, 1, 8};
-
-    // When the repeat stride is 0, the vector unit repeatedly reads and computes the first 8 consecutive blocks.
-    // For xDup we repeatedly use it, so we set src0RepStride = 0
     AscendC::BinaryRepeatParams dotProductParams_ = {1, 1, 1, 8, 0, 8};
 };
 
@@ -371,8 +453,8 @@ private:
         op.Process();                                                                                                  \
     }
 
-// declare all dtype kernel
 SGEMMV_EXPAND_TYPE_DECLARE(half)
+
 #if (__CCE_AICORE__ >= 220)
 SGEMMV_EXPAND_TYPE_DECLARE(bfloat16_t)
 #endif

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -203,6 +203,7 @@ private:
             pipe_barrier(PIPE_V);
         }
 
+        //TODO: can be vectorized
         for (int32_t i = maxLoRARank_; i < NUM_ELEMENTS_PER_REPEAT; i += maxLoRARank_) {
             for (int32_t j = 0; j < maxLoRARank_; j++) {
                 float entry = xDup.GetValue(j);
@@ -321,6 +322,7 @@ private:
 
         pipe_barrier(PIPE_V);
 
+        //TODO: can be vectorized
         for (int32_t row = 0; row < rows; ++row) {
             const int32_t base = row * rank;
             float sum = 0.0f;

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -277,7 +277,8 @@ private:
         pipe_barrier(PIPE_V);
     }
 
-    __aicore__ inline void Compute(int32_t progress, int32_t blockReduceRepeatCount = BLOCK_REDUCE_NUM_REPEATS, int32_t /*pairReduceRepeat16*/ = 0, int32_t /*pairReduceRepeat32*/ = 0)
+    __aicore__ inline void Compute(int32_t progress, int32_t blockReduceRepeatCount = BLOCK_REDUCE_NUM_REPEATS,
+                                   int32_t /*pairReduceRepeat16*/ = 0, int32_t /*pairReduceRepeat32*/ = 0)
     {
         if (blockReduceRepeatCount <= 0) {
             return;
@@ -287,13 +288,14 @@ private:
         AscendC::LocalTensor<float> xDup = dupBufferX_.Get<float>();
         AscendC::LocalTensor<W_T> wLocal = inQueueW_.DeQue<W_T>();
         AscendC::LocalTensor<float> wTmp = tmpBufferW_.Get<float>();
-        
+
         const int32_t rank = reqLoRARank_;
         const int32_t rows = (blockReduceRepeatCount * NUM_ELEMENTS_PER_REPEAT) / rank;
         const int32_t logicalElements = rows * rank;
 
         const uint32_t paddedRowBytes =
-            ((static_cast<uint32_t>(rank) * sizeof(W_T) + DATA_VECTOR_BLOCK - 1) / DATA_VECTOR_BLOCK) * DATA_VECTOR_BLOCK;
+            ((static_cast<uint32_t>(rank) * sizeof(W_T) + DATA_VECTOR_BLOCK - 1) / DATA_VECTOR_BLOCK) *
+            DATA_VECTOR_BLOCK;
         const int32_t paddedRowElements = static_cast<int32_t>(paddedRowBytes / sizeof(W_T));
 
         for (int32_t row = 0; row < rows; ++row) {

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -203,9 +203,10 @@ private:
             pipe_barrier(PIPE_V);
         }
 
-        for (int32_t i = reqLoRARank_; i < NUM_ELEMENTS_PER_REPEAT; i += reqLoRARank_) {
-            for (int32_t j = 0; j < reqLoRARank_; ++j) {
-                xDup.SetValue(i + j, xDup.GetValue(j));
+       for (int32_t i = maxLoRARank_; i < NUM_ELEMENTS_PER_REPEAT; i += maxLoRARank_) {
+            for (int32_t j = 0; j < maxLoRARank_; j++) {
+                float entry = xDup.GetValue(j);
+                xDup.SetValue(i + j, entry);
             }
         }
 

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -312,7 +312,6 @@ private:
     __aicore__ inline void CopyOut(int32_t progress, int32_t numElements = Y_OUT_TILE_NUM_ELEMENTS)
     {
         AscendC::LocalTensor<Y_T> yOutLocal = outQueueY_.DeQue<Y_T>();
-
         DataCopy(yOutGm_[yOffset_ + progress * Y_OUT_TILE_NUM_ELEMENTS], yOutLocal, numElements);
         outQueueY_.FreeTensor(yOutLocal);
     }

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -47,7 +47,7 @@ public:
     static constexpr int32_t MASK_COUNT = NUM_BYTES_PER_REPEAT / sizeof(float);
     // Refer to numOutputElementsPerInputTile_ initialization for the constraints on the following constants.
     static constexpr int32_t W_IN_TILE_NUM_ELEMENTS = 8192;
-    static constexpr int32_t Y_OUT_TILE_NUM_ELEMENTS = 2048;
+    static constexpr int32_t Y_OUT_TILE_NUM_ELEMENTS = 4096;
     static constexpr int32_t BLOCK_REDUCE_NUM_REPEATS = W_IN_TILE_NUM_ELEMENTS / NUM_ELEMENTS_PER_REPEAT;
     // BlockReduceSum would generate(BLOCK_REDUCE_NUM_REPEATS * NUM_BLOCKS_PER_REPEAT)floats.
     // So need to read them all and apply PairReduceSum

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -249,6 +249,7 @@ private:
         AscendC::LocalTensor<float> yLocal = tmpBufferY_.Get<float>();
         AscendC::LocalTensor<Y_T> yInLocal = inQueueY_.DeQue<Y_T>();
         AscendC::LocalTensor<float> yInLocalFP32 = inBufferY_.Get<float>();
+
         Cast(yInLocalFP32, yInLocal, AscendC::RoundMode::CAST_NONE, numElements);
         AscendC::PipeBarrier<PIPE_V>();
         inQueueY_.FreeTensor(yInLocal);

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -252,6 +252,7 @@ private:
         Cast(yInLocalFP32, yInLocal, AscendC::RoundMode::CAST_NONE, numElements);
         AscendC::PipeBarrier<PIPE_V>();
         inQueueY_.FreeTensor(yInLocal);
+
         Add(yLocal, yLocal, yInLocalFP32, numElements);
         AscendC::PipeBarrier<PIPE_V>();
 

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) Huawei Technologies Co., Ltd. 2024. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,31 +30,31 @@ public:
     using W_T = scalar_t;
     using Y_T = scalar_t;
 
-    static constexpr int32_t LORA_RANK_8 = 8;
-    static constexpr int32_t LORA_RANK_16 = 16;
-    static constexpr int32_t LORA_RANK_32 = 32;
-    static constexpr int32_t LORA_RANK_64 = 64;
-
+    static constexpr uint64_t LORA_RANK_8 = 8;
+    static constexpr uint64_t LORA_RANK_16 = 16;
+    static constexpr uint64_t LORA_RANK_32 = 32;
+    static constexpr uint64_t LORA_RANK_64 = 64;
+    static constexpr uint64_t SUPPORTED_RANKS[] = {LORA_RANK_8, LORA_RANK_16, LORA_RANK_32, LORA_RANK_64};
     static constexpr int32_t BUFFER_NUM = 2;
-
     static constexpr int32_t DATA_VECTOR_BLOCK = 32;
+
+    // The vector unit reads 8 blocks (32 bytes each and 256 bytes in total) of contiguous data each time.
     static constexpr int32_t NUM_BYTES_PER_REPEAT = 256;
     static constexpr int32_t NUM_BLOCKS_PER_REPEAT = 8;
-
+    // The maximum number of elements in a single iteration is 256 / sizeof(intermediate data type).
     static constexpr int32_t NUM_ELEMENTS_PER_REPEAT = NUM_BYTES_PER_REPEAT / sizeof(float);
-
+    // Mask is used to control the elements that participate in computation in each iteration.
     static constexpr int32_t MASK_COUNT = NUM_BYTES_PER_REPEAT / sizeof(float);
-    static constexpr int32_t W_IN_TILE_NUM_ELEMENTS = 4096;
-
-    static constexpr int32_t W_IN_TILE_STORAGE_ELEMENTS = 8192;
-
-    static constexpr int32_t Y_OUT_TILE_NUM_ELEMENTS = 512;
-
+    // Refer to numOutputElementsPerInputTile_ initialization for the constraints on the following constants.
+    static constexpr int32_t W_IN_TILE_NUM_ELEMENTS = 8192;
+    static constexpr int32_t Y_OUT_TILE_NUM_ELEMENTS = 2048;
     static constexpr int32_t BLOCK_REDUCE_NUM_REPEATS = W_IN_TILE_NUM_ELEMENTS / NUM_ELEMENTS_PER_REPEAT;
-
+    // BlockReduceSum would generate(BLOCK_REDUCE_NUM_REPEATS * NUM_BLOCKS_PER_REPEAT)floats.
+    // So need to read them all and apply PairReduceSum
     static constexpr int32_t PAIR_REDUCE_NUM_REPEATS_16 =
         (BLOCK_REDUCE_NUM_REPEATS * NUM_BLOCKS_PER_REPEAT + NUM_ELEMENTS_PER_REPEAT - 1) / NUM_ELEMENTS_PER_REPEAT;
-
+    // The second PairReduceSum for rank=32, needs half of the repetition that happened for rank=16.
+    // Same for rank=64, we do not support ranks greater than 64.
     static constexpr int32_t PAIR_REDUCE_NUM_REPEATS_32 = (PAIR_REDUCE_NUM_REPEATS_16 + 1) / 2;
 
 public:
@@ -69,15 +69,9 @@ public:
         batchSize_ = batchSize;
         numTokensPerCore_ = numTokensPerCore;
         maxLoRARank_ = maxLoRARank;
+        sliceCount_ = sliceOffsetsSize - 1;
         outputFullDim_ = outputFullDim;
-
-        if (sliceOffsetsSize >= 2) {
-            sliceCount_ = sliceOffsetsSize - 1;
-        } else {
-            sliceCount_ = 0;
-        }
-
-        singleLoRAWeightLen_ = static_cast<uint64_t>(maxLoRARank_) * static_cast<uint64_t>(outputFullDim_);
+        singleLoRAWeightLen_ = maxLoRARank_ * outputFullDim_;
 
         xGm_.SetGlobalBuffer(reinterpret_cast<__gm__ X_T *>(x));
         wGm_.SetGlobalBuffer(reinterpret_cast<__gm__ W_T *>(weight));
@@ -89,10 +83,11 @@ public:
         sliceOffsetsGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(sliceOffsets), sliceOffsetsSize);
 
         pipe_->InitBuffer(inQueueX_, 1, NUM_ELEMENTS_PER_REPEAT * sizeof(float));
-        pipe_->InitBuffer(inQueueW_, BUFFER_NUM, W_IN_TILE_STORAGE_ELEMENTS * sizeof(W_T));
-        pipe_->InitBuffer(inQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(Y_T));
-        pipe_->InitBuffer(outQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(Y_T));
-        pipe_->InitBuffer(dupBufferX_, W_IN_TILE_NUM_ELEMENTS * sizeof(float));
+        pipe_->InitBuffer(inQueueW_, BUFFER_NUM, W_IN_TILE_NUM_ELEMENTS * sizeof(float));
+        pipe_->InitBuffer(inQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(float));
+        pipe_->InitBuffer(outQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(float));
+
+        pipe_->InitBuffer(dupBufferX_, NUM_ELEMENTS_PER_REPEAT * sizeof(float));
         pipe_->InitBuffer(tmpBufferW_, W_IN_TILE_NUM_ELEMENTS * sizeof(float));
         pipe_->InitBuffer(inBufferY_, Y_OUT_TILE_NUM_ELEMENTS * sizeof(float));
         pipe_->InitBuffer(tmpBufferY_, Y_OUT_TILE_NUM_ELEMENTS * sizeof(float));
@@ -100,117 +95,132 @@ public:
 
     __aicore__ inline void Process()
     {
-        if (sliceCount_ == 0) {
-            return;
+        int64_t blockIdx_Slice = AscendC::GetBlockIdx();
+        int64_t blockIdx = blockIdx_Slice / sliceCount_;
+        int64_t startIdx = blockIdx * numTokensPerCore_;
+        int64_t endIdx = startIdx + numTokensPerCore_;
+        reqSlice_ = blockIdx_Slice % sliceCount_;
+
+        sliceOffset_ = sliceOffsetsGm_.GetValue(reqSlice_);
+        outputHiddenDim_ = sliceOffsetsGm_.GetValue(reqSlice_ + 1) - sliceOffset_;
+
+        if (endIdx > batchSize_) {
+            endIdx = batchSize_;
         }
 
-        const int64_t blockIdxSlice = static_cast<int64_t>(AscendC::GetBlockIdx());
-        const int64_t blockIdx = blockIdxSlice / static_cast<int64_t>(sliceCount_);
-        const int64_t startIdx = blockIdx * static_cast<int64_t>(numTokensPerCore_);
-        int64_t endIdx = startIdx + static_cast<int64_t>(numTokensPerCore_);
-        if (endIdx > static_cast<int64_t>(batchSize_)) {
-            endIdx = static_cast<int64_t>(batchSize_);
-        }
-
-        reqSlice_ = static_cast<int32_t>(blockIdxSlice % static_cast<int64_t>(sliceCount_));
-
-        sliceOffset_ = static_cast<uint32_t>(sliceOffsetsGm_.GetValue(reqSlice_));
-        outputHiddenDim_ = static_cast<uint32_t>(sliceOffsetsGm_.GetValue(reqSlice_ + 1)) - sliceOffset_;
-
+        int64_t requestBlock = 0;
         lora_common::BlockIterator blockIterator(seqLenGm_);
-        for (int64_t idx = startIdx; idx < endIdx; ++idx) {
-            yOffset_ = static_cast<uint64_t>(outputFullDim_) * static_cast<uint64_t>(idx) +
-                       static_cast<uint64_t>(sliceOffset_);
+        for (int64_t idx = startIdx; idx < endIdx; idx++) {
+            yOffset_ = outputFullDim_ * idx + sliceOffset_;
 
-            const int64_t requestBlock = blockIterator.GetBlockIdx(idx);
-
+            requestBlock = blockIterator.GetBlockIdx(idx);
             if (requestBlock < 0) {
                 continue;
             }
 
+            // Set up LoRA index
             reqLoRAIndex_ = loraIndicesGm_.GetValue(requestBlock);
-
             if (reqLoRAIndex_ < 0) {
                 continue;
             }
 
             reqLoRARank_ = loraRanksGm_.GetValue(reqLoRAIndex_);
-
-            if (!IsSupportedRank(reqLoRARank_)) {
+            if (reqLoRARank_ == 0) {
                 continue;
             }
-            reqLoRAWeightOffset_ = static_cast<uint64_t>(reqLoRAIndex_) * singleLoRAWeightLen_ +
-                                   static_cast<uint64_t>(sliceOffset_) * static_cast<uint64_t>(maxLoRARank_);
+
+            reqLoRAWeightOffset_ = reqLoRAIndex_ * singleLoRAWeightLen_ + sliceOffset_ * maxLoRARank_;
+
+            // Each compute iteration would generate not one, but several output elements.
+            // Therefore, the following variable would determine how many output elements are calculated in each
+            // iteration.
             numOutputElementsPerInputTile_ = BLOCK_REDUCE_NUM_REPEATS * (NUM_ELEMENTS_PER_REPEAT / reqLoRARank_);
-            numStreamInPerOutputTile_ =
-                (Y_OUT_TILE_NUM_ELEMENTS + numOutputElementsPerInputTile_ - 1) / numOutputElementsPerInputTile_;
+            numStreamInPerOutputTile_ = Y_OUT_TILE_NUM_ELEMENTS / numOutputElementsPerInputTile_;
 
             CopyInX(idx);
-            const int32_t numFullYTiles = outputHiddenDim_ / Y_OUT_TILE_NUM_ELEMENTS;
-            for (int32_t i = 0; i < numFullYTiles; ++i) {
-                CopyInY(i, Y_OUT_TILE_NUM_ELEMENTS);
-                ClearAccumulator();
-                for (int32_t j = 0; j < numStreamInPerOutputTile_; ++j) {
-                    CopyInW(i * numStreamInPerOutputTile_ + j, W_IN_TILE_NUM_ELEMENTS);
+            int32_t numStreamOut = outputHiddenDim_ / Y_OUT_TILE_NUM_ELEMENTS;
+            for (int32_t i = 0; i < numStreamOut; i++) {
+                CopyInY(i);
+                for (int32_t j = 0; j < numStreamInPerOutputTile_; j++) {
+                    CopyInW(i * numStreamInPerOutputTile_ + j);
                     Compute(j * numOutputElementsPerInputTile_);
                 }
-                ScaleOutput(Y_OUT_TILE_NUM_ELEMENTS);
-                CopyOut(i, Y_OUT_TILE_NUM_ELEMENTS);
+                ScaleOutput();
+                CopyOut(i);
             }
-
             ComputeLastIteration();
         }
     }
 
 private:
-    __aicore__ inline bool IsSupportedRank(int32_t rank)
+    __aicore__ inline void ComputeLastIteration()
     {
-        return rank == LORA_RANK_8 || rank == LORA_RANK_16 || rank == LORA_RANK_32 || rank == LORA_RANK_64;
-    }
+        int32_t remainingY = outputHiddenDim_ % Y_OUT_TILE_NUM_ELEMENTS;
+        if (remainingY == 0) {
+            return;
+        }
+        int32_t numStreamOut = outputHiddenDim_ / Y_OUT_TILE_NUM_ELEMENTS;
+        int32_t remainingW = remainingY * reqLoRARank_;
+        int32_t numCompleteWTileInForLastIteration = remainingW / W_IN_TILE_NUM_ELEMENTS;
+        int32_t remainingWForLastRepeat = remainingW % W_IN_TILE_NUM_ELEMENTS;
 
-    __aicore__ inline void CopyInX(int64_t idx)
-    {
-        AscendC::LocalTensor<X_T> xLocal = inQueueX_.AllocTensor<X_T>();
+        CopyInY(numStreamOut, remainingY);
 
-        const uint64_t xOffset =
-            static_cast<uint64_t>(sliceCount_) * static_cast<uint64_t>(maxLoRARank_) * static_cast<uint64_t>(idx) +
-            static_cast<uint64_t>(reqSlice_) * static_cast<uint64_t>(maxLoRARank_);
-
-        if constexpr (std::is_same_v<X_T, float>) {
-            DataCopy(xLocal, xGm_[xOffset], reqLoRARank_);
-
-        } else {
-            AscendC::DataCopyExtParams copyParams{1, static_cast<uint32_t>(reqLoRARank_ * sizeof(X_T)), 0, 0, 0};
-            const uint32_t paddedElements = ((reqLoRARank_ * sizeof(X_T) + DATA_VECTOR_BLOCK - 1) / DATA_VECTOR_BLOCK) *
-                                            DATA_VECTOR_BLOCK / sizeof(X_T);
-            const uint32_t rightPadding = paddedElements - reqLoRARank_;
-            AscendC::DataCopyPadExtParams<X_T> padParams{true, 0, static_cast<uint8_t>(rightPadding),
-                                                         static_cast<X_T>(0)};
-            DataCopyPad(xLocal, xGm_[xOffset], copyParams, padParams);
+        int32_t outputIdx = 0;
+        for (outputIdx = 0; outputIdx < numCompleteWTileInForLastIteration; outputIdx++) {
+            CopyInW(numStreamOut * numStreamInPerOutputTile_ + outputIdx);
+            Compute(outputIdx * numOutputElementsPerInputTile_);
         }
 
+        if (remainingWForLastRepeat != 0) {
+            CopyInW(numStreamOut * numStreamInPerOutputTile_ + numCompleteWTileInForLastIteration,
+                    remainingWForLastRepeat);
+            int32_t lastRepeatCount = remainingWForLastRepeat / NUM_ELEMENTS_PER_REPEAT;
+            int32_t pairReduceRepeat16 =
+                (lastRepeatCount * NUM_BLOCKS_PER_REPEAT + NUM_ELEMENTS_PER_REPEAT - 1) / NUM_ELEMENTS_PER_REPEAT;
+            int32_t pairReduceRepeat32 = (pairReduceRepeat16 + 1) / 2;
+            int32_t lastComputeOutputElement = outputIdx * numOutputElementsPerInputTile_;
+            Compute(lastComputeOutputElement, lastRepeatCount, pairReduceRepeat16, pairReduceRepeat32);
+        }
+
+        ScaleOutput(remainingY);
+        CopyOut(numStreamOut, remainingY);
+    }
+
+    __aicore__ inline void CopyInX(const int64_t idx)
+    {
+        AscendC::LocalTensor<X_T> xLocal = inQueueX_.AllocTensor<X_T>();
+        if constexpr (std::is_same_v<X_T, float>) {
+            DataCopy(xLocal, xGm_[sliceCount_ * maxLoRARank_ * idx + reqLoRARank_ * reqSlice_], reqLoRARank_);
+        } else {
+            uint16_t blockLen = static_cast<uint16_t>(reqLoRARank_ * sizeof(X_T));
+            DataCopyPad(xLocal, xGm_[sliceCount_ * maxLoRARank_ * idx + reqLoRARank_ * reqSlice_], {1, blockLen, 0, 0},
+                        {});
+        }
         inQueueX_.EnQue(xLocal);
         xLocal = inQueueX_.DeQue<X_T>();
         AscendC::LocalTensor<float> xDup = dupBufferX_.Get<float>();
 
+        // As we are generating multiple output elements with one API invocation,
+        // we need to duplicate the X vector multiple times to fill one NUM_BYTES_PER_REPEAT
         if constexpr (std::is_same_v<X_T, float>) {
-            for (int32_t j = 0; j < reqLoRARank_; ++j) {
-                xDup.SetValue(j, xLocal.GetValue(j));
+            for (int32_t i = 0; i < NUM_ELEMENTS_PER_REPEAT; i += reqLoRARank_) {
+                for (int32_t j = 0; j < reqLoRARank_; j++) {
+                    float entry = xLocal.GetValue(j);
+                    xDup.SetValue(i + j, entry);
+                }
             }
-
         } else {
             Cast(xDup, xLocal, AscendC::RoundMode::CAST_NONE, reqLoRARank_);
-            pipe_barrier(PIPE_V);
-        }
+            AscendC::PipeBarrier<PIPE_V>();
 
-        // TODO: can be vectorized
-        for (int32_t i = maxLoRARank_; i < NUM_ELEMENTS_PER_REPEAT; i += maxLoRARank_) {
-            for (int32_t j = 0; j < maxLoRARank_; j++) {
-                float entry = xDup.GetValue(j);
-                xDup.SetValue(i + j, entry);
+            for (int32_t i = reqLoRARank_; i < NUM_ELEMENTS_PER_REPEAT; i += reqLoRARank_) {
+                for (int32_t j = 0; j < reqLoRARank_; j++) {
+                    float entry = xDup.GetValue(j);
+                    xDup.SetValue(i + j, entry);
+                }
             }
         }
-
         inQueueX_.FreeTensor(xLocal);
     }
 
@@ -231,176 +241,121 @@ private:
         inQueueW_.EnQue(wLocal);
     }
 
-    __aicore__ inline void ClearAccumulator()
-    {
-        AscendC::LocalTensor<float> yLocal = tmpBufferY_.Get<float>();
-        Duplicate(yLocal, 0.0f, Y_OUT_TILE_NUM_ELEMENTS);
-        pipe_barrier(PIPE_V);
-    }
-
-    __aicore__ inline void Compute(int32_t progress, int32_t blockReduceRepeatCount = BLOCK_REDUCE_NUM_REPEATS,
-                                   int32_t /*pairReduceRepeat16*/ = 0, int32_t /*pairReduceRepeat32*/ = 0)
-    {
-        if (blockReduceRepeatCount <= 0) {
-            return;
-        }
-
-        AscendC::LocalTensor<float> yLocal = tmpBufferY_.Get<float>();
-        AscendC::LocalTensor<float> xDup = dupBufferX_.Get<float>();
-        AscendC::LocalTensor<W_T> wLocal = inQueueW_.DeQue<W_T>();
-        AscendC::LocalTensor<float> wTmp = tmpBufferW_.Get<float>();
-
-        const int32_t rank = reqLoRARank_;
-        const int32_t rows = (blockReduceRepeatCount * NUM_ELEMENTS_PER_REPEAT) / rank;
-        const int32_t logicalElements = rows * rank;
-
-        const uint32_t paddedRowBytes =
-            ((static_cast<uint32_t>(rank) * sizeof(W_T) + DATA_VECTOR_BLOCK - 1) / DATA_VECTOR_BLOCK) *
-            DATA_VECTOR_BLOCK;
-        const int32_t paddedRowElements = static_cast<int32_t>(paddedRowBytes / sizeof(W_T));
-
-        for (int32_t row = 0; row < rows; ++row) {
-            AscendC::LocalTensor<W_T> src = wLocal[row * paddedRowElements];
-
-            AscendC::LocalTensor<float> dst = wTmp[row * rank];
-
-            Cast(dst, src, AscendC::RoundMode::CAST_NONE, rank);
-        }
-
-        if (logicalElements < W_IN_TILE_NUM_ELEMENTS) {
-            Duplicate(wTmp[logicalElements], 0.0f, W_IN_TILE_NUM_ELEMENTS - logicalElements);
-
-            pipe_barrier(PIPE_V);
-        }
-
-        pipe_barrier(PIPE_V);
-
-        inQueueW_.FreeTensor(wLocal);
-
-        Mul(wTmp, wTmp, xDup, MASK_COUNT, blockReduceRepeatCount, dotProductParams_);
-
-        pipe_barrier(PIPE_V);
-
-        // TODO: can be vectorized
-        for (int32_t row = 0; row < rows; ++row) {
-            const int32_t base = row * rank;
-            float sum = 0.0f;
-
-            for (int32_t k = 0; k < rank; ++k) {
-                sum += wTmp.GetValue(base + k);
-            }
-
-            yLocal.SetValue(progress + row, sum);
-        }
-
-        pipe_barrier(PIPE_V);
-    }
-
-    __aicore__ inline void ScaleOutput(int32_t numElements)
+    __aicore__ inline void ScaleOutput(int32_t numElements = Y_OUT_TILE_NUM_ELEMENTS)
     {
         AscendC::LocalTensor<float> yLocal = tmpBufferY_.Get<float>();
         AscendC::LocalTensor<Y_T> yInLocal = inQueueY_.DeQue<Y_T>();
         AscendC::LocalTensor<float> yInLocalFP32 = inBufferY_.Get<float>();
         Cast(yInLocalFP32, yInLocal, AscendC::RoundMode::CAST_NONE, numElements);
-        pipe_barrier(PIPE_V);
+        AscendC::PipeBarrier<PIPE_V>();
         inQueueY_.FreeTensor(yInLocal);
         Add(yLocal, yLocal, yInLocalFP32, numElements);
-        pipe_barrier(PIPE_V);
+        AscendC::PipeBarrier<PIPE_V>();
+
         AscendC::LocalTensor<Y_T> yOutLocal = outQueueY_.AllocTensor<Y_T>();
-        Cast(yOutLocal, yLocal, AscendC::RoundMode::CAST_RINT, numElements);
-        pipe_barrier(PIPE_V);
-        outQueueY_.EnQue(yOutLocal);
+        Cast(yOutLocal, yLocal, AscendC::RoundMode::CAST_NONE, numElements);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        outQueueY_.EnQue<Y_T>(yOutLocal);
     }
 
-    __aicore__ inline void ComputeLastIteration()
+    __aicore__ inline void Compute(int32_t progress, int32_t blockReduceRepeatCount = BLOCK_REDUCE_NUM_REPEATS,
+                                   int32_t pairReduceRepeat16 = PAIR_REDUCE_NUM_REPEATS_16,
+                                   int32_t pairReduceRepeat32 = PAIR_REDUCE_NUM_REPEATS_32)
     {
-        const int32_t remainingY = outputHiddenDim_ % Y_OUT_TILE_NUM_ELEMENTS;
-        if (remainingY == 0) {
-            return;
-        }
+        AscendC::LocalTensor<float> yLocal = tmpBufferY_.Get<float>();
+        AscendC::LocalTensor<float> xDup = dupBufferX_.Get<float>();
+        AscendC::LocalTensor<W_T> wLocal = inQueueW_.DeQue<W_T>();
+        AscendC::LocalTensor<float> wTmpTensor = tmpBufferW_.Get<float>();
 
-        const int32_t numStreamOut = outputHiddenDim_ / Y_OUT_TILE_NUM_ELEMENTS;
-        const int32_t remainingW = remainingY * reqLoRARank_;
-        const int32_t fullWTiles = remainingW / W_IN_TILE_NUM_ELEMENTS;
-        const int32_t remainingWElements = remainingW % W_IN_TILE_NUM_ELEMENTS;
-        CopyInY(numStreamOut, remainingY);
-        ClearAccumulator();
-        for (int32_t i = 0; i < fullWTiles; ++i) {
-            CopyInW(numStreamOut * numStreamInPerOutputTile_ + i, W_IN_TILE_NUM_ELEMENTS);
-            Compute(i * numOutputElementsPerInputTile_);
-        }
+        Cast(wTmpTensor, wLocal, AscendC::RoundMode::CAST_NONE, MASK_COUNT, blockReduceRepeatCount, castParams_);
+        AscendC::PipeBarrier<PIPE_V>();
+        inQueueW_.FreeTensor(wLocal);
 
-        if (remainingWElements > 0) {
-            const int32_t progress = numStreamOut * numStreamInPerOutputTile_ + fullWTiles;
-            CopyInW(progress, remainingWElements);
-            const int32_t lastRepeatCount =
-                (remainingWElements + NUM_ELEMENTS_PER_REPEAT - 1) / NUM_ELEMENTS_PER_REPEAT;
-            const int32_t pairReduceRepeat16 =
-                (lastRepeatCount * NUM_BLOCKS_PER_REPEAT + NUM_ELEMENTS_PER_REPEAT - 1) / NUM_ELEMENTS_PER_REPEAT;
-            const int32_t pairReduceRepeat32 = (pairReduceRepeat16 + 1) / 2;
-            const int32_t outputProgress = fullWTiles * numOutputElementsPerInputTile_;
-            Compute(outputProgress, lastRepeatCount, pairReduceRepeat16, pairReduceRepeat32);
+        
+        Mul(wTmpTensor, xDup, wTmpTensor, MASK_COUNT, blockReduceRepeatCount, dotProductParams_);
+        AscendC::PipeBarrier<PIPE_V>();
+        
+        if (reqLoRARank_ == LORA_RANK_8) {
+            BlockReduceSum(yLocal[progress], wTmpTensor, blockReduceRepeatCount, MASK_COUNT,
+                           reduceSumParams_.dstRepStride, reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
+            AscendC::PipeBarrier<PIPE_V>();
+        } else if (reqLoRARank_ == LORA_RANK_16) {
+            BlockReduceSum(wTmpTensor, wTmpTensor, blockReduceRepeatCount, MASK_COUNT, reduceSumParams_.dstRepStride,
+                           reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
+            AscendC::PipeBarrier<PIPE_V>();
+            PairReduceSum(yLocal[progress], wTmpTensor, pairReduceRepeat16, MASK_COUNT, reduceSumParams_.dstRepStride,
+                          reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
+            AscendC::PipeBarrier<PIPE_V>();
+        } else if (reqLoRARank_ == LORA_RANK_32) {
+            BlockReduceSum(wTmpTensor, wTmpTensor, blockReduceRepeatCount, MASK_COUNT, reduceSumParams_.dstRepStride,
+                           reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
+            AscendC::PipeBarrier<PIPE_V>();
+            PairReduceSum(wTmpTensor, wTmpTensor, pairReduceRepeat16, MASK_COUNT, reduceSumParams_.dstRepStride,
+                          reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
+            AscendC::PipeBarrier<PIPE_V>();
+            PairReduceSum(yLocal[progress], wTmpTensor, pairReduceRepeat32, MASK_COUNT, reduceSumParams_.dstRepStride,
+                          reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
+            AscendC::PipeBarrier<PIPE_V>();
+        } else if (reqLoRARank_ == LORA_RANK_64) {
+            BlockReduceSum(wTmpTensor, wTmpTensor, blockReduceRepeatCount, MASK_COUNT, reduceSumParams_.dstRepStride,
+                           reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
+            AscendC::PipeBarrier<PIPE_V>();
+            BlockReduceSum(yLocal[progress], wTmpTensor, pairReduceRepeat16, MASK_COUNT, reduceSumParams_.dstRepStride,
+                           reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
+            AscendC::PipeBarrier<PIPE_V>();
         }
-
-        ScaleOutput(remainingY);
-        CopyOut(numStreamOut, remainingY);
     }
 
-    __aicore__ inline void CopyOut(int32_t progress, int32_t numElements)
+    __aicore__ inline void CopyOut(int32_t progress, int32_t numElements = Y_OUT_TILE_NUM_ELEMENTS)
     {
         AscendC::LocalTensor<Y_T> yOutLocal = outQueueY_.DeQue<Y_T>();
-        const uint64_t offset = yOffset_ + static_cast<uint64_t>(progress) * Y_OUT_TILE_NUM_ELEMENTS;
 
-        if (numElements == Y_OUT_TILE_NUM_ELEMENTS) {
-            DataCopy(yOutGm_[offset], yOutLocal, numElements);
-
-        } else {
-            AscendC::DataCopyExtParams copyParams{1, static_cast<uint32_t>(numElements * sizeof(Y_T)), 0, 0, 0};
-
-            DataCopyPad(yOutGm_[offset], yOutLocal, copyParams);
-        }
-
+        DataCopy(yOutGm_[yOffset_ + progress * Y_OUT_TILE_NUM_ELEMENTS], yOutLocal, numElements);
         outQueueY_.FreeTensor(yOutLocal);
     }
 
 private:
     AscendC::TPipe *pipe_;
-    AscendC::TQue<AscendC::QuePosition::VECIN, BUFFER_NUM> inQueueY_;
-    AscendC::TQue<AscendC::QuePosition::VECIN, 8 * BUFFER_NUM> inQueueW_;
+    AscendC::TQue<AscendC::QuePosition::VECIN, BUFFER_NUM> inQueueY_, inQueueW_;
     AscendC::TQue<AscendC::QuePosition::VECIN, 1> inQueueX_;
     AscendC::TQue<AscendC::QuePosition::VECOUT, BUFFER_NUM> outQueueY_;
-    AscendC::TBuf<AscendC::QuePosition::VECCALC> tmpBufferW_;
-    AscendC::TBuf<AscendC::QuePosition::VECCALC> dupBufferX_;
-    AscendC::TBuf<AscendC::QuePosition::VECCALC> inBufferY_;
-    AscendC::TBuf<AscendC::QuePosition::VECCALC> tmpBufferY_;
-
+    AscendC::TBuf<AscendC::QuePosition::VECCALC> tmpBufferW_, dupBufferX_, inBufferY_, tmpBufferY_;
     AscendC::GlobalTensor<X_T> xGm_;
     AscendC::GlobalTensor<W_T> wGm_;
     AscendC::GlobalTensor<Y_T> yInGm_;
     AscendC::GlobalTensor<Y_T> yOutGm_;
-
     AscendC::GlobalTensor<int32_t> loraIndicesGm_;
     AscendC::GlobalTensor<int32_t> seqLenGm_;
     AscendC::GlobalTensor<int32_t> loraRanksGm_;
     AscendC::GlobalTensor<int32_t> sliceOffsetsGm_;
+    uint32_t batchSize_;
+    uint32_t sliceCount_;
+    uint32_t numTokensPerCore_;
+    uint32_t maxLoRARank_;
+    uint32_t outputHiddenDim_;
+    uint32_t sliceOffset_;
+    uint32_t outputFullDim_;
+    uint32_t singleLoRAWeightLen_;
+    int64_t reqLoRAIndex_;
+    int32_t reqLoRARank_;
+    uint64_t reqLoRAWeightOffset_;
+    int32_t reqSlice_;
+    uint32_t numOutputElementsPerInputTile_;
+    uint32_t numStreamInPerOutputTile_;
+    uint64_t yOffset_;
 
-    uint32_t batchSize_ = 0;
-    uint32_t sliceCount_ = 0;
-    uint32_t numTokensPerCore_ = 0;
-    uint32_t maxLoRARank_ = 0;
-    uint32_t outputHiddenDim_ = 0;
-    uint32_t sliceOffset_ = 0;
-    uint32_t outputFullDim_ = 0;
-    uint64_t singleLoRAWeightLen_ = 0;
-    int64_t reqLoRAIndex_ = -1;
-    int32_t reqLoRARank_ = 0;
-    uint64_t reqLoRAWeightOffset_ = 0;
-    int32_t reqSlice_ = 0;
-    uint32_t numOutputElementsPerInputTile_ = 0;
-    uint32_t numStreamInPerOutputTile_ = 0;
-    uint64_t yOffset_ = 0;
-
+    // The block stride is set to 1, and 8 blocks in the same repeat are processed continuously.
+    // The repeat stride is 8, so the vector unit reads 8 consecutive blocks in the first repeat,
+    // reads next 8 consecutive blocks in the second repeat.
     AscendC::UnaryRepeatParams castParams_ = {1, 1, 8, 4};
+
+    // For each repeat in BlockReduceSum and PairReduceSum we should move forward only one block,
+    // so we set dstRepStride = 1
+    AscendC::UnaryRepeatParams reduceSumParams_ = {1, 1, 1, 8};
+
+    // When the repeat stride is 0, the vector unit repeatedly reads and computes the first 8 consecutive blocks.
+    // For xDup we repeatedly use it, so we set src0RepStride = 0
     AscendC::BinaryRepeatParams dotProductParams_ = {1, 1, 1, 8, 0, 8};
 };
 
@@ -417,8 +372,8 @@ private:
         op.Process();                                                                                                  \
     }
 
+// declare all dtype kernel
 SGEMMV_EXPAND_TYPE_DECLARE(half)
-
 #if (__CCE_AICORE__ >= 220)
 SGEMMV_EXPAND_TYPE_DECLARE(bfloat16_t)
 #endif

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -84,8 +84,8 @@ public:
 
         pipe_->InitBuffer(inQueueX_, 1, NUM_ELEMENTS_PER_REPEAT * sizeof(float));
         pipe_->InitBuffer(inQueueW_, BUFFER_NUM, W_IN_TILE_NUM_ELEMENTS * sizeof(float));
-        pipe_->InitBuffer(inQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(float));
-        pipe_->InitBuffer(outQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(float));
+        pipe_->InitBuffer(inQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(Y_T));
+        pipe_->InitBuffer(outQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(Y_T));
 
         pipe_->InitBuffer(dupBufferX_, NUM_ELEMENTS_PER_REPEAT * sizeof(float));
         pipe_->InitBuffer(tmpBufferW_, W_IN_TILE_NUM_ELEMENTS * sizeof(float));

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -83,7 +83,10 @@ public:
         sliceOffsetsGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(sliceOffsets), sliceOffsetsSize);
 
         pipe_->InitBuffer(inQueueX_, 1, NUM_ELEMENTS_PER_REPEAT * sizeof(X_T));
-        pipe_->InitBuffer(inQueueW_, BUFFER_NUM, W_IN_TILE_NUM_ELEMENTS * 2 * sizeof(W_T)); // because block size is 32, type of W_T is float16 = 16 => we need x2 memory in buffer
+        pipe_->InitBuffer(
+            inQueueW_, BUFFER_NUM,
+            W_IN_TILE_NUM_ELEMENTS * 2 *
+                sizeof(W_T));  // because block size is 32, type of W_T is float16 = 16 => we need x2 memory in buffer
         pipe_->InitBuffer(inQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(Y_T));
         pipe_->InitBuffer(outQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(Y_T));
 

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) Huawei Technologies Co., Ltd. 2024. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -83,7 +83,7 @@ public:
         sliceOffsetsGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(sliceOffsets), sliceOffsetsSize);
 
         pipe_->InitBuffer(inQueueX_, 1, NUM_ELEMENTS_PER_REPEAT * sizeof(float));
-        pipe_->InitBuffer(inQueueW_, BUFFER_NUM, W_IN_TILE_NUM_ELEMENTS * sizeof(float));
+        pipe_->InitBuffer(inQueueW_, BUFFER_NUM, W_IN_TILE_NUM_ELEMENTS * 2 * sizeof(W_T)); // because block size is 32, type of W_T is float16 = 16 => we need x2 memory in buffer
         pipe_->InitBuffer(inQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(Y_T));
         pipe_->InitBuffer(outQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(Y_T));
 

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -1,4 +1,4 @@
-/*
+/* 
  * Copyright (c) Huawei Technologies Co., Ltd. 2024. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -272,10 +272,9 @@ private:
         AscendC::PipeBarrier<PIPE_V>();
         inQueueW_.FreeTensor(wLocal);
 
-        
         Mul(wTmpTensor, xDup, wTmpTensor, MASK_COUNT, blockReduceRepeatCount, dotProductParams_);
         AscendC::PipeBarrier<PIPE_V>();
-        
+
         if (reqLoRARank_ == LORA_RANK_8) {
             BlockReduceSum(yLocal[progress], wTmpTensor, blockReduceRepeatCount, MASK_COUNT,
                            reduceSumParams_.dstRepStride, reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -249,7 +249,6 @@ private:
         AscendC::LocalTensor<float> yLocal = tmpBufferY_.Get<float>();
         AscendC::LocalTensor<Y_T> yInLocal = inQueueY_.DeQue<Y_T>();
         AscendC::LocalTensor<float> yInLocalFP32 = inBufferY_.Get<float>();
-
         Cast(yInLocalFP32, yInLocal, AscendC::RoundMode::CAST_NONE, numElements);
         AscendC::PipeBarrier<PIPE_V>();
         inQueueY_.FreeTensor(yInLocal);

--- a/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
+++ b/csrc/lora/op_kernel/sgemmv_expand_kernel.cpp
@@ -82,7 +82,7 @@ public:
         loraRanksGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(loraRanks), loraRanksSize);
         sliceOffsetsGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(sliceOffsets), sliceOffsetsSize);
 
-        pipe_->InitBuffer(inQueueX_, 1, NUM_ELEMENTS_PER_REPEAT * sizeof(float));
+        pipe_->InitBuffer(inQueueX_, 1, NUM_ELEMENTS_PER_REPEAT * sizeof(X_T));
         pipe_->InitBuffer(inQueueW_, BUFFER_NUM, W_IN_TILE_NUM_ELEMENTS * 2 * sizeof(W_T)); // because block size is 32, type of W_T is float16 = 16 => we need x2 memory in buffer
         pipe_->InitBuffer(inQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(Y_T));
         pipe_->InitBuffer(outQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(Y_T));

--- a/tests/python/sgl_kernel_npu/test_lora_kernels.py
+++ b/tests/python/sgl_kernel_npu/test_lora_kernels.py
@@ -12,7 +12,7 @@ torch.set_printoptions(threshold=float("inf"))
 class TestLoraKernels(unittest.TestCase):
     def test_sgemmv_shrink(self):
         batch_size = 2
-        input_dim = 2*1024
+        input_dim = 2 * 1024
         num_loras = 3
         dtype = torch.float16
         device_dtype = torch.float16
@@ -84,7 +84,7 @@ class TestLoraKernels(unittest.TestCase):
 
     def test_sgemmv_expand(self):
         batch_size = 4
-        output_dim = 2*1024
+        output_dim = 2 * 1024
         num_loras = 8
         dtype = torch.float16
         device_dtype = torch.float16

--- a/tests/python/sgl_kernel_npu/test_lora_kernels.py
+++ b/tests/python/sgl_kernel_npu/test_lora_kernels.py
@@ -140,7 +140,8 @@ class TestLoraKernels(unittest.TestCase):
         actual_output_cpu = actual_output.to(device="cpu")
 
         max_value, max_index = (actual_output_cpu - expect_output).max(dim=1)
-        
+
+        print(max_lora_rank)
         print(max_value, max_index)
         print(torch.gather(actual_output_cpu, dim=1, index=max_index.unsqueeze(1)))
         print(torch.gather(expect_output, dim=1, index=max_index.unsqueeze(1)))

--- a/tests/python/sgl_kernel_npu/test_lora_kernels.py
+++ b/tests/python/sgl_kernel_npu/test_lora_kernels.py
@@ -12,12 +12,12 @@ torch.set_printoptions(threshold=float("inf"))
 class TestLoraKernels(unittest.TestCase):
     def test_sgemmv_shrink(self):
         batch_size = 2
-        input_dim = 1024
+        input_dim = 2*1024
         num_loras = 3
         dtype = torch.float16
         device_dtype = torch.float16
 
-        possible_lora_ranks = [16, 32, 64]
+        possible_lora_ranks = [8, 16, 32, 64]
         lora_ranks = random.sample(
             possible_lora_ranks,
             counts=[num_loras] * len(possible_lora_ranks),
@@ -84,12 +84,12 @@ class TestLoraKernels(unittest.TestCase):
 
     def test_sgemmv_expand(self):
         batch_size = 4
-        output_dim = 1024
+        output_dim = 2*1024
         num_loras = 8
         dtype = torch.float16
         device_dtype = torch.float16
 
-        possible_lora_ranks = [16, 32, 64]
+        possible_lora_ranks = [8, 16, 32, 64]
         lora_ranks = random.sample(
             possible_lora_ranks,
             counts=[num_loras] * len(possible_lora_ranks),

--- a/tests/python/sgl_kernel_npu/test_lora_kernels.py
+++ b/tests/python/sgl_kernel_npu/test_lora_kernels.py
@@ -139,6 +139,12 @@ class TestLoraKernels(unittest.TestCase):
 
         actual_output_cpu = actual_output.to(device="cpu")
 
+        max_value, max_index = (actual_output_cpu - expect_output).max(dim=1)
+        
+        print(max_value, max_index)
+        print(torch.gather(actual_output_cpu, dim=1, index=max_index.unsqueeze(1)))
+        print(torch.gather(expect_output, dim=1, index=max_index.unsqueeze(1)))
+        
         self.assertTrue(
             torch.allclose(actual_output_cpu, expect_output, atol=1e-3, rtol=1e-3)
         )


### PR DESCRIPTION
There was an issue with buffer overlap in LoRA (with `r=8`) that caused the kernel to return NaNs during execution; this problem was resolved by switching the buffers from `float16` to `float32`.