### PR TITLE
Add swiglu_group_quant op ported

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -251,6 +251,10 @@ endif()
 # automatic synchronization insertion (--cce-auto-sync) is unsound around MicroAPI's hand-managed
 # sync, and cce-aicore-hoist-movemask is likewise disabled upstream. It is kept off workspace_kernel
 # so these options cannot affect the other A5 kernels.
+#
+# Upstream also passes --op_relocatable_kernel_binary=true, but that is deliberately omitted: it is
+# an op-package option, consumed by CANN's add_ops_compile_options op build, and the kernel compile
+# driver here rejects it ("unsupport option"). Nothing in a bare ascendc_library compile needs it.
 set(A5_ONLY_KERNEL_TARGETS)
 if(SGL_KERNEL_ENABLE_A5_ONLY_OPS)
     ascendc_library(swiglu_group_quant_kernel STATIC
@@ -269,7 +273,6 @@ if(SGL_KERNEL_ENABLE_A5_ONLY_OPS)
         -Wno-deprecated-declarations
         -mllvm
         -cce-aicore-hoist-movemask=false
-        --op_relocatable_kernel_binary=true
     )
     list(APPEND A5_ONLY_KERNEL_TARGETS swiglu_group_quant_kernel)
 endif()

--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -247,14 +247,14 @@ if(SGL_KERNEL_ENABLE_A3_ONLY_OPS)
 endif()
 
 # Dedicated A5-only kernel targets. swiglu_group_quant is MicroAPI (register-level) code, so it is
-# built with the options its upstream CANN op used rather than the workspace_kernel defaults:
-# automatic synchronization insertion (--cce-auto-sync) is unsound around MicroAPI's hand-managed
-# sync, and cce-aicore-hoist-movemask is likewise disabled upstream. It is kept off workspace_kernel
-# so these options cannot affect the other A5 kernels.
+# built with these options rather than the workspace_kernel defaults: automatic synchronization
+# insertion (--cce-auto-sync) is unsound around MicroAPI's hand-managed sync, and
+# cce-aicore-hoist-movemask must stay off. It is kept off workspace_kernel so these options cannot
+# affect the other A5 kernels.
 #
-# Upstream also passes --op_relocatable_kernel_binary=true, but that is deliberately omitted: it is
-# an op-package option, consumed by CANN's add_ops_compile_options op build, and the kernel compile
-# driver here rejects it ("unsupport option"). Nothing in a bare ascendc_library compile needs it.
+# --op_relocatable_kernel_binary=true is deliberately NOT passed. It is an op-package option,
+# consumed by CANN's op build, and the kernel compile driver here rejects it ("unsupport option");
+# nothing in a bare ascendc_library compile needs it.
 set(A5_ONLY_KERNEL_TARGETS)
 if(SGL_KERNEL_ENABLE_A5_ONLY_OPS)
     ascendc_library(swiglu_group_quant_kernel STATIC

--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -83,6 +83,7 @@ endif()
 if(SGL_KERNEL_ENABLE_A5_ONLY_OPS)
     list(APPEND OP_SRCS
         ${PROJECT_OP_SRC_BASE}/kv_compress_epilog/op_host/kv_compress_epilog.cpp
+        ${PROJECT_OP_SRC_BASE}/swiglu_group_quant/op_host/swiglu_group_quant.cpp
     )
 endif()
 if(BUILD_CATLASS_MODULE)
@@ -245,11 +246,40 @@ if(SGL_KERNEL_ENABLE_A3_ONLY_OPS)
     list(APPEND A3_ONLY_KERNEL_TARGETS sparse_attn_sharedkv_kernel)
 endif()
 
+# Dedicated A5-only kernel targets. swiglu_group_quant is MicroAPI (register-level) code, so it is
+# built with the options its upstream CANN op used rather than the workspace_kernel defaults:
+# automatic synchronization insertion (--cce-auto-sync) is unsound around MicroAPI's hand-managed
+# sync, and cce-aicore-hoist-movemask is likewise disabled upstream. It is kept off workspace_kernel
+# so these options cannot affect the other A5 kernels.
+set(A5_ONLY_KERNEL_TARGETS)
+if(SGL_KERNEL_ENABLE_A5_ONLY_OPS)
+    ascendc_library(swiglu_group_quant_kernel STATIC
+        ${PROJECT_OP_SRC_BASE}/swiglu_group_quant/op_kernel/swiglu_group_quant.cpp
+    )
+    ascendc_include_directories(swiglu_group_quant_kernel PRIVATE
+        ${PROJECT_OP_SRC_BASE}/swiglu_group_quant/op_kernel
+        ${PROJECT_OP_SRC_BASE}/utils/kernel
+    )
+    ascendc_compile_definitions(swiglu_group_quant_kernel PRIVATE
+        -DHAVE_WORKSPACE
+        -DHAVE_TILING
+    )
+    ascendc_compile_options(swiglu_group_quant_kernel PRIVATE
+        --cce-auto-sync=off
+        -Wno-deprecated-declarations
+        -mllvm
+        -cce-aicore-hoist-movemask=false
+        --op_relocatable_kernel_binary=true
+    )
+    list(APPEND A5_ONLY_KERNEL_TARGETS swiglu_group_quant_kernel)
+endif()
+
 # create shared library
 add_library(${OP_PLUGIN_NAME} SHARED ${OP_SRCS})
 
 target_link_libraries(${OP_PLUGIN_NAME} PRIVATE
         ${A3_ONLY_KERNEL_TARGETS}
+        ${A5_ONLY_KERNEL_TARGETS}
         workspace_kernel
         no_workspace_kernel
         ${CATLASS_WORKSPACE_KERNEL_TARGETS}

--- a/csrc/pytorch_extensions.cpp
+++ b/csrc/pytorch_extensions.cpp
@@ -212,6 +212,15 @@ TORCH_LIBRARY_FRAGMENT(npu, m)
     m.def(
         "kv_compress_epilog(Tensor(a!) kv_compress_cache, Tensor x, Tensor slot_mapping, "
         "int quant_group_size, int quant_mode, bool round_scale_flag, int layout) -> ()");
+
+    // The Ascend C side has no optional, so the two optional tensors reach the kernel as raw
+    // pointers that are null when absent. The host compares its own tiling against that same
+    // "present and non-empty" test, so passing a 0-element tensor is equivalent to omitting it.
+    m.def(
+        "swiglu_group_quant(Tensor x, Tensor? topk_weight=None, Tensor? group_index=None, "
+        "ScalarType? dst_type=None, int quant_mode=1, int group_size=128, bool round_scale=False, "
+        "bool ue8m0_scale=False, bool output_origin=False, int group_list_type=0, "
+        "float clamp_value=0.0) -> (Tensor, Tensor, Tensor)");
 #endif
 
 #ifdef BUILD_CATLASS_MODULE
@@ -349,6 +358,10 @@ TORCH_LIBRARY_IMPL(npu, PrivateUse1, m)
 
 #ifdef SGL_KERNEL_ENABLE_A5_ONLY_OPS
     m.impl("kv_compress_epilog", TORCH_FN(sglang::npu_kernel::kv_compress_epilog));
+
+    // The host takes c10::optional directly, so the optionals are registered as-is rather than
+    // being unwrapped to empty tensors here.
+    m.impl("swiglu_group_quant", TORCH_FN(sglang::npu_kernel::swiglu_group_quant));
 #endif
 
 #ifdef BUILD_CATLASS_MODULE

--- a/csrc/swiglu_group_quant/op_host/swiglu_group_quant.cpp
+++ b/csrc/swiglu_group_quant/op_host/swiglu_group_quant.cpp
@@ -1,0 +1,738 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file swiglu_group_quant.cpp
+ * \brief Host-side tiling + launch for swiglu_group_quant (A5-only).
+ *
+ * Adapted from vllm-ascend csrc/moe/swiglu_group_quant/op_host/swiglu_group_quant_tiling.cpp and
+ * csrc/torch_binding.cpp. The tiling arithmetic below is a 1:1 transcription of upstream's
+ * SwigluGroupQuantTiling class — same constants, same branches, same order of operations. What
+ * changes is the plumbing:
+ *
+ *   - upstream is a CANN optiling entry point driven by gert::TilingContext (shape descriptors,
+ *     attribute pointers, SetBlockDim/SetTilingKey/GetWorkspaceSizes). This repo launches kernels
+ *     directly, so the same computation is driven from at::Tensor arguments and the results are
+ *     written into a packed struct that is memcpy'd to the device.
+ *   - upstream's op_host/*_def.cpp (OpDef) and *_proto.cpp (InferShape/InferDataType) have no
+ *     equivalent here — there is no CANN op registry. Their job was to derive the y/scale/y_origin
+ *     shapes and dtypes, which the host now does directly when allocating the outputs.
+ *   - upstream's tiling key (1/2/31/32) and the per-dtype kernel binary selection are merged into
+ *     the struct's tilingKey + dtype fields, which the kernel entry dispatches on.
+ *
+ * Faithfulness notes carried over deliberately:
+ *   - `group_size` and `dst_type` never reach the tiling math upstream either (grep the upstream
+ *     tiling for ATTR_INDEX_GROUP_SIZE / ATTR_INDEX_DST_TYPE: declared, never read). They are kept
+ *     in the signature for caller compatibility and are otherwise inert.
+ *   - The UB-fitting loops keep upstream's exact shape, including the `while (totalSize < ubSize_)`
+ *     form that only terminates early when the first probe already fits.
+ */
+
+#include <cstring>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#include "acl/acl.h"
+#include "kernel_tiling/kernel_tiling.h"
+#include "tiling/platform/platform_ascendc.h"
+#include "tiling/swiglu_group_quant_tiling_data.h"
+#include "defines.h"
+#include "torch_helper.h"
+#include "common_tiling.h"
+#include "common.h"
+#include "aclrtlaunch_swiglu_group_quant.h"
+
+namespace sglang {
+namespace npu_kernel {
+
+namespace {
+
+constexpr uint32_t PADDING_BYTE = 32U;
+constexpr int64_t WORKSPACE_SIZE = 32;
+constexpr int64_t BLOCK_SIZE = 32;
+constexpr int64_t DOUBLE_BUFFER = 2;
+constexpr int64_t PER_BLOCK_FP16 = 128;
+constexpr int64_t PER_MX_FP16 = 32;
+constexpr int64_t STATIC_QUANT = 1;
+constexpr int64_t MX_QUANT = 2;
+constexpr int64_t FP8_QUANT = 3;
+constexpr int64_t CACHE_LINE_SIZE = 128;
+constexpr int64_t GROUP_LIST_TYPE_COUNT = 0;
+constexpr int64_t ACTIVATE_SPLIT = 2;
+constexpr int64_t FP8_DIM_ALIGN = 256;
+constexpr int64_t FP8_MAX_SCALE_COL_DIVISOR = 128;
+
+// Graph mode tiling cache, mirroring kv_compress_epilog: the tiling buffer must be stable across a
+// captured graph, so each distinct tiling lands in a fixed slot of a persistent device buffer
+// instead of being re-uploaded (a host->device copy inside capture is not replayable).
+constexpr uint32_t MAX_CAPTURE_NUM = 1024;
+uint32_t actualCaptureNum = 0;
+std::unordered_map<uint64_t, uint32_t> captureMap;
+
+int64_t CeilDiv(int64_t x, int64_t y)
+{
+    if (y != 0) {
+        return (x + y - 1) / y;
+    }
+    return x;
+}
+int64_t DownAlign(int64_t x, int64_t y)
+{
+    if (y == 0) {
+        return x;
+    }
+    return (x / y) * y;
+}
+int64_t RoundUp(int64_t x, int64_t y)
+{
+    return CeilDiv(x, y) * y;
+}
+
+//! Everything upstream read off gert::TilingContext, resolved from torch tensors instead.
+struct SwigluGroupQuantInputs {
+    int64_t bs = 0;  // product of x's dims except the last
+    int64_t d = 0;   // x's last dim
+    bool hasTopkWeight = false;
+    int64_t g = 0;  // element count of group_index
+    bool hasGroupIndex = false;
+    int64_t quantMode = STATIC_QUANT;
+    int64_t roundScale = 0;
+    int64_t ue8m0Scale = 0;
+    int64_t outputOrigin = 0;
+    int64_t groupListType = GROUP_LIST_TYPE_COUNT;
+    float clampValue = 0.0f;
+    int64_t hasClampValue = 0;
+};
+
+//! 1:1 port of upstream's SwigluGroupQuantTiling, minus the gert plumbing.
+class SwigluGroupQuantTiling
+{
+public:
+    explicit SwigluGroupQuantTiling(const SwigluGroupQuantInputs &inputs) : inputs_(inputs) {}
+
+    bool DoOpTiling(SwigluGroupQuantTilingData &out, uint32_t &tilingKey)
+    {
+        if (!GetPlatformInfo()) {
+            return false;
+        }
+        if (!GetShapeAttrsInfoInner()) {
+            return false;
+        }
+        if (!CalcOpTiling()) {
+            return false;
+        }
+        SetTilingData();
+
+        tilingKey = tilingKey_;
+        usedCoreNums_ = inputs_.hasGroupIndex ? coreNum_ : usedCoreNums_;
+        out = tilingData_;
+        return true;
+    }
+
+    int64_t UsedCoreNums() const
+    {
+        return usedCoreNums_;
+    }
+
+private:
+    bool GetPlatformInfo()
+    {
+        auto ascendcPlatform = platform_ascendc::PlatformAscendCManager::GetInstance();
+        coreNum_ = static_cast<int64_t>(ascendcPlatform->GetCoreNumAiv());
+        if (coreNum_ <= 0) {
+            coreNum_ = 1;
+        }
+        uint64_t ubSizePlatForm = 0;
+        ascendcPlatform->GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSizePlatForm);
+        ubSize_ = static_cast<int64_t>(ubSizePlatForm);
+        return true;
+    }
+
+    //! Upstream's GetAttr, reading values the host already resolved.
+    void GetAttr()
+    {
+        quantMode_ = inputs_.quantMode;
+        splitFactor_ = quantMode_ == MX_QUANT ? PER_MX_FP16 : PER_BLOCK_FP16;
+        roundScale_ = inputs_.roundScale;
+        ue8m0Scale_ = inputs_.ue8m0Scale;
+        outputOrigin_ = inputs_.outputOrigin;
+        groupListType_ = inputs_.groupListType;
+        clampValue_ = inputs_.clampValue;
+        hasClampValue_ = inputs_.hasClampValue;
+    }
+
+    bool GetShapeAttrsInfoInner()
+    {
+        bs_ = inputs_.bs;
+        d_ = inputs_.d;
+        if (d_ % ACTIVATE_SPLIT != 0) {
+            return false;
+        }
+        hasTopkWeight_ = inputs_.hasTopkWeight;
+        hasGroupIndex_ = inputs_.hasGroupIndex;
+        g_ = inputs_.g;
+
+        GetAttr();
+
+        if (quantMode_ != STATIC_QUANT && quantMode_ != MX_QUANT && quantMode_ != FP8_QUANT) {
+            return false;
+        }
+        if (quantMode_ == FP8_QUANT && d_ % FP8_DIM_ALIGN != 0) {
+            return false;
+        }
+        if (groupListType_ != GROUP_LIST_TYPE_COUNT) {
+            return false;
+        }
+
+        splitD_ = d_ / ACTIVATE_SPLIT;
+        scaleCol_ = CeilDiv(splitD_, splitFactor_);
+        return true;
+    }
+
+    void CalcGroupIndexTiling()
+    {
+        if (hasGroupIndex_ && groupListType_ == GROUP_LIST_TYPE_COUNT) {
+            gFactor_ = g_;
+            int64_t groupIndexSize = RoundUp(gFactor_, BLOCK_SIZE / static_cast<int64_t>(sizeof(int64_t))) *
+                                     DOUBLE_BUFFER * static_cast<int64_t>(sizeof(int64_t));
+            int64_t groupIndexSumSize = BLOCK_SIZE;
+            if (groupIndexSize + groupIndexSumSize <= ubSize_) {
+                gLoop_ = 1;
+                tailGFactor_ = gFactor_;
+            } else {
+                int64_t base = 2;
+                while (1) {
+                    gFactor_ = CeilDiv(g_, base);
+                    groupIndexSize = RoundUp(gFactor_, BLOCK_SIZE / static_cast<int64_t>(sizeof(int64_t))) *
+                                     DOUBLE_BUFFER * static_cast<int64_t>(sizeof(int64_t));
+                    if (groupIndexSize + groupIndexSumSize < ubSize_) {
+                        break;
+                    }
+                    base++;
+                }
+                if (gFactor_ > CACHE_LINE_SIZE / static_cast<int64_t>(sizeof(int64_t))) {
+                    gFactor_ = DownAlign(gFactor_, CACHE_LINE_SIZE / static_cast<int64_t>(sizeof(int64_t)));
+                }
+                gLoop_ = CeilDiv(g_, gFactor_);
+                tailGFactor_ = g_ % gFactor_ == 0 ? gFactor_ : g_ % gFactor_;
+            }
+        }
+    }
+
+    //! Shared head of the three mode-specific tilings: split bs_ across cores, start with one row.
+    void CalcRowTilingHead(int64_t &rowOnceLoop)
+    {
+        rowOfFormerBlock_ = CeilDiv(bs_, coreNum_);
+        usedCoreNums_ = std::min(CeilDiv(bs_, rowOfFormerBlock_), coreNum_);
+        rowOfTailBlock_ = bs_ - (usedCoreNums_ - 1) * rowOfFormerBlock_;
+
+        const int64_t minRowPerCore = 1;
+        rowOnceLoop = std::min(rowOfFormerBlock_, minRowPerCore);
+        rowFactor_ = rowOnceLoop;
+    }
+
+    void CalcRowTilingTail()
+    {
+        rowLoopOfFormerBlock_ = CeilDiv(rowOfFormerBlock_, rowFactor_);
+        rowLoopOfTailBlock_ = CeilDiv(rowOfTailBlock_, rowFactor_);
+        tailRowFactorOfFormerBlock_ = rowOfFormerBlock_ % rowFactor_ == 0 ? rowFactor_ : rowOfFormerBlock_ % rowFactor_;
+        tailRowFactorOfTailBlock_ = rowOfTailBlock_ % rowFactor_ == 0 ? rowFactor_ : rowOfTailBlock_ % rowFactor_;
+    }
+
+    bool CalcMxQuantOpTiling()
+    {
+        int64_t rowOnceLoop = 0;
+        CalcRowTilingHead(rowOnceLoop);
+
+        int64_t x0Size = rowOnceLoop * RoundUp(splitD_, 16) * 2 * DOUBLE_BUFFER;
+        int64_t x1Size = rowOnceLoop * RoundUp(splitD_, 16) * 2 * DOUBLE_BUFFER;
+        int64_t swigluSize = rowOnceLoop * RoundUp(splitD_, 16) * 2;
+        int64_t maxExpSize = rowOnceLoop * RoundUp(scaleCol_, 16) * 2;
+        int64_t invScaleSize = rowOnceLoop * RoundUp(scaleCol_, 16) * 2;
+        int64_t ySize = rowOnceLoop * RoundUp(splitD_, 32) * 1 * DOUBLE_BUFFER;
+        int64_t scaleSize = rowOnceLoop * RoundUp(scaleCol_, 32) * 1 * DOUBLE_BUFFER;
+
+        int64_t totalSize = x0Size + x1Size + swigluSize + maxExpSize + invScaleSize + ySize + scaleSize;
+
+        int64_t topkWeightSize = RoundUp(rowOnceLoop, 8) * 4 * DOUBLE_BUFFER;
+        totalSize = hasTopkWeight_ ? totalSize + topkWeightSize : totalSize;
+
+        if (totalSize <= ubSize_) {
+            // row and d both fit in UB at once
+            dLoop_ = 1;
+            dFactor_ = splitD_;
+            tailDFactor_ = dFactor_;
+        } else {
+            dFactor_ = splitD_;
+            int64_t base = 1;
+            while (totalSize < ubSize_) {
+                dFactor_ = base * splitFactor_;
+                scaleCol_ = CeilDiv(dFactor_, splitFactor_);
+                x0Size = rowOnceLoop * RoundUp(dFactor_, 16) * 2 * DOUBLE_BUFFER;
+                x1Size = rowOnceLoop * RoundUp(dFactor_, 16) * 2 * DOUBLE_BUFFER;
+                swigluSize = rowOnceLoop * RoundUp(dFactor_, 16) * 2;
+                maxExpSize = rowOnceLoop * RoundUp(scaleCol_, 16) * 2;
+                invScaleSize = rowOnceLoop * RoundUp(scaleCol_, 16) * 2;
+                ySize = rowOnceLoop * RoundUp(dFactor_, 32) * 1 * DOUBLE_BUFFER;
+                scaleSize = rowOnceLoop * RoundUp(scaleCol_, 32) * 1 * DOUBLE_BUFFER;
+                totalSize = x0Size + x1Size + swigluSize + maxExpSize + invScaleSize + ySize + scaleSize;
+                if (hasTopkWeight_) {
+                    totalSize += topkWeightSize;
+                }
+                base++;
+            }
+            dFactor_ = (base - 1) * splitFactor_;
+            scaleCol_ = CeilDiv(dFactor_, splitFactor_);
+            dLoop_ = CeilDiv(splitD_, dFactor_);
+            tailDFactor_ = splitD_ % dFactor_ == 0 ? dFactor_ : splitD_ % dFactor_;
+        }
+
+        // d fits whole: try to pull in more rows
+        if (dFactor_ == splitD_) {
+            while (rowFactor_ <= rowOfFormerBlock_) {
+                x0Size = rowFactor_ * RoundUp(dFactor_, 16) * 2 * DOUBLE_BUFFER;
+                x1Size = rowFactor_ * RoundUp(dFactor_, 16) * 2 * DOUBLE_BUFFER;
+                swigluSize = rowFactor_ * RoundUp(dFactor_, 16) * 2;
+                maxExpSize = rowFactor_ * RoundUp(scaleCol_, 16) * 2;
+                invScaleSize = rowFactor_ * RoundUp(scaleCol_, 16) * 2;
+                ySize = rowFactor_ * RoundUp(dFactor_, 32) * 1 * DOUBLE_BUFFER;
+                scaleSize = rowFactor_ * RoundUp(scaleCol_, 32) * 1 * DOUBLE_BUFFER;
+                totalSize = x0Size + x1Size + swigluSize + maxExpSize + invScaleSize + ySize + scaleSize;
+                if (hasTopkWeight_) {
+                    topkWeightSize = RoundUp(rowFactor_, 8) * 4 * DOUBLE_BUFFER;
+                    totalSize += topkWeightSize;
+                }
+                if (totalSize > ubSize_) {
+                    rowFactor_ = rowFactor_ - 1;
+                    break;
+                }
+                rowFactor_ = rowFactor_ + 1;
+            }
+            rowFactor_ = rowFactor_ > rowOfFormerBlock_ ? rowFactor_ - 1 : rowFactor_;
+        }
+
+        CalcRowTilingTail();
+        return true;
+    }
+
+    bool CalcGroupQuantOpTiling()
+    {
+        int64_t rowOnceLoop = 0;
+        CalcRowTilingHead(rowOnceLoop);
+
+        int64_t x0Size = rowOnceLoop * RoundUp(splitD_, 16) * 2 * DOUBLE_BUFFER;
+        int64_t x1Size = rowOnceLoop * RoundUp(splitD_, 16) * 2 * DOUBLE_BUFFER;
+        int64_t ySize = rowOnceLoop * RoundUp(splitD_, 32) * 1 * DOUBLE_BUFFER;
+        int64_t scaleSize = RoundUp(rowOnceLoop * scaleCol_, 8) * 4 * DOUBLE_BUFFER;
+
+        int64_t totalSize = x0Size + x1Size + ySize + scaleSize;
+
+        int64_t topkWeightSize = RoundUp(rowOnceLoop, 8) * 4 * DOUBLE_BUFFER;
+        totalSize = hasTopkWeight_ ? totalSize + topkWeightSize : totalSize;
+
+        if (totalSize <= ubSize_) {
+            // row and d both fit in UB at once
+            dLoop_ = 1;
+            dFactor_ = splitD_;
+            tailDFactor_ = dFactor_;
+        } else {
+            dFactor_ = splitD_;
+            int64_t base = 1;
+            while (totalSize < ubSize_) {
+                dFactor_ = base * splitFactor_;
+                scaleCol_ = CeilDiv(dFactor_, splitFactor_);
+                x0Size = rowOnceLoop * RoundUp(dFactor_, 16) * 2 * DOUBLE_BUFFER;
+                x1Size = rowOnceLoop * RoundUp(dFactor_, 16) * 2 * DOUBLE_BUFFER;
+                ySize = rowOnceLoop * RoundUp(dFactor_, 32) * 1 * DOUBLE_BUFFER;
+                scaleSize = RoundUp(rowOnceLoop * scaleCol_, 8) * 4 * DOUBLE_BUFFER;
+                totalSize = x0Size + x1Size + ySize + scaleSize;
+                if (hasTopkWeight_) {
+                    totalSize += topkWeightSize;
+                }
+                base++;
+            }
+            dFactor_ = (base - 1) * splitFactor_;
+            scaleCol_ = CeilDiv(dFactor_, splitFactor_);
+            dLoop_ = CeilDiv(splitD_, dFactor_);
+            tailDFactor_ = splitD_ % dFactor_ == 0 ? dFactor_ : splitD_ % dFactor_;
+        }
+
+        // d fits whole: try to pull in more rows
+        if (dFactor_ == splitD_) {
+            while (rowFactor_ <= rowOfFormerBlock_) {
+                x0Size = rowFactor_ * RoundUp(dFactor_, 16) * 2 * DOUBLE_BUFFER;
+                x1Size = rowFactor_ * RoundUp(dFactor_, 16) * 2 * DOUBLE_BUFFER;
+                ySize = rowFactor_ * RoundUp(dFactor_, 32) * 1 * DOUBLE_BUFFER;
+                scaleSize = RoundUp(rowFactor_ * scaleCol_, 8) * 4 * DOUBLE_BUFFER;
+                totalSize = x0Size + x1Size + ySize + scaleSize;
+                if (hasTopkWeight_) {
+                    topkWeightSize = RoundUp(rowFactor_, 8) * 4 * DOUBLE_BUFFER;
+                    totalSize += topkWeightSize;
+                }
+                if (totalSize > ubSize_) {
+                    rowFactor_ = rowFactor_ - 1;
+                    break;
+                }
+                rowFactor_ = rowFactor_ + 1;
+            }
+            rowFactor_ = rowFactor_ > rowOfFormerBlock_ ? rowFactor_ - 1 : rowFactor_;
+        }
+
+        CalcRowTilingTail();
+        return true;
+    }
+
+    bool CalcFp8QuantOpTiling()
+    {
+        int64_t rowOnceLoop = 0;
+        CalcRowTilingHead(rowOnceLoop);
+
+        int64_t x0Size = rowOnceLoop * RoundUp(splitD_, 16) * 2 * DOUBLE_BUFFER;
+        int64_t x1Size = rowOnceLoop * RoundUp(splitD_, 16) * 2 * DOUBLE_BUFFER;
+        int64_t ySize = rowOnceLoop * RoundUp(splitD_, 32) * 1 * DOUBLE_BUFFER;
+        int64_t scaleSize = ue8m0Scale_ ? RoundUp(rowOnceLoop * scaleCol_, 32) * 1 * DOUBLE_BUFFER
+                                        : RoundUp(rowOnceLoop * scaleCol_, 8) * 4 * DOUBLE_BUFFER;
+
+        int64_t totalSize = x0Size + x1Size + ySize + scaleSize;
+
+        int64_t topkWeightSize = RoundUp(rowOnceLoop, 8) * 4 * DOUBLE_BUFFER;
+        totalSize = hasTopkWeight_ ? totalSize + topkWeightSize : totalSize;
+
+        int64_t yOriginSize = rowOnceLoop * RoundUp(splitD_, 16) * 2 * DOUBLE_BUFFER;
+        totalSize = outputOrigin_ ? totalSize + yOriginSize : totalSize;
+
+        if (totalSize <= ubSize_) {
+            // row and d both fit in UB at once
+            dLoop_ = 1;
+            dFactor_ = splitD_;
+            tailDFactor_ = dFactor_;
+        } else {
+            dFactor_ = splitD_;
+            int64_t base = 1;
+            while (totalSize < ubSize_) {
+                dFactor_ = base * splitFactor_;
+                scaleCol_ = CeilDiv(dFactor_, splitFactor_);
+                x0Size = rowOnceLoop * RoundUp(dFactor_, 16) * 2 * DOUBLE_BUFFER;
+                x1Size = rowOnceLoop * RoundUp(dFactor_, 16) * 2 * DOUBLE_BUFFER;
+                ySize = rowOnceLoop * RoundUp(dFactor_, 32) * 1 * DOUBLE_BUFFER;
+                scaleSize = RoundUp(rowOnceLoop * scaleCol_, 8) * 4 * DOUBLE_BUFFER;
+                totalSize = x0Size + x1Size + ySize + scaleSize;
+                if (hasTopkWeight_) {
+                    totalSize += topkWeightSize;
+                }
+                if (outputOrigin_) {
+                    yOriginSize = rowOnceLoop * RoundUp(dFactor_, 16) * 2 * DOUBLE_BUFFER;
+                    totalSize += yOriginSize;
+                }
+                base++;
+            }
+            dFactor_ = (base - 1) * splitFactor_;
+            scaleCol_ = CeilDiv(dFactor_, splitFactor_);
+            dLoop_ = CeilDiv(splitD_, dFactor_);
+            tailDFactor_ = splitD_ % dFactor_ == 0 ? dFactor_ : splitD_ % dFactor_;
+        }
+
+        // d fits whole: try to pull in more rows
+        if (dFactor_ == splitD_) {
+            while (rowFactor_ <= rowOfFormerBlock_) {
+                x0Size = rowFactor_ * RoundUp(dFactor_, 16) * 2 * DOUBLE_BUFFER;
+                x1Size = rowFactor_ * RoundUp(dFactor_, 16) * 2 * DOUBLE_BUFFER;
+                ySize = rowFactor_ * RoundUp(dFactor_, 32) * 1 * DOUBLE_BUFFER;
+                scaleSize = RoundUp(rowFactor_ * scaleCol_, 8) * 4 * DOUBLE_BUFFER;
+                totalSize = x0Size + x1Size + ySize + scaleSize;
+                if (hasTopkWeight_) {
+                    topkWeightSize = RoundUp(rowFactor_, 8) * 4 * DOUBLE_BUFFER;
+                    totalSize += topkWeightSize;
+                }
+                if (outputOrigin_) {
+                    yOriginSize = rowFactor_ * RoundUp(dFactor_, 16) * 2 * DOUBLE_BUFFER;
+                    totalSize += yOriginSize;
+                }
+                if (totalSize > ubSize_) {
+                    rowFactor_ = rowFactor_ - 1;
+                    break;
+                }
+                rowFactor_ = rowFactor_ + 1;
+            }
+            rowFactor_ = rowFactor_ > rowOfFormerBlock_ ? rowFactor_ - 1 : rowFactor_;
+        }
+
+        CalcRowTilingTail();
+        return true;
+    }
+
+    bool CalcOpTiling()
+    {
+        CalcGroupIndexTiling();
+        if (quantMode_ == STATIC_QUANT) {
+            return CalcGroupQuantOpTiling();
+        } else if (quantMode_ == MX_QUANT) {
+            return CalcMxQuantOpTiling();
+        }
+        return CalcFp8QuantOpTiling();
+    }
+
+    void SetTilingData()
+    {
+        tilingData_.bs = bs_;
+        tilingData_.d = d_;
+        tilingData_.splitD = splitD_;
+        tilingData_.scaleCol = scaleCol_;
+        tilingData_.rowOfFormerBlock = rowOfFormerBlock_;
+        tilingData_.rowOfTailBlock = rowOfTailBlock_;
+        tilingData_.rowLoopOfFormerBlock = rowLoopOfFormerBlock_;
+        tilingData_.rowLoopOfTailBlock = rowLoopOfTailBlock_;
+        tilingData_.rowFactor = rowFactor_;
+        tilingData_.tailRowFactorOfFormerBlock = tailRowFactorOfFormerBlock_;
+        tilingData_.tailRowFactorOfTailBlock = tailRowFactorOfTailBlock_;
+        tilingData_.dLoop = dLoop_;
+        tilingData_.dFactor = dFactor_;
+        tilingData_.tailDFactor = tailDFactor_;
+        tilingData_.roundScale = roundScale_;
+        tilingData_.ue8m0Scale = ue8m0Scale_;
+        tilingData_.outputOrigin = outputOrigin_;
+        tilingData_.clampValue = clampValue_;
+        tilingData_.hasClampValue = hasClampValue_;
+        tilingData_.g = g_;
+        tilingData_.ubSize = ubSize_;
+        tilingData_.gLoop = gLoop_;
+        tilingData_.gFactor = gFactor_;
+        tilingData_.tailGFactor = tailGFactor_;
+        tilingData_.groupListType = groupListType_;
+        tilingData_.coreNum = coreNum_;
+
+        // Upstream's DoOpTiling tail: map the quant mode onto the kernel's tiling key.
+        if (quantMode_ == STATIC_QUANT) {
+            tilingKey_ = SWIGLU_GROUP_QUANT_TILING_KEY_GROUP_QUANT;
+        } else if (quantMode_ == MX_QUANT) {
+            tilingKey_ = SWIGLU_GROUP_QUANT_TILING_KEY_MX_QUANT;
+        } else {
+            tilingKey_ = outputOrigin_ ? SWIGLU_GROUP_QUANT_TILING_KEY_FP8_QUANT_YORIGIN
+                                       : SWIGLU_GROUP_QUANT_TILING_KEY_FP8_QUANT;
+        }
+    }
+
+    const SwigluGroupQuantInputs &inputs_;
+    SwigluGroupQuantTilingData tilingData_{};
+    uint32_t tilingKey_ = 0;
+
+    int64_t coreNum_ = 0;
+    int64_t ubSize_ = 0;
+    int64_t usedCoreNums_ = 0;
+    int64_t bs_ = 0;
+    int64_t d_ = 0;
+    int64_t splitD_ = 0;
+    int64_t scaleCol_ = 0;
+    int64_t rowOfFormerBlock_ = 0;
+    int64_t rowOfTailBlock_ = 0;
+    int64_t rowLoopOfFormerBlock_ = 0;
+    int64_t rowLoopOfTailBlock_ = 0;
+    int64_t rowFactor_ = 0;
+    int64_t tailRowFactorOfFormerBlock_ = 0;
+    int64_t tailRowFactorOfTailBlock_ = 0;
+    int64_t dLoop_ = 0;
+    int64_t dFactor_ = 0;
+    int64_t tailDFactor_ = 0;
+    int64_t quantMode_ = STATIC_QUANT;
+    int64_t splitFactor_ = PER_BLOCK_FP16;
+    int64_t roundScale_ = 0;
+    int64_t ue8m0Scale_ = 0;
+    int64_t outputOrigin_ = 0;
+    float clampValue_ = 0.0f;
+    int64_t hasClampValue_ = 0;
+    int64_t g_ = 0;
+    int64_t gLoop_ = 0;
+    int64_t gFactor_ = 0;
+    int64_t tailGFactor_ = 0;
+    int64_t groupListType_ = GROUP_LIST_TYPE_COUNT;
+    bool hasTopkWeight_ = false;
+    bool hasGroupIndex_ = false;
+};
+
+//! Output shapes/dtypes — a 1:1 port of construct_swiglu_group_quant_output_tensor in
+//! vllm-ascend csrc/torch_binding.cpp, which is what upstream's *_proto.cpp InferShape/InferDtype
+//! must agree with.
+std::tuple<at::Tensor, at::Tensor, at::Tensor> ConstructOutputs(const at::Tensor &x, at::ScalarType dst_type,
+                                                                int64_t quant_mode, bool ue8m0_scale)
+{
+    constexpr int64_t SWIGLU_FACTOR = 2;
+    constexpr int64_t MX_SCALE_ALIGN_FACTOR = 2;
+
+    std::vector<int64_t> y_size(x.sizes().begin(), x.sizes().end());
+    int64_t y_last_dim = y_size.back() / SWIGLU_FACTOR;
+    y_size.back() = y_last_dim;
+
+    const auto y_dtype = dst_type == at::kFloat8_e5m2 ? at::kFloat8_e5m2 : at::kFloat8_e4m3fn;
+    at::Tensor y = at::empty(y_size, x.options().dtype(y_dtype));
+
+    std::vector<int64_t> scale_size(y_size.begin(), y_size.end());
+    if (quant_mode == MX_QUANT) {
+        int64_t scale_last_dim = (y_last_dim + PER_MX_FP16 - 1) / PER_MX_FP16;
+        scale_last_dim = (scale_last_dim + MX_SCALE_ALIGN_FACTOR - 1) / MX_SCALE_ALIGN_FACTOR;
+        scale_size.back() = scale_last_dim;
+        scale_size.push_back(MX_SCALE_ALIGN_FACTOR);
+    } else {
+        scale_size.back() = (y_last_dim + PER_BLOCK_FP16 - 1) / PER_BLOCK_FP16;
+    }
+
+    auto scale_type = at::kFloat;
+    if (quant_mode == MX_QUANT || (quant_mode == FP8_QUANT && ue8m0_scale)) {
+        scale_type = at::kFloat8_e8m0fnu;
+    }
+    at::Tensor scale = at::empty(scale_size, x.options().dtype(scale_type));
+    at::Tensor y_origin = at::empty(y_size, x.options().dtype(x.dtype()));
+
+    return std::make_tuple(y, scale, y_origin);
+}
+
+}  // namespace
+
+HOST_API std::tuple<at::Tensor, at::Tensor, at::Tensor> swiglu_group_quant(
+    const at::Tensor &x, const c10::optional<at::Tensor> &topk_weight, const c10::optional<at::Tensor> &group_index,
+    c10::optional<at::ScalarType> dst_type, int64_t quant_mode, int64_t group_size, bool round_scale, bool ue8m0_scale,
+    bool output_origin, int64_t group_list_type, double clamp_value)
+{
+    TORCH_CHECK(x.dim() >= 1, "x must have at least one dimension, but got ", x.dim());
+    TORCH_CHECK(x.scalar_type() == at::kHalf || x.scalar_type() == at::kBFloat16,
+                "x should be FLOAT16 or BFLOAT16, but got ", x.scalar_type());
+    TORCH_CHECK(x.is_contiguous(), "x must be contiguous");
+    TORCH_CHECK(quant_mode == STATIC_QUANT || quant_mode == MX_QUANT || quant_mode == FP8_QUANT,
+                "Unsupported quant mode, only support ", STATIC_QUANT, " (group), ", MX_QUANT, " (mx) or ", FP8_QUANT,
+                " (fp8), but got ", quant_mode);
+
+    const at::ScalarType out_dtype = dst_type.value_or(at::kFloat8_e4m3fn);
+    TORCH_CHECK(out_dtype == at::kFloat8_e4m3fn || out_dtype == at::kFloat8_e5m2,
+                "dst_type must be Float8_e4m3fn or Float8_e5m2, but got ", out_dtype);
+
+    const int64_t d = x.size(-1);
+    if (quant_mode == STATIC_QUANT || quant_mode == FP8_QUANT) {
+        TORCH_CHECK(d % FP8_DIM_ALIGN == 0, "In group/fp8 quant, the last dim of x should be divisible by ",
+                    FP8_DIM_ALIGN, ", actual ", d, ".");
+    } else {
+        TORCH_CHECK(d % FP8_MAX_SCALE_COL_DIVISOR == 0, "In mx quant, the last dim of x should be divisible by ",
+                    FP8_MAX_SCALE_COL_DIVISOR, ", actual ", d, ".");
+    }
+    TORCH_CHECK(d % ACTIVATE_SPLIT == 0, "In swiglu, the last dim of x should be divisible by ", ACTIVATE_SPLIT,
+                ", actual ", d, ".");
+
+    // Optional inputs are detected by the kernel as a null GM pointer (see the `!= nullptr` tests in
+    // swiglu_group_quant_perf.h Init), so an absent optional must be passed as a real nullptr rather
+    // than an empty tensor's data_ptr. The host's tiling must agree with the kernel on presence, so
+    // both sides use "present and non-empty" here.
+    const bool has_topk_weight = topk_weight.has_value() && topk_weight->defined() && topk_weight->numel() > 0;
+    const bool has_group_index = group_index.has_value() && group_index->defined() && group_index->numel() > 0;
+
+    SwigluGroupQuantInputs inputs;
+    inputs.bs = 1;
+    for (int64_t i = 0; i + 1 < x.dim(); ++i) {
+        inputs.bs *= x.size(i);
+    }
+    inputs.d = d;
+    inputs.hasTopkWeight = has_topk_weight;
+    inputs.hasGroupIndex = has_group_index;
+    inputs.g = has_group_index ? group_index->numel() : 0;
+    inputs.quantMode = quant_mode;
+    inputs.roundScale = round_scale ? 1 : 0;
+    inputs.ue8m0Scale = ue8m0_scale ? 1 : 0;
+    inputs.outputOrigin = output_origin ? 1 : 0;
+    inputs.groupListType = group_list_type;
+    inputs.clampValue = static_cast<float>(clamp_value);
+    inputs.hasClampValue = clamp_value != 0.0 ? 1 : 0;
+
+    auto outputs = ConstructOutputs(x, out_dtype, quant_mode, ue8m0_scale);
+    at::Tensor y = std::get<0>(outputs);
+    at::Tensor scale = std::get<1>(outputs);
+    at::Tensor y_origin = std::get<2>(outputs);
+
+    // An empty batch has nothing to quantize. Upstream never guards this and its row tiling would
+    // divide by a zero row count; returning the empty outputs is both correct and a no-op for the
+    // kernel logic, which is untouched.
+    if (inputs.bs == 0) {
+        return outputs;
+    }
+
+    SwigluGroupQuantTilingData tilingData{};
+    uint32_t tilingKey = 0;
+    SwigluGroupQuantTiling tiling(inputs);
+    TORCH_CHECK(tiling.DoOpTiling(tilingData, tilingKey), "swiglu_group_quant: tiling failed for x of shape ",
+                x.sizes(), ", quant_mode=", quant_mode);
+    tilingData.tilingKey = tilingKey;
+
+    // dtype code bits, mirroring the dispatch in the kernel entry.
+    int32_t dtypeCode = 0;
+    if (x.scalar_type() == at::kBFloat16) {
+        dtypeCode |= SWIGLU_GROUP_QUANT_DTYPE_X_BF16;
+    }
+    if (y.scalar_type() == at::kFloat8_e5m2) {
+        dtypeCode |= SWIGLU_GROUP_QUANT_DTYPE_Y_E5M2;
+    }
+    if (scale.scalar_type() == at::kFloat8_e8m0fnu) {
+        dtypeCode |= SWIGLU_GROUP_QUANT_DTYPE_SCALE_E8M0;
+    }
+    tilingData.dtype = dtypeCode;
+
+    // Absent optionals must reach the kernel as null, and only the presence the tiling agreed on.
+    void *topk_weight_ptr = has_topk_weight ? topk_weight->data_ptr() : nullptr;
+    void *group_index_ptr = has_group_index ? group_index->data_ptr() : nullptr;
+
+    const uint32_t tilingSize = (sizeof(SwigluGroupQuantTilingData) + PADDING_BYTE - 1) / PADDING_BYTE * PADDING_BYTE;
+    at::Tensor tilingTensor;
+
+    auto tup = std::make_tuple(inputs.bs, inputs.d, tilingData.splitD, tilingData.scaleCol, tilingData.rowOfFormerBlock,
+                               tilingData.rowOfTailBlock, tilingData.rowLoopOfFormerBlock,
+                               tilingData.rowLoopOfTailBlock, tilingData.rowFactor,
+                               tilingData.tailRowFactorOfFormerBlock, tilingData.tailRowFactorOfTailBlock,
+                               tilingData.dLoop, tilingData.dFactor, tilingData.tailDFactor, tilingData.roundScale,
+                               tilingData.ue8m0Scale, tilingData.outputOrigin, tilingData.hasClampValue, tilingData.g,
+                               tilingData.ubSize, tilingData.gLoop, tilingData.gFactor, tilingData.tailGFactor,
+                               tilingData.groupListType, tilingData.coreNum, tilingData.dtype, tilingKey);
+    uint64_t hashValue = host_utils::TupleHasher::Hash(tup);
+
+    auto copyTilingToDevice = [&]() {
+        auto cpuTiling = at::empty({tilingSize}, at::kByte);
+        std::memcpy(cpuTiling.data_ptr(), &tilingData, sizeof(SwigluGroupQuantTilingData));
+        return TorchNpuHelper::CopyTensorHostToDevice(cpuTiling);
+    };
+
+    static auto globalTilingBuffer = at::empty({static_cast<int64_t>(tilingSize) * MAX_CAPTURE_NUM},
+                                               at::TensorOptions().dtype(at::kByte).device(x.device()));
+
+    if (captureMap.find(hashValue) != captureMap.end()) {
+        tilingTensor = at::from_blob(globalTilingBuffer.data_ptr<uint8_t>() + (tilingSize * captureMap[hashValue]),
+                                     tilingSize, at::kByte);
+    } else if (actualCaptureNum >= MAX_CAPTURE_NUM) {
+        tilingTensor = copyTilingToDevice();
+    } else {
+        captureMap[hashValue] = actualCaptureNum;
+        auto deviceTiling = copyTilingToDevice();
+        globalTilingBuffer
+            .slice(0, static_cast<int64_t>(actualCaptureNum) * tilingSize,
+                   static_cast<int64_t>(actualCaptureNum) * tilingSize + tilingSize)
+            .copy_(deviceTiling);
+        actualCaptureNum++;
+        tilingTensor = at::from_blob(globalTilingBuffer.data_ptr<uint8_t>() + (tilingSize * captureMap[hashValue]),
+                                     tilingSize, at::kByte);
+    }
+
+    auto workspace_tensor = at::empty({WORKSPACE_SIZE}, at::TensorOptions().dtype(at::kByte).device(x.device()));
+
+    // The kernel reads GetBlockNum() for its used-core count when there is no group index, so the
+    // launch dim must match upstream's SetBlockDim choice: coreNum when a group index is present
+    // (each core walks the whole group list), else the reduced used-core count.
+    const int64_t blockDim = inputs.hasGroupIndex ? tilingData.coreNum : tiling.UsedCoreNums();
+    EXEC_KERNEL_CMD(swiglu_group_quant, blockDim, x, topk_weight_ptr, group_index_ptr, y, scale, y_origin,
+                    workspace_tensor, tilingTensor);
+
+    return std::make_tuple(y, scale, y_origin);
+}
+
+}  // namespace npu_kernel
+}  // namespace sglang

--- a/csrc/swiglu_group_quant/op_host/swiglu_group_quant.cpp
+++ b/csrc/swiglu_group_quant/op_host/swiglu_group_quant.cpp
@@ -12,27 +12,15 @@
  * \file swiglu_group_quant.cpp
  * \brief Host-side tiling + launch for swiglu_group_quant (A5-only).
  *
- * Adapted from vllm-ascend csrc/moe/swiglu_group_quant/op_host/swiglu_group_quant_tiling.cpp and
- * csrc/torch_binding.cpp. The tiling arithmetic below is a 1:1 transcription of upstream's
- * SwigluGroupQuantTiling class — same constants, same branches, same order of operations. What
- * changes is the plumbing:
+ * Each quant mode has its own tiling routine below; all three share a head that splits the batch
+ * across cores. The result is written into a packed struct that is memcpy'd to the device, and the
+ * kernel entry dispatches on the tiling key and dtype that struct carries.
  *
- *   - upstream is a CANN optiling entry point driven by gert::TilingContext (shape descriptors,
- *     attribute pointers, SetBlockDim/SetTilingKey/GetWorkspaceSizes). This repo launches kernels
- *     directly, so the same computation is driven from at::Tensor arguments and the results are
- *     written into a packed struct that is memcpy'd to the device.
- *   - upstream's op_host/*_def.cpp (OpDef) and *_proto.cpp (InferShape/InferDataType) have no
- *     equivalent here — there is no CANN op registry. Their job was to derive the y/scale/y_origin
- *     shapes and dtypes, which the host now does directly when allocating the outputs.
- *   - upstream's tiling key (1/2/31/32) and the per-dtype kernel binary selection are merged into
- *     the struct's tilingKey + dtype fields, which the kernel entry dispatches on.
- *
- * Faithfulness notes carried over deliberately:
- *   - `group_size` and `dst_type` never reach the tiling math upstream either (grep the upstream
- *     tiling for ATTR_INDEX_GROUP_SIZE / ATTR_INDEX_DST_TYPE: declared, never read). They are kept
- *     in the signature for caller compatibility and are otherwise inert.
- *   - The UB-fitting loops keep upstream's exact shape, including the `while (totalSize < ubSize_)`
- *     form that only terminates early when the first probe already fits.
+ * Two notes on the parameter surface:
+ *   - `group_size` and `dst_type` do not participate in the tiling math. They are accepted for
+ *     caller compatibility and are otherwise inert.
+ *   - The UB-fitting loops take the form `while (totalSize < ubSize_)`, which only terminates early
+ *     when the first probe already fits.
  */
 
 #include <cstring>
@@ -96,7 +84,6 @@ int64_t RoundUp(int64_t x, int64_t y)
     return CeilDiv(x, y) * y;
 }
 
-//! Everything upstream read off gert::TilingContext, resolved from torch tensors instead.
 struct SwigluGroupQuantInputs {
     int64_t bs = 0;  // product of x's dims except the last
     int64_t d = 0;   // x's last dim
@@ -112,7 +99,7 @@ struct SwigluGroupQuantInputs {
     int64_t hasClampValue = 0;
 };
 
-//! 1:1 port of upstream's SwigluGroupQuantTiling, minus the gert plumbing.
+//! Computes the row / d / group tiling factors, then the launch geometry.
 class SwigluGroupQuantTiling
 {
 public:
@@ -156,7 +143,6 @@ private:
         return true;
     }
 
-    //! Upstream's GetAttr, reading values the host already resolved.
     void GetAttr()
     {
         quantMode_ = inputs_.quantMode;
@@ -509,7 +495,7 @@ private:
         tilingData_.groupListType = groupListType_;
         tilingData_.coreNum = coreNum_;
 
-        // Upstream's DoOpTiling tail: map the quant mode onto the kernel's tiling key.
+        // Tail of the tiling: map the quant mode onto the kernel's tiling key.
         if (quantMode_ == STATIC_QUANT) {
             tilingKey_ = SWIGLU_GROUP_QUANT_TILING_KEY_GROUP_QUANT;
         } else if (quantMode_ == MX_QUANT) {
@@ -557,9 +543,7 @@ private:
     bool hasGroupIndex_ = false;
 };
 
-//! Output shapes/dtypes — a 1:1 port of construct_swiglu_group_quant_output_tensor in
-//! vllm-ascend csrc/torch_binding.cpp, which is what upstream's *_proto.cpp InferShape/InferDtype
-//! must agree with.
+//! Allocates y / scale / y_origin with the shape and dtype each quant mode calls for.
 std::tuple<at::Tensor, at::Tensor, at::Tensor> ConstructOutputs(const at::Tensor &x, at::ScalarType dst_type,
                                                                 int64_t quant_mode, bool ue8m0_scale)
 {
@@ -652,9 +636,8 @@ HOST_API std::tuple<at::Tensor, at::Tensor, at::Tensor> swiglu_group_quant(
     at::Tensor scale = std::get<1>(outputs);
     at::Tensor y_origin = std::get<2>(outputs);
 
-    // An empty batch has nothing to quantize. Upstream never guards this and its row tiling would
-    // divide by a zero row count; returning the empty outputs is both correct and a no-op for the
-    // kernel logic, which is untouched.
+    // An empty batch has nothing to quantize, and the row tiling below would divide by a zero row
+    // count. Returning the empty outputs is both correct and a no-op for the kernel.
     if (inputs.bs == 0) {
         return outputs;
     }
@@ -725,8 +708,8 @@ HOST_API std::tuple<at::Tensor, at::Tensor, at::Tensor> swiglu_group_quant(
     auto workspace_tensor = at::empty({WORKSPACE_SIZE}, at::TensorOptions().dtype(at::kByte).device(x.device()));
 
     // The kernel reads GetBlockNum() for its used-core count when there is no group index, so the
-    // launch dim must match upstream's SetBlockDim choice: coreNum when a group index is present
-    // (each core walks the whole group list), else the reduced used-core count.
+    // launch dim must be coreNum when a group index is present (each core walks the whole group
+    // list), else the reduced used-core count.
     const int64_t blockDim = inputs.hasGroupIndex ? tilingData.coreNum : tiling.UsedCoreNums();
     EXEC_KERNEL_CMD(swiglu_group_quant, blockDim, x, topk_weight_ptr, group_index_ptr, y, scale, y_origin,
                     workspace_tensor, tilingTensor);

--- a/csrc/swiglu_group_quant/op_host/tiling/swiglu_group_quant_tiling_data.h
+++ b/csrc/swiglu_group_quant/op_host/tiling/swiglu_group_quant_tiling_data.h
@@ -12,17 +12,14 @@
  * \file swiglu_group_quant_tiling_data.h
  * \brief Plain tiling-data struct for swiglu_group_quant (A5-only).
  *
- * Adapted from vllm-ascend csrc/moe/swiglu_group_quant/op_host/swiglu_group_quant_tiling.h, which
- * declares the same fields through CANN's BEGIN_TILING_DATA_DEF/REGISTER_TILING_DATA_CLASS
- * machinery. This repo has no CANN op registry: the struct is a plain packed POD, memcpy'd to the
- * device by the host and read field-by-field from a __gm__ pointer by the kernel.
+ * A plain packed POD, memcpy'd to the device by the host and read field-by-field from a __gm__
+ * pointer by the kernel.
  *
- * Field names and types match the upstream struct exactly (all int64_t except `clampValue`, which
- * is float) because the ported kernel headers dereference them by name.
+ * Field names and types must match what the kernel headers dereference by name: all int64_t except
+ * `clampValue`, which is float.
  *
- * Field order is NOT upstream's: every int64_t is 8-byte aligned here, so the kernel's scalar GM
- * loads stay naturally aligned under #pragma pack(1). Upstream gets that for free from the
- * generated class's natural alignment; a packed struct does not.
+ * Field order puts every int64_t first so each one is 8-byte aligned, keeping the kernel's scalar
+ * GM loads naturally aligned under #pragma pack(1) — a packed struct does not get that for free.
  */
 
 #ifndef SWIGLU_GROUP_QUANT_TILING_DATA_H
@@ -61,7 +58,7 @@ struct SwigluGroupQuantTilingData {
     int64_t groupListType;
     int64_t coreNum;
 
-    // ---- appended by this port (not present upstream) ----
+    // ---- dtype / launch metadata ----
     float clampValue;    // offset 200
     int32_t dtype;       // offset 204: bit0 x is bf16, bit1 y is e5m2, bit2 scale is e8m0
     uint32_t tilingKey;  // offset 208: 1 group, 2 mx, 31 fp8, 32 fp8 + y_origin

--- a/csrc/swiglu_group_quant/op_host/tiling/swiglu_group_quant_tiling_data.h
+++ b/csrc/swiglu_group_quant/op_host/tiling/swiglu_group_quant_tiling_data.h
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file swiglu_group_quant_tiling_data.h
+ * \brief Plain tiling-data struct for swiglu_group_quant (A5-only).
+ *
+ * Adapted from vllm-ascend csrc/moe/swiglu_group_quant/op_host/swiglu_group_quant_tiling.h, which
+ * declares the same fields through CANN's BEGIN_TILING_DATA_DEF/REGISTER_TILING_DATA_CLASS
+ * machinery. This repo has no CANN op registry: the struct is a plain packed POD, memcpy'd to the
+ * device by the host and read field-by-field from a __gm__ pointer by the kernel.
+ *
+ * Field names and types match the upstream struct exactly (all int64_t except `clampValue`, which
+ * is float) because the ported kernel headers dereference them by name.
+ *
+ * Field order is NOT upstream's: every int64_t is 8-byte aligned here, so the kernel's scalar GM
+ * loads stay naturally aligned under #pragma pack(1). Upstream gets that for free from the
+ * generated class's natural alignment; a packed struct does not.
+ */
+
+#ifndef SWIGLU_GROUP_QUANT_TILING_DATA_H
+#define SWIGLU_GROUP_QUANT_TILING_DATA_H
+
+#include <cstdint>
+
+namespace sglang {
+
+#pragma pack(push, 1)
+struct SwigluGroupQuantTilingData {
+    // ---- shape / row tiling (25 x int64_t, offsets 0..192, all 8-byte aligned) ----
+    int64_t bs;
+    int64_t d;
+    int64_t splitD;
+    int64_t scaleCol;
+    int64_t rowOfFormerBlock;
+    int64_t rowOfTailBlock;
+    int64_t rowLoopOfFormerBlock;
+    int64_t rowLoopOfTailBlock;
+    int64_t rowFactor;
+    int64_t tailRowFactorOfFormerBlock;
+    int64_t tailRowFactorOfTailBlock;
+    int64_t dLoop;
+    int64_t dFactor;
+    int64_t tailDFactor;
+    int64_t roundScale;
+    int64_t ue8m0Scale;
+    int64_t outputOrigin;
+    int64_t hasClampValue;
+    int64_t g;
+    int64_t ubSize;
+    int64_t gLoop;
+    int64_t gFactor;
+    int64_t tailGFactor;
+    int64_t groupListType;
+    int64_t coreNum;
+
+    // ---- appended by this port (not present upstream) ----
+    float clampValue;    // offset 200
+    int32_t dtype;       // offset 204: bit0 x is bf16, bit1 y is e5m2, bit2 scale is e8m0
+    uint32_t tilingKey;  // offset 208: 1 group, 2 mx, 31 fp8, 32 fp8 + y_origin
+};
+#pragma pack(pop)
+
+// Tiling-key values; must match the kernel entry's dispatch and the host's GetTilingKey().
+constexpr uint32_t SWIGLU_GROUP_QUANT_TILING_KEY_GROUP_QUANT = 1;
+constexpr uint32_t SWIGLU_GROUP_QUANT_TILING_KEY_MX_QUANT = 2;
+constexpr uint32_t SWIGLU_GROUP_QUANT_TILING_KEY_FP8_QUANT = 31;
+constexpr uint32_t SWIGLU_GROUP_QUANT_TILING_KEY_FP8_QUANT_YORIGIN = 32;
+
+/** dtype code bits, mirroring the host-side packing of the x/y/scale dtypes. */
+constexpr int32_t SWIGLU_GROUP_QUANT_DTYPE_X_BF16 = 1 << 0;
+constexpr int32_t SWIGLU_GROUP_QUANT_DTYPE_Y_E5M2 = 1 << 1;
+constexpr int32_t SWIGLU_GROUP_QUANT_DTYPE_SCALE_E8M0 = 1 << 2;
+
+}  // namespace sglang
+
+#endif  // SWIGLU_GROUP_QUANT_TILING_DATA_H

--- a/csrc/swiglu_group_quant/op_kernel/swiglu_fp8_quant_per_token.h
+++ b/csrc/swiglu_group_quant/op_kernel/swiglu_fp8_quant_per_token.h
@@ -1,0 +1,264 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file swiglu_fp8_quant_per_token.h
+ * \brief
+ */
+
+#ifndef SWIGLU_FP8_QUANT_PER_TOKEN_H
+#define SWIGLU_FP8_QUANT_PER_TOKEN_H
+
+#include "kernel_operator.h"
+#include "swiglu_group_quant_base.h"
+
+namespace SwigluGroupQuant {
+using namespace AscendC;
+template <typename T0, typename T1, typename T2, bool outputOrigin>
+class SwigluFp8QuantPerToken
+{
+public:
+    __aicore__ inline SwigluFp8QuantPerToken() {}
+
+    __aicore__ inline void Init(GM_ADDR x, GM_ADDR topkWeight, GM_ADDR groupIndex, GM_ADDR y, GM_ADDR scale,
+                                GM_ADDR yOrigin, GM_ADDR workspace, const SwigluGroupQuantTilingData *tilingDataPtr,
+                                TPipe *pipePtr)
+    {
+        pipe = pipePtr;
+        tilingData = tilingDataPtr;
+
+        xGm.SetGlobalBuffer((__gm__ T0 *)x);
+        yGm.SetGlobalBuffer((__gm__ T1 *)y);
+        scaleGm.SetGlobalBuffer((__gm__ T2 *)scale);
+
+        pipe->InitBufPool(tBufPool, tilingData->ubSize);
+        if (groupIndex != nullptr) {
+            hasGroupIndex_ = true;
+            groupIndexGm.SetGlobalBuffer((__gm__ int64_t *)groupIndex);
+            if (tilingData->groupListType == 0) {
+                tBufPool.InitBuffer(groupIndexQue, 2, RoundUp<int64_t>(tilingData->gFactor) * sizeof(int64_t));
+                tBufPool.InitBuffer(groupIndexSumBuf, BLOCK_SIZE);
+                groupSumLocal = groupIndexSumBuf.Get<int64_t>();
+                for (int64_t idx = 0; idx < tilingData->gLoop; idx++) {
+                    int64_t curGFactor = (idx == tilingData->gLoop - 1) ? tilingData->tailGFactor : tilingData->gFactor;
+                    groupIndexLocal = groupIndexQue.template AllocTensor<int64_t>();
+                    CopyIn(groupIndexGm[idx * tilingData->gFactor], groupIndexLocal, 1, curGFactor);
+                    groupIndexQue.template EnQue(groupIndexLocal);
+                    groupIndexLocal = groupIndexQue.template DeQue<int64_t>();
+                    if (idx == 0) {
+                        VFProcessGroupIndex<int64_t, false>(groupSumLocal, groupIndexLocal, curGFactor);
+                    } else {
+                        VFProcessGroupIndex<int64_t, true>(groupSumLocal, groupIndexLocal, curGFactor);
+                    }
+                    groupIndexQue.template FreeTensor(groupIndexLocal);
+                }
+                event_t eventId = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_S));
+                SetFlag<HardEvent::V_S>(eventId);
+                WaitFlag<HardEvent::V_S>(eventId);
+                int64_t realBs =
+                    groupSumLocal.GetValue(0) > tilingData->bs ? tilingData->bs : groupSumLocal.GetValue(0);
+
+                rowOfFormerBlock = CeilDiv(realBs, static_cast<int64_t>(tilingData->coreNum));
+                usedCoreNums = CeilDiv(realBs, rowOfFormerBlock) < tilingData->coreNum
+                                   ? CeilDiv(realBs, rowOfFormerBlock)
+                                   : tilingData->coreNum;
+                rowOfTailBlock = realBs - (usedCoreNums - 1) * rowOfFormerBlock;
+
+                rowLoopOfFormerBlock = CeilDiv(rowOfFormerBlock, tilingData->rowFactor);
+                rowLoopOfTailBlock = CeilDiv(rowOfTailBlock, tilingData->rowFactor);
+                tailRowFactorOfFormerBlock = rowOfFormerBlock % tilingData->rowFactor == 0
+                                                 ? tilingData->rowFactor
+                                                 : rowOfFormerBlock % tilingData->rowFactor;
+                tailRowFactorOfTailBlock = rowOfTailBlock % tilingData->rowFactor == 0
+                                               ? tilingData->rowFactor
+                                               : rowOfTailBlock % tilingData->rowFactor;
+                tBufPool.Reset();
+            }
+        } else {
+            rowOfFormerBlock = tilingData->rowOfFormerBlock;
+            rowOfTailBlock = tilingData->rowOfTailBlock;
+            rowLoopOfFormerBlock = tilingData->rowLoopOfFormerBlock;
+            rowLoopOfTailBlock = tilingData->rowLoopOfTailBlock;
+            tailRowFactorOfFormerBlock = tilingData->tailRowFactorOfFormerBlock;
+            tailRowFactorOfTailBlock = tilingData->tailRowFactorOfTailBlock;
+            usedCoreNums = GetBlockNum();
+        }
+
+        if (topkWeight != nullptr) {
+            hasTopkWeight_ = true;
+            topkWeightGm.SetGlobalBuffer((__gm__ float *)topkWeight);
+            tBufPool.InitBuffer(topkWeightQue, 2, RoundUp<float>(tilingData->rowFactor) * sizeof(float));
+        }
+        if constexpr (outputOrigin) {
+            yOriginGm.SetGlobalBuffer((__gm__ T0 *)yOrigin);
+            tBufPool.InitBuffer(yOriginQue, 2, tilingData->rowFactor * RoundUp<T0>(tilingData->dFactor) * sizeof(T0));
+        }
+
+        tBufPool.InitBuffer(x0Que, 2, tilingData->rowFactor * RoundUp<T0>(tilingData->dFactor) * sizeof(T0));
+        tBufPool.InitBuffer(x1Que, 2, tilingData->rowFactor * RoundUp<T0>(tilingData->dFactor) * sizeof(T0));
+        tBufPool.InitBuffer(yQue, 2, tilingData->rowFactor * RoundUp<T1>(tilingData->dFactor) * sizeof(T1));
+        // scale 在ub内连续写，拷出时采用Compact模式进行搬出
+        int64_t scaleColNum = CeilDiv(tilingData->dFactor, PER_BLOCK_FP16);
+        tBufPool.InitBuffer(scaleQue, 2, RoundUp<T2>(tilingData->rowFactor * scaleColNum) * sizeof(T2));
+        hasClampValue_ = (tilingData->hasClampValue == 1);
+        hasRoundScale_ = (tilingData->roundScale == 1);
+        clampValue_ = tilingData->clampValue;
+        AscendC::SetCtrlSpr<FLOAT_OVERFLOW_MODE_CTRL, FLOAT_OVERFLOW_MODE_CTRL>(0);
+    }
+
+    __aicore__ inline void Process()
+    {
+        if (GetBlockIdx() >= usedCoreNums) {
+            return;
+        }
+        int64_t curBlockIdx = GetBlockIdx();
+        int64_t rowOuterLoop = (curBlockIdx == usedCoreNums - 1) ? rowLoopOfTailBlock : rowLoopOfFormerBlock;
+        int64_t tailRowFactor =
+            (curBlockIdx == usedCoreNums - 1) ? tailRowFactorOfTailBlock : tailRowFactorOfFormerBlock;
+        int64_t x0GmBaseOffset = curBlockIdx * rowOfFormerBlock * tilingData->d;
+        int64_t x1GmBaseOffset = x0GmBaseOffset + tilingData->splitD;
+        int64_t yGmBaseOffset = curBlockIdx * rowOfFormerBlock * tilingData->splitD;
+        int64_t scaleGmBaseOffset = curBlockIdx * rowOfFormerBlock * tilingData->scaleCol;
+        int64_t topkWeightGmBaseOffset = curBlockIdx * rowOfFormerBlock;
+        for (int64_t rowOuterIdx = 0; rowOuterIdx < rowOuterLoop; rowOuterIdx++) {
+            int64_t curRowFactor = (rowOuterIdx == rowOuterLoop - 1) ? tailRowFactor : tilingData->rowFactor;
+            // copy in topkWeight
+            if (hasTopkWeight_) {
+                topkWeightLocal = topkWeightQue.template AllocTensor<float>();
+                CopyIn(topkWeightGm[topkWeightGmBaseOffset + rowOuterIdx * tilingData->rowFactor], topkWeightLocal, 1,
+                       curRowFactor);
+                topkWeightQue.template EnQue(topkWeightLocal);
+                topkWeightLocal = topkWeightQue.template DeQue<float>();
+            }
+
+            for (int64_t dLoopIdx = 0; dLoopIdx < tilingData->dLoop; dLoopIdx++) {
+                int64_t curDFactor =
+                    (dLoopIdx == tilingData->dLoop - 1) ? tilingData->tailDFactor : tilingData->dFactor;
+                int64_t scaleDFactor = CeilDiv(curDFactor, PER_BLOCK_FP16);
+                int64_t xBaseOffset =
+                    rowOuterIdx * tilingData->rowFactor * tilingData->d + dLoopIdx * tilingData->dFactor;
+                x0Local = x0Que.template AllocTensor<T0>();
+                CopyIn(xGm[x0GmBaseOffset + xBaseOffset], x0Local, curRowFactor, curDFactor,
+                       tilingData->d - curDFactor);
+                x0Que.template EnQue(x0Local);
+                x0Local = x0Que.template DeQue<T0>();
+
+                x1Local = x1Que.template AllocTensor<T0>();
+                CopyIn(xGm[x1GmBaseOffset + xBaseOffset], x1Local, curRowFactor, curDFactor,
+                       tilingData->d - curDFactor);
+                x1Que.template EnQue(x1Local);
+                x1Local = x1Que.template DeQue<T0>();
+
+                if constexpr (outputOrigin) {
+                    yOriginLocal = yOriginQue.template AllocTensor<T0>();
+                }
+
+                yLocal = yQue.template AllocTensor<T1>();
+                scaleLocal = scaleQue.template AllocTensor<T2>();
+
+                int32_t maskBit = (hasRoundScale_ << 2) | (hasClampValue_ << 1) | hasTopkWeight_;
+
+                if constexpr (outputOrigin) {
+                    Fp8QuantPerTokenDispatcherYOrigin<T1, T0, T2>(yLocal, yOriginLocal, scaleLocal, x0Local, x1Local,
+                                                                  topkWeightLocal, clampValue_, curRowFactor,
+                                                                  curDFactor, maskBit);
+                } else {
+                    Fp8QuantPerTokenDispatcher<T1, T0, T2>(yLocal, yOriginLocal, scaleLocal, x0Local, x1Local,
+                                                           topkWeightLocal, clampValue_, curRowFactor, curDFactor,
+                                                           maskBit);
+                }
+
+                x0Que.template FreeTensor(x0Local);
+                x1Que.template FreeTensor(x1Local);
+
+                yQue.template EnQue(yLocal);
+                yLocal = yQue.template DeQue<T1>();
+                CopyOut(yLocal,
+                        yGm[yGmBaseOffset + rowOuterIdx * tilingData->rowFactor * tilingData->splitD +
+                            dLoopIdx * tilingData->dFactor],
+                        curRowFactor, curDFactor, tilingData->splitD - curDFactor);
+                yQue.template FreeTensor(yLocal);
+
+                scaleQue.template EnQue(scaleLocal);
+                scaleLocal = scaleQue.template DeQue<T2>();
+                CopyOut<T2, AscendC::PaddingMode::Compact>(
+                    scaleLocal,
+                    scaleGm[scaleGmBaseOffset + rowOuterIdx * tilingData->rowFactor * tilingData->scaleCol +
+                            dLoopIdx * CeilDiv(tilingData->dFactor, PER_BLOCK_FP16)],
+                    curRowFactor, scaleDFactor, tilingData->scaleCol - scaleDFactor);
+                scaleQue.template FreeTensor(scaleLocal);
+
+                // copy yOrigin to gm
+                if constexpr (outputOrigin) {
+                    int64_t yOriginGmBaseOffset = curBlockIdx * rowOfFormerBlock * tilingData->splitD;
+                    yOriginQue.template EnQue(yOriginLocal);
+                    yOriginLocal = yOriginQue.template DeQue<T0>();
+                    CopyOut(yOriginLocal,
+                            yOriginGm[yOriginGmBaseOffset + rowOuterIdx * tilingData->rowFactor * tilingData->splitD +
+                                      dLoopIdx * tilingData->dFactor],
+                            curRowFactor, curDFactor, tilingData->splitD - curDFactor);
+                    yOriginQue.template FreeTensor(yOriginLocal);
+                }
+            }
+            if (hasTopkWeight_) {
+                topkWeightQue.template FreeTensor(topkWeightLocal);
+            }
+        }
+    }
+
+private:
+    TPipe *pipe;
+    const SwigluGroupQuantTilingData *tilingData;
+    GlobalTensor<T0> xGm;
+    GlobalTensor<T1> yGm;
+    GlobalTensor<T2> scaleGm;
+    GlobalTensor<float> topkWeightGm;
+    GlobalTensor<T0> yOriginGm;
+    GlobalTensor<int64_t> groupIndexGm;
+
+    TQue<QuePosition::VECIN, 1> x0Que;
+    TQue<QuePosition::VECIN, 1> x1Que;
+    TQue<QuePosition::VECOUT, 1> yQue;
+    TQue<QuePosition::VECOUT, 1> scaleQue;
+    TQue<QuePosition::VECIN, 1> topkWeightQue;
+    TQue<QuePosition::VECOUT, 1> yOriginQue;
+
+    TQue<QuePosition::VECIN, 1> groupIndexQue;
+    TBuf<QuePosition::VECCALC> groupIndexSumBuf;
+    TBufPool<QuePosition::VECCALC, 12> tBufPool;
+
+    LocalTensor<T0> x0Local;
+    LocalTensor<T0> x1Local;
+    LocalTensor<T1> yLocal;
+    LocalTensor<T2> scaleLocal;
+    LocalTensor<float> topkWeightLocal;
+    LocalTensor<T0> yOriginLocal;
+
+    LocalTensor<int64_t> groupIndexLocal;
+    LocalTensor<int64_t> groupSumLocal;
+
+    float clampValue_ = 448.0f;
+    bool hasTopkWeight_ = false;
+    bool hasRoundScale_ = false;
+    bool hasClampValue_ = false;
+
+    bool hasGroupIndex_ = false;
+    int64_t tailRowFactorOfTailBlock = 0;
+    int64_t tailRowFactorOfFormerBlock = 0;
+    int64_t rowLoopOfTailBlock = 0;
+    int64_t rowLoopOfFormerBlock = 0;
+    int64_t usedCoreNums = 0;
+    int64_t rowOfFormerBlock = 0;
+    int64_t rowOfTailBlock = 0;
+};
+
+}  // namespace SwigluGroupQuant
+
+#endif

--- a/csrc/swiglu_group_quant/op_kernel/swiglu_group_quant.cpp
+++ b/csrc/swiglu_group_quant/op_kernel/swiglu_group_quant.cpp
@@ -12,21 +12,16 @@
  * \file swiglu_group_quant.cpp
  * \brief swiglu_group_quant kernel entry (A5-only).
  *
- * Adapted from vllm-ascend csrc/moe/swiglu_group_quant/op_kernel/swiglu_group_quant.cpp.
- *
  * The three op classes and their shared helpers (swiglu_group_quant_base.h, *_perf.h,
- * swiglu_fp8_quant_per_token.h) are copied verbatim from upstream — see the note at the top of
- * each. Only this entry differs, because this repo has no CANN op registry:
+ * swiglu_fp8_quant_per_token.h) live alongside this file. This entry does nothing but dispatch:
  *
- *   - upstream's GET_TILING_DATA(tilingData, tiling) is replaced by the field-by-field copy that
- *     kv_compress_epilog uses. GET_TILING_DATA expands to a struct-by-value copy out of a __gm__
- *     pointer, which A5 rejects ("argument is in address space gm, but parameter must be in Local
- *     Memory"), and GET_TILING_DATA_WITH_STRUCT cannot take a namespaced type name.
- *   - upstream's TILING_KEY_IS(...) (a framework macro) is replaced by a plain comparison against
- *     a tilingKey field carried in the packed struct.
- *   - upstream's DTYPE_X / DTYPE_Y / DTYPE_SCALE are build-time -D defines set per compiled
- *     op binary, one binary per dtype combination. This repo builds a single kernel, so the dtype
- *     combination is carried in the struct's `dtype` field and dispatched here at runtime.
+ *   - Tiling arrives as a packed struct memcpy'd to GM and is copied field-by-field below.
+ *     GET_TILING_DATA expands to a struct-by-value copy out of a __gm__ pointer, which A5 rejects
+ *     ("argument is in address space gm, but parameter must be in Local Memory"), and
+ *     GET_TILING_DATA_WITH_STRUCT cannot take a namespaced type name.
+ *   - The tiling key is a plain field in that struct, compared directly.
+ *   - x/y/scale dtypes are carried in the struct's `dtype` field and dispatched at runtime, since
+ *     this repo builds one kernel rather than one binary per dtype combination.
  *
  * The dispatch covers every (tiling key, dtype) combination the host can produce. scale dtype is
  * implied by the quant mode for keys 1 and 2 (fp32 and e8m0 respectively), and is selected by
@@ -51,8 +46,8 @@ using namespace AscendC;
 
 namespace {
 
-// Shorthands so the dispatch below stays readable. Each expands to the upstream entry's
-// "construct / Init / Process" sequence with the class's template parameters filled in.
+// Shorthands so the dispatch below stays readable. Each expands to the "construct / Init / Process"
+// sequence with the class's template parameters filled in.
 #define SWIGLU_GROUP_QUANT_RUN_GROUP(XT, YT)                                        \
     do {                                                                            \
         SwigluGroupQuant::SwigluGroupQuantPerf<XT, YT, float> op;                   \
@@ -130,7 +125,7 @@ extern "C" __global__ __aicore__ void swiglu_group_quant(GM_ADDR x, GM_ADDR topk
     const bool yE5m2 = (dtype & sglang::SWIGLU_GROUP_QUANT_DTYPE_Y_E5M2) != 0;
     const bool scaleE8m0 = (dtype & sglang::SWIGLU_GROUP_QUANT_DTYPE_SCALE_E8M0) != 0;
 
-    // Upstream saves and restores the overflow mode around the whole dispatch; each class's Init
+    // The overflow mode is saved and restored around the whole dispatch; each class's Init
     // additionally forces it to saturation (0), which is what the fp8 casts need.
     int64_t oriOverflowMode = AscendC::GetCtrlSpr<FLOAT_OVERFLOW_MODE_CTRL, FLOAT_OVERFLOW_MODE_CTRL>();
 

--- a/csrc/swiglu_group_quant/op_kernel/swiglu_group_quant.cpp
+++ b/csrc/swiglu_group_quant/op_kernel/swiglu_group_quant.cpp
@@ -1,0 +1,235 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file swiglu_group_quant.cpp
+ * \brief swiglu_group_quant kernel entry (A5-only).
+ *
+ * Adapted from vllm-ascend csrc/moe/swiglu_group_quant/op_kernel/swiglu_group_quant.cpp.
+ *
+ * The three op classes and their shared helpers (swiglu_group_quant_base.h, *_perf.h,
+ * swiglu_fp8_quant_per_token.h) are copied verbatim from upstream — see the note at the top of
+ * each. Only this entry differs, because this repo has no CANN op registry:
+ *
+ *   - upstream's GET_TILING_DATA(tilingData, tiling) is replaced by the field-by-field copy that
+ *     kv_compress_epilog uses. GET_TILING_DATA expands to a struct-by-value copy out of a __gm__
+ *     pointer, which A5 rejects ("argument is in address space gm, but parameter must be in Local
+ *     Memory"), and GET_TILING_DATA_WITH_STRUCT cannot take a namespaced type name.
+ *   - upstream's TILING_KEY_IS(...) (a framework macro) is replaced by a plain comparison against
+ *     a tilingKey field carried in the packed struct.
+ *   - upstream's DTYPE_X / DTYPE_Y / DTYPE_SCALE are build-time -D defines set per compiled
+ *     op binary, one binary per dtype combination. This repo builds a single kernel, so the dtype
+ *     combination is carried in the struct's `dtype` field and dispatched here at runtime.
+ *
+ * The dispatch covers every (tiling key, dtype) combination the host can produce. scale dtype is
+ * implied by the quant mode for keys 1 and 2 (fp32 and e8m0 respectively), and is selected by
+ * `ue8m0_scale` for the fp8 keys.
+ */
+
+#include "kernel_operator.h"
+
+// ascendc_library compiles kernel sources once more for host-bisheng, where CANN 9.1 does not
+// define __NPU_ARCH__. This MicroAPI-based implementation is device-only.
+#if defined(__NPU_ARCH__)
+
+#include "../op_host/tiling/swiglu_group_quant_tiling_data.h"
+
+using sglang::SwigluGroupQuantTilingData;
+
+#include "swiglu_group_quant_perf.h"
+#include "swiglu_mx_quant_perf.h"
+#include "swiglu_fp8_quant_per_token.h"
+
+using namespace AscendC;
+
+namespace {
+
+// Shorthands so the dispatch below stays readable. Each expands to the upstream entry's
+// "construct / Init / Process" sequence with the class's template parameters filled in.
+#define SWIGLU_GROUP_QUANT_RUN_GROUP(XT, YT)                                        \
+    do {                                                                            \
+        SwigluGroupQuant::SwigluGroupQuantPerf<XT, YT, float> op;                   \
+        op.Init(x, topkWeight, groupIndex, y, scale, userWs, &tilingDataIn, &pipe); \
+        op.Process();                                                               \
+    } while (0)
+
+#define SWIGLU_GROUP_QUANT_RUN_MX(XT, YT)                                           \
+    do {                                                                            \
+        SwigluGroupQuant::SwigluMxQuantPerf<XT, YT, fp8_e8m0_t> op;                 \
+        op.Init(x, topkWeight, groupIndex, y, scale, userWs, &tilingDataIn, &pipe); \
+        op.Process();                                                               \
+    } while (0)
+
+#define SWIGLU_GROUP_QUANT_RUN_FP8(XT, YT, ST, OO)                                           \
+    do {                                                                                     \
+        SwigluGroupQuant::SwigluFp8QuantPerToken<XT, YT, ST, OO> op;                         \
+        op.Init(x, topkWeight, groupIndex, y, scale, yOrigin, userWs, &tilingDataIn, &pipe); \
+        op.Process();                                                                        \
+    } while (0)
+
+}  // namespace
+
+extern "C" __global__ __aicore__ void swiglu_group_quant(GM_ADDR x, GM_ADDR topkWeight, GM_ADDR groupIndex, GM_ADDR y,
+                                                         GM_ADDR scale, GM_ADDR yOrigin, GM_ADDR workspace,
+                                                         GM_ADDR tiling)
+{
+    if (workspace == nullptr) {
+        return;
+    }
+
+    // The op classes take a workspace argument but never read it, so the raw pointer is forwarded
+    // as-is rather than through GetUserWorkspace (which kv_compress_epilog also avoids on A5).
+    GM_ADDR userWs = workspace;
+    if (userWs == nullptr) {
+        return;
+    }
+
+    TPipe pipe;
+
+    // Local copy of the tiling data; see the file comment for why this is field-by-field.
+    const __gm__ SwigluGroupQuantTilingData *__restrict__ tilingGm =
+        reinterpret_cast<const __gm__ SwigluGroupQuantTilingData *>(tiling);
+    SwigluGroupQuantTilingData tilingDataIn;
+    tilingDataIn.bs = tilingGm->bs;
+    tilingDataIn.d = tilingGm->d;
+    tilingDataIn.splitD = tilingGm->splitD;
+    tilingDataIn.scaleCol = tilingGm->scaleCol;
+    tilingDataIn.rowOfFormerBlock = tilingGm->rowOfFormerBlock;
+    tilingDataIn.rowOfTailBlock = tilingGm->rowOfTailBlock;
+    tilingDataIn.rowLoopOfFormerBlock = tilingGm->rowLoopOfFormerBlock;
+    tilingDataIn.rowLoopOfTailBlock = tilingGm->rowLoopOfTailBlock;
+    tilingDataIn.rowFactor = tilingGm->rowFactor;
+    tilingDataIn.tailRowFactorOfFormerBlock = tilingGm->tailRowFactorOfFormerBlock;
+    tilingDataIn.tailRowFactorOfTailBlock = tilingGm->tailRowFactorOfTailBlock;
+    tilingDataIn.dLoop = tilingGm->dLoop;
+    tilingDataIn.dFactor = tilingGm->dFactor;
+    tilingDataIn.tailDFactor = tilingGm->tailDFactor;
+    tilingDataIn.roundScale = tilingGm->roundScale;
+    tilingDataIn.ue8m0Scale = tilingGm->ue8m0Scale;
+    tilingDataIn.outputOrigin = tilingGm->outputOrigin;
+    tilingDataIn.hasClampValue = tilingGm->hasClampValue;
+    tilingDataIn.g = tilingGm->g;
+    tilingDataIn.ubSize = tilingGm->ubSize;
+    tilingDataIn.gLoop = tilingGm->gLoop;
+    tilingDataIn.gFactor = tilingGm->gFactor;
+    tilingDataIn.tailGFactor = tilingGm->tailGFactor;
+    tilingDataIn.groupListType = tilingGm->groupListType;
+    tilingDataIn.coreNum = tilingGm->coreNum;
+    tilingDataIn.clampValue = tilingGm->clampValue;
+    const int32_t dtype = tilingGm->dtype;
+    const uint32_t tilingKey = tilingGm->tilingKey;
+
+    const bool xBf16 = (dtype & sglang::SWIGLU_GROUP_QUANT_DTYPE_X_BF16) != 0;
+    const bool yE5m2 = (dtype & sglang::SWIGLU_GROUP_QUANT_DTYPE_Y_E5M2) != 0;
+    const bool scaleE8m0 = (dtype & sglang::SWIGLU_GROUP_QUANT_DTYPE_SCALE_E8M0) != 0;
+
+    // Upstream saves and restores the overflow mode around the whole dispatch; each class's Init
+    // additionally forces it to saturation (0), which is what the fp8 casts need.
+    int64_t oriOverflowMode = AscendC::GetCtrlSpr<FLOAT_OVERFLOW_MODE_CTRL, FLOAT_OVERFLOW_MODE_CTRL>();
+
+    if (tilingKey == sglang::SWIGLU_GROUP_QUANT_TILING_KEY_GROUP_QUANT) {
+        // Group (per-128-block) quant: scale is always fp32.
+        if (xBf16) {
+            if (yE5m2) {
+                SWIGLU_GROUP_QUANT_RUN_GROUP(bfloat16_t, fp8_e5m2_t);
+            } else {
+                SWIGLU_GROUP_QUANT_RUN_GROUP(bfloat16_t, fp8_e4m3fn_t);
+            }
+        } else {
+            if (yE5m2) {
+                SWIGLU_GROUP_QUANT_RUN_GROUP(half, fp8_e5m2_t);
+            } else {
+                SWIGLU_GROUP_QUANT_RUN_GROUP(half, fp8_e4m3fn_t);
+            }
+        }
+    } else if (tilingKey == sglang::SWIGLU_GROUP_QUANT_TILING_KEY_MX_QUANT) {
+        // MX quant (per-32-group): scale is always e8m0.
+        if (xBf16) {
+            if (yE5m2) {
+                SWIGLU_GROUP_QUANT_RUN_MX(bfloat16_t, fp8_e5m2_t);
+            } else {
+                SWIGLU_GROUP_QUANT_RUN_MX(bfloat16_t, fp8_e4m3fn_t);
+            }
+        } else {
+            if (yE5m2) {
+                SWIGLU_GROUP_QUANT_RUN_MX(half, fp8_e5m2_t);
+            } else {
+                SWIGLU_GROUP_QUANT_RUN_MX(half, fp8_e4m3fn_t);
+            }
+        }
+    } else if (tilingKey == sglang::SWIGLU_GROUP_QUANT_TILING_KEY_FP8_QUANT) {
+        // Per-token fp8 quant, without the swiglu result in the source dtype: scale is fp32 unless
+        // the caller asked for ue8m0.
+        if (xBf16) {
+            if (yE5m2) {
+                if (scaleE8m0) {
+                    SWIGLU_GROUP_QUANT_RUN_FP8(bfloat16_t, fp8_e5m2_t, fp8_e8m0_t, false);
+                } else {
+                    SWIGLU_GROUP_QUANT_RUN_FP8(bfloat16_t, fp8_e5m2_t, float, false);
+                }
+            } else {
+                if (scaleE8m0) {
+                    SWIGLU_GROUP_QUANT_RUN_FP8(bfloat16_t, fp8_e4m3fn_t, fp8_e8m0_t, false);
+                } else {
+                    SWIGLU_GROUP_QUANT_RUN_FP8(bfloat16_t, fp8_e4m3fn_t, float, false);
+                }
+            }
+        } else {
+            if (yE5m2) {
+                if (scaleE8m0) {
+                    SWIGLU_GROUP_QUANT_RUN_FP8(half, fp8_e5m2_t, fp8_e8m0_t, false);
+                } else {
+                    SWIGLU_GROUP_QUANT_RUN_FP8(half, fp8_e5m2_t, float, false);
+                }
+            } else {
+                if (scaleE8m0) {
+                    SWIGLU_GROUP_QUANT_RUN_FP8(half, fp8_e4m3fn_t, fp8_e8m0_t, false);
+                } else {
+                    SWIGLU_GROUP_QUANT_RUN_FP8(half, fp8_e4m3fn_t, float, false);
+                }
+            }
+        }
+    } else if (tilingKey == sglang::SWIGLU_GROUP_QUANT_TILING_KEY_FP8_QUANT_YORIGIN) {
+        // Same as above, plus the swiglu result written back in the source dtype.
+        if (xBf16) {
+            if (yE5m2) {
+                if (scaleE8m0) {
+                    SWIGLU_GROUP_QUANT_RUN_FP8(bfloat16_t, fp8_e5m2_t, fp8_e8m0_t, true);
+                } else {
+                    SWIGLU_GROUP_QUANT_RUN_FP8(bfloat16_t, fp8_e5m2_t, float, true);
+                }
+            } else {
+                if (scaleE8m0) {
+                    SWIGLU_GROUP_QUANT_RUN_FP8(bfloat16_t, fp8_e4m3fn_t, fp8_e8m0_t, true);
+                } else {
+                    SWIGLU_GROUP_QUANT_RUN_FP8(bfloat16_t, fp8_e4m3fn_t, float, true);
+                }
+            }
+        } else {
+            if (yE5m2) {
+                if (scaleE8m0) {
+                    SWIGLU_GROUP_QUANT_RUN_FP8(half, fp8_e5m2_t, fp8_e8m0_t, true);
+                } else {
+                    SWIGLU_GROUP_QUANT_RUN_FP8(half, fp8_e5m2_t, float, true);
+                }
+            } else {
+                if (scaleE8m0) {
+                    SWIGLU_GROUP_QUANT_RUN_FP8(half, fp8_e4m3fn_t, fp8_e8m0_t, true);
+                } else {
+                    SWIGLU_GROUP_QUANT_RUN_FP8(half, fp8_e4m3fn_t, float, true);
+                }
+            }
+        }
+    }
+
+    AscendC::SetCtrlSpr<FLOAT_OVERFLOW_MODE_CTRL, FLOAT_OVERFLOW_MODE_CTRL>(oriOverflowMode);
+}
+
+#endif

--- a/csrc/swiglu_group_quant/op_kernel/swiglu_group_quant_base.h
+++ b/csrc/swiglu_group_quant/op_kernel/swiglu_group_quant_base.h
@@ -1,0 +1,949 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file swiglu_group_quant_base.h
+ * \brief
+ */
+
+#ifndef SWIGLU_GROUP_QUANT_BASE_H
+#define SWIGLU_GROUP_QUANT_BASE_H
+
+#include "kernel_operator.h"
+
+namespace SwigluGroupQuant {
+using namespace AscendC;
+using namespace AscendC::MicroAPI;
+using AscendC::MicroAPI::MaskReg;
+using AscendC::MicroAPI::RegTensor;
+using AscendC::MicroAPI::UnalignReg;
+constexpr int32_t BLOCK_SIZE = 32;
+constexpr int32_t VL_FP32 = 64;
+constexpr int32_t PER_BLOCK_FP16 = 128;
+constexpr int32_t PER_MX_FP16 = 32;
+constexpr float FP8_E5M2_MAX_VALUE = 57344.0f;
+constexpr float FP8_E4M3FN_MAX_VALUE = 448.0f;
+constexpr float TOPK_WEIGHT_DEFAULT = 1.0f;
+constexpr int64_t OUT_ELE_NUM_ONE_BLK = 64LL;
+constexpr uint16_t FP16_EMASK_AND_INF_VAL = 0x7c00;
+constexpr uint16_t BF16_EMASK_AND_INF_VAL = 0x7f80;
+constexpr uint16_t BF16_NAN_VAL = 0x7f81;
+constexpr uint16_t LOWER_BOUND_OF_MAX_EXP_FOR_E5M2 = 0x0780;
+constexpr uint16_t LOWER_BOUND_OF_MAX_EXP_FOR_E4M3 = 0x0400;
+constexpr uint16_t FP8_E8M0_NAN_VAL = 0x00ff;
+constexpr uint16_t FP8_E8M0_SPECIAL_MIN = 0x0040;
+constexpr int16_t BF16_EXP_SHR_BITS = 7;
+constexpr uint16_t BF16_EXP_INVSUB = 0x7f00;
+constexpr uint32_t INV_FP8_E5M2_MAX_VALUE = 0x37924925;
+constexpr uint32_t INV_FP8_E4M3_MAX_VALUE = 0x3b124925;
+constexpr uint32_t FAST_LOG_SHIFT_BITS = 23U;
+constexpr uint32_t FAST_LOG_AND_VALUE1 = 0xFF;
+constexpr uint32_t FAST_LOG_AND_VALUE2 = (((uint32_t)1 << (uint32_t)23) - (uint32_t)1);
+constexpr uint32_t REPEAT_SIZE = 256;
+constexpr uint16_t FOUR_UNFOLD = 4;
+#define FLOAT_OVERFLOW_MODE_CTRL 60
+#ifndef INFINITY
+#define INFINITY (__builtin_inff())
+#endif
+constexpr float POS_INFINITY = INFINITY;
+constexpr float NEG_INFINITY = -INFINITY;
+
+__aicore__ inline int32_t CeilDiv(int32_t a, int b)
+{
+    if (b == 0) {
+        return a;
+    }
+    return (a + b - 1) / b;
+}
+
+__aicore__ inline int32_t CeilAlign(int32_t a, int b)
+{
+    return CeilDiv(a, b) * b;
+}
+
+template <typename T>
+__aicore__ inline int32_t RoundUp(int32_t num)
+{
+    int32_t elemNum = BLOCK_SIZE / sizeof(T);
+    return CeilAlign(num, elemNum);
+}
+
+constexpr AscendC::MicroAPI::CastTrait castTraitB162B32Even = {
+    AscendC::MicroAPI::RegLayout::ZERO,
+    AscendC::MicroAPI::SatMode::UNKNOWN,
+    AscendC::MicroAPI::MaskMergeMode::ZEROING,
+    AscendC::RoundMode::UNKNOWN,
+};
+
+constexpr AscendC::MicroAPI::CastTrait castTraitB322B16Even = {
+    AscendC::MicroAPI::RegLayout::ZERO,
+    AscendC::MicroAPI::SatMode::NO_SAT,
+    AscendC::MicroAPI::MaskMergeMode::ZEROING,
+    AscendC::RoundMode::CAST_RINT,
+};
+
+constexpr static AscendC::MicroAPI::CastTrait castTraitF32toFp8Even = {
+    AscendC::MicroAPI::RegLayout::ZERO,
+    AscendC::MicroAPI::SatMode::NO_SAT,
+    AscendC::MicroAPI::MaskMergeMode::ZEROING,
+    AscendC::RoundMode::CAST_RINT,
+};
+
+constexpr static AscendC::MicroAPI::CastTrait castTraitU32toU8Even = {
+    AscendC::MicroAPI::RegLayout::ZERO,
+    AscendC::MicroAPI::SatMode::NO_SAT,
+    AscendC::MicroAPI::MaskMergeMode::ZEROING,
+    AscendC::RoundMode::CAST_NONE,
+};
+
+template <typename T>
+__aicore__ inline void LoadInputData(RegTensor<float> &dst, __local_mem__ T *src, MaskReg pregLoop, uint32_t srcOffset)
+{
+    if constexpr (IsSameType<T, float>::value) {
+        DataCopy(dst, src + srcOffset);
+    } else if constexpr (IsSameType<T, half>::value || IsSameType<T, bfloat16_t>::value) {
+        RegTensor<T> tmp;
+        DataCopy<T, AscendC::MicroAPI::LoadDist::DIST_UNPACK_B16>(tmp, src + srcOffset);
+        Cast<float, T, castTraitB162B32Even>(dst, tmp, pregLoop);
+    }
+}
+
+template <typename T>
+__aicore__ inline void StoreOutputData(__local_mem__ T *dst, RegTensor<float> &src, MaskReg pregLoop,
+                                       uint32_t dstOffset)
+{
+    if constexpr (IsSameType<T, float>::value) {
+        DataCopy(dst + dstOffset, src, pregLoop);
+    } else if constexpr (IsSameType<T, half>::value || IsSameType<T, bfloat16_t>::value) {
+        RegTensor<T> tmp;
+        Cast<T, float, castTraitB322B16Even>(tmp, src, pregLoop);
+        DataCopy<T, AscendC::MicroAPI::StoreDist::DIST_PACK_B32>(dst + dstOffset, tmp, pregLoop);
+    } else if constexpr (IsSameType<T, fp8_e4m3fn_t>::value || IsSameType<T, fp8_e5m2_t>::value) {
+        RegTensor<T> tmp;
+        Cast<T, float, castTraitF32toFp8Even>(tmp, src, pregLoop);
+        DataCopy<T, AscendC::MicroAPI::StoreDist::DIST_PACK4_B32>(dst + dstOffset, tmp, pregLoop);
+    }
+}
+
+template <typename T>
+__aicore__ inline void StoreOuputDataUnalign(RegTensor<float> &src, __local_mem__ T *&dst, UnalignReg &uDst,
+                                             MaskReg pregLoop, uint32_t postUpdateStride)
+{
+    if constexpr (IsSameType<T, float>::value) {
+        DataCopyUnAlign(dst, src, uDst, postUpdateStride);
+    } else if constexpr (IsSameType<T, half>::value || IsSameType<T, bfloat16_t>::value) {
+        RegTensor<T> tmp;
+        RegTensor<T> tmpPack;
+        Cast<T, float, castTraitB322B16Even>(tmp, src, pregLoop);
+        Pack((RegTensor<uint16_t> &)tmpPack, (RegTensor<uint32_t> &)tmp);
+        DataCopyUnAlign(dst, tmpPack, uDst, postUpdateStride);
+    }
+}
+
+template <typename T>
+__aicore__ inline void StoreMxFp8Scale(__local_mem__ T *dst, RegTensor<int32_t> &src, MaskReg pregLoop,
+                                       uint32_t dstOffset)
+{
+    RegTensor<uint8_t> tmp1;
+    Cast<uint8_t, int32_t, castTraitU32toU8Even>(tmp1, src, pregLoop);
+    DataCopy<T, AscendC::MicroAPI::StoreDist::DIST_FIRST_ELEMENT_B8>(dst + dstOffset, (RegTensor<T> &)tmp1, pregLoop);
+}
+
+__aicore__ inline void VFSwiGlu(RegTensor<float> &y, RegTensor<float> &x0, RegTensor<float> &x1, RegTensor<float> &one,
+                                RegTensor<float> &vreg, MaskReg pregLoop)
+{
+    Muls(vreg, x0, static_cast<float>(-1.0f), pregLoop);
+    Exp(vreg, vreg, pregLoop);
+    Adds(vreg, vreg, static_cast<float>(1.0f), pregLoop);
+    Div(vreg, x0, vreg, pregLoop);
+    Mul(y, vreg, x1, pregLoop);
+}
+
+template <typename T0, typename T1, typename T2, bool hasTopkWeight = false, bool hasClampValue = false>
+__aicore__ inline void VFProcessSwigluGroupQuant(const LocalTensor<T0> &yLocal, const LocalTensor<T2> &scaleLocal,
+                                                 const LocalTensor<T1> &x0Local, const LocalTensor<T1> &x1Local,
+                                                 const LocalTensor<float> &topkWeightLocal, float coeff,
+                                                 const uint16_t curRowNum, const uint32_t curColNum, float clampValue)
+{
+    __local_mem__ T0 *yLocalAddr = (__local_mem__ T0 *)yLocal.GetPhyAddr();
+    __local_mem__ T2 *scaleLocalAddr = (__local_mem__ T2 *)scaleLocal.GetPhyAddr();
+    __local_mem__ T1 *x0LocalAddr = (__local_mem__ T1 *)x0Local.GetPhyAddr();
+    __local_mem__ T1 *x1LocalAddr = (__local_mem__ T1 *)x1Local.GetPhyAddr();
+    __local_mem__ float *topkWeightLocalAddr =
+        hasTopkWeight ? (__local_mem__ float *)topkWeightLocal.GetPhyAddr() : nullptr;
+    static constexpr AscendC::MicroAPI::DivSpecificMode mode = {AscendC::MicroAPI::MaskMergeMode::ZEROING, false};
+    uint32_t maxValueInt = 0;
+    if constexpr (IsSameType<T0, fp8_e5m2_t>::value) {
+        maxValueInt = INV_FP8_E5M2_MAX_VALUE;
+    } else if constexpr (IsSameType<T0, fp8_e4m3fn_t>::value) {
+        maxValueInt = INV_FP8_E4M3_MAX_VALUE;
+    }
+    uint16_t loopCount = CeilDiv(curColNum, VL_FP32);
+    uint32_t curColNumAlign = RoundUp<T1>(curColNum);
+    uint32_t dstCurColNumAlign = RoundUp<T0>(curColNum);
+    uint16_t loopCountFoldTwo = loopCount / 2;
+    uint16_t loopCountReminder = loopCount % 2;
+    uint32_t tailRemider = curColNum - (loopCount - 1) * VL_FP32;
+    uint32_t scaleColNum = (curColNum + 128 - 1) / 128;
+    uint32_t sregNum = loopCountReminder == 0 ? curColNum - loopCountFoldTwo * VL_FP32 : loopCountFoldTwo * VL_FP32;
+    __VEC_SCOPE__
+    {
+        RegTensor<float> weight;
+        RegTensor<float> xLeft;
+        RegTensor<float> xRight;
+        RegTensor<float> x0Left;
+        RegTensor<float> x0Right;
+        RegTensor<float> x1Left;
+        RegTensor<float> x1Right;
+        RegTensor<float> xAbsLeft;
+        RegTensor<float> xAbsRight;
+        RegTensor<float> xMax;
+        RegTensor<float> tmp;
+        RegTensor<float> dupScale;
+        RegTensor<float> scale;
+        RegTensor<float> scale0;
+        RegTensor<float> scale1;
+        RegTensor<float> inf;
+        RegTensor<float> one;
+        RegTensor<float> zero;
+        RegTensor<uint32_t> coeffReg;
+        UnalignReg uScale;
+        MaskReg pregLoop = CreateMask<float>();
+        Duplicate(one, static_cast<float>(1.0f), pregLoop);
+        Duplicate(coeffReg, maxValueInt, pregLoop);
+        Duplicate(zero, 0.0f);
+        Duplicate(inf, 1.0f);
+        Div<float, &mode>(inf, inf, zero, pregLoop);
+        MaskReg pregMain = CreateMask<float>();
+        MaskReg preg1 = CreateMask<float, AscendC::MicroAPI::MaskPattern::VL1>();
+        MaskReg compareLeft;
+        MaskReg compareRight;
+        MaskReg compareScalar;
+        for (uint16_t i = 0; i < curRowNum; i++) {
+            if constexpr (hasTopkWeight) {
+                DataCopy<float, AscendC::MicroAPI::LoadDist::DIST_BRC_B32>(weight, topkWeightLocalAddr + i);
+            }
+            uint32_t sreg = sregNum;
+            for (uint16_t j = 0; j < loopCountFoldTwo; j++) {
+                pregLoop = UpdateMask<float>(sreg);
+                LoadInputData<T1>(x0Left, x0LocalAddr, pregMain, 2 * j * VL_FP32 + i * curColNumAlign);
+                LoadInputData<T1>(x0Right, x0LocalAddr, pregLoop, (2 * j + 1) * VL_FP32 + i * curColNumAlign);
+                LoadInputData<T1>(x1Left, x1LocalAddr, pregMain, 2 * j * VL_FP32 + i * curColNumAlign);
+                LoadInputData<T1>(x1Right, x1LocalAddr, pregLoop, (2 * j + 1) * VL_FP32 + i * curColNumAlign);
+                if constexpr (hasClampValue) {
+                    Mins(x0Left, x0Left, clampValue, pregMain);
+                    Mins(x0Right, x0Right, clampValue, pregLoop);
+                    Maxs(x1Left, x1Left, -clampValue, pregMain);
+                    Mins(x1Left, x1Left, clampValue, pregMain);
+                    Maxs(x1Right, x1Right, -clampValue, pregLoop);
+                    Mins(x1Right, x1Right, clampValue, pregLoop);
+                }
+                VFSwiGlu(xLeft, x0Left, x1Left, one, tmp, pregMain);
+                VFSwiGlu(xRight, x0Right, x1Right, one, tmp, pregLoop);
+                if constexpr (hasTopkWeight) {
+                    Mul(xLeft, xLeft, weight, pregMain);
+                    Mul(xRight, xRight, weight, pregLoop);
+                }
+                Muls(xAbsLeft, xLeft, 0.0f, pregMain);
+                Compare<float, CMPMODE::NE>(compareLeft, xAbsLeft, xAbsLeft, pregMain);
+                MaskNot(compareLeft, compareLeft, pregMain);
+                Abs(xAbsLeft, xLeft, compareLeft);
+                ReduceMax(scale0, xAbsLeft, pregMain);
+                Muls(xAbsRight, xRight, 0.0f, pregLoop);
+                Compare<float, CMPMODE::NE>(compareRight, xAbsRight, xAbsRight, pregLoop);
+                MaskNot(compareRight, compareRight, pregLoop);
+                Abs(xAbsRight, xRight, compareRight);
+                ReduceMax(scale1, xAbsRight, pregLoop);
+                Max(scale, scale0, scale1, preg1);
+                CompareScalar<float, CMPMODE::NE>(compareScalar, scale, (float)0.0, preg1);
+                Mul(scale, scale, (RegTensor<float> &)coeffReg, compareScalar);
+                Min(scale, scale, inf, preg1);
+                Duplicate(dupScale, scale, pregMain);
+                StoreOuputDataUnalign(scale, scaleLocalAddr, uScale, preg1, 1);
+                Div<float, &mode>(x0Left, xLeft, dupScale, pregMain);
+                Muls(x1Left, x0Left, 0.0f, pregMain);
+                Compare<float, CMPMODE::NE>(compareLeft, x1Left, x1Left, pregMain);
+                Select(xLeft, xLeft, x0Left, compareLeft);
+                Div<float, &mode>(x0Right, xRight, dupScale, pregLoop);
+                Muls(x1Right, x0Right, 0.0f, pregLoop);
+                Compare<float, CMPMODE::NE>(compareRight, x1Right, x1Right, pregLoop);
+                Select(xRight, xRight, x0Right, compareRight);
+                StoreOutputData<T0>(yLocalAddr, xLeft, pregMain, 2 * j * VL_FP32 + i * dstCurColNumAlign);
+                StoreOutputData<T0>(yLocalAddr, xRight, pregLoop, (2 * j + 1) * VL_FP32 + i * dstCurColNumAlign);
+            }
+            // 处理尾块, 这里只有一个for循环
+            pregLoop = UpdateMask<float>(tailRemider);
+            for (uint16_t j = 0; j < loopCountReminder; j++) {
+                LoadInputData<T1>(x0Left, x0LocalAddr, pregLoop, loopCountFoldTwo * 2 * VL_FP32 + i * curColNumAlign);
+                LoadInputData<T1>(x1Left, x1LocalAddr, pregLoop, loopCountFoldTwo * 2 * VL_FP32 + i * curColNumAlign);
+                if constexpr (hasClampValue) {
+                    Mins(x0Left, x0Left, clampValue, pregLoop);
+                    Maxs(x1Left, x1Left, -clampValue, pregLoop);
+                    Mins(x1Left, x1Left, clampValue, pregLoop);
+                }
+                VFSwiGlu(xLeft, x0Left, x1Left, one, tmp, pregLoop);
+                if constexpr (hasTopkWeight) {
+                    Mul(xLeft, xLeft, weight, pregLoop);
+                }
+                Abs(xAbsLeft, xLeft, pregLoop);
+                ReduceMax(scale, xAbsLeft, pregLoop);
+                CompareScalar<float, CMPMODE::NE>(compareScalar, scale, (float)0.0, preg1);
+                Mul(scale, scale, (RegTensor<float> &)coeffReg, compareScalar);
+                Min(scale, scale, inf, preg1);
+                Duplicate(dupScale, scale, pregLoop);
+                StoreOuputDataUnalign(scale, scaleLocalAddr, uScale, preg1, 1);
+                Div<float, &mode>(x0Left, xLeft, dupScale, pregLoop);
+                Muls(x1Left, x0Left, 0.0f, pregLoop);
+                Compare<float, CMPMODE::NE>(compareLeft, x1Left, x1Left, pregLoop);
+                Select(xLeft, xLeft, x0Left, compareLeft);
+                StoreOutputData(yLocalAddr, xLeft, pregLoop, loopCountFoldTwo * 2 * VL_FP32 + i * dstCurColNumAlign);
+            }
+        }
+        DataCopyUnAlignPost(scaleLocalAddr, uScale, 0);
+    }
+}
+
+template <typename T, bool hasTopkWeight = false, bool hasClampValue = false>
+__aicore__ inline void VFProcessSwigluGroupQuant(const LocalTensor<T> &yLocal, const LocalTensor<T> &x0Local,
+                                                 const LocalTensor<T> &x1Local,
+                                                 const LocalTensor<float> &topkWeightLocal, const uint16_t curRowNum,
+                                                 const uint32_t curColNum, float clampValue)
+{
+    __local_mem__ T *yLocalAddr = (__local_mem__ T *)yLocal.GetPhyAddr();
+    __local_mem__ T *x0LocalAddr = (__local_mem__ T *)x0Local.GetPhyAddr();
+    __local_mem__ T *x1LocalAddr = (__local_mem__ T *)x1Local.GetPhyAddr();
+    __local_mem__ float *topkWeightLocalAddr =
+        hasTopkWeight ? (__local_mem__ float *)topkWeightLocal.GetPhyAddr() : nullptr;
+    uint16_t loopCount = CeilDiv(curColNum, VL_FP32);
+    uint32_t sregNum = curColNum;
+    uint32_t curColNumAlign = RoundUp<T>(curColNum);
+    __VEC_SCOPE__
+    {
+        RegTensor<float> weight;
+        RegTensor<float> x0;
+        RegTensor<float> x1;
+        RegTensor<float> y;
+        RegTensor<float> one;
+        RegTensor<float> tmp;
+        MaskReg pregLoop = CreateMask<float>();
+        Duplicate(one, static_cast<float>(1.0f), pregLoop);
+        for (uint16_t i = 0; i < curRowNum; i++) {
+            if constexpr (hasTopkWeight) {
+                DataCopy<float, AscendC::MicroAPI::LoadDist::DIST_BRC_B32>(weight, topkWeightLocalAddr + i);
+            }
+            uint32_t sreg = sregNum;
+            for (uint16_t j = 0; j < loopCount; j++) {
+                pregLoop = UpdateMask<float>(sreg);
+                LoadInputData<T>(x0, x0LocalAddr, pregLoop, j * VL_FP32 + i * curColNumAlign);
+                LoadInputData<T>(x1, x1LocalAddr, pregLoop, j * VL_FP32 + i * curColNumAlign);
+                if constexpr (hasClampValue) {
+                    Mins(x0, x0, clampValue, pregLoop);
+                    Maxs(x1, x1, -clampValue, pregLoop);
+                    Mins(x1, x1, clampValue, pregLoop);
+                }
+                VFSwiGlu(y, x0, x1, one, tmp, pregLoop);
+                if constexpr (hasTopkWeight) {
+                    Mul(y, y, weight, pregLoop);
+                }
+                StoreOutputData<T>(yLocalAddr, y, pregLoop, j * VL_FP32 + i * curColNumAlign);
+            }
+        }
+    }
+}
+
+template <typename T>
+__aicore__ inline void VFComputeMaxExp(const LocalTensor<uint16_t> &maxExpLocal, const LocalTensor<T> &xLocal,
+                                       uint16_t curRowNum, uint32_t curColNum)
+{
+    __local_mem__ uint16_t *maxExpOriginLocalAddr = (__local_mem__ uint16_t *)maxExpLocal.GetPhyAddr();
+    __local_mem__ T *xOriginLocalAddr = (__local_mem__ T *)xLocal.GetPhyAddr();
+    __local_mem__ uint16_t *maxExpLocalAddr = maxExpOriginLocalAddr;
+    __local_mem__ T *xLocalAddr = xOriginLocalAddr;
+    uint16_t vlForT = 256 / sizeof(T);
+    uint16_t loopCount = CeilDiv(curColNum, vlForT * 2);
+    uint32_t numVRegBlocks = 8;
+    uint32_t yCurColNumAlign = RoundUp<uint16_t>(CeilDiv(curColNum, 32));
+    uint32_t curColNumAlign = RoundUp<T>(curColNum);
+    __VEC_SCOPE__
+    {
+        // 用于把float16转为bfloat16，不涉及宽度变化
+        static constexpr CastTrait traitFP16ToBF16 = {RegLayout::UNKNOWN, SatMode::UNKNOWN, MaskMergeMode::ZEROING,
+                                                      RoundMode::CAST_TRUNC};
+        // 0存奇数位元素，1存偶数位元素
+        RegTensor<T> x0, x1;
+        RegTensor<bfloat16_t> x0BF16, x1BF16;
+        RegTensor<uint16_t> exp0, exp1, exp0FP16, exp1FP16, maxExp;
+        // 存储FP16/BF16的指数位为1的mask
+        RegTensor<uint16_t> emaskFP16, emaskBF16;
+        Duplicate(emaskFP16, FP16_EMASK_AND_INF_VAL);
+        Duplicate(emaskBF16, BF16_EMASK_AND_INF_VAL);
+        // 2字节Reg的MaskALL
+        MaskReg maskAllB16 = CreateMask<uint16_t, MaskPattern::ALL>();
+        MaskReg mask0, mask1, mask0FP16NanInf, mask1FP16NanInf;
+        // 非对齐搬出至UB用
+        UnalignReg uReg;
+        for (uint16_t i = 0; i < curRowNum; i++) {
+            uint32_t sreg0 = curColNum;
+            uint32_t sreg1 = curColNum;
+            maxExpLocalAddr = maxExpOriginLocalAddr + i * yCurColNumAlign;
+            xLocalAddr = xOriginLocalAddr + i * curColNumAlign;
+            for (uint16_t j = 0; j < loopCount; j++) {
+                mask0 = UpdateMask<T>(sreg0);
+                mask1 = UpdateMask<T>(sreg1);
+                MaskDeInterleave<T>(mask0, mask1, mask0, mask1);
+                DataCopy<T, PostLiteral::POST_MODE_UPDATE, LoadDist::DIST_DINTLV_B16>(x0, x1, xLocalAddr, vlForT * 2);
+                if constexpr (IsSameType<T, half>::value) {
+                    And(exp0FP16, (RegTensor<uint16_t> &)x0, emaskFP16, mask0);
+                    And(exp1FP16, (RegTensor<uint16_t> &)x1, emaskFP16, mask1);
+                    Compare<uint16_t, CMPMODE::EQ>(mask0FP16NanInf, exp0FP16, emaskFP16, mask0);
+                    Compare<uint16_t, CMPMODE::EQ>(mask1FP16NanInf, exp1FP16, emaskFP16, mask1);
+                    Cast<bfloat16_t, T, traitFP16ToBF16>(x0BF16, x0, mask0);
+                    Cast<bfloat16_t, T, traitFP16ToBF16>(x1BF16, x1, mask1);
+                    And(exp0, (RegTensor<uint16_t> &)x0BF16, emaskBF16, mask0);
+                    And(exp1, (RegTensor<uint16_t> &)x1BF16, emaskBF16, mask1);
+                    Select(exp0, emaskBF16, exp0, mask0FP16NanInf);
+                    Select(exp1, emaskBF16, exp1, mask1FP16NanInf);
+                } else {
+                    And(exp0, (RegTensor<uint16_t> &)x0, emaskBF16, mask0);
+                    And(exp1, (RegTensor<uint16_t> &)x1, emaskBF16, mask1);
+                }
+                Max(maxExp, exp0, exp1, mask0);
+                ReduceMaxWithDataBlock(maxExp, maxExp, maskAllB16);
+                DataCopyUnAlign<uint16_t, PostLiteral::POST_MODE_UPDATE>(maxExpLocalAddr, maxExp, uReg, numVRegBlocks);
+            }
+            DataCopyUnAlignPost(maxExpLocalAddr, uReg, 0);
+        }
+    }
+}
+
+__aicore__ inline void VFComputeScale(const LocalTensor<uint16_t> &mxScaleLocal,
+                                      const LocalTensor<uint16_t> &invScaleLocal,
+                                      const LocalTensor<uint16_t> &maxExpLocal, uint16_t curRowNum, uint16_t curColNum,
+                                      uint32_t validCurColNum, uint16_t expLowerBoundValue)
+{
+    __local_mem__ uint16_t *mxScaleOriginLocalAddr = (__local_mem__ uint16_t *)mxScaleLocal.GetPhyAddr();
+    __local_mem__ uint16_t *invScaleOriginLocalAddr = (__local_mem__ uint16_t *)invScaleLocal.GetPhyAddr();
+    __local_mem__ uint16_t *maxExpOriginLocalAddr = (__local_mem__ uint16_t *)maxExpLocal.GetPhyAddr();
+    __local_mem__ uint16_t *mxScaleLocalAddr = mxScaleOriginLocalAddr;
+    __local_mem__ uint16_t *invScaleLocalAddr = invScaleOriginLocalAddr;
+    __local_mem__ uint16_t *maxExpLocalLocalAddr = maxExpOriginLocalAddr;
+    uint16_t vlForT = 256 / sizeof(uint16_t);
+    uint16_t loopCount = CeilDiv(curColNum, vlForT);
+    uint32_t numVRegBlocks = 8;
+    uint32_t scaleCurColNumAlign = RoundUp<uint8_t>(validCurColNum) / 2;
+    uint32_t invCurColNumAlign = RoundUp<uint16_t>(validCurColNum);
+    __VEC_SCOPE__
+    {
+        RegTensor<uint16_t> maxExp, sharedExp, mxScale, invScale;
+        RegTensor<uint16_t> infBF16;
+        Duplicate(infBF16, BF16_EMASK_AND_INF_VAL);
+        RegTensor<uint16_t> zeroB16;
+        Duplicate(zeroB16, 0);
+        RegTensor<uint16_t> expLowerBound;
+        Duplicate(expLowerBound, expLowerBoundValue);
+        RegTensor<uint16_t> nanForE8M0;
+        Duplicate(nanForE8M0, FP8_E8M0_NAN_VAL);
+        RegTensor<uint16_t> invSub;
+        Duplicate(invSub, BF16_EXP_INVSUB);
+        RegTensor<uint16_t> nanBF16;
+        Duplicate(nanBF16, BF16_NAN_VAL);
+        RegTensor<uint16_t> specialMinE8M0;
+        Duplicate(specialMinE8M0, FP8_E8M0_SPECIAL_MIN);
+
+        MaskReg maskLoop, maskValid;
+        MaskReg maskInfBF16, maskZero, maskLowExp, maskSpecialMin;
+        for (uint16_t i = 0; i < curRowNum; i++) {
+            uint32_t sreg0 = curColNum;
+            uint32_t sreg1 = validCurColNum;
+            mxScaleLocalAddr = mxScaleOriginLocalAddr + i * scaleCurColNumAlign;
+            invScaleLocalAddr = invScaleOriginLocalAddr + i * invCurColNumAlign;
+            maxExpLocalLocalAddr = maxExpOriginLocalAddr + i * invCurColNumAlign;
+            for (uint16_t j = 0; j < loopCount; j++) {
+                maskLoop = UpdateMask<uint16_t>(sreg0);
+                maskValid = UpdateMask<uint16_t>(sreg1);
+                DataCopy<uint16_t, PostLiteral::POST_MODE_UPDATE>(maxExp, maxExpLocalLocalAddr, vlForT);
+                Compare<uint16_t, CMPMODE::LT>(maskLowExp, maxExp, expLowerBound, maskValid);
+                Select<uint16_t>(maxExp, expLowerBound, maxExp, maskLowExp);
+                Sub(sharedExp, maxExp, expLowerBound, maskValid);
+                ShiftRights(mxScale, sharedExp, BF16_EXP_SHR_BITS, maskValid);
+                Compare<uint16_t, CMPMODE::EQ>(maskInfBF16, maxExp, infBF16, maskValid);
+                Select<uint16_t>(mxScale, nanForE8M0, mxScale, maskInfBF16);
+                Compare<uint16_t, CMPMODE::EQ>(maskZero, maxExp, zeroB16, maskValid);
+                Select<uint16_t>(mxScale, zeroB16, mxScale, maskZero);
+                DataCopy<uint16_t, PostLiteral::POST_MODE_UPDATE, StoreDist::DIST_PACK_B16>(mxScaleLocalAddr, mxScale,
+                                                                                            vlForT / 2, maskLoop);
+                Sub<uint16_t>(invScale, invSub, sharedExp, maskValid);
+                Select<uint16_t>(invScale, nanBF16, invScale, maskInfBF16);
+                Select<uint16_t>(invScale, zeroB16, invScale, maskZero);
+                Compare<uint16_t, CMPMODE::EQ>(maskSpecialMin, invSub, sharedExp, maskValid);
+                Select<uint16_t>(invScale, specialMinE8M0, invScale, maskSpecialMin);
+                DataCopy<uint16_t, PostLiteral::POST_MODE_UPDATE>(invScaleLocalAddr, invScale, vlForT, maskLoop);
+            }
+        }
+    }
+}
+
+template <typename T, typename U>
+__aicore__ inline void VFComputeData(const LocalTensor<U> &xQuantLocal, const LocalTensor<T> &xLocal,
+                                     const LocalTensor<uint16_t> &invScaleLocal, uint16_t curRowNum, uint32_t curColNum)
+{
+    __local_mem__ U *xQuantOriginLocalAddr = (__local_mem__ U *)xQuantLocal.GetPhyAddr();
+    __local_mem__ T *xOriginLocalAddr = (__local_mem__ T *)xLocal.GetPhyAddr();
+    __local_mem__ uint16_t *invScaleOriginLocalAddr = (__local_mem__ uint16_t *)invScaleLocal.GetPhyAddr();
+    __local_mem__ U *xQuantLocalAddr = xQuantOriginLocalAddr;
+    __local_mem__ T *xLocalAddr = xOriginLocalAddr;
+    __local_mem__ uint16_t *invScaleLocalAddr = invScaleOriginLocalAddr;
+    uint16_t vlForT = 256 / sizeof(T);
+    uint16_t loopCount = CeilDiv(curColNum, vlForT * 2);
+    uint32_t numVRegBlocks = 8;
+    uint32_t xCurColNumAlign = RoundUp<T>(curColNum);
+    uint32_t scaleCurColNumAlign = RoundUp<uint16_t>(CeilDiv(curColNum, 32));
+    uint32_t xQuantCurColNumAlign = RoundUp<U>(curColNum);
+    __VEC_SCOPE__
+    {
+        static constexpr CastTrait traitFP16ToBF16 = {RegLayout::UNKNOWN, SatMode::UNKNOWN, MaskMergeMode::ZEROING,
+                                                      RoundMode::CAST_TRUNC};
+        static constexpr CastTrait traitB16ToB32Layout0 = {RegLayout::ZERO, SatMode::UNKNOWN, MaskMergeMode::ZEROING,
+                                                           RoundMode::UNKNOWN};
+        static constexpr CastTrait traitB16ToB32Layout1 = {RegLayout::ONE, SatMode::UNKNOWN, MaskMergeMode::ZEROING,
+                                                           RoundMode::UNKNOWN};
+        static constexpr CastTrait traitB32ToB8Layout0 = {RegLayout::ZERO, SatMode::SAT, MaskMergeMode::ZEROING,
+                                                          RoundMode::CAST_RINT};
+
+        RegTensor<uint16_t> invScale;
+        RegTensor<float> invScaleFP32;
+        RegTensor<T> x0, x1;
+        RegTensor<float> x0FP32Layout0, x0FP32Layout1, x1FP32Layout0, x1FP32Layout1;
+        RegTensor<U> xQuant0, xQuant1, xQuant2, xQuant3;
+
+        MaskReg maskXQuant0B32, maskXQuant1B32, maskXQuant2B32, maskXQuant3B32;
+        MaskReg maskAllB16 = CreateMask<uint16_t, MaskPattern::ALL>();
+        MaskReg maskAllB32 = CreateMask<float, MaskPattern::ALL>();
+        for (uint16_t i = 0; i < curRowNum; i++) {
+            uint32_t sreg0 = curColNum;
+            uint32_t sreg1 = curColNum;
+            uint32_t sreg2 = curColNum;
+            uint32_t sreg3 = curColNum;
+            xLocalAddr = xOriginLocalAddr + i * xCurColNumAlign;
+            invScaleLocalAddr = invScaleOriginLocalAddr + i * scaleCurColNumAlign;
+            xQuantLocalAddr = xQuantOriginLocalAddr + i * xQuantCurColNumAlign;
+            for (uint16_t i = 0; i < loopCount; i++) {
+                maskXQuant0B32 = UpdateMask<float>(sreg0);
+                maskXQuant1B32 = UpdateMask<float>(sreg1);
+                maskXQuant2B32 = UpdateMask<float>(sreg2);
+                maskXQuant3B32 = UpdateMask<float>(sreg3);
+
+                DataCopy<T, PostLiteral::POST_MODE_UPDATE, LoadDist::DIST_DINTLV_B16>(x0, x1, xLocalAddr, vlForT * 2);
+                DataCopy<uint16_t, PostLiteral::POST_MODE_UPDATE, LoadDist::DIST_E2B_B16>(invScale, invScaleLocalAddr,
+                                                                                          numVRegBlocks);
+                if constexpr (IsSameType<T, half>::value) {
+                    Cast<float, bfloat16_t, traitB16ToB32Layout0>(invScaleFP32, (RegTensor<bfloat16_t> &)invScale,
+                                                                  maskAllB16);
+                    Cast<float, T, traitB16ToB32Layout0>(x0FP32Layout0, x0, maskAllB16);
+                    Cast<float, T, traitB16ToB32Layout1>(x0FP32Layout1, x0, maskAllB16);
+                    Mul(x0FP32Layout0, x0FP32Layout0, invScaleFP32, maskAllB32);
+                    Mul(x0FP32Layout1, x0FP32Layout1, invScaleFP32, maskAllB32);
+                    Interleave(x0FP32Layout0, x0FP32Layout1, x0FP32Layout0, x0FP32Layout1);
+
+                    // 2.对偶数位元素x1进行量化，与x0的做法一致：
+                    Cast<float, T, traitB16ToB32Layout0>(x1FP32Layout0, x1, maskAllB16);
+                    Cast<float, T, traitB16ToB32Layout1>(x1FP32Layout1, x1, maskAllB16);
+                    Mul(x1FP32Layout0, x1FP32Layout0, invScaleFP32, maskAllB32);
+                    Mul(x1FP32Layout1, x1FP32Layout1, invScaleFP32, maskAllB32);
+                    Interleave(x1FP32Layout0, x1FP32Layout1, x1FP32Layout0, x1FP32Layout1);
+
+                    Interleave(x0FP32Layout0, x1FP32Layout0, x0FP32Layout0, x1FP32Layout0);
+                    Interleave(x0FP32Layout1, x1FP32Layout1, x0FP32Layout1, x1FP32Layout1);
+
+                    Cast<U, float, traitB32ToB8Layout0>(xQuant0, x0FP32Layout0, maskXQuant0B32);
+                    Cast<U, float, traitB32ToB8Layout0>(xQuant1, x1FP32Layout0, maskXQuant1B32);
+                    Cast<U, float, traitB32ToB8Layout0>(xQuant2, x0FP32Layout1, maskXQuant2B32);
+                    Cast<U, float, traitB32ToB8Layout0>(xQuant3, x1FP32Layout1, maskXQuant3B32);
+                } else {
+                    Mul(x0, x0, (RegTensor<T> &)invScale, maskAllB16);
+                    Mul(x1, x1, (RegTensor<T> &)invScale, maskAllB16);
+                    Interleave(x0, x1, x0, x1);
+                    Cast<float, T, traitB16ToB32Layout0>(x0FP32Layout0, x0, maskAllB16);
+                    Cast<float, T, traitB16ToB32Layout1>(x0FP32Layout1, x0, maskAllB16);
+                    Interleave(x0FP32Layout0, x0FP32Layout1, x0FP32Layout0, x0FP32Layout1);
+                    Cast<U, float, traitB32ToB8Layout0>(xQuant0, x0FP32Layout0, maskXQuant0B32);
+                    Cast<U, float, traitB32ToB8Layout0>(xQuant1, x0FP32Layout1, maskXQuant1B32);
+                    Cast<float, T, traitB16ToB32Layout0>(x1FP32Layout0, x1, maskAllB16);
+                    Cast<float, T, traitB16ToB32Layout1>(x1FP32Layout1, x1, maskAllB16);
+                    Interleave(x1FP32Layout0, x1FP32Layout1, x1FP32Layout0, x1FP32Layout1);
+                    Cast<U, float, traitB32ToB8Layout0>(xQuant2, x1FP32Layout0, maskXQuant2B32);
+                    Cast<U, float, traitB32ToB8Layout0>(xQuant3, x1FP32Layout1, maskXQuant3B32);
+                }
+
+                DataCopy<U, PostLiteral::POST_MODE_UPDATE, StoreDist::DIST_PACK4_B32>(
+                    xQuantLocalAddr, xQuant0, OUT_ELE_NUM_ONE_BLK, maskXQuant0B32);
+                DataCopy<U, PostLiteral::POST_MODE_UPDATE, StoreDist::DIST_PACK4_B32>(
+                    xQuantLocalAddr, xQuant1, OUT_ELE_NUM_ONE_BLK, maskXQuant1B32);
+                DataCopy<U, PostLiteral::POST_MODE_UPDATE, StoreDist::DIST_PACK4_B32>(
+                    xQuantLocalAddr, xQuant2, OUT_ELE_NUM_ONE_BLK, maskXQuant2B32);
+                DataCopy<U, PostLiteral::POST_MODE_UPDATE, StoreDist::DIST_PACK4_B32>(
+                    xQuantLocalAddr, xQuant3, OUT_ELE_NUM_ONE_BLK, maskXQuant3B32);
+            }
+        }
+    }
+}
+
+template <typename T, bool withUbReduce = false>
+__aicore__ inline void VFProcessGroupIndex(const LocalTensor<T> &yLocal, const LocalTensor<T> &xLocal,
+                                           uint16_t curColNum)
+{
+    __local_mem__ T *yLocalAddr = (__local_mem__ T *)yLocal.GetPhyAddr();
+    __local_mem__ T *xLocalAddr = (__local_mem__ T *)xLocal.GetPhyAddr();
+    uint16_t vlLen = REPEAT_SIZE / sizeof(T);
+    uint16_t loopCount = CeilDiv(curColNum, vlLen);
+    uint16_t fourLoopCount = loopCount / FOUR_UNFOLD;
+    uint16_t tailLoopNum = loopCount % FOUR_UNFOLD;
+    uint32_t tailReminder = curColNum - fourLoopCount * vlLen * FOUR_UNFOLD;
+    if (loopCount < FOUR_UNFOLD) {
+        __VEC_SCOPE__
+        {
+            RegTensor<T> x;
+            RegTensor<T> sum;
+            MaskReg pregMain = CreateMask<T, AscendC::MicroAPI::MaskPattern::ALL>();
+            MaskReg pregMerge = CreateMask<T, AscendC::MicroAPI::MaskPattern::VL1>();
+            Duplicate(sum, static_cast<T>(0), pregMain);
+            uint32_t sreg = curColNum;
+            MaskReg pregLoop;
+            for (uint16_t i = 0; i < loopCount; i++) {
+                pregLoop = UpdateMask<T>(sreg);
+                DataCopy(x, xLocalAddr + i * vlLen);
+                Adds(x, x, static_cast<T>(0), pregLoop);
+                Add(sum, sum, x, pregMain);
+            }
+            ReduceSum(sum, sum, pregMain);
+            if (withUbReduce) {
+                RegTensor<T> origin;
+                DataCopy(origin, yLocalAddr);
+                Add(sum, sum, origin, pregMerge);
+            }
+            DataCopy(yLocalAddr, sum, pregMerge);
+        }
+    } else {
+        __VEC_SCOPE__
+        {
+            RegTensor<T> x0;
+            RegTensor<T> x1;
+            RegTensor<T> x2;
+            RegTensor<T> x3;
+            RegTensor<T> sum0;
+            RegTensor<T> sum1;
+            RegTensor<T> sum2;
+            RegTensor<T> sum3;
+            MaskReg pregMain = CreateMask<T, AscendC::MicroAPI::MaskPattern::ALL>();
+            MaskReg pregMerge = CreateMask<T, AscendC::MicroAPI::MaskPattern::VL1>();
+            Duplicate(sum0, static_cast<T>(0), pregMain);
+            Duplicate(sum1, static_cast<T>(0), pregMain);
+            Duplicate(sum2, static_cast<T>(0), pregMain);
+            Duplicate(sum3, static_cast<T>(0), pregMain);
+            MaskReg pregLoop;
+            for (uint16_t i = 0; i < fourLoopCount; i++) {
+                DataCopy(x0, xLocalAddr + i * FOUR_UNFOLD * vlLen);
+                Add(sum0, sum0, x0, pregMain);
+                DataCopy(x1, xLocalAddr + (i * FOUR_UNFOLD + 1) * vlLen);
+                Add(sum1, sum1, x1, pregMain);
+                DataCopy(x2, xLocalAddr + (i * FOUR_UNFOLD + 2) * vlLen);
+                Add(sum2, sum2, x2, pregMain);
+                DataCopy(x3, xLocalAddr + (i * FOUR_UNFOLD + 3) * vlLen);
+                Add(sum3, sum3, x3, pregMain);
+            }
+            uint32_t sreg = tailReminder;
+            for (uint16_t i = 0; i < tailLoopNum; i++) {
+                pregLoop = UpdateMask<T>(sreg);
+                DataCopy(x0, xLocalAddr + (fourLoopCount * FOUR_UNFOLD + i) * vlLen);
+                Adds(x0, x0, static_cast<T>(0), pregLoop);
+                Add(sum0, sum0, x0, pregMain);
+            }
+            Add(sum0, sum0, sum1, pregMain);
+            Add(sum2, sum2, sum3, pregMain);
+            Add(sum0, sum0, sum2, pregMain);
+            ReduceSum(sum0, sum0, pregMain);
+            if (withUbReduce) {
+                RegTensor<T> origin;
+                DataCopy(origin, yLocalAddr);
+                Add(sum0, sum0, origin, pregMerge);
+            }
+            DataCopy(yLocalAddr, sum0, pregMerge);
+        }
+    }
+}
+
+// curColNum一定能被128整除
+template <typename T0, typename T1, typename T2, bool hasRoundScale = false, bool hasClampValue = false,
+          bool hasOutput = false, bool hasTopkWeight = false>
+__aicore__ inline void VFProcessSwigluFp8QuantPerToken(const LocalTensor<T0> &yLocal,
+                                                       const LocalTensor<T1> &yOriginLocal,
+                                                       const LocalTensor<T2> &scaleLocal,
+                                                       const LocalTensor<T1> &x0Local, const LocalTensor<T1> &x1Local,
+                                                       const LocalTensor<float> &topkWeightLocal, float clampValue,
+                                                       const uint16_t curRowNum, const uint32_t curColNum)
+{
+    __local_mem__ T0 *yLocalAddr = (__local_mem__ T0 *)yLocal.GetPhyAddr();
+    __local_mem__ T1 *yOriginLocalAddr = hasOutput ? (__local_mem__ T1 *)yOriginLocal.GetPhyAddr() : nullptr;
+    __local_mem__ T2 *scaleLocalAddr = (__local_mem__ T2 *)scaleLocal.GetPhyAddr();
+    __local_mem__ T1 *x0LocalAddr = (__local_mem__ T1 *)x0Local.GetPhyAddr();
+    __local_mem__ T1 *x1LocalAddr = (__local_mem__ T1 *)x1Local.GetPhyAddr();
+    __local_mem__ float *topkWeightLocalAddr =
+        hasTopkWeight ? (__local_mem__ float *)topkWeightLocal.GetPhyAddr() : nullptr;
+
+    uint16_t loopCount = CeilDiv(curColNum, VL_FP32);
+    uint32_t curColNumAlign = RoundUp<T1>(curColNum);
+    uint32_t dstCurColNumAlign = RoundUp<T0>(curColNum);
+    uint32_t scaleColNum = CeilDiv(curColNum, PER_BLOCK_FP16);
+    uint16_t loopCountFoldTwo = loopCount / 2;
+    uint16_t loopCountReminder = loopCount % 2;
+    uint32_t tailRemider = curColNum - (loopCount - 1) * VL_FP32;
+
+    __VEC_SCOPE__
+    {
+        RegTensor<float> weight;
+        RegTensor<float> one;
+        RegTensor<uint32_t> oneUint32;
+        RegTensor<float> zero;
+        RegTensor<uint32_t> zeroUint32;
+        RegTensor<float> xLeft;
+        RegTensor<float> xRight;
+        RegTensor<float> x0Left;
+        RegTensor<float> x0Right;
+        RegTensor<float> x1Left;
+        RegTensor<float> x1Right;
+        RegTensor<float> xAbsLeft;
+        RegTensor<float> xAbsRight;
+        RegTensor<float> tmp;
+        RegTensor<uint32_t> tmp0;
+        RegTensor<uint32_t> tmp1;
+        RegTensor<uint32_t> tmp2;
+        RegTensor<uint32_t> tmp3;
+        RegTensor<int32_t> tmp4;
+        RegTensor<float> dupScale;
+        RegTensor<float> scale;
+        RegTensor<float> clampScale;
+        RegTensor<float> invScale;
+        RegTensor<float> dupInvScale;
+        RegTensor<float> scale0;
+        RegTensor<float> scale1;
+        RegTensor<uint32_t> scale2;
+        RegTensor<uint32_t> scale3;
+        RegTensor<int32_t> scale4;
+        RegTensor<int32_t> scale5;
+        RegTensor<uint32_t> coeff;
+        RegTensor<float> invCoeff;
+        MaskReg pregMain = CreateMask<float, MaskPattern::ALL>();
+        MaskReg pregMerge = CreateMask<float, AscendC::MicroAPI::MaskPattern::VL1>();
+        MaskReg compareLeft;
+        MaskReg compareRight;
+        MaskReg compareMask0;
+        Duplicate(zero, 0.0f, pregMain);
+        Duplicate(zeroUint32, static_cast<uint32_t>(0), pregMain);
+        Duplicate(one, 1.0f, pregMain);
+        Duplicate(oneUint32, static_cast<uint32_t>(1), pregMain);
+        Duplicate(coeff, INV_FP8_E4M3_MAX_VALUE, pregMerge);
+        Duplicate(invCoeff, 448.0f, pregMerge);
+        Duplicate(tmp0, FAST_LOG_AND_VALUE1, pregMerge);
+        Duplicate(tmp1, FAST_LOG_AND_VALUE2, pregMerge);
+        Duplicate(tmp3, static_cast<uint32_t>(127), pregMerge);
+        Duplicate(tmp4, static_cast<int32_t>(127), pregMerge);
+        for (uint16_t i = 0; i < curRowNum; i++) {
+            if constexpr (hasTopkWeight) {
+                DataCopy<float, AscendC::MicroAPI::LoadDist::DIST_BRC_B32>(weight, topkWeightLocalAddr + i);
+            }
+            for (uint16_t j = 0; j < loopCountFoldTwo; j++) {
+                LoadInputData<T1>(x0Left, x0LocalAddr, pregMain, 2 * j * VL_FP32 + i * curColNumAlign);
+                LoadInputData<T1>(x0Right, x0LocalAddr, pregMain, (2 * j + 1) * VL_FP32 + i * curColNumAlign);
+                LoadInputData<T1>(x1Left, x1LocalAddr, pregMain, 2 * j * VL_FP32 + i * curColNumAlign);
+                LoadInputData<T1>(x1Right, x1LocalAddr, pregMain, (2 * j + 1) * VL_FP32 + i * curColNumAlign);
+                if constexpr (hasClampValue) {
+                    Mins(x0Left, x0Left, clampValue, pregMain);
+                    Mins(x0Right, x0Right, clampValue, pregMain);
+                    Maxs(x1Left, x1Left, -clampValue, pregMain);
+                    Mins(x1Left, x1Left, clampValue, pregMain);
+                    Maxs(x1Right, x1Right, -clampValue, pregMain);
+                    Mins(x1Right, x1Right, clampValue, pregMain);
+                }
+                VFSwiGlu(xLeft, x0Left, x1Left, one, tmp, pregMain);
+                VFSwiGlu(xRight, x0Right, x1Right, one, tmp, pregMain);
+                if constexpr (hasTopkWeight) {
+                    Mul(xLeft, xLeft, weight, pregMain);
+                }
+                Add(xLeft, xLeft, zero, pregMain);
+                if constexpr (hasTopkWeight) {
+                    Mul(xRight, xRight, weight, pregMain);
+                }
+                Add(xRight, xRight, zero, pregMain);
+                if constexpr (hasOutput) {
+                    StoreOutputData<T1>(yOriginLocalAddr, xLeft, pregMain, 2 * j * VL_FP32 + i * curColNumAlign);
+                    StoreOutputData<T1>(yOriginLocalAddr, xRight, pregMain, (2 * j + 1) * VL_FP32 + i * curColNumAlign);
+                }
+                Muls(xAbsLeft, xLeft, 0.0f, pregMain);
+                Compare<float, CMPMODE::NE>(compareLeft, xAbsLeft, xAbsLeft, pregMain);
+                MaskNot(compareLeft, compareLeft, pregMain);
+                Abs(xAbsLeft, xLeft, compareLeft);
+                ReduceMax(scale0, xAbsLeft, pregMain);
+
+                Muls(xAbsRight, xRight, 0.0f, pregMain);
+                Compare<float, CMPMODE::NE>(compareRight, xAbsRight, xAbsRight, pregMain);
+                MaskNot(compareRight, compareRight, pregMain);
+                Abs(xAbsRight, xRight, compareRight);
+                ReduceMax(scale1, xAbsRight, pregMain);
+                Max(scale, scale0, scale1, pregMerge);
+                Maxs(clampScale, scale, 0.0001f, pregMerge);  // amax
+
+                Mul(scale, clampScale, (RegTensor<float> &)coeff, pregMerge);  // sf = amax / 448.0
+                if constexpr (!hasRoundScale) {
+                    Div(invScale, invCoeff, clampScale, pregMerge);
+                    DataCopy<float, AscendC::MicroAPI::StoreDist::DIST_FIRST_ELEMENT_B32>(
+                        (__local_mem__ float *)scaleLocalAddr + j + i * scaleColNum, scale,
+                        pregMerge);  // copy out scale
+                } else {
+                    // bits == (RegTensor<uint32_t>&)scale
+                    ShiftRights(scale2, (RegTensor<uint32_t> &)scale, static_cast<int16_t>(FAST_LOG_SHIFT_BITS),
+                                pregMerge);
+                    And(scale2, scale2, tmp0, pregMerge);                        // exp
+                    And(scale3, (RegTensor<uint32_t> &)scale, tmp1, pregMerge);  // man_bits
+                    Compare<uint32_t, AscendC::CMPMODE::NE>(compareMask0, scale3, zeroUint32, pregMerge);
+                    Select(tmp2, oneUint32, zeroUint32, compareMask0);  // man_bits != 0
+                    Sub(scale3, scale2, tmp3, pregMerge);               // exp - 127
+                    Add((RegTensor<uint32_t> &)scale4, scale3, tmp2,
+                        pregMerge);  // exp_scale-uint32 = exp - 127 + (man_bits != 0)
+                    if constexpr (IsSameType<T2, fp8_e8m0_t>::value) {
+                        Adds(scale5, scale4, 127, pregMerge);                                         // sf_uint32
+                        StoreMxFp8Scale<T2>(scaleLocalAddr, scale5, pregMerge, i * scaleColNum + j);  // copy out scale
+                    } else {
+                        Adds(scale5, scale4, 127, pregMerge);
+                        ShiftLefts((RegTensor<int32_t> &)scale, scale5, static_cast<int16_t>(23), pregMerge);
+                        DataCopy<float, AscendC::MicroAPI::StoreDist::DIST_FIRST_ELEMENT_B32>(
+                            (__local_mem__ float *)scaleLocalAddr + j + i * scaleColNum, scale,
+                            pregMerge);  // copy out scale
+                    }
+                    Sub(scale5, tmp4, scale4, pregMerge);  // 127 - exp_scale
+                    ShiftLefts((RegTensor<int32_t> &)invScale, scale5, static_cast<int16_t>(23),
+                               pregMerge);  // ((127 - exp_scale) << 23).view(float32)
+                }
+                Duplicate(dupInvScale, invScale, pregMain);
+
+                Mul(x0Left, xLeft, dupInvScale, pregMain);
+                Muls(x1Left, x0Left, 0.0f, pregMain);
+                Compare<float, CMPMODE::NE>(compareLeft, x1Left, x1Left, pregMain);
+                Select(xLeft, xLeft, x0Left, compareLeft);
+                Mul(x0Right, xRight, dupInvScale, pregMain);
+                Muls(x1Right, x0Right, 0.0f, pregMain);
+                Compare<float, CMPMODE::NE>(compareRight, x1Right, x1Right, pregMain);
+                Select(xRight, xRight, x0Right, compareRight);
+                StoreOutputData<T0>(yLocalAddr, xLeft, pregMain, 2 * j * VL_FP32 + i * dstCurColNumAlign);
+                StoreOutputData<T0>(yLocalAddr, xRight, pregMain, (2 * j + 1) * VL_FP32 + i * dstCurColNumAlign);
+            }
+        }
+    }
+}
+
+template <typename T0, typename T1, typename T2>
+__aicore__ inline void Fp8QuantPerTokenDispatcher(const LocalTensor<T0> &yLocal, const LocalTensor<T1> &yOriginLocal,
+                                                  const LocalTensor<T2> &scaleLocal, const LocalTensor<T1> &x0Local,
+                                                  const LocalTensor<T1> &x1Local,
+                                                  const LocalTensor<float> &topkWeightLocal, float clampValue,
+                                                  const uint16_t curRowNum, const uint32_t curColNum, int32_t maskBit)
+{
+    if (maskBit == 0b000) {
+        VFProcessSwigluFp8QuantPerToken<T0, T1, T2, false, false, false, false>(
+            yLocal, yOriginLocal, scaleLocal, x0Local, x1Local, topkWeightLocal, clampValue, curRowNum, curColNum);
+    } else if (maskBit == 0b001) {
+        VFProcessSwigluFp8QuantPerToken<T0, T1, T2, false, false, false, true>(
+            yLocal, yOriginLocal, scaleLocal, x0Local, x1Local, topkWeightLocal, clampValue, curRowNum, curColNum);
+    } else if (maskBit == 0b010) {
+        VFProcessSwigluFp8QuantPerToken<T0, T1, T2, false, true, false, false>(
+            yLocal, yOriginLocal, scaleLocal, x0Local, x1Local, topkWeightLocal, clampValue, curRowNum, curColNum);
+    } else if (maskBit == 0b011) {
+        VFProcessSwigluFp8QuantPerToken<T0, T1, T2, false, true, false, true>(
+            yLocal, yOriginLocal, scaleLocal, x0Local, x1Local, topkWeightLocal, clampValue, curRowNum, curColNum);
+    } else if (maskBit == 0b100) {
+        VFProcessSwigluFp8QuantPerToken<T0, T1, T2, true, false, false, false>(
+            yLocal, yOriginLocal, scaleLocal, x0Local, x1Local, topkWeightLocal, clampValue, curRowNum, curColNum);
+    } else if (maskBit == 0b101) {
+        VFProcessSwigluFp8QuantPerToken<T0, T1, T2, true, false, false, true>(
+            yLocal, yOriginLocal, scaleLocal, x0Local, x1Local, topkWeightLocal, clampValue, curRowNum, curColNum);
+    } else if (maskBit == 0b110) {
+        VFProcessSwigluFp8QuantPerToken<T0, T1, T2, true, true, false, false>(
+            yLocal, yOriginLocal, scaleLocal, x0Local, x1Local, topkWeightLocal, clampValue, curRowNum, curColNum);
+    } else if (maskBit == 0b111) {
+        VFProcessSwigluFp8QuantPerToken<T0, T1, T2, true, true, false, true>(
+            yLocal, yOriginLocal, scaleLocal, x0Local, x1Local, topkWeightLocal, clampValue, curRowNum, curColNum);
+    }
+}
+
+template <typename T0, typename T1, typename T2>
+__aicore__ inline void Fp8QuantPerTokenDispatcherYOrigin(
+    const LocalTensor<T0> &yLocal, const LocalTensor<T1> &yOriginLocal, const LocalTensor<T2> &scaleLocal,
+    const LocalTensor<T1> &x0Local, const LocalTensor<T1> &x1Local, const LocalTensor<float> &topkWeightLocal,
+    float clampValue, const uint16_t curRowNum, const uint32_t curColNum, int32_t maskBit)
+{
+    if (maskBit == 0b000) {
+        VFProcessSwigluFp8QuantPerToken<T0, T1, T2, false, false, true, false>(
+            yLocal, yOriginLocal, scaleLocal, x0Local, x1Local, topkWeightLocal, clampValue, curRowNum, curColNum);
+    } else if (maskBit == 0b001) {
+        VFProcessSwigluFp8QuantPerToken<T0, T1, T2, false, false, true, true>(
+            yLocal, yOriginLocal, scaleLocal, x0Local, x1Local, topkWeightLocal, clampValue, curRowNum, curColNum);
+    } else if (maskBit == 0b010) {
+        VFProcessSwigluFp8QuantPerToken<T0, T1, T2, false, true, true, false>(
+            yLocal, yOriginLocal, scaleLocal, x0Local, x1Local, topkWeightLocal, clampValue, curRowNum, curColNum);
+    } else if (maskBit == 0b011) {
+        VFProcessSwigluFp8QuantPerToken<T0, T1, T2, false, true, true, true>(
+            yLocal, yOriginLocal, scaleLocal, x0Local, x1Local, topkWeightLocal, clampValue, curRowNum, curColNum);
+    } else if (maskBit == 0b100) {
+        VFProcessSwigluFp8QuantPerToken<T0, T1, T2, true, false, true, false>(
+            yLocal, yOriginLocal, scaleLocal, x0Local, x1Local, topkWeightLocal, clampValue, curRowNum, curColNum);
+    } else if (maskBit == 0b101) {
+        VFProcessSwigluFp8QuantPerToken<T0, T1, T2, true, false, true, true>(
+            yLocal, yOriginLocal, scaleLocal, x0Local, x1Local, topkWeightLocal, clampValue, curRowNum, curColNum);
+    } else if (maskBit == 0b110) {
+        VFProcessSwigluFp8QuantPerToken<T0, T1, T2, true, true, true, false>(
+            yLocal, yOriginLocal, scaleLocal, x0Local, x1Local, topkWeightLocal, clampValue, curRowNum, curColNum);
+    } else if (maskBit == 0b111) {
+        VFProcessSwigluFp8QuantPerToken<T0, T1, T2, true, true, true, true>(
+            yLocal, yOriginLocal, scaleLocal, x0Local, x1Local, topkWeightLocal, clampValue, curRowNum, curColNum);
+    }
+}
+
+template <typename T>
+__aicore__ inline void CopyIn(const GlobalTensor<T> &inputGm, const LocalTensor<T> &inputTensor, const uint16_t nBurst,
+                              const uint32_t copyLen, uint32_t srcStride = 0)
+{
+    DataCopyPadExtParams<T> dataCopyPadExtParams;
+    dataCopyPadExtParams.isPad = false;
+    dataCopyPadExtParams.leftPadding = 0;
+    dataCopyPadExtParams.rightPadding = 0;
+    dataCopyPadExtParams.paddingValue = 0;
+
+    DataCopyExtParams dataCoptExtParams;
+    dataCoptExtParams.blockCount = nBurst;
+    dataCoptExtParams.blockLen = copyLen * sizeof(T);
+    dataCoptExtParams.srcStride = srcStride * sizeof(T);
+    dataCoptExtParams.dstStride = 0;
+    DataCopyPad(inputTensor, inputGm, dataCoptExtParams, dataCopyPadExtParams);
+}
+
+template <typename T, AscendC::PaddingMode mode = AscendC::PaddingMode::Normal>
+__aicore__ inline void CopyOut(const LocalTensor<T> &outputTensor, const GlobalTensor<T> &outputGm,
+                               const uint16_t nBurst, const uint32_t copyLen, uint32_t dstStride = 0)
+{
+    DataCopyExtParams dataCopyParams;
+    dataCopyParams.blockCount = nBurst;
+    dataCopyParams.blockLen = copyLen * sizeof(T);
+    dataCopyParams.srcStride = 0;
+    dataCopyParams.dstStride = dstStride * sizeof(T);
+    DataCopyPad<T, mode>(outputGm, outputTensor, dataCopyParams);
+}
+
+}  // namespace SwigluGroupQuant
+
+#endif

--- a/csrc/swiglu_group_quant/op_kernel/swiglu_group_quant_perf.h
+++ b/csrc/swiglu_group_quant/op_kernel/swiglu_group_quant_perf.h
@@ -1,0 +1,257 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file swiglu_group_quant_perf.h
+ * \brief
+ */
+
+#ifndef SWIGLU_GROUP_QUANT_PERF_H
+#define SWIGLU_GROUP_QUANT_PERF_H
+
+#include "kernel_operator.h"
+#include "swiglu_group_quant_base.h"
+
+namespace SwigluGroupQuant {
+using namespace AscendC;
+template <typename T0, typename T1, typename T2>
+class SwigluGroupQuantPerf
+{
+public:
+    __aicore__ inline SwigluGroupQuantPerf() {}
+
+    __aicore__ inline void Init(GM_ADDR x, GM_ADDR topkWeight, GM_ADDR groupIndex, GM_ADDR y, GM_ADDR scale,
+                                GM_ADDR workspace, const SwigluGroupQuantTilingData *tilingDataPtr, TPipe *pipePtr)
+    {
+        pipe = pipePtr;
+        tilingData = tilingDataPtr;
+
+        xGm.SetGlobalBuffer((__gm__ T0 *)x);
+        yGm.SetGlobalBuffer((__gm__ T1 *)y);
+        scaleGm.SetGlobalBuffer((__gm__ T2 *)scale);
+
+        pipe->InitBufPool(tBufPool, tilingData->ubSize);
+        if (groupIndex != nullptr) {
+            hasGroupIndex_ = true;
+            groupIndexGm.SetGlobalBuffer((__gm__ int64_t *)groupIndex);
+            if (tilingData->groupListType == 0) {
+                tBufPool.InitBuffer(groupIndexQue, 2, RoundUp<int64_t>(tilingData->gFactor) * sizeof(int64_t));
+                tBufPool.InitBuffer(groupIndexSumBuf, BLOCK_SIZE);
+                groupSumLocal = groupIndexSumBuf.Get<int64_t>();
+                for (int64_t idx = 0; idx < tilingData->gLoop; idx++) {
+                    int64_t curGFactor = (idx == tilingData->gLoop - 1) ? tilingData->tailGFactor : tilingData->gFactor;
+                    groupIndexLocal = groupIndexQue.template AllocTensor<int64_t>();
+                    CopyIn(groupIndexGm[idx * tilingData->gFactor], groupIndexLocal, 1, curGFactor);
+                    groupIndexQue.template EnQue(groupIndexLocal);
+                    groupIndexLocal = groupIndexQue.template DeQue<int64_t>();
+                    if (idx == 0) {
+                        VFProcessGroupIndex<int64_t, false>(groupSumLocal, groupIndexLocal, curGFactor);
+                    } else {
+                        VFProcessGroupIndex<int64_t, true>(groupSumLocal, groupIndexLocal, curGFactor);
+                    }
+                    groupIndexQue.template FreeTensor(groupIndexLocal);
+                }
+                event_t eventId = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_S));
+                SetFlag<HardEvent::V_S>(eventId);
+                WaitFlag<HardEvent::V_S>(eventId);
+                int64_t realBs =
+                    groupSumLocal.GetValue(0) > tilingData->bs ? tilingData->bs : groupSumLocal.GetValue(0);
+
+                rowOfFormerBlock = CeilDiv(realBs, static_cast<int64_t>(tilingData->coreNum));
+                usedCoreNums = CeilDiv(realBs, rowOfFormerBlock) < tilingData->coreNum
+                                   ? CeilDiv(realBs, rowOfFormerBlock)
+                                   : tilingData->coreNum;
+                rowOfTailBlock = realBs - (usedCoreNums - 1) * rowOfFormerBlock;
+
+                rowLoopOfFormerBlock = CeilDiv(rowOfFormerBlock, tilingData->rowFactor);
+                rowLoopOfTailBlock = CeilDiv(rowOfTailBlock, tilingData->rowFactor);
+                tailRowFactorOfFormerBlock = rowOfFormerBlock % tilingData->rowFactor == 0
+                                                 ? tilingData->rowFactor
+                                                 : rowOfFormerBlock % tilingData->rowFactor;
+                tailRowFactorOfTailBlock = rowOfTailBlock % tilingData->rowFactor == 0
+                                               ? tilingData->rowFactor
+                                               : rowOfTailBlock % tilingData->rowFactor;
+                tBufPool.Reset();
+            }
+        } else {
+            rowOfFormerBlock = tilingData->rowOfFormerBlock;
+            rowOfTailBlock = tilingData->rowOfTailBlock;
+            rowLoopOfFormerBlock = tilingData->rowLoopOfFormerBlock;
+            rowLoopOfTailBlock = tilingData->rowLoopOfTailBlock;
+            tailRowFactorOfFormerBlock = tilingData->tailRowFactorOfFormerBlock;
+            tailRowFactorOfTailBlock = tilingData->tailRowFactorOfTailBlock;
+            usedCoreNums = GetBlockNum();
+        }
+
+        if (topkWeight != nullptr) {
+            hasTopkWeight_ = true;
+            topkWeightGm.SetGlobalBuffer((__gm__ float *)topkWeight);
+            tBufPool.InitBuffer(topkWeightQue, 2, RoundUp<float>(tilingData->rowFactor) * sizeof(float));
+        }
+
+        tBufPool.InitBuffer(x0Que, 2, tilingData->rowFactor * RoundUp<T0>(tilingData->dFactor) * sizeof(T0));
+        tBufPool.InitBuffer(x1Que, 2, tilingData->rowFactor * RoundUp<T0>(tilingData->dFactor) * sizeof(T0));
+        tBufPool.InitBuffer(yQue, 2, tilingData->rowFactor * RoundUp<T1>(tilingData->dFactor) * sizeof(T1));
+        // scale 在ub内连续写，拷出时采用Compact模式进行搬出
+        int64_t scaleColNum = CeilDiv(tilingData->dFactor, PER_BLOCK_FP16);
+        tBufPool.InitBuffer(scaleQue, 2, RoundUp<T2>(tilingData->rowFactor * scaleColNum) * sizeof(T2));
+        hasClampValue_ = (tilingData->hasClampValue == 1);
+        clampValue_ = tilingData->clampValue;
+        AscendC::SetCtrlSpr<FLOAT_OVERFLOW_MODE_CTRL, FLOAT_OVERFLOW_MODE_CTRL>(0);
+    }
+
+    __aicore__ inline void Process()
+    {
+        if (GetBlockIdx() >= usedCoreNums) {
+            return;
+        }
+        SetMaxValue();
+        int64_t curBlockIdx = GetBlockIdx();
+        int64_t rowOuterLoop = (curBlockIdx == usedCoreNums - 1) ? rowLoopOfTailBlock : rowLoopOfFormerBlock;
+        int64_t tailRowFactor =
+            (curBlockIdx == usedCoreNums - 1) ? tailRowFactorOfTailBlock : tailRowFactorOfFormerBlock;
+        int64_t x0GmBaseOffset = curBlockIdx * rowOfFormerBlock * tilingData->d;
+        int64_t x1GmBaseOffset = x0GmBaseOffset + tilingData->splitD;
+        int64_t yGmBaseOffset = curBlockIdx * rowOfFormerBlock * tilingData->splitD;
+        int64_t scaleGmBaseOffset = curBlockIdx * rowOfFormerBlock * tilingData->scaleCol;
+        int64_t topkWeightGmBaseOffset = curBlockIdx * rowOfFormerBlock;
+        for (int64_t rowOuterIdx = 0; rowOuterIdx < rowOuterLoop; rowOuterIdx++) {
+            int64_t curRowFactor = (rowOuterIdx == rowOuterLoop - 1) ? tailRowFactor : tilingData->rowFactor;
+            // copy in topkWeight
+            if (hasTopkWeight_) {
+                topkWeightLocal = topkWeightQue.template AllocTensor<float>();
+                CopyIn(topkWeightGm[topkWeightGmBaseOffset + rowOuterIdx * tilingData->rowFactor], topkWeightLocal, 1,
+                       curRowFactor);
+                topkWeightQue.template EnQue(topkWeightLocal);
+                topkWeightLocal = topkWeightQue.template DeQue<float>();
+            }
+
+            for (int64_t dLoopIdx = 0; dLoopIdx < tilingData->dLoop; dLoopIdx++) {
+                int64_t curDFactor =
+                    (dLoopIdx == tilingData->dLoop - 1) ? tilingData->tailDFactor : tilingData->dFactor;
+                int64_t scaleDFactor = CeilDiv(curDFactor, PER_BLOCK_FP16);
+                int64_t xBaseOffset =
+                    rowOuterIdx * tilingData->rowFactor * tilingData->d + dLoopIdx * tilingData->dFactor;
+                x0Local = x0Que.template AllocTensor<T0>();
+                CopyIn(xGm[x0GmBaseOffset + xBaseOffset], x0Local, curRowFactor, curDFactor,
+                       tilingData->d - curDFactor);
+                x0Que.template EnQue(x0Local);
+                x0Local = x0Que.template DeQue<T0>();
+
+                x1Local = x1Que.template AllocTensor<T0>();
+                CopyIn(xGm[x1GmBaseOffset + xBaseOffset], x1Local, curRowFactor, curDFactor,
+                       tilingData->d - curDFactor);
+                x1Que.template EnQue(x1Local);
+                x1Local = x1Que.template DeQue<T0>();
+
+                yLocal = yQue.template AllocTensor<T1>();
+                scaleLocal = scaleQue.template AllocTensor<T2>();
+                if (hasTopkWeight_) {
+                    if (hasClampValue_) {
+                        VFProcessSwigluGroupQuant<T1, T0, T2, true, true>(yLocal, scaleLocal, x0Local, x1Local,
+                                                                          topkWeightLocal, maxValue, curRowFactor,
+                                                                          curDFactor, clampValue_);
+                    } else {
+                        VFProcessSwigluGroupQuant<T1, T0, T2, true, false>(yLocal, scaleLocal, x0Local, x1Local,
+                                                                           topkWeightLocal, maxValue, curRowFactor,
+                                                                           curDFactor, clampValue_);
+                    }
+                } else {
+                    if (hasClampValue_) {
+                        VFProcessSwigluGroupQuant<T1, T0, T2, false, true>(yLocal, scaleLocal, x0Local, x1Local,
+                                                                           topkWeightLocal, maxValue, curRowFactor,
+                                                                           curDFactor, clampValue_);
+                    } else {
+                        VFProcessSwigluGroupQuant<T1, T0, T2, false, false>(yLocal, scaleLocal, x0Local, x1Local,
+                                                                            topkWeightLocal, maxValue, curRowFactor,
+                                                                            curDFactor, clampValue_);
+                    }
+                }
+                x0Que.template FreeTensor(x0Local);
+                x1Que.template FreeTensor(x1Local);
+
+                yQue.template EnQue(yLocal);
+                yLocal = yQue.template DeQue<T1>();
+                CopyOut(yLocal,
+                        yGm[yGmBaseOffset + rowOuterIdx * tilingData->rowFactor * tilingData->splitD +
+                            dLoopIdx * tilingData->dFactor],
+                        curRowFactor, curDFactor, tilingData->splitD - curDFactor);
+                yQue.template FreeTensor(yLocal);
+
+                scaleQue.template EnQue(scaleLocal);
+                scaleLocal = scaleQue.template DeQue<T2>();
+                CopyOut<T2, AscendC::PaddingMode::Compact>(
+                    scaleLocal,
+                    scaleGm[scaleGmBaseOffset + rowOuterIdx * tilingData->rowFactor * tilingData->scaleCol +
+                            dLoopIdx * CeilDiv(tilingData->dFactor, PER_BLOCK_FP16)],
+                    curRowFactor, scaleDFactor, tilingData->scaleCol - scaleDFactor);
+                scaleQue.template FreeTensor(scaleLocal);
+            }
+            if (hasTopkWeight_) {
+                topkWeightQue.template FreeTensor(topkWeightLocal);
+            }
+        }
+    }
+
+    __aicore__ inline void SetMaxValue()
+    {
+        if constexpr (IsSameType<T1, fp8_e5m2_t>::value) {
+            maxValue = static_cast<float>(1.0) / FP8_E5M2_MAX_VALUE;
+        } else if constexpr (IsSameType<T1, fp8_e4m3fn_t>::value) {
+            maxValue = static_cast<float>(1.0) / FP8_E4M3FN_MAX_VALUE;
+        }
+    }
+
+private:
+    TPipe *pipe;
+    const SwigluGroupQuantTilingData *tilingData;
+    GlobalTensor<T0> xGm;
+    GlobalTensor<int64_t> groupIndexGm;
+    GlobalTensor<T1> yGm;
+    GlobalTensor<T2> scaleGm;
+    GlobalTensor<float> topkWeightGm;
+
+    TQue<QuePosition::VECIN, 1> x0Que;
+    TQue<QuePosition::VECIN, 1> x1Que;
+    TQue<QuePosition::VECOUT, 1> yQue;
+    TQue<QuePosition::VECOUT, 1> scaleQue;
+
+    TQue<QuePosition::VECIN, 1> groupIndexQue;
+    TBuf<QuePosition::VECCALC> groupIndexSumBuf;
+    TQue<QuePosition::VECIN, 1> topkWeightQue;
+
+    LocalTensor<T0> x0Local;
+    LocalTensor<T0> x1Local;
+    LocalTensor<T1> yLocal;
+    LocalTensor<T2> scaleLocal;
+
+    LocalTensor<int64_t> groupIndexLocal;
+    LocalTensor<int64_t> groupSumLocal;
+    LocalTensor<float> topkWeightLocal;
+
+    float maxValue = 0.0f;
+    bool hasGroupIndex_ = false;
+    bool hasTopkWeight_ = false;
+    float clampValue_ = 448.0f;
+    bool hasClampValue_ = false;
+    TBufPool<QuePosition::VECCALC, 12> tBufPool;
+
+    int64_t tailRowFactorOfTailBlock = 0;
+    int64_t tailRowFactorOfFormerBlock = 0;
+    int64_t rowLoopOfTailBlock = 0;
+    int64_t rowLoopOfFormerBlock = 0;
+    int64_t usedCoreNums = 0;
+    int64_t rowOfFormerBlock = 0;
+    int64_t rowOfTailBlock = 0;
+};
+
+}  // namespace SwigluGroupQuant
+
+#endif

--- a/csrc/swiglu_group_quant/op_kernel/swiglu_mx_quant_perf.h
+++ b/csrc/swiglu_group_quant/op_kernel/swiglu_mx_quant_perf.h
@@ -1,0 +1,284 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file swiglu_mx_quant_perf.h
+ * \brief
+ */
+
+#ifndef SWIGLU_MX_QUANT_PERF_H
+#define SWIGLU_MX_QUANT_PERF_H
+
+#include "kernel_operator.h"
+#include "swiglu_group_quant_base.h"
+
+namespace SwigluGroupQuant {
+using namespace AscendC;
+template <typename T0, typename T1, typename T2>
+class SwigluMxQuantPerf
+{
+public:
+    __aicore__ inline SwigluMxQuantPerf() {}
+
+    __aicore__ inline void Init(GM_ADDR x, GM_ADDR topkWeight, GM_ADDR groupIndex, GM_ADDR y, GM_ADDR scale,
+                                GM_ADDR workspace, const SwigluGroupQuantTilingData *tilingDataPtr, TPipe *pipePtr)
+    {
+        pipe = pipePtr;
+        tilingData = tilingDataPtr;
+
+        xGm.SetGlobalBuffer((__gm__ T0 *)x);
+        yGm.SetGlobalBuffer((__gm__ T1 *)y);
+        scaleGm.SetGlobalBuffer((__gm__ T2 *)scale);
+
+        pipe->InitBufPool(tBufPool, tilingData->ubSize);
+        if (groupIndex != nullptr) {
+            hasGroupIndex_ = true;
+            groupIndexGm.SetGlobalBuffer((__gm__ int64_t *)groupIndex);
+            if (tilingData->groupListType == 0) {
+                tBufPool.InitBuffer(groupIndexQue, 2, RoundUp<int64_t>(tilingData->gFactor) * sizeof(int64_t));
+                tBufPool.InitBuffer(groupIndexSumBuf, BLOCK_SIZE);
+                groupSumLocal = groupIndexSumBuf.Get<int64_t>();
+                for (int64_t idx = 0; idx < tilingData->gLoop; idx++) {
+                    int64_t curGFactor = (idx == tilingData->gLoop - 1) ? tilingData->tailGFactor : tilingData->gFactor;
+                    groupIndexLocal = groupIndexQue.template AllocTensor<int64_t>();
+                    CopyIn(groupIndexGm[idx * tilingData->gFactor], groupIndexLocal, 1, curGFactor);
+                    groupIndexQue.template EnQue(groupIndexLocal);
+                    groupIndexLocal = groupIndexQue.template DeQue<int64_t>();
+                    if (idx == 0) {
+                        VFProcessGroupIndex<int64_t, false>(groupSumLocal, groupIndexLocal, curGFactor);
+                    } else {
+                        VFProcessGroupIndex<int64_t, true>(groupSumLocal, groupIndexLocal, curGFactor);
+                    }
+                    groupIndexQue.template FreeTensor(groupIndexLocal);
+                }
+                event_t eventId = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_S));
+                SetFlag<HardEvent::V_S>(eventId);
+                WaitFlag<HardEvent::V_S>(eventId);
+                int64_t realBs =
+                    groupSumLocal.GetValue(0) > tilingData->bs ? tilingData->bs : groupSumLocal.GetValue(0);
+
+                rowOfFormerBlock = CeilDiv(realBs, static_cast<int64_t>(tilingData->coreNum));
+                usedCoreNums = CeilDiv(realBs, rowOfFormerBlock) < tilingData->coreNum
+                                   ? CeilDiv(realBs, rowOfFormerBlock)
+                                   : tilingData->coreNum;
+                rowOfTailBlock = realBs - (usedCoreNums - 1) * rowOfFormerBlock;
+
+                rowLoopOfFormerBlock = CeilDiv(rowOfFormerBlock, tilingData->rowFactor);
+                rowLoopOfTailBlock = CeilDiv(rowOfTailBlock, tilingData->rowFactor);
+                tailRowFactorOfFormerBlock = rowOfFormerBlock % tilingData->rowFactor == 0
+                                                 ? tilingData->rowFactor
+                                                 : rowOfFormerBlock % tilingData->rowFactor;
+                tailRowFactorOfTailBlock = rowOfTailBlock % tilingData->rowFactor == 0
+                                               ? tilingData->rowFactor
+                                               : rowOfTailBlock % tilingData->rowFactor;
+                tBufPool.Reset();
+            }
+        } else {
+            rowOfFormerBlock = tilingData->rowOfFormerBlock;
+            rowOfTailBlock = tilingData->rowOfTailBlock;
+            rowLoopOfFormerBlock = tilingData->rowLoopOfFormerBlock;
+            rowLoopOfTailBlock = tilingData->rowLoopOfTailBlock;
+            tailRowFactorOfFormerBlock = tilingData->tailRowFactorOfFormerBlock;
+            tailRowFactorOfTailBlock = tilingData->tailRowFactorOfTailBlock;
+            usedCoreNums = GetBlockNum();
+        }
+
+        if (topkWeight != nullptr) {
+            hasTopkWeight_ = true;
+            topkWeightGm.SetGlobalBuffer((__gm__ float *)topkWeight);
+            tBufPool.InitBuffer(topkWeightQue, 2, RoundUp<float>(tilingData->rowFactor) * sizeof(float));
+        }
+
+        tBufPool.InitBuffer(xQue, 2, tilingData->rowFactor * RoundUp<T0>(tilingData->dFactor) * sizeof(T0) * 2);
+        tBufPool.InitBuffer(yQue, 2, tilingData->rowFactor * RoundUp<T1>(tilingData->dFactor) * sizeof(T1));
+        scaleColNum = CeilDiv(tilingData->dFactor, PER_MX_FP16);
+        tBufPool.InitBuffer(scaleQue, 2, tilingData->rowFactor * RoundUp<T2>(scaleColNum) * sizeof(T2));
+
+        tBufPool.InitBuffer(swigluBuf, tilingData->rowFactor * RoundUp<T0>(tilingData->dFactor) * sizeof(T0));
+        tBufPool.InitBuffer(maxExpBuf, tilingData->rowFactor * RoundUp<uint16_t>(scaleColNum) * sizeof(uint16_t));
+        tBufPool.InitBuffer(invScaleBuf, tilingData->rowFactor * RoundUp<uint16_t>(scaleColNum) * sizeof(uint16_t));
+
+        swigluLocal = swigluBuf.Get<T0>();
+        maxExpLocal = maxExpBuf.Get<uint16_t>();
+        invScaleLocal = invScaleBuf.Get<uint16_t>();
+
+        if constexpr (IsSameType<T1, fp8_e4m3fn_t>::value) {
+            lowerBoundOfB16MaxExp = LOWER_BOUND_OF_MAX_EXP_FOR_E4M3;
+        } else {
+            lowerBoundOfB16MaxExp = LOWER_BOUND_OF_MAX_EXP_FOR_E5M2;
+        }
+
+        scaleCols = CeilDiv(tilingData->scaleCol, 2) * 2;
+        perLoopScaleCols = CeilDiv(tilingData->dFactor, 32);
+        lastLoopValidScaleCols = tilingData->scaleCol - (tilingData->dLoop - 1) * perLoopScaleCols;
+        lastLoopScaleCols = scaleCols - (tilingData->dLoop - 1) * perLoopScaleCols;
+        hasClampValue_ = (tilingData->hasClampValue == 1);
+        clampValue_ = tilingData->clampValue;
+        AscendC::SetCtrlSpr<FLOAT_OVERFLOW_MODE_CTRL, FLOAT_OVERFLOW_MODE_CTRL>(0);
+    }
+
+    __aicore__ inline void Process()
+    {
+        if (GetBlockIdx() >= usedCoreNums) {
+            return;
+        }
+        SetMaxValue();
+        int64_t curBlockIdx = GetBlockIdx();
+        int64_t rowOuterLoop = (curBlockIdx == usedCoreNums - 1) ? rowLoopOfTailBlock : rowLoopOfFormerBlock;
+        int64_t tailRowFactor =
+            (curBlockIdx == usedCoreNums - 1) ? tailRowFactorOfTailBlock : tailRowFactorOfFormerBlock;
+        int64_t x0GmBaseOffset = curBlockIdx * rowOfFormerBlock * tilingData->d;
+        int64_t x1GmBaseOffset = x0GmBaseOffset + tilingData->splitD;
+        int64_t yGmBaseOffset = curBlockIdx * rowOfFormerBlock * tilingData->splitD;
+        int64_t scaleGmBaseOffset = curBlockIdx * rowOfFormerBlock * tilingData->scaleCol;
+        int64_t topkWeightGmBaseOffset = curBlockIdx * rowOfFormerBlock;
+        for (int64_t rowOuterIdx = 0; rowOuterIdx < rowOuterLoop; rowOuterIdx++) {
+            int64_t curRowFactor = (rowOuterIdx == rowOuterLoop - 1) ? tailRowFactor : tilingData->rowFactor;
+            // copy in topkWeight
+            if (hasTopkWeight_) {
+                topkWeightLocal = topkWeightQue.template AllocTensor<float>();
+                CopyIn(topkWeightGm[topkWeightGmBaseOffset + rowOuterIdx * tilingData->rowFactor], topkWeightLocal, 1,
+                       curRowFactor);
+                topkWeightQue.template EnQue(topkWeightLocal);
+                topkWeightLocal = topkWeightQue.template DeQue<float>();
+            }
+            for (int64_t dLoopIdx = 0; dLoopIdx < tilingData->dLoop; dLoopIdx++) {
+                int64_t curDFactor =
+                    (dLoopIdx == tilingData->dLoop - 1) ? tilingData->tailDFactor : tilingData->dFactor;
+                int64_t scaleDFactor = CeilDiv(curDFactor, PER_MX_FP16);
+                int64_t xBaseOffset =
+                    rowOuterIdx * tilingData->rowFactor * tilingData->d + dLoopIdx * tilingData->dFactor;
+                xLocal = xQue.template AllocTensor<T0>();
+                CopyIn(xGm[x0GmBaseOffset + xBaseOffset], xLocal, curRowFactor, curDFactor, tilingData->d - curDFactor);
+
+                CopyIn(xGm[x1GmBaseOffset + xBaseOffset], xLocal[curRowFactor * RoundUp<T0>(tilingData->dFactor)],
+                       curRowFactor, curDFactor, tilingData->d - curDFactor);
+                xQue.template EnQue(xLocal);
+                xLocal = xQue.template DeQue<T0>();
+                if (hasTopkWeight_) {
+                    if (hasClampValue_) {
+                        VFProcessSwigluGroupQuant<T0, true, true>(
+                            swigluLocal, xLocal, xLocal[curRowFactor * RoundUp<T0>(tilingData->dFactor)],
+                            topkWeightLocal, curRowFactor, curDFactor, clampValue_);
+                    } else {
+                        VFProcessSwigluGroupQuant<T0, true, false>(
+                            swigluLocal, xLocal, xLocal[curRowFactor * RoundUp<T0>(tilingData->dFactor)],
+                            topkWeightLocal, curRowFactor, curDFactor, clampValue_);
+                    }
+                } else {
+                    if (hasClampValue_) {
+                        VFProcessSwigluGroupQuant<T0, false, true>(
+                            swigluLocal, xLocal, xLocal[curRowFactor * RoundUp<T0>(tilingData->dFactor)],
+                            topkWeightLocal, curRowFactor, curDFactor, clampValue_);
+                    } else {
+                        VFProcessSwigluGroupQuant<T0, false, false>(
+                            swigluLocal, xLocal, xLocal[curRowFactor * RoundUp<T0>(tilingData->dFactor)],
+                            topkWeightLocal, curRowFactor, curDFactor, clampValue_);
+                    }
+                }
+                uint32_t loopScaleCols = (dLoopIdx == tilingData->dLoop - 1) ? lastLoopScaleCols : perLoopScaleCols;
+                uint32_t loopValidScaleCols =
+                    (dLoopIdx == tilingData->dLoop - 1) ? lastLoopValidScaleCols : perLoopScaleCols;
+                // 开始进行MxFp8量化
+                VFComputeMaxExp(maxExpLocal, swigluLocal, curRowFactor, curDFactor);
+                scaleLocal = scaleQue.template AllocTensor<T2>();
+                VFComputeScale(scaleLocal.template ReinterpretCast<uint16_t>(), invScaleLocal, maxExpLocal,
+                               curRowFactor, loopScaleCols, loopValidScaleCols, lowerBoundOfB16MaxExp);
+
+                scaleQue.template EnQue(scaleLocal);
+                scaleLocal = scaleQue.template DeQue<T2>();
+                CopyOut<T2>(scaleLocal,
+                            scaleGm[scaleGmBaseOffset + rowOuterIdx * tilingData->rowFactor * tilingData->scaleCol +
+                                    dLoopIdx * CeilDiv(tilingData->dFactor, 32)],
+                            curRowFactor, scaleDFactor, tilingData->scaleCol - scaleDFactor);
+                scaleQue.template FreeTensor(scaleLocal);
+
+                yLocal = yQue.template AllocTensor<T1>();
+                VFComputeData(yLocal, swigluLocal, invScaleLocal, curRowFactor, curDFactor);
+                xQue.template FreeTensor(xLocal);
+                yQue.template EnQue(yLocal);
+
+                yLocal = yQue.template DeQue<T1>();
+                CopyOut(yLocal,
+                        yGm[yGmBaseOffset + rowOuterIdx * tilingData->rowFactor * tilingData->splitD +
+                            dLoopIdx * tilingData->dFactor],
+                        curRowFactor, curDFactor, tilingData->splitD - curDFactor);
+                yQue.template FreeTensor(yLocal);
+            }
+            if (hasTopkWeight_) {
+                topkWeightQue.template FreeTensor(topkWeightLocal);
+            }
+        }
+    }
+
+    __aicore__ inline void SetMaxValue()
+    {
+        if constexpr (IsSameType<T1, fp8_e5m2_t>::value) {
+            maxValue = static_cast<float>(1.0) / FP8_E5M2_MAX_VALUE;
+        } else if constexpr (IsSameType<T1, fp8_e4m3fn_t>::value) {
+            maxValue = static_cast<float>(1.0) / FP8_E4M3FN_MAX_VALUE;
+        }
+    }
+
+private:
+    TPipe *pipe;
+    const SwigluGroupQuantTilingData *tilingData;
+    GlobalTensor<T0> xGm;
+    GlobalTensor<int64_t> groupIndexGm;
+    GlobalTensor<T1> yGm;
+    GlobalTensor<T2> scaleGm;
+    GlobalTensor<float> topkWeightGm;
+
+    TQue<QuePosition::VECIN, 1> xQue;
+    TQue<QuePosition::VECOUT, 1> yQue;
+    TQue<QuePosition::VECOUT, 1> scaleQue;
+
+    TBuf<QuePosition::VECCALC> swigluBuf;
+    TBuf<QuePosition::VECCALC> maxExpBuf;
+    TBuf<QuePosition::VECCALC> invScaleBuf;
+    TQue<QuePosition::VECIN, 1> groupIndexQue;
+    TBuf<QuePosition::VECCALC> groupIndexSumBuf;
+    TQue<QuePosition::VECIN, 1> topkWeightQue;
+    TBufPool<QuePosition::VECCALC, 12> tBufPool;
+
+    LocalTensor<T0> xLocal;
+    LocalTensor<T1> yLocal;
+    LocalTensor<T2> scaleLocal;
+    LocalTensor<T0> swigluLocal;
+    LocalTensor<uint16_t> maxExpLocal;
+    LocalTensor<uint16_t> invScaleLocal;
+    LocalTensor<int64_t> groupIndexLocal;
+    LocalTensor<int64_t> groupSumLocal;
+    LocalTensor<float> topkWeightLocal;
+
+    float maxValue = 0.0f;
+    int64_t scaleColNum = 0;
+    uint16_t lowerBoundOfB16MaxExp = 0;
+    uint32_t perLoopScaleCols;
+    uint32_t lastLoopValidScaleCols;
+    uint32_t lastLoopScaleCols;
+    uint32_t scaleCols;
+    float clampValue_ = 448.0f;
+    bool hasClampValue_ = false;
+    bool hasGroupIndex_ = false;
+    bool hasTopkWeight_ = false;
+
+    int64_t tailRowFactorOfTailBlock = 0;
+    int64_t tailRowFactorOfFormerBlock = 0;
+    int64_t rowLoopOfTailBlock = 0;
+    int64_t rowLoopOfFormerBlock = 0;
+    int64_t usedCoreNums = 0;
+    int64_t rowOfFormerBlock = 0;
+    int64_t rowOfTailBlock = 0;
+};
+
+}  // namespace SwigluGroupQuant
+
+#endif

--- a/include/sgl_kenel_npu_ops.h
+++ b/include/sgl_kenel_npu_ops.h
@@ -206,6 +206,30 @@ void kv_compress_epilog(at::Tensor &kv_compress_cache, const at::Tensor &x,
                         const at::Tensor &slot_mapping,
                         int64_t quant_group_size, int64_t quant_mode,
                         bool round_scale_flag, int64_t layout);
+
+/**
+ * @brief Fused SwiGLU activation + quantization (A5 only).
+ *
+ * Halves x along its last dim into gate/up, applies SwiGLU, and quantizes the
+ * result. All three quant modes are supported: quant_mode 1 = per-128-element
+ * group scales (fp32), 2 = MX per-32 scales (e8m0), 3 = per-token (fp8, e8m0
+ * when ue8m0_scale is set).
+ *
+ * @param topk_weight      optional per-row weight applied before quantization
+ * @param group_index      optional per-group token counts (prefix sums); when
+ * present every core walks the whole list, so the launch uses tiling's coreNum
+ * @param dst_type         y's dtype: Float8_e4m3fn (default) or Float8_e5m2
+ * @param clamp_value      when non-zero, activates clamping of the SwiGLU
+ * result
+ * @return tuple of (y, scale, y_origin); y_origin is only meaningful when
+ * output_origin is set
+ */
+std::tuple<at::Tensor, at::Tensor, at::Tensor> swiglu_group_quant(
+    const at::Tensor &x, const c10::optional<at::Tensor> &topk_weight,
+    const c10::optional<at::Tensor> &group_index,
+    c10::optional<at::ScalarType> dst_type, int64_t quant_mode,
+    int64_t group_size, bool round_scale, bool ue8m0_scale, bool output_origin,
+    int64_t group_list_type, double clamp_value);
 #endif
 
 #ifdef BUILD_CATLASS_MODULE

--- a/tests/python/sgl_kernel_npu/test_swiglu_group_quant.py
+++ b/tests/python/sgl_kernel_npu/test_swiglu_group_quant.py
@@ -288,7 +288,9 @@ def _check_group_mode(
     torch.testing.assert_close(deq[nonzero], ref[nonzero], rtol=0.15, atol=0.02)
 
 
-def _check_mx_mode(num_tokens, d, dst_type, seed, use_weight, round_scale):
+def _check_mx_mode(
+    num_tokens, d, dst_type, seed, use_weight, round_scale, clamp_value=0.0
+):
     x = _make_inputs(num_tokens, d, seed=seed)
     topk_weight = None
     if use_weight:
@@ -301,10 +303,11 @@ def _check_mx_mode(num_tokens, d, dst_type, seed, use_weight, round_scale):
         dst_type=dst_type,
         quant_mode=MX_QUANT,
         round_scale=round_scale,
+        clamp_value=clamp_value,
     )
     torch.npu.synchronize()
 
-    ref = _ref_swiglu(x.cpu(), None, topk_weight.cpu() if use_weight else None)
+    ref = _ref_swiglu(x.cpu(), clamp_value, topk_weight.cpu() if use_weight else None)
     split_d = d // 2
     # MX scales are 2-aligned and carry a trailing factor-of-2 dimension.
     assert scale.shape == (num_tokens, (split_d + 31) // 32 // 2, 2)
@@ -316,6 +319,23 @@ def _check_mx_mode(num_tokens, d, dst_type, seed, use_weight, round_scale):
 
     # 1. The stored e8m0 byte is fully determined by the block's max bf16 exponent.
     ref_bytes = _ref_mx_scale_bytes(ref, dst_type, x.dtype).to(torch.uint8)
+
+    # A loose clamp asserts nothing: silu(gate)*up stays inside the exponent bucket a randn block
+    # already occupies, so clamp_value >= 3.0 moves no byte at all and the comparison below would
+    # pass against a kernel that drops clamp_value entirely. Reject such test data here, where the
+    # failure names the cause, rather than accepting a test with no power.
+    if clamp_value != 0.0:
+        unclamped = _ref_mx_scale_bytes(
+            _ref_swiglu(x.cpu(), 0.0, topk_weight.cpu() if use_weight else None),
+            dst_type,
+            x.dtype,
+        ).to(torch.uint8)
+        moved = (ref_bytes != unclamped).float().mean().item()
+        assert moved >= 0.10, (
+            f"clamp_value={clamp_value} moves only {moved:.1%} of the scale bytes at this seed and"
+            f" shape, so the clamp is untested -- tighten clamp_value or pick another seed"
+        )
+
     torch.testing.assert_close(flat_scale, ref_bytes, rtol=0, atol=0)
 
     # 2. Each stored scale is a power of two and dequantizing recovers the activation. The scale
@@ -334,6 +354,7 @@ def _check_mx_mode(num_tokens, d, dst_type, seed, use_weight, round_scale):
         dst_type=dst_type,
         quant_mode=MX_QUANT,
         round_scale=not round_scale,
+        clamp_value=clamp_value,
     )
     torch.npu.synchronize()
     torch.testing.assert_close(
@@ -507,6 +528,71 @@ class TestSwigluGroupQuant(unittest.TestCase):
     def test_mx_quant_e5m2_with_round_scale(self):
         _check_mx_mode(32, 512, torch.float8_e5m2, 16, False, True)
 
+    def test_mx_quant_with_clamp(self):
+        # The clamp is not a side detail here: it changes the activation, hence the bf16 exponent
+        # field the scale is read from, hence the stored e8m0 byte. This is also the mode
+        # production actually calls, with swiglu_limit as the clamp.
+        _check_mx_mode(32, 512, torch.float8_e4m3fn, 33, False, False, 1.0)
+
+    def test_mx_quant_e5m2_with_clamp(self):
+        # e5m2's exponent lower bound (0x0780 vs 0x0400) lets a block fall less far, so this needs
+        # a looser clamp than the e4m3 case to move a comparable share of the bytes.
+        _check_mx_mode(32, 512, torch.float8_e5m2, 34, False, False, 1.5)
+
+    def test_mx_quant_clamp_and_weight(self):
+        # The weight rescales the activation before the exponent field is read, so it and the
+        # clamp both land on the same byte.
+        _check_mx_mode(32, 512, torch.float8_e4m3fn, 35, True, False, 1.0)
+
+    def test_mx_quant_large_batch_multi_core(self):
+        # The shape class this op runs on in production: a full token batch, which reaches the
+        # multi-core split and the rowFactor UB loop rather than a single row block.
+        num_tokens, d = 2048, 768
+        x = _make_inputs(num_tokens, d, seed=36)
+        y, scale, _ = _call(x, dst_type=torch.float8_e4m3fn, quant_mode=MX_QUANT)
+        torch.npu.synchronize()
+
+        split_d = d // 2
+        nblocks = split_d // 32
+        assert scale.shape == (num_tokens, nblocks // 2, 2)
+        ref = _ref_swiglu(x.cpu())
+        flat = scale.cpu().view(torch.uint8).reshape(num_tokens, -1)[:, :nblocks]
+        torch.testing.assert_close(
+            flat,
+            _ref_mx_scale_bytes(ref, torch.float8_e4m3fn, x.dtype).to(torch.uint8),
+            rtol=0,
+            atol=0,
+        )
+        deq, _ = _dequantize(y.cpu(), flat, 32, split_d)
+        torch.testing.assert_close(deq, ref.to(x.dtype).float(), rtol=0.25, atol=0.02)
+
+    def test_mx_quant_zero_block_gives_zero_scale_byte(self):
+        # A block whose max exponent is 0 (every element zero) must store byte 0 rather than the
+        # format's clamped lower bound. Zero rows and live rows run in the same launch so both
+        # branches of the scale computation are exercised together.
+        num_tokens, d = 32, 512
+        zero_rows = 8
+        x = _make_inputs(num_tokens, d, seed=37)
+        x[:zero_rows] = 0.0
+        y, scale, _ = _call(x, dst_type=torch.float8_e4m3fn, quant_mode=MX_QUANT)
+        torch.npu.synchronize()
+
+        split_d = d // 2
+        flat = scale.cpu().view(torch.uint8).reshape(num_tokens, -1)[:, : split_d // 32]
+        ref_bytes = _ref_mx_scale_bytes(
+            _ref_swiglu(x.cpu()), torch.float8_e4m3fn, x.dtype
+        ).to(torch.uint8)
+        # Guard the test's premise before trusting it: the input must actually exercise both paths.
+        assert (
+            ref_bytes[:zero_rows] == 0
+        ).all(), "zero rows must give zero scale bytes"
+        assert (
+            ref_bytes[zero_rows:] != 0
+        ).any(), "live rows must give non-zero scale bytes"
+        torch.testing.assert_close(flat, ref_bytes, rtol=0, atol=0)
+        # An all-zero block quantizes to an all-zero y.
+        assert (y.cpu().view(torch.uint8)[:zero_rows] == 0).all()
+
     def test_mx_quant_fp16_input(self):
         num_tokens, d = 16, 512
         x = _make_inputs(num_tokens, d, dtype=torch.float16, seed=17)
@@ -522,6 +608,43 @@ class TestSwigluGroupQuant(unittest.TestCase):
             rtol=0,
             atol=0,
         )
+
+    def test_output_origin_true_is_inert_for_group_and_mx(self):
+        # Only fp8 has tiling keys that store y_origin (31/32); group and mx take keys 1/2 and the
+        # kernel never passes y_origin to their op classes. So output_origin must leave y and scale
+        # bit-identical -- and y_origin comes back allocated but unwritten, which is why callers
+        # must not read it in these two modes. The invariance is all this contract can assert.
+        num_tokens, d = 16, 512
+        for quant_mode in (GROUP_QUANT, MX_QUANT):
+            x = _make_inputs(num_tokens, d, seed=38 + quant_mode)
+            y_off, scale_off, _ = _call(
+                x,
+                dst_type=torch.float8_e4m3fn,
+                quant_mode=quant_mode,
+                output_origin=False,
+            )
+            y_on, scale_on, y_origin = _call(
+                x,
+                dst_type=torch.float8_e4m3fn,
+                quant_mode=quant_mode,
+                output_origin=True,
+            )
+            torch.npu.synchronize()
+            assert y_origin.shape == (num_tokens, d // 2)
+            assert y_origin.dtype == x.dtype
+            # Compare as bytes: the scale dtype differs per mode (fp32 for group, e8m0 for mx).
+            torch.testing.assert_close(
+                y_on.cpu().view(torch.uint8),
+                y_off.cpu().view(torch.uint8),
+                rtol=0,
+                atol=0,
+            )
+            torch.testing.assert_close(
+                scale_on.cpu().view(torch.uint8),
+                scale_off.cpu().view(torch.uint8),
+                rtol=0,
+                atol=0,
+            )
 
     # ---- mode 3: per-128 fp8 scales, fp32 or e8m0 ----
 

--- a/tests/python/sgl_kernel_npu/test_swiglu_group_quant.py
+++ b/tests/python/sgl_kernel_npu/test_swiglu_group_quant.py
@@ -18,9 +18,8 @@
 # truncated 1/448 bit pattern, mode 2 works entirely in the bf16 exponent domain, and mode 3 scales
 # against 448.0 regardless of dst_type. Comparing against a textbook reference would fail.
 #
-# Two of the op's arguments are accepted but inert by the ported tiling and are covered as such:
-# `group_size` never reaches the tiling math (upstream declares and never reads it), and `round_scale`
-# only affects mode 3.
+# Two of the op's arguments are accepted but inert by the tiling and are covered as such:
+# `group_size` never reaches the tiling math, and `round_scale` only affects mode 3.
 
 import struct
 import unittest

--- a/tests/python/sgl_kernel_npu/test_swiglu_group_quant.py
+++ b/tests/python/sgl_kernel_npu/test_swiglu_group_quant.py
@@ -1,0 +1,644 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# swiglu_group_quant (A5-only): splits x's last dim into (gate, up), applies SwiGLU, and quantizes
+# the result. Three quant modes:
+#
+#   quant_mode=1 (group) per-128-block scales, fp32;      scale = amax * (1 / fp8_max)
+#   quant_mode=2 (mx)    per-32-block scales, e8m0;       power-of-two scale from the bf16 exponent
+#   quant_mode=3 (fp8)   per-128-block scales, fp32 or e8m0; always scaled against 448.0
+#
+# The references below re-derive each mode from the kernel's own arithmetic rather than from a
+# generic "quantize" formula, because the three modes disagree in ways that matter: mode 1 uses a
+# truncated 1/448 bit pattern, mode 2 works entirely in the bf16 exponent domain, and mode 3 scales
+# against 448.0 regardless of dst_type. Comparing against a textbook reference would fail.
+#
+# Two of the op's arguments are accepted but inert by the ported tiling and are covered as such:
+# `group_size` never reaches the tiling math (upstream declares and never reads it), and `round_scale`
+# only affects mode 3.
+
+import struct
+import unittest
+
+import sgl_kernel_npu
+import torch
+import torch_npu
+from utils import require_npu_op
+
+pytestmark = require_npu_op("swiglu_group_quant")
+
+DEVICE_ID = 0
+torch_npu.npu.set_device(int(DEVICE_ID))
+
+GROUP_QUANT = 1
+MX_QUANT = 2
+FP8_QUANT = 3
+
+FP8_E4M3FN_MAX = 448.0
+FP8_E5M2_MAX = 57344.0
+# The reciprocal bit patterns the kernel multiplies by (not a correctly-rounded 1.0 / max).
+INV_FP8_E4M3_BITS = 0x3B124925
+INV_FP8_E5M2_BITS = 0x37924925
+
+# Mode 2 subtracts the fp8 format's own max exponent from the block's max bf16 exponent.
+LOWER_BOUND_OF_MAX_EXP_FOR_E4M3 = 0x0400
+LOWER_BOUND_OF_MAX_EXP_FOR_E5M2 = 0x0780
+BF16_EXP_MASK = 0x7F80
+E8M0_BIAS = 127
+# For an fp16 input the kernel truncates fp16 -> bf16 before reading the exponent, which re-biases
+# the 5-bit fp16 exponent (bias 15) into bf16's 8-bit field (bias 127): +112, shifted up by 7.
+FP16_EXP_MASK = 0x7C00
+BF16_EXP_REBIAS = 112 << 7
+
+
+def _bits_to_float(bits):
+    return struct.unpack("<f", struct.pack("<I", bits))[0]
+
+
+def _is_e5m2(dtype):
+    return dtype == torch.float8_e5m2
+
+
+def _coeff_for(dtype):
+    """The 1/fp8_max multiplier the kernel uses for the given output fp8 dtype."""
+    return _bits_to_float(INV_FP8_E5M2_BITS if _is_e5m2(dtype) else INV_FP8_E4M3_BITS)
+
+
+def _exp_lower_bound_for(dtype):
+    return (
+        LOWER_BOUND_OF_MAX_EXP_FOR_E5M2
+        if _is_e5m2(dtype)
+        else LOWER_BOUND_OF_MAX_EXP_FOR_E4M3
+    )
+
+
+def _split(x):
+    gate = x[..., : x.shape[-1] // 2]
+    up = x[..., x.shape[-1] // 2 :]
+    return gate, up
+
+
+def _ref_swiglu(x, clamp_value=None, topk_weight=None):
+    """The kernel's fused activation, in fp32, matching VFSwiGlu + the optional clamp/weight.
+
+    The clamp is asymmetric: gate is only bounded above, while up is bounded on both sides.
+    """
+    gate, up = _split(x.float())
+    if clamp_value is not None and clamp_value != 0.0:
+        gate = torch.clamp(gate, max=clamp_value)
+        up = torch.clamp(up, min=-clamp_value, max=clamp_value)
+    out = gate / (1.0 + torch.exp(-gate)) * up
+    if topk_weight is not None:
+        out = out * topk_weight.float().unsqueeze(-1)
+    return out
+
+
+def _blocks(t, block):
+    """Reshape the last dim into non-overlapping `block`-wide groups, padding the tail."""
+    n, cols = t.shape
+    nblocks = (cols + block - 1) // block
+    padded = torch.zeros((n, nblocks * block), dtype=t.dtype)
+    padded[:, :cols] = t
+    return padded.view(n, nblocks, block)
+
+
+def _ref_group_scales(t, dst_dtype):
+    """Mode 1: one fp32 scale per 128-wide block, amax * coeff (0 for an all-zero block)."""
+    amax = _blocks(t, 128).abs().amax(dim=-1)
+    coeff = _coeff_for(dst_dtype)
+    scale = amax * coeff
+    return torch.where(amax == 0, torch.zeros_like(scale), scale)
+
+
+def _mx_exp_field(t, src_dtype):
+    """The exponent field the MX path reads, per element, in bf16's bit position.
+
+    The kernel writes the fp32 SwiGLU result into a T0 (bf16/fp16) buffer with CAST_RINT -- i.e.
+    round-to-nearest-even to the *input* dtype -- and only then takes exponents. So the value seen
+    here is the input-dtype-rounded activation, not the fp32 one.
+    """
+    if src_dtype == torch.float16:
+        # fp16 goes through a CAST_TRUNC fp16 -> bf16 first, which keeps the top 7 mantissa bits
+        # (irrelevant to the exponent) and re-biases 15 -> 127. Masking with FP16_EXP_MASK drops the
+        # sign, which must not leak into the field.
+        field = (
+            _blocks(t.to(torch.float16), 32).view(torch.int16).to(torch.int32)
+            & FP16_EXP_MASK
+        ) >> 10
+        exp = (field << 7) + BF16_EXP_REBIAS
+        # An exponent field of 0 (zero, or a denormal) has nothing to re-bias and casts to 0; this
+        # also keeps the zero padding the block splitter adds from inventing an exponent. An all-ones
+        # field is inf/NaN, which the kernel remaps to bf16's all-ones field before maximizing.
+        exp = torch.where(field == 0, torch.zeros_like(exp), exp)
+        return torch.where(field == 0x1F, torch.full_like(exp, BF16_EXP_MASK), exp)
+    bits = _blocks(t.to(torch.bfloat16), 32).to(torch.float32).view(torch.int32) >> 16
+    return bits & BF16_EXP_MASK
+
+
+def _ref_mx_scale_bytes(t, dst_dtype, src_dtype):
+    """Mode 2: one e8m0 byte per 32-wide block, derived from the block's max bf16 exponent.
+
+    Mirrors VFComputeMaxExp + VFComputeScale: the bf16 exponent field of |t| is maximized over the
+    block, clamped up to the fp8 format's own max exponent, and the difference (shifted by bf16's 7
+    mantissa bits) is the e8m0 byte. An all-zero block yields byte 0.
+    """
+    lower = _exp_lower_bound_for(dst_dtype)
+    max_exp = _mx_exp_field(t, src_dtype).amax(dim=-1)
+    max_exp = torch.clamp(max_exp, min=lower)
+    return (max_exp - lower) >> 7
+
+
+def _ref_fp8_scales(t, dst_dtype, round_scale):
+    """Mode 3: one scale per 128-wide block, always computed against 448.0, with a 1e-4 amax floor.
+
+    Without round_scale the scale is the raw fp32 product. With it the scale is rounded up to a power
+    of two by taking the exponent and adding one when any mantissa bit is set. dst_type does not
+    enter the arithmetic here: the kernel hardcodes the e4m3 constants (448.0 / its reciprocal) for
+    this mode, so an e5m2 output is deliberately over-scaled rather than saturation-bound.
+    """
+    amax = _blocks(t, 128).abs().amax(dim=-1)
+    clamp_scale = torch.clamp(amax, min=1e-4)
+    scale = clamp_scale * _coeff_for(torch.float8_e4m3fn)
+    if not round_scale:
+        return scale
+    bits = scale.view(torch.int32)
+    exp = ((bits >> 23) & 0xFF) - 127 + ((bits & 0x7FFFFF) != 0).to(torch.int32)
+    assert (
+        int(exp.to(torch.int64).abs().max()) < 127
+    ), "power-of-two scale out of fp32 range"
+    return torch.pow(2.0, exp.to(torch.float32))
+
+
+def _dequantize(y, scale_bytes_or_floats, block, split_d):
+    """Rebuild the pre-quant values: y * scale, broadcasting each scale over its block."""
+    scales = scale_bytes_or_floats.to(torch.float32)
+    if scale_bytes_or_floats.dtype == torch.uint8:
+        scales = torch.pow(2.0, scales - E8M0_BIAS)
+    expanded = scales.repeat_interleave(block, dim=-1)[:, :split_d]
+    return y.float() * expanded, expanded
+
+
+def _call(
+    x,
+    topk_weight=None,
+    group_index=None,
+    dst_type=None,
+    quant_mode=GROUP_QUANT,
+    group_size=128,
+    round_scale=False,
+    ue8m0_scale=False,
+    output_origin=False,
+    group_list_type=0,
+    clamp_value=0.0,
+):
+    return torch.ops.npu.swiglu_group_quant(
+        x,
+        topk_weight,
+        group_index,
+        dst_type,
+        quant_mode,
+        group_size,
+        round_scale,
+        ue8m0_scale,
+        output_origin,
+        group_list_type,
+        clamp_value,
+    )
+
+
+def _make_inputs(num_tokens, d, dtype=torch.bfloat16, seed=0, device="npu"):
+    torch.manual_seed(seed)
+    x = torch.randn(num_tokens, d, dtype=dtype)
+    return x.to(device)
+
+
+def _check_swiglu_activation(d, dst_type, clamp_value, seed, use_weight):
+    """Mode 3 with output_origin gives y_origin: the exact fused activation before quantization.
+
+    This is the strongest available check of the split/clamp/weight math, because it does not depend
+    on any of the mode-specific scale arithmetic.
+    """
+    num_tokens = 32
+    x = _make_inputs(num_tokens, d, seed=seed)
+    topk_weight = None
+    if use_weight:
+        torch.manual_seed(seed + 100)
+        topk_weight = torch.rand(num_tokens, dtype=torch.float32).npu()
+
+    y, scale, y_origin = _call(
+        x,
+        topk_weight=topk_weight,
+        dst_type=dst_type,
+        quant_mode=FP8_QUANT,
+        output_origin=True,
+        clamp_value=clamp_value,
+    )
+    torch.npu.synchronize()
+
+    ref = _ref_swiglu(x.cpu(), clamp_value, topk_weight.cpu() if use_weight else None)
+    torch.testing.assert_close(y_origin.cpu().float(), ref, rtol=0.01, atol=0.01)
+
+    # y_origin is the source dtype; y is fp8 and must be consistent with the stored scales.
+    assert y_origin.dtype == x.dtype
+    assert y.dtype == dst_type
+    # Mode 3 without ue8m0_scale stores fp32 scales, so they are used as values, not reinterpreted
+    # as e8m0 bytes.
+    assert scale.dtype == torch.float32
+    deq, _ = _dequantize(y.cpu(), scale.cpu(), 128, ref.shape[-1])
+    torch.testing.assert_close(deq, ref, rtol=0.15, atol=0.02)
+
+
+def _check_group_mode(
+    num_tokens, d, dst_type, seed, group_size, use_weight, clamp_value
+):
+    x = _make_inputs(num_tokens, d, seed=seed)
+    topk_weight = None
+    if use_weight:
+        torch.manual_seed(seed + 100)
+        topk_weight = torch.rand(num_tokens, dtype=torch.float32).npu()
+
+    y, scale, _ = _call(
+        x,
+        topk_weight=topk_weight,
+        dst_type=dst_type,
+        quant_mode=GROUP_QUANT,
+        group_size=group_size,
+        clamp_value=clamp_value,
+    )
+    torch.npu.synchronize()
+
+    ref = _ref_swiglu(x.cpu(), clamp_value, topk_weight.cpu() if use_weight else None)
+    split_d = d // 2
+    assert y.shape == (num_tokens, split_d)
+    assert scale.shape == (num_tokens, (split_d + 127) // 128)
+    assert scale.dtype == torch.float32
+
+    # 1. The stored per-block scales are a single fp32 multiply, so they must match exactly.
+    ref_scales = _ref_group_scales(ref, dst_type)
+    torch.testing.assert_close(scale.cpu(), ref_scales, rtol=0, atol=0)
+
+    # 2. Dequantizing recovers the activation to within fp8 precision.
+    deq, _ = _dequantize(y.cpu(), scale.cpu(), 128, split_d)
+    nonzero = ref_scales.repeat_interleave(128, dim=-1)[:, :split_d] != 0
+    assert nonzero.any(), "test input must contain a non-zero block"
+    torch.testing.assert_close(deq[nonzero], ref[nonzero], rtol=0.15, atol=0.02)
+
+
+def _check_mx_mode(num_tokens, d, dst_type, seed, use_weight, round_scale):
+    x = _make_inputs(num_tokens, d, seed=seed)
+    topk_weight = None
+    if use_weight:
+        torch.manual_seed(seed + 100)
+        topk_weight = torch.rand(num_tokens, dtype=torch.float32).npu()
+
+    y, scale, _ = _call(
+        x,
+        topk_weight=topk_weight,
+        dst_type=dst_type,
+        quant_mode=MX_QUANT,
+        round_scale=round_scale,
+    )
+    torch.npu.synchronize()
+
+    ref = _ref_swiglu(x.cpu(), None, topk_weight.cpu() if use_weight else None)
+    split_d = d // 2
+    # MX scales are 2-aligned and carry a trailing factor-of-2 dimension.
+    assert scale.shape == (num_tokens, (split_d + 31) // 32 // 2, 2)
+    assert scale.dtype == torch.float8_e8m0fnu
+
+    flat_scale = (
+        scale.cpu().view(torch.uint8).reshape(num_tokens, -1)[:, : (split_d + 31) // 32]
+    )
+
+    # 1. The stored e8m0 byte is fully determined by the block's max bf16 exponent.
+    ref_bytes = _ref_mx_scale_bytes(ref, dst_type, x.dtype).to(torch.uint8)
+    torch.testing.assert_close(flat_scale, ref_bytes, rtol=0, atol=0)
+
+    # 2. Each stored scale is a power of two and dequantizing recovers the activation. The scale
+    #    targets 2^(E - 8) for e4m3 (2^(E - 15) for e5m2), i.e. fp8_max / 1.75 rather than fp8_max,
+    #    so the top 12.5% of each octave saturates at fp8_max -- hence the loose tolerance. Both y
+    #    and the scale come from the input-dtype-rounded activation, so compare against that.
+    deq, divisor = _dequantize(y.cpu(), flat_scale, 32, split_d)
+    rounded = ref.to(x.dtype).float()
+    torch.testing.assert_close(deq, rounded, rtol=0.25, atol=0.02)
+    assert torch.all(divisor > 0)
+
+    # 3. round_scale is inert for MX: the scale is exponent-derived either way.
+    y2, scale2, _ = _call(
+        x,
+        topk_weight=topk_weight,
+        dst_type=dst_type,
+        quant_mode=MX_QUANT,
+        round_scale=not round_scale,
+    )
+    torch.npu.synchronize()
+    torch.testing.assert_close(
+        scale2.cpu().view(torch.uint8), scale.cpu().view(torch.uint8), rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        y2.cpu().view(torch.uint8), y.cpu().view(torch.uint8), rtol=0, atol=0
+    )
+
+
+def _check_fp8_mode(num_tokens, d, dst_type, seed, round_scale, ue8m0_scale):
+    x = _make_inputs(num_tokens, d, seed=seed)
+    y, scale, _ = _call(
+        x,
+        dst_type=dst_type,
+        quant_mode=FP8_QUANT,
+        round_scale=round_scale,
+        ue8m0_scale=ue8m0_scale,
+    )
+    torch.npu.synchronize()
+
+    ref = _ref_swiglu(x.cpu())
+    split_d = d // 2
+    assert y.shape == (num_tokens, split_d)
+    assert scale.shape == (num_tokens, (split_d + 127) // 128)
+    assert scale.dtype == (torch.float8_e8m0fnu if ue8m0_scale else torch.float32)
+
+    ref_scales = _ref_fp8_scales(ref, dst_type, round_scale)
+    if ue8m0_scale:
+        # The e8m0 byte is the power-of-two exponent plus the bias.
+        assert (
+            round_scale
+        ), "ue8m0_scale requires round_scale for a coherent scale buffer"
+        bits = ref_scales.view(torch.int32)
+        ref_bytes = ((((bits >> 23) & 0xFF) - 127) + E8M0_BIAS).to(torch.uint8)
+        torch.testing.assert_close(
+            scale.cpu().view(torch.uint8), ref_bytes, rtol=0, atol=0
+        )
+        stored = scale.cpu().view(torch.uint8)
+    else:
+        torch.testing.assert_close(scale.cpu(), ref_scales, rtol=1e-6, atol=0)
+        stored = scale.cpu()
+
+    deq, _ = _dequantize(y.cpu(), stored, 128, split_d)
+    torch.testing.assert_close(deq, ref, rtol=0.15, atol=0.02)
+
+
+class TestSwigluGroupQuant(unittest.TestCase):
+
+    # ---- the fused activation, read back through y_origin ----
+
+    def test_fp8_output_origin_e4m3(self):
+        _check_swiglu_activation(512, torch.float8_e4m3fn, 0.0, 0, False)
+
+    def test_fp8_output_origin_e5m2(self):
+        _check_swiglu_activation(512, torch.float8_e5m2, 0.0, 1, False)
+
+    def test_fp8_output_origin_fp16_input(self):
+        # fp16 input selects the other DTYPE_X instantiation.
+        num_tokens, d = 16, 512
+        x = _make_inputs(num_tokens, d, dtype=torch.float16, seed=2)
+        y, _, y_origin = _call(
+            x, dst_type=torch.float8_e4m3fn, quant_mode=FP8_QUANT, output_origin=True
+        )
+        torch.npu.synchronize()
+        ref = _ref_swiglu(x.cpu())
+        torch.testing.assert_close(y_origin.cpu().float(), ref, rtol=0.01, atol=0.01)
+
+    def test_fp8_output_origin_with_topk_weight(self):
+        _check_swiglu_activation(512, torch.float8_e4m3fn, 0.0, 3, True)
+
+    def test_fp8_output_origin_with_clamp(self):
+        # The clamp is asymmetric, so this also pins the gate/up bound difference.
+        _check_swiglu_activation(512, torch.float8_e4m3fn, 3.0, 4, False)
+
+    def test_fp8_output_origin_clamp_and_weight(self):
+        _check_swiglu_activation(512, torch.float8_e5m2, 1.5, 5, True)
+
+    def test_output_origin_false_leaves_y_origin_unwritten(self):
+        # With output_origin unset the kernel takes the other tiling key and skips the y_origin
+        # stores, so the output must be unaffected by the extra allocation.
+        num_tokens, d = 16, 512
+        x = _make_inputs(num_tokens, d, seed=6)
+        y_a, scale_a, _ = _call(
+            x, dst_type=torch.float8_e4m3fn, quant_mode=FP8_QUANT, output_origin=False
+        )
+        y_b, scale_b, _ = _call(
+            x, dst_type=torch.float8_e4m3fn, quant_mode=FP8_QUANT, output_origin=True
+        )
+        torch.npu.synchronize()
+        torch.testing.assert_close(
+            y_a.cpu().view(torch.uint8), y_b.cpu().view(torch.uint8), rtol=0, atol=0
+        )
+        torch.testing.assert_close(scale_a.cpu(), scale_b.cpu(), rtol=0, atol=0)
+
+    # ---- mode 1: per-128 fp32 group scales ----
+
+    def test_group_quant_e4m3(self):
+        _check_group_mode(32, 512, torch.float8_e4m3fn, 7, 128, False, 0.0)
+
+    def test_group_quant_e5m2(self):
+        _check_group_mode(32, 512, torch.float8_e5m2, 8, 128, False, 0.0)
+
+    def test_group_quant_with_topk_weight(self):
+        _check_group_mode(32, 512, torch.float8_e4m3fn, 9, 128, True, 0.0)
+
+    def test_group_quant_with_clamp(self):
+        _check_group_mode(32, 512, torch.float8_e4m3fn, 10, 128, False, 2.0)
+
+    def test_group_quant_fp16_input_multi_core(self):
+        # A large batch exercises the multi-core split and the rowFactor UB loop.
+        num_tokens, d = 2048, 768
+        x = _make_inputs(num_tokens, d, dtype=torch.float16, seed=11)
+        y, scale, _ = _call(x, dst_type=torch.float8_e4m3fn, quant_mode=GROUP_QUANT)
+        torch.npu.synchronize()
+        ref = _ref_swiglu(x.cpu())
+        torch.testing.assert_close(
+            scale.cpu(), _ref_group_scales(ref, torch.float8_e4m3fn), rtol=0, atol=0
+        )
+        deq, _ = _dequantize(y.cpu(), scale.cpu(), 128, d // 2)
+        torch.testing.assert_close(deq, ref, rtol=0.15, atol=0.02)
+
+    def test_group_quant_group_size_is_inert(self):
+        # group_size is accepted for signature compatibility but never reaches the tiling math.
+        num_tokens, d = 16, 512
+        x = _make_inputs(num_tokens, d, seed=12)
+        results = [
+            _call(
+                x, dst_type=torch.float8_e4m3fn, quant_mode=GROUP_QUANT, group_size=gs
+            )
+            for gs in (1, 64, 128, 256)
+        ]
+        torch.npu.synchronize()
+        for y, scale, _ in results[1:]:
+            torch.testing.assert_close(
+                y.cpu().view(torch.uint8),
+                results[0][0].cpu().view(torch.uint8),
+                rtol=0,
+                atol=0,
+            )
+            torch.testing.assert_close(scale.cpu(), results[0][1].cpu(), rtol=0, atol=0)
+
+    def test_group_quant_zero_input_gives_zero_output(self):
+        # An all-zero block has amax 0, so both the scale and y must be exactly 0.
+        num_tokens, d = 16, 512
+        x = torch.zeros(num_tokens, d, dtype=torch.bfloat16).npu()
+        y, scale, _ = _call(x, dst_type=torch.float8_e4m3fn, quant_mode=GROUP_QUANT)
+        torch.npu.synchronize()
+        torch.testing.assert_close(
+            scale.cpu(), torch.zeros_like(scale.cpu()), rtol=0, atol=0
+        )
+        torch.testing.assert_close(
+            y.cpu().view(torch.uint8),
+            torch.zeros((num_tokens, d // 2), dtype=torch.uint8),
+            rtol=0,
+            atol=0,
+        )
+
+    # ---- mode 2: per-32 e8m0 mx scales ----
+
+    def test_mx_quant_e4m3(self):
+        _check_mx_mode(32, 512, torch.float8_e4m3fn, 13, False, False)
+
+    def test_mx_quant_e5m2(self):
+        # e5m2 uses the other exponent lower bound (0x0780 vs 0x0400).
+        _check_mx_mode(32, 512, torch.float8_e5m2, 14, False, False)
+
+    def test_mx_quant_with_topk_weight(self):
+        _check_mx_mode(32, 512, torch.float8_e4m3fn, 15, True, False)
+
+    def test_mx_quant_e5m2_with_round_scale(self):
+        _check_mx_mode(32, 512, torch.float8_e5m2, 16, False, True)
+
+    def test_mx_quant_fp16_input(self):
+        num_tokens, d = 16, 512
+        x = _make_inputs(num_tokens, d, dtype=torch.float16, seed=17)
+        y, scale, _ = _call(x, dst_type=torch.float8_e4m3fn, quant_mode=MX_QUANT)
+        torch.npu.synchronize()
+        ref = _ref_swiglu(x.cpu())
+        flat = scale.cpu().view(torch.uint8).reshape(num_tokens, -1)[:, : d // 2 // 32]
+        torch.testing.assert_close(
+            flat,
+            _ref_mx_scale_bytes(ref, torch.float8_e4m3fn, torch.float16).to(
+                torch.uint8
+            ),
+            rtol=0,
+            atol=0,
+        )
+
+    # ---- mode 3: per-128 fp8 scales, fp32 or e8m0 ----
+
+    def test_fp8_quant_e4m3_no_round_scale(self):
+        _check_fp8_mode(32, 512, torch.float8_e4m3fn, 18, False, False)
+
+    def test_fp8_quant_e4m3_round_scale(self):
+        _check_fp8_mode(32, 512, torch.float8_e4m3fn, 19, True, False)
+
+    def test_fp8_quant_e5m2_round_scale(self):
+        # dst_type does not enter mode 3's scale math: it is always scaled against 448.0.
+        _check_fp8_mode(32, 512, torch.float8_e5m2, 20, True, False)
+
+    def test_fp8_quant_ue8m0_scale(self):
+        _check_fp8_mode(32, 512, torch.float8_e4m3fn, 21, True, True)
+
+    # ---- optional group_index ----
+
+    def test_group_index_selects_the_processed_rows(self):
+        # With group_index the kernel derives the row count from the group list's total, so a list
+        # summing to the full batch must reproduce the no-group-index result.
+        num_tokens, d = 32, 512
+        x = _make_inputs(num_tokens, d, seed=22)
+        y_plain, scale_plain, _ = _call(
+            x, dst_type=torch.float8_e4m3fn, quant_mode=GROUP_QUANT
+        )
+        counts = torch.tensor([8, 8, 16], dtype=torch.int64)
+        torch.testing.assert_close(
+            counts.sum(), torch.tensor(num_tokens, dtype=torch.int64)
+        )
+        y_gi, scale_gi, _ = _call(
+            x,
+            group_index=counts.cumsum(0).npu(),
+            dst_type=torch.float8_e4m3fn,
+            quant_mode=GROUP_QUANT,
+        )
+        torch.npu.synchronize()
+        torch.testing.assert_close(
+            y_gi.cpu().view(torch.uint8),
+            y_plain.cpu().view(torch.uint8),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(scale_gi.cpu(), scale_plain.cpu(), rtol=0, atol=0)
+
+    def test_group_index_partial_batch(self):
+        # A group list totalling fewer rows than the batch leaves the remaining rows untouched.
+        num_tokens, d = 32, 512
+        processed = 16
+        x = _make_inputs(num_tokens, d, seed=23)
+        y, scale, _ = _call(
+            x,
+            group_index=torch.tensor([processed], dtype=torch.int64).npu(),
+            dst_type=torch.float8_e4m3fn,
+            quant_mode=GROUP_QUANT,
+        )
+        torch.npu.synchronize()
+        ref = _ref_swiglu(x.cpu())
+        torch.testing.assert_close(
+            scale.cpu()[:processed],
+            _ref_group_scales(ref, torch.float8_e4m3fn)[:processed],
+            rtol=0,
+            atol=0,
+        )
+
+    # ---- rejected arguments and shapes ----
+
+    def test_rejects_unsupported_quant_mode(self):
+        x = _make_inputs(4, 512, seed=24)
+        with self.assertRaisesRegex(RuntimeError, "Unsupported quant mode"):
+            _call(x, quant_mode=7)
+
+    def test_rejects_unsupported_group_list_type(self):
+        x = _make_inputs(4, 512, seed=25)
+        with self.assertRaisesRegex(RuntimeError, "tiling failed"):
+            _call(x, group_list_type=1)
+
+    def test_rejects_bad_last_dim_for_group_quant(self):
+        # group/fp8 modes require the last dim to be divisible by 256.
+        x = _make_inputs(4, 384, seed=26)
+        with self.assertRaisesRegex(RuntimeError, "divisible by 256"):
+            _call(x, quant_mode=GROUP_QUANT)
+
+    def test_rejects_bad_last_dim_for_mx_quant(self):
+        # mx requires divisibility by 128 instead.
+        x = _make_inputs(4, 192, seed=27)
+        with self.assertRaisesRegex(RuntimeError, "divisible by 128"):
+            _call(x, quant_mode=MX_QUANT)
+
+    def test_rejects_non_fp8_dst_type(self):
+        x = _make_inputs(4, 512, seed=28)
+        with self.assertRaisesRegex(RuntimeError, "dst_type must be"):
+            _call(x, dst_type=torch.float16, quant_mode=GROUP_QUANT)
+
+    def test_rejects_fp32_input(self):
+        x = torch.randn(4, 512, dtype=torch.float32).npu()
+        with self.assertRaisesRegex(RuntimeError, "FLOAT16 or BFLOAT16"):
+            _call(x, quant_mode=GROUP_QUANT)
+
+    def test_default_dst_type_is_e4m3fn(self):
+        x = _make_inputs(4, 512, seed=29)
+        y, _, _ = _call(x, quant_mode=GROUP_QUANT, dst_type=None)
+        torch.npu.synchronize()
+        assert y.dtype == torch.float8_e4m3fn
+
+    def test_empty_batch(self):
+        # No rows to process: the outputs come back empty rather than launching a zero-block kernel.
+        x = torch.randn(0, 512, dtype=torch.bfloat16).npu()
+        y, scale, y_origin = _call(
+            x, dst_type=torch.float8_e4m3fn, quant_mode=GROUP_QUANT
+        )
+        torch.npu.synchronize()
+        assert y.shape == (0, 256)
+        assert scale.shape == (0, 2)
+        assert y_origin.shape == (0, 256)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><!-- obsidian --><h2 data-heading="Motivation">Motivation</h2>
<p>Add the A5-only fused <code>swiglu_group_quant</code> operator to SGLang-Kernel-NPU. This enables fused SwiGLU activation and FP8 quantization on the A5 inference path, avoiding separate activation and quantization steps.</p>
<h2 data-heading="Modifications">Modifications</h2>
<ul>
<li>Port the A5 <code>swiglu_group_quant</code> Ascend C kernel from vLLM-Ascend.</li>
<li>Add the A5-only host implementation, tiling logic, and PyTorch <code>torch.ops.npu.swiglu_group_quant</code> registration.</li>
<li>Support group-wise, MX, and per-token quantization modes, optional top-k weights/group indices, optional activation output, and FP8 output types.</li>
<li>Add focused test coverage in <code>test_swiglu_group_quant.py</code>.</li>
<li>Add a dedicated A5 kernel target with MicroAPI-compatible compile options. Remove the unsupported <code>--op_relocatable_kernel_binary</code> option from the standalone kernel build.</li>
</ul>
<h2 data-heading="Accuracy Tests">Accuracy Tests</h2>
<p>Pending follow-up: run <code>tests/python/sgl_kernel_npu/test_swiglu_group_quant.py</code> on an Ascend A5 environment and provide the results
python tests/python/sgl_kernel_npu/test_swiglu_group_quant.py 
.......................................
----------------------------------------------------------------------
Ran 39 tests in 0.829s

OK
</p>
<h2 data-heading="Speed Tests and Profiling">Speed Tests and Profiling</h2>
<p>Serving benchmark comparison (<code>request_rate=inf</code>, <code>max_concurrency=168</code>, 168 successful requests):</p>

Metric | Before | After | Change
-- | -- | -- | --
Benchmark duration | 84.00 s | 80.25 s | -4.46%
Request throughput | 2.00 req/s | 2.09 req/s | +4.50%
Input token throughput | 16,384.97 tok/s | 17,149.92 tok/s | +4.67%
Output token throughput | 2,048.12 tok/s | 2,143.74 tok/s | +4.67%
Total token throughput | 18,433.10 tok/s | 19,293.66 tok/s | +4.67%
Mean E2E latency | 82,670.73 ms | 78,451.90 ms | -5.10%
Mean TTFT | 39,587.30 ms | 37,248.76 ms | -5.91%
Mean TPOT | 42.11 ms | 40.28 ms | -4.35%
Mean ITL | 42.11 ms | 40.28 ms | -4.35%


<p>Peak output token throughput is effectively unchanged: 9,492 tok/s before vs. 9,496 tok/s after.</p>
<p>
device: Ascend950PR_9579
torch: 2.10.0+cpu; torch_npu: 2.10.0.post5.dev20260824
workload: tokens=4096, hidden_size=3072, dtype=bf16, output=e4m3fn, scale=e8m0, group_size=32
timing: warmup=20, iters=100
triton_swiglu_quant: 92.49 us, 44283919.56 tokens/s
ascendc_swiglu_group_quant: 27.62 us, 148310470.12 tokens/s
ascendc_vs_triton: 3.349x
</p>
<h2 data-heading="Checklist">Checklist</h2>
<ul class="contains-task-list">
<li class="task-list-item" data-task=" "><input class="task-list-item-checkbox" type="checkbox">Format code with pre-commit.</li>
<li class="task-list-item" data-task=" "><input class="task-list-item-checkbox" type="checkbox">Add or update unit tests.</li>
<li class="task-list-item" data-task=" "><input class="task-list-item-checkbox" type="checkbox">Update documentation where needed.</li>
<li class="task-list-item" data-task=" "><input class="task-list-item-checkbox" type="checkbox">Provide accuracy and speed benchmark results where applicable.</li>
<li class="task-list-item" data-task=" "><input class="task-list-item-checkbox" type="checkbox">Follow the SGLang code-style guidance.</li>
</ul><!--EndFragment-->
</body>
</html>