### PR TITLE
Bump pto-isa to latest master (d621a13e)

### DIFF
--- a/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
+++ b/csrc/mega_chunk_gdn/op_kernel/mega_kernel.cpp
@@ -58,18 +58,18 @@ AICORE inline void SyncAllImpl()
 {
     pipe_barrier(PIPE_ALL);
     if constexpr (isAIVOnly) {
-        ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x0, SYNC_AIV_ONLY_ALL));
-        wait_flag_dev(SYNC_AIV_ONLY_ALL);
+        ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x0, ::SYNC_AIV_ONLY_ALL));
+        wait_flag_dev(::SYNC_AIV_ONLY_ALL);
         return;
     }
 #if defined(__DAV_C220_CUBE__)
-    wait_flag_dev(SYNC_AIV_FLAG);
-    ffts_cross_core_sync(PIPE_FIX, GetffstMsg(0x0, SYNC_AIC_FLAG));
-    wait_flag_dev(SYNC_AIC_FLAG);
-    ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x02, SYNC_AIC_AIV_FLAG));
+    wait_flag_dev(::SYNC_AIV_FLAG);
+    ffts_cross_core_sync(PIPE_FIX, GetffstMsg(0x0, ::SYNC_AIC_FLAG));
+    wait_flag_dev(::SYNC_AIC_FLAG);
+    ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x02, ::SYNC_AIC_AIV_FLAG));
 #elif defined(__DAV_C220_VEC__)
-    ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x02, SYNC_AIV_FLAG));
-    wait_flag_dev(SYNC_AIC_AIV_FLAG);
+    ffts_cross_core_sync(PIPE_MTE3, GetffstMsg(0x02, ::SYNC_AIV_FLAG));
+    wait_flag_dev(::SYNC_AIC_AIV_FLAG);
 #endif
 }
 


### PR DESCRIPTION
## What

- Bump `third_party/pto-isa` to the current gitcode master `d621a13e`
  ("Optimized TTRANS for b16 with vtranspose on A2A3").
- Qualify the `SYNC_*` uses in `mega_chunk_gdn`'s `SyncAllImpl()` to `::`
  to keep it building against the new pto-isa.

## Why

Move the pinned pto-isa reference up to the current version so future
code additions that use pto-isa build against an up-to-date base.

## The mega_chunk_gdn fix

The new pto-isa defines `SYNC_AIV_ONLY_ALL`, `SYNC_AIV_FLAG`, `SYNC_AIC_FLAG`
and `SYNC_AIC_AIV_FLAG` in `namespace pto`. `mega_kernel.cpp` does
`using namespace pto` while also defining its own file-scope constants of the
same names, so the unqualified uses in `SyncAllImpl()` became ambiguous. Fixed
by qualifying those uses to `::` (the file-scope globals the file already
defines) — definitions untouched, values identical, no behavior change.

## Testing

- Kernels module compiles with 0 errors against the new pto-isa.
- `mega_chunk_gdn` correctness (`test_chunk_gdn_pto.py`): 13/13 PASS.